### PR TITLE
Initial IP settings support

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -36,6 +36,7 @@ def interfaces():
                 'name': dev['name'],
                 'type': dev['type'],
                 'state': dev['state'],
+                'ip': dev['ip'],
             }
             for dev in devices()
         ]
@@ -47,11 +48,32 @@ def devices():
 
     devlist = []
     for device in client.get_devices():
+        ip4info = {}
+        connection = device.get_active_connection()
+        if connection:
+            ip4config = connection.get_ip4_config()
+            if ip4config:
+                ip4info["enabled"] = True
+                addresslist = []
+
+                addresses = ip4config.get_addresses()
+                for address in addresses:
+                    addressinfo = {"ip": address.get_address(),
+                                   "prefix-length": address.get_prefix()}
+                    addresslist.append(addressinfo)
+                if addresslist:
+                    ip4info["addresses"] = addresslist
+            else:
+                ip4info["enabled"] = False
+        else:
+            ip4info["enabled"] = False
+
         devinfo = {
             'name': device.get_iface(),
             'type_id': device.get_device_type(),
             'type': resolve_nm_dev_type(device.get_type_description()),
             'state': resolve_nm_dev_state(device.get_state()),
+            'ip': ip4info,
         }
         devlist.append(devinfo)
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -45,17 +45,15 @@ def interfaces():
 def devices():
     client = nmclient.client()
 
-    devs = client.get_devices()
-
-    devlist = [
-        {
-            'name': dev.get_iface(),
-            'type_id': dev.get_device_type(),
-            'type': resolve_nm_dev_type(dev.get_type_description()),
-            'state': resolve_nm_dev_state(dev.get_state()),
+    devlist = []
+    for device in client.get_devices():
+        devinfo = {
+            'name': device.get_iface(),
+            'type_id': device.get_device_type(),
+            'type': resolve_nm_dev_type(device.get_type_description()),
+            'state': resolve_nm_dev_state(device.get_state()),
         }
-        for dev in devs
-    ]
+        devlist.append(devinfo)
 
     return devlist
 

--- a/libnmstate/nmclient.py
+++ b/libnmstate/nmclient.py
@@ -37,3 +37,16 @@ def client():
     if _nmclient is None:
         _nmclient = NM.Client.new(None)
     return _nmclient
+
+
+def connection_ensure_setting(connection, setting_type):
+    """ From network system role: library/network_connections.py
+
+    ensure that connection contains a setting of setting_type
+
+    """
+    setting = connection.get_setting(setting_type)
+    if not setting:
+        setting = setting_type.new()
+        connection.add_setting(setting)
+    return setting

--- a/tests/lib/mock_nm.py
+++ b/tests/lib/mock_nm.py
@@ -1,5 +1,22 @@
-#!/usr/bin/python3 -tt
-# vim: fileencoding=utf8
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
 
 UP = 1
 DOWN = 0
@@ -10,6 +27,9 @@ NM_DEVICE_TYPE_GENERIC = 14
 class MockNmConnection(object):
     def get_ip4_config(self):
         return None
+
+    def get_connection(self):
+        return MockNmConnection()
 
 
 class MockNmDevice(object):

--- a/tests/lib/mock_nm.py
+++ b/tests/lib/mock_nm.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3 -tt
+# vim: fileencoding=utf8
+
+UP = 1
+DOWN = 0
+
+NM_DEVICE_TYPE_GENERIC = 14
+
+
+class MockNmConnection(object):
+    def get_ip4_config(self):
+        return None
+
+
+class MockNmDevice(object):
+    def __init__(self, devstate=DOWN, active_connection=MockNmConnection(),
+                 iface="lo"):
+        self._devstate = devstate
+        self._active_connection = active_connection
+        self._iface = iface
+
+    def get_active_connection(self):
+        return self._active_connection
+
+    def get_device_type(self):
+        return NM_DEVICE_TYPE_GENERIC
+
+    def get_iface(self):
+        return self._iface
+
+    def get_state(self):
+        return self._devstate
+
+    def get_type_description(self):
+        return 'Generic device'

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -75,7 +75,7 @@ class TestDevStateChange(object):
     def test_apply_iface_state_up_to_down(self, mk_client, mk_nm, config):
         mock_get_device_by_iface = mk_client.return_value.get_device_by_iface
         mock_get_device_by_iface.return_value = MockNmDevice(
-            devstate=UP, active_connection='con0')
+            devstate=UP)
         mk_nm.DeviceState.ACTIVATED = UP
 
         config['interfaces'][0]['state'] = 'down'

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -25,9 +25,7 @@ from .compat import mock
 
 from libnmstate import netapplier
 
