### PR TITLE
netapplier: Apply settings twice to get it to work

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -34,7 +34,14 @@ def apply(desired_state):
     _apply_ifaces_state(desired_state['interfaces'], interfaces_current_state)
 
     # FIXME: Remove the sleep when the mainloop is added.
+    # FIXME: Also revert to use assert_called_once_with() instead of
+    # assert_called_with() in corresponding test cases
     time.sleep(1)
+
+    interfaces_current_state = netinfo.interfaces()
+    _apply_ifaces_state(desired_state['interfaces'], interfaces_current_state)
+    time.sleep(1)
+    # END FIXME
 
 
 def _apply_ifaces_state(interfaces_desired_state, interfaces_current_state):

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -75,7 +75,7 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     desired_config['interfaces'][0]['state'] = 'down'
     netapplier.apply(desired_config)
 
-    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_called_once_with(
+    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_called_with(
         desired_config['interfaces'])
 
 
@@ -102,10 +102,10 @@ def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_once_with([])
+    m_prepare.assert_called_with([])
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
-    m_prepare.assert_called_once_with(desired_config['interfaces'])
+    m_prepare.assert_called_with(desired_config['interfaces'])
 
 
 def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
@@ -149,10 +149,10 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_once_with(desired_config['interfaces'])
+    m_prepare.assert_called_with(desired_config['interfaces'])
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
-    m_prepare.assert_called_once_with([])
+    m_prepare.assert_called_with([])
 
 
 class TestDesiredStateMetadata(object):


### PR DESCRIPTION
This might be related to the missing GLib.MainLoop.