### PR TITLE
Do not require "-f/--file" to specify state

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ nmstatectl show
 
 Change to desired state:
 ```shell
-nmstatectl set --file <desired-state.json>
+nmstatectl set desired-state.json
+```
+
+`nmstatectl` will also read from stdin when no file is specified:
+
+
+```shell
+nmstatectl set < desired-state.json
 ```
 
 Desired/Current state example:
@@ -67,6 +74,14 @@ Desired/Current state example:
     ]
 }
 ```
+
+The state is also supported as YAML, to get the current state in YAML format:
+
+```shell
+nmstatectl show --yaml
+```
+
+The `set` command accepts both YAML and JSON.
 
 ## Supported Interfaces:
 - bond

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -25,7 +25,7 @@ from nmstatectl import nmstatectl
 
 @mock.patch('sys.argv', ['nmstatectl', 'show'])
 @mock.patch.object(nmstatectl.netinfo, 'show', lambda: {})
-@mock.patch('sys.argv', ['nmstatectl', 'set', '-f', 'mystate.json'])
+@mock.patch('sys.argv', ['nmstatectl', 'set', 'mystate.json'])
 @mock.patch.object(nmstatectl.netapplier, 'apply', lambda state: None)
 def test_run_ctl_directly():
     nmstatectl.main()


### PR DESCRIPTION
Since the network state file is always requirer/not optional, specify it
as an argument, not as an option.