-
-UP = 1
-DOWN = 0
+from tests.lib.mock_nm import MockNmDevice, UP, DOWN
 
 
 @pytest.fixture()
@@ -64,7 +62,8 @@ class TestDevStateChange(object):
 
     def test_apply_iface_state_down_to_down(self, mk_client, mk_nm, config):
         mock_get_device_by_iface = mk_client.return_value.get_device_by_iface
-        mock_get_device_by_iface.return_value = MockNmDevice(devstate=DOWN)
+        mock_get_device_by_iface.return_value = MockNmDevice(
+            devstate=DOWN, active_connection=None)
         mk_nm.DeviceState.ACTIVATED = UP
 
         config['interfaces'][0]['state'] = 'down'
@@ -84,16 +83,3 @@ class TestDevStateChange(object):
 
         mk_client.return_value.activate_connection_async.assert_not_called()
         mk_client.return_value.deactivate_connection_async.assert_called_once()
-
-
-class MockNmDevice(object):
-
-    def __init__(self, devstate, active_connection=None):
-        self._state = devstate
-        self._active_connection = active_connection
-
-    def get_active_connection(self):
-        return self._active_connection
-
-    def get_state(self):
-        return self._state

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -38,6 +38,11 @@ def test_netinfo_show(mock_client, mock_nm):
     assert 'lo' in iface_names
 
 
+class MockNmConnection(object):
+    def get_ip4_config(self):
+        return None
+
+
 class MockNmDevice(object):
     def get_iface(self):
         return 'lo'
@@ -50,3 +55,6 @@ class MockNmDevice(object):
 
     def get_state(self):
         return NM_DEVICE_STATE_UNKNOWN
+
+    def get_active_connection(self):
+        return MockNmConnection()

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -22,10 +22,7 @@ from __future__ import absolute_import
 from .compat import mock
 
 from libnmstate import netinfo
-
-
-NM_DEVICE_STATE_UNKNOWN = 0
-NM_DEVICE_TYPE_GENERIC = 14
+from tests.lib.mock_nm import MockNmDevice
 
 
 @mock.patch.object(netinfo.nmclient, 'NM')
@@ -36,25 +33,3 @@ def test_netinfo_show(mock_client, mock_nm):
     report = netinfo.show()
     iface_names = [iface['name'] for iface in report['interfaces']]
     assert 'lo' in iface_names
-
-
-class MockNmConnection(object):
-    def get_ip4_config(self):
-        return None
-
-
-class MockNmDevice(object):
-    def get_iface(self):
-        return 'lo'
-
-    def get_device_type(self):
-        return NM_DEVICE_TYPE_GENERIC
-
-    def get_type_description(self):
-        return 'Generic device'
-
-    def get_state(self):
-        return NM_DEVICE_STATE_UNKNOWN
-
-    def get_active_connection(self):
-        return MockNmConnection()


### PR DESCRIPTION
Add initial support to get and configure IP address. This needs nmstate to run the GLib MainLoop so that the async() methods to activate the connections are actually called. Inspecting /etc/sysconfig/network-script  shows here, that IP settings are changed as expected.