### PR TITLE
Decouple nm provider

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -213,7 +213,8 @@ def _index_by_name(ifaces_state):
 
 
 def _build_connection_profile(iface_desired_state, base_con_profile=None):
-    iface_type = nm.translator.api2nm_iface_type(iface_desired_state['type'])
+    iface_type = nm.translator.Api2Nm.get_iface_type(
+        iface_desired_state['type'])
     master = iface_desired_state.get('_master')
     settings = [
         nm.ipv4.create_setting(),
@@ -232,7 +233,7 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
 
     if iface_type == 'bond':
         bond_conf = iface_desired_state['link-aggregation']
-        bond_opts = nm.translator.api2nm_bond_options(bond_conf)
+        bond_opts = nm.translator.Api2Nm.get_bond_options(bond_conf)
 
         settings.append(nm.bond.create_setting(bond_opts))
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -65,12 +65,12 @@ def _ifaceinfo_bond(dev, iface_info):
 def _devinfo_common(dev):
     type_name = dev.get_type_description()
     if type_name != 'ethernet':
-        type_name = nm.translator.nm2api_iface_type(type_name)
+        type_name = nm.translator.Nm2Api.get_iface_type(type_name)
     return {
         'name': dev.get_iface(),
         'type_id': dev.get_device_type(),
         'type': type_name,
-        'state': nm.translator.nm2api_iface_admin_state(dev.get_state()),
+        'state': nm.translator.Nm2Api.get_iface_admin_state(dev.get_state()),
     }
 
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -70,7 +70,7 @@ def _devinfo_common(dev):
         'name': dev.get_iface(),
         'type_id': dev.get_device_type(),
         'type': type_name,
-        'state': resolve_nm_dev_state(dev.get_state()),
+        'state': nm.translator.nm2api_iface_admin_state(dev.get_state()),
     }
 
 
@@ -90,9 +90,3 @@ def _devinfo_bond(dev, devinfo):
                     }
             }
     return {}
-
-
-def resolve_nm_dev_state(nm_state):
-    if nm_state == nmclient.NM.DeviceState.ACTIVATED:
-        return 'up'
-    return 'down'

--- a/libnmstate/nm/__init__.py
+++ b/libnmstate/nm/__init__.py
@@ -18,6 +18,7 @@
 # Refer to the README and COPYING files for full details of the license
 #
 
+from . import applier
 from . import bond
 from . import connection
 from . import device
@@ -25,6 +26,7 @@ from . import ipv4
 from . import ipv6
 from . import translator
 
+applier
 bond
 connection
 device

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -1,0 +1,114 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+
+from . import bond
+from . import connection
+from . import device
+from . import ipv4
+from . import ipv6
+from . import translator
+
+
+class UnsupportedIfaceStateError(Exception):
+    pass
+
+
+def create_new_ifaces(con_profiles):
+    for connection_profile in con_profiles:
+        connection.add_profile(connection_profile, save_to_disk=True)
+
+
+def prepare_new_ifaces_configuration(ifaces_desired_state):
+    new_con_profiles = [
+        _build_connection_profile(iface_desired_state)
+        for iface_desired_state in ifaces_desired_state
+    ]
+    return new_con_profiles
+
+
+def edit_existing_ifaces(con_profiles):
+    for connection_profile in con_profiles:
+        devname = connection_profile.get_interface_name()
+        nmdev = device.get_device_by_name(devname)
+        if nmdev:
+            cur_con_profile = connection.get_device_connection(nmdev)
+            if cur_con_profile:
+                connection.commit_profile(connection_profile)
+            else:
+                # Missing connection, attempting to create a new one.
+                connection.add_profile(connection_profile, save_to_disk=True)
+
+
+def prepare_edited_ifaces_configuration(ifaces_desired_state):
+    con_profiles = []
+    for iface_desired_state in ifaces_desired_state:
+        nmdev = device.get_device_by_name(iface_desired_state['name'])
+        if nmdev:
+            cur_con_profile = connection.get_device_connection(nmdev)
+            new_con_profile = _build_connection_profile(
+                iface_desired_state, base_con_profile=cur_con_profile)
+            if cur_con_profile:
+                connection.update_profile(cur_con_profile, new_con_profile)
+                con_profiles.append(cur_con_profile)
+            else:
+                # Missing connection, attempting to create a new one.
+                con_profiles.append(new_con_profile)
+
+    return con_profiles
+
+
+def set_ifaces_admin_state(ifaces_desired_state):
+    for iface_desired_state in ifaces_desired_state:
+        nmdev = device.get_device_by_name(iface_desired_state['name'])
+        if nmdev:
+            if iface_desired_state['state'] == 'up':
+                device.activate(nmdev)
+            elif iface_desired_state['state'] == 'down':
+                device.deactivate(nmdev)
+            elif iface_desired_state['state'] == 'absent':
+                device.delete(nmdev)
+            else:
+                raise UnsupportedIfaceStateError(iface_desired_state)
+
+
+def _build_connection_profile(iface_desired_state, base_con_profile=None):
+    iface_type = translator.Api2Nm.get_iface_type(iface_desired_state['type'])
+
+    settings = [
+        ipv4.create_setting(),
+        ipv6.create_setting(),
+    ]
+    if base_con_profile:
+        con_setting = connection.duplicate_settings(base_con_profile)
+    else:
+        con_setting = connection.create_setting(
+            con_name=iface_desired_state['name'],
+            iface_name=iface_desired_state['name'],
+            iface_type=iface_type,
+        )
+    master = iface_desired_state.get('_master')
+    connection.set_master_setting(con_setting, master, 'bond')
+    settings.append(con_setting)
+
+    bond_opts = translator.Api2Nm.get_bond_options(iface_desired_state)
+    if bond_opts:
+        settings.append(bond.create_setting(bond_opts))
+
+    return connection.create_profile(settings)

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -34,6 +34,17 @@ def create_setting(options):
     return bond_setting
 
 
