### PR TITLE
libnmstate: Support IPv4 info reporting

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -36,6 +36,9 @@ def interfaces():
         type_id = devinfo['type_id']
         iface_info = nm.translator.Nm2Api.get_common_device_info(devinfo)
 
+        act_con = nm.connection.get_device_active_connection(dev)
+        iface_info['ipv4'] = nm.ipv4.get_info(act_con)
+
         if nm.bond.is_bond_type_id(type_id):
             bondinfo = nm.bond.get_bond_info(dev)
             iface_info.update(_ifaceinfo_bond(bondinfo))

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -75,7 +75,11 @@ def set_master_setting(con_setting, master, slave_type):
 
 
 def get_device_connection(nm_device):
-    act_connection = nm_device.get_active_connection()
+    act_connection = get_device_active_connection(nm_device)
     if act_connection:
         return act_connection.props.connection
     return None
+
+
+def get_device_active_connection(nm_device):
+    return nm_device.get_active_connection()

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -25,3 +25,33 @@ def create_setting():
     setting_ipv4 = nmclient.NM.SettingIP4Config.new()
     setting_ipv4.props.method = nmclient.NM.SETTING_IP4_CONFIG_METHOD_DISABLED
     return setting_ipv4
+
+
+def get_info(active_connection):
+    """
+    Provides the current active values for an active connection.
+    It includes not only the configured values, but the consequences of the
+    configuration (as in the case of ipv4.method=auto, where the address is
+    not explicitly defined).
+    """
+    info = {'enabled': False}
+    if active_connection is None:
+        return info
+
+    ip4config = active_connection.get_ip4_config()
+    if ip4config is None:
+        return info
+
+    addresses = [
+        {
+            'ip': address.get_address(),
+            'prefix-length': address.get_prefix()
+        }
+        for address in ip4config.get_addresses()
+    ]
+    if not addresses:
+        return info
+
+    info['enabled'] = True
+    info['addresses'] = addresses
+    return info

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -56,7 +56,14 @@ def netinfo_nm_mock():
 def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     current_config = {
         'interfaces': [
-            {'name': 'foo', 'type': 'unknown', 'state': 'up'}
+            {
+                'name': 'foo',
+                'type': 'unknown',
+                'state': 'up',
+                'ipv4': {
+                    'enabled': False,
+                },
+            }
         ]
     }
     desired_config = copy.deepcopy(current_config)
@@ -65,6 +72,8 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     netinfo_nm_mock.translator.Nm2Api.get_common_device_info.return_value = (
         current_config['interfaces'][0])
     netinfo_nm_mock.bond.is_bond_type_id.return_value = False
+    netinfo_nm_mock.ipv4.get_info.return_value = (
+        current_config['interfaces'][0]['ipv4'])
 
     desired_config['interfaces'][0]['state'] = 'down'
     netapplier.apply(desired_config)
@@ -115,7 +124,10 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
                     'options': {
                         'miimon': '100',
                     }
-                }
+                },
+                'ipv4': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -130,6 +142,8 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     netinfo_nm_mock.translator.Nm2Api.get_bond_info.return_value = {
         'link-aggregation': current_config['interfaces'][0]['link-aggregation']
     }
+    netinfo_nm_mock.ipv4.get_info.return_value = (
+        current_config['interfaces'][0]['ipv4'])
 
     desired_config = copy.deepcopy(current_config)
     options = desired_config['interfaces'][0]['link-aggregation']['options']

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -33,7 +33,14 @@ def nm_mock():
 def test_netinfo_show_generic_iface(nm_mock):
     current_config = {
         'interfaces': [
-            {'name': 'foo', 'type': 'unknown', 'state': 'up'}
+            {
+                'name': 'foo',
+                'type': 'unknown',
+                'state': 'up',
+                'ipv4': {
+                    'enabled': False,
+                },
+            }
         ]
     }
 
@@ -41,6 +48,8 @@ def test_netinfo_show_generic_iface(nm_mock):
     nm_mock.translator.Nm2Api.get_common_device_info.return_value = (
         current_config['interfaces'][0])
     nm_mock.bond.is_bond_type_id.return_value = False
+    nm_mock.ipv4.get_info.return_value = (
+        current_config['interfaces'][0]['ipv4'])
 
     report = netinfo.show()
 
@@ -60,7 +69,10 @@ def test_netinfo_show_bond_iface(nm_mock):
                     'options': {
                         'miimon': '100',
                     }
-                }
+                },
+                'ipv4': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -75,6 +87,8 @@ def test_netinfo_show_bond_iface(nm_mock):
     nm_mock.translator.Nm2Api.get_bond_info.return_value = {
         'link-aggregation': current_config['interfaces'][0]['link-aggregation']
     }
+    nm_mock.ipv4.get_info.return_value = (
+        current_config['interfaces'][0]['ipv4'])
 
     report = netinfo.show()
 

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -30,3 +30,37 @@ def test_create_setting(NM_mock):
     assert ipv4_setting == NM_mock.SettingIP4Config.new.return_value
     assert (ipv4_setting.props.method ==
             NM_mock.SETTING_IP4_CONFIG_METHOD_DISABLED)
+
+
+def test_get_info_witn_no_connection():
+    info = nm.ipv4.get_info(active_connection=None)
+
+    assert info == {'enabled': False}
+
+
+def test_get_info_with_no_ipv4_config():
+    con_mock = mock.MagicMock()
+    con_mock.get_ip4_config.return_value = None
+
+    info = nm.ipv4.get_info(active_connection=con_mock)
+
+    assert info == {'enabled': False}
+
+
+def test_get_info_with_ipv4_config():
+    act_con_mock = mock.MagicMock()
+    config_mock = act_con_mock.get_ip4_config.return_value
+    address_mock = mock.MagicMock()
+    config_mock.get_addresses.return_value = [address_mock]
+
+    info = nm.ipv4.get_info(active_connection=act_con_mock)
+
+    assert info == {
+        'enabled': True,
+        'addresses': [
+            {
+                'ip': address_mock.get_address.return_value,
+                'prefix-length': address_mock.get_prefix.return_value,
+            }
+        ]
+    }


### PR DESCRIPTION
These are the current active values on an active connection profile.

Based on #28

DHCP will be added in a future patch.

Signed-off-by: Till Maas <till@redhat.com>
Signed-off-by: Edward Haas <edwardh@redhat.com>