### PR TITLE
Use variable for pytest specification in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ deps =
     pytest-cov
     pytest==3.5.1
 changedir = {toxinidir}/tests
+covtarget = libnmstate
+pytesttarget = lib
 
 [testenv:check-py27]
 passenv = {[base]passenv}
@@ -26,10 +28,10 @@ basepython = python2.7
 commands =
     pytest \
         --durations=5 \
-        --cov=libnmstate \
+        --cov={[base]covtarget} \
         --cov-report=html:htmlcov-py27 \
         {posargs} \
-        lib
+        {[base]pytesttarget}
 
 [testenv:check-py36]
 passenv = {[base]passenv}
@@ -41,10 +43,10 @@ basepython = python3.6
 commands =
     pytest \
         --durations=5 \
-        --cov=libnmstate \
+        --cov={[base]covtarget} \
         --cov-report=html:htmlcov-py36 \
         {posargs} \
-        lib 
+        {[base]pytesttarget}
 
 [testenv:pylint]
 setenv =


### PR DESCRIPTION
This reduces repetition and makes it easier to adjust the tox
configuration.