+def is_bond_type_id(type_id):
+    return type_id == nmclient.NM.DeviceType.BOND
+
+
+def get_bond_info(nm_device):
+    return {
+        'slaves': get_slaves(nm_device),
+        'options': get_options(nm_device)
+    }
+
+
 def get_options(nm_device):
     con = connection.get_device_connection(nm_device)
     if con:

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -24,3 +24,12 @@ from libnmstate import nmclient
 def list_devices():
     client = nmclient.client(refresh=True)
     return client.get_devices()
+
+
+def get_device_common_info(dev):
+    return {
+        'name': dev.get_iface(),
+        'type_id': dev.get_device_type(),
+        'type_name': dev.get_type_description(),
+        'state': dev.get_state(),
+    }

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -21,6 +21,36 @@
 from libnmstate import nmclient
 
 
+def activate(dev):
+    client = nmclient.client()
+    client.activate_connection_async(device=dev)
+
+
+def deactivate(dev):
+    """
+    Deactivating the current active connection,
+    The profile itself is not removed.
+
+    For software devices, deactivation removes the devices from the kernel.
+    """
+    client = nmclient.client()
+    act_connection = dev.get_active_connection()
+    if act_connection:
+        client.deactivate_connection_async(act_connection)
+
+
+def delete(dev):
+    """Removes all device profiles."""
+    connections = dev.get_available_connections()
+    for con in connections:
+        con.delete_async()
+
+
+def get_device_by_name(devname):
+    client = nmclient.client()
+    return client.get_device_by_iface(devname)
+
+
 def list_devices():
     client = nmclient.client(refresh=True)
     return client.get_devices()

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -51,10 +51,16 @@ class Api2Nm(object):
         return Api2Nm._iface_types_map
 
     @staticmethod
-    def get_bond_options(bond_conf):
-        # Is the mode a must config parameter?
-        bond_opts = {'mode': bond_conf['mode']}
-        bond_opts.update(bond_conf.get('options', {}))
+    def get_bond_options(iface_desired_state):
+        iface_type = Api2Nm.get_iface_type(iface_desired_state['type'])
+        if iface_type == 'bond':
+            # Is the mode a must config parameter?
+            bond_conf = iface_desired_state['link-aggregation']
+            bond_opts = {'mode': bond_conf['mode']}
+            bond_opts.update(bond_conf.get('options', {}))
+        else:
+            bond_opts = {}
+
         return bond_opts
 
 

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -31,48 +31,47 @@ class ApiIfaceAdminState(object):
     UP = 'up'
 
 
