### PR TITLE
Introduce a basic schema with validation tests

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -19,5 +19,13 @@
 #
 from __future__ import absolute_import
 
-from . import validator
-validator
+import json
+import pkgutil
+
+
+def load(schema_name):
+    return json.loads(
+        pkgutil.get_data('libnmstate', 'schemas/' + schema_name + '.json'))
+
+
+ifaces_schema = load('interfaces')

--- a/libnmstate/schemas/interfaces.json
+++ b/libnmstate/schemas/interfaces.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "title": "Interfaces tree",
+    "type": "object",
+    "properties": {
+        "interfaces": {
+            "title": "Interfaces",
+            "type": "array",
+            "items": {
+                "title": "Interface",
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "description": { "type": "string" },
+                    "type": {
+                        "type": "string",
+                        "enum": ["ethernet", "bond", "vlan"]
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": ["absent", "up", "down", "unknown"]
+                    }
+                },
+                "required": ["name"]
+            }
+        }
+    },
+    "required": ["interfaces"]
+}

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -19,5 +19,10 @@
 #
 from __future__ import absolute_import
 
-from . import validator
-validator
+import jsonschema as js
+
+from . import schema
+
+
+def verify(data, validation_schema=schema.ifaces_schema):
+    js.validate(data, validation_schema)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@
 #packageB!=4.4,>=4.0
 #packageC>=3.0.0
 #packageD!=0.13.0,<0.14,>=0.12.0
+
+jsonschema

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -19,5 +19,40 @@
 #
 from __future__ import absolute_import
 
-from . import validator
-validator
+import pytest
+
+import jsonschema as js
+
+import libnmstate
+
+
+def test_valid_basic_instance():
+    data = {
+        'interfaces': [
+            {
+                'name': 'lo',
+                'description': 'Loopback Interface',
+                'type': 'ethernet',
+                'state': 'down'
+            }
+        ]
+    }
+
+    libnmstate.validator.verify(data)
+
+
+def test_invalid_basic_instance():
+    data = {
+        'interfaces': [
+            {
+                'name': 'lo',
+                'description': 'Loopback Interface',
+                'type': 'ethernet',
+                'state': 'bad-state'
+            }
+        ]
+    }
+
+    with pytest.raises(js.ValidationError) as err:
+        libnmstate.validator.verify(data)
+        assert 'bad-state' in err.value.args[0]

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ commands =
 [testenv:pylint]
 skip_install = true
 deps =
+    -rrequirements.txt
+    pytest==3.5.1
     pylint==1.8.4
 commands =
     pylint \


### PR DESCRIPTION
A basic schema is introduced, defined in json-schema[1] and implemented
by jsonschema[2] python implementation.

The full/partial definition for the nmstate schema will be introduced in
a seperate patch.

[1] http://json-schema.org
[2] https://github.com/Julian/jsonschema