### PR TITLE
add basic logging initialization

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 import argparse
 import json
+import logging
 
 import yaml
 
@@ -26,6 +27,10 @@ from libnmstate import netinfo
 
 
 def main():
+    logging.basicConfig(
+        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        level=logging.DEBUG)
+
     parser = argparse.ArgumentParser()
 
     subparsers = parser.add_subparsers()


### PR DESCRIPTION
Log everything to stderr. More configuration will be allowed later. Output is a little messy, if not redirected, command output and logging is mixed.

Example output:

```
2018-06-27 12:18:37,066 root         DEBUG    This is a debug message
2018-06-27 12:18:37,067 root         ERROR    This is an exception message
Traceback (most recent call last):
  File "/home/phoracek/Code/nmstate/env/lib/python2.7/site-packages/nmstatectl/nmstatectl.py", line 34, in main
    a = 1/0
ZeroDivisionError: integer division or modulo by zero
```