-def nm2api_iface_admin_state(state_name):
-    if state_name == nmclient.NM.DeviceState.ACTIVATED:
-        return ApiIfaceAdminState.UP
-    return ApiIfaceAdminState.DOWN
+class Api2Nm(object):
+    _iface_types_map = None
+
+    @staticmethod
+    def get_iface_type(name):
+        return Api2Nm.get_iface_type_map().get(name, IFACE_TYPE_UNKNOWN)
+
+    @staticmethod
+    def get_iface_type_map():
+        if Api2Nm._iface_types_map is None:
+            Api2Nm._iface_types_map = {
+                'ethernet': nmclient.NM.SETTING_WIRED_SETTING_NAME,
+                'bond': nmclient.NM.SETTING_BOND_SETTING_NAME,
+                'dummy': nmclient.NM.SETTING_DUMMY_SETTING_NAME,
+            }
+        return Api2Nm._iface_types_map
+
+    @staticmethod
+    def get_bond_options(bond_conf):
+        # Is the mode a must config parameter?
+        bond_opts = {'mode': bond_conf['mode']}
+        bond_opts.update(bond_conf.get('options', {}))
+        return bond_opts
 
 
-def api2nm_iface_type(name):
-    return _get_api2nm_iface_type_map().get(name, IFACE_TYPE_UNKNOWN)
+class Nm2Api(object):
+    _iface_types_map = None
 
+    @staticmethod
+    def get_iface_type(name):
+        if Nm2Api._iface_types_map is None:
+            Nm2Api._iface_types_map = Nm2Api._swap_dict_keyval(
+                Api2Nm.get_iface_type_map())
+        return Nm2Api._iface_types_map.get(name, IFACE_TYPE_UNKNOWN)
 
-def nm2api_iface_type(name):
-    return _get_nm2api_iface_type_map().get(name, IFACE_TYPE_UNKNOWN)
+    @staticmethod
+    def get_iface_admin_state(state_name):
+        if state_name == nmclient.NM.DeviceState.ACTIVATED:
+            return ApiIfaceAdminState.UP
+        return ApiIfaceAdminState.DOWN
 
-
-def api2nm_bond_options(bond_conf):
-    # Is the mode a must config parameter?
-    bond_opts = {'mode': bond_conf['mode']}
-    bond_opts.update(bond_conf.get('options', {}))
-    return bond_opts
-
-
-def _swap_dict_keyval(dictionary):
-    return {val: key for key, val in six.viewitems(dictionary)}
-
-
-_api2nm_iface_types = None
-_nm2api_iface_types = None
-
-
-def _get_api2nm_iface_type_map():
-    global _api2nm_iface_types
-    if _api2nm_iface_types is None:
-        _api2nm_iface_types = {
-            'ethernet': nmclient.NM.SETTING_WIRED_SETTING_NAME,
-            'bond': nmclient.NM.SETTING_BOND_SETTING_NAME,
-            'dummy': nmclient.NM.SETTING_DUMMY_SETTING_NAME,
-        }
-    return _api2nm_iface_types
-
-
-def _get_nm2api_iface_type_map():
-    global _nm2api_iface_types
-    if _nm2api_iface_types is None:
-        _nm2api_iface_types = _swap_dict_keyval(_get_api2nm_iface_type_map())
-    return _nm2api_iface_types
+    @staticmethod
+    def _swap_dict_keyval(dictionary):
+        return {val: key for key, val in six.viewitems(dictionary)}

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -26,6 +26,17 @@ from libnmstate import nmclient
 IFACE_TYPE_UNKNOWN = 'unknown'
 
 
+class ApiIfaceAdminState(object):
+    DOWN = 'down'
+    UP = 'up'
+
+
+def nm2api_iface_admin_state(state_name):
+    if state_name == nmclient.NM.DeviceState.ACTIVATED:
+        return ApiIfaceAdminState.UP
+    return ApiIfaceAdminState.DOWN
+
+
 def api2nm_iface_type(name):
     return _get_api2nm_iface_type_map().get(name, IFACE_TYPE_UNKNOWN)
 

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -29,7 +29,7 @@ NM_DEVICE_TYPE_BOND = 10
 NM_DEVICE_TYPE_GENERIC = 14
 
 
-@mock.patch.object(netinfo.nmclient, 'NM')
+@mock.patch.object(netinfo.nm.translator.nmclient, 'NM')
 @mock.patch.object(netinfo.nm.device.nmclient, 'client')
 def test_netinfo_show(mock_client, mock_nm):
     mock_client.return_value.get_devices.return_value = [


### PR DESCRIPTION
The NM package should include all the logic on how to access NM.
The translator needs to include all the translation logic between the formats while the individual NM modules (which represents the NM API structure) should provide access to NM API.