### PR TITLE
NM mainloop

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from contextlib import contextmanager
+
 import collections
 import copy
 import six
@@ -54,8 +56,18 @@ def _apply_ifaces_state(interfaces_desired_state, interfaces_current_state):
 
     generate_ifaces_metadata(ifaces_desired_state, ifaces_current_state)
 
-    _add_interfaces(ifaces_desired_state, ifaces_current_state)
-    _edit_interfaces(ifaces_desired_state, ifaces_current_state)
+    with _setup_providers():
+        _add_interfaces(ifaces_desired_state, ifaces_current_state)
+        _edit_interfaces(ifaces_desired_state, ifaces_current_state)
+
+
+@contextmanager
+def _setup_providers():
+    mainloop = nmclient.mainloop()
+    yield
+    if mainloop.actions_exists():
+        mainloop.execute_next_action()
+        mainloop.run(timeout=20)
 
 
 def generate_ifaces_metadata(ifaces_desired_state, ifaces_current_state):

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -27,6 +27,10 @@ from libnmstate import nmclient
 from libnmstate import validator
 
 
+class ApplyError(Exception):
+    pass
+
+
 def apply(desired_state):
     validator.verify(desired_state)
     validator.verify_capabilities(desired_state, netinfo.capabilities())
@@ -56,7 +60,9 @@ def _setup_providers():
     yield
     if mainloop.actions_exists():
         mainloop.execute_next_action()
-        mainloop.run(timeout=20)
+        success = mainloop.run(timeout=20)
+        if not success:
+            raise ApplyError(mainloop.error)
 
 
 def generate_ifaces_metadata(ifaces_desired_state, ifaces_current_state):

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -20,7 +20,6 @@ from contextlib import contextmanager
 import collections
 import copy
 import six
-import time
 
 from libnmstate import netinfo
 from libnmstate import nm
@@ -35,16 +34,6 @@ def apply(desired_state):
     interfaces_current_state = netinfo.interfaces()
 
     _apply_ifaces_state(desired_state['interfaces'], interfaces_current_state)
-
-    # FIXME: Remove the sleep when the mainloop is added.
-    # FIXME: Also revert to use assert_called_once_with() instead of
-    # assert_called_with() in corresponding test cases
-    time.sleep(1)
-
-    interfaces_current_state = netinfo.interfaces()
-    _apply_ifaces_state(desired_state['interfaces'], interfaces_current_state)
-    time.sleep(1)
-    # END FIXME
 
 
 def _apply_ifaces_state(interfaces_desired_state, interfaces_current_state):

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -15,12 +15,45 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import logging
+
 from libnmstate import nmclient
 
 
 def activate(dev):
     client = nmclient.client()
-    client.activate_connection_async(device=dev)
+    mainloop = nmclient.mainloop()
+    connection = specific_object = None
+    user_data = mainloop
+    mainloop.push_action(
+        client.activate_connection_async,
+        connection,
+        dev,
+        specific_object,
+        mainloop.cancellable,
+        _active_connection_callback,
+        user_data,
+    )
+
+
+def _active_connection_callback(src_object, result, user_data):
+    mainloop = user_data
+    try:
+        act_con = src_object.activate_connection_finish(result)
+    except Exception as e:
+        if mainloop.is_action_canceled(e):
+            logging.debug(
+                'Connection activation canceled: error=%s', e)
+        else:
+            mainloop.quit('Connection activation failed: error={}'.format(e))
+        return
+
+    if act_con is None:
+        mainloop.quit('Connection activation failed: error=unknown')
+    else:
+        devname = act_con.props.connection.get_interface_name()
+        logging.debug('Connection activation succeeded: dev=%s', devname)
+        mainloop.execute_next_action()
 
 
 def deactivate(dev):
@@ -33,14 +66,68 @@ def deactivate(dev):
     client = nmclient.client()
     act_connection = dev.get_active_connection()
     if act_connection:
-        client.deactivate_connection_async(act_connection)
+        mainloop = nmclient.mainloop()
+        user_data = mainloop
+        mainloop.push_action(
+            client.deactivate_connection_async,
+            act_connection,
+            mainloop.cancellable,
+            _deactivate_connection_callback,
+            user_data,
+        )
+
+
+def _deactivate_connection_callback(src_object, result, user_data):
+    mainloop = user_data
+    try:
+        success = src_object.deactivate_connection_finish(result)
+    except Exception as e:
+        if mainloop.is_action_canceled(e):
+            logging.debug('Connection deactivation aborted: error=%s', e)
+        else:
+            mainloop.quit('Connection deactivation failed: error={}'.format(e))
+        return
+
+    if success:
+        logging.debug('Connection deactivation succeeded')
+        mainloop.execute_next_action()
+    else:
+        mainloop.quit('Connection deactivation failed: error=unknown')
 
 
 def delete(dev):
     """Removes all device profiles."""
     connections = dev.get_available_connections()
+    mainloop = nmclient.mainloop()
+    user_data = mainloop
     for con in connections:
-        con.delete_async()
+        mainloop.push_action(
+            con.delete_async,
+            mainloop.cancellable,
+            _delete_connection_callback,
+            user_data,
+        )
+
+
+def _delete_connection_callback(src_object, result, user_data):
+    mainloop = user_data
+    try:
+        success = src_object.delete_finish(result)
+    except Exception as e:
+        if mainloop.is_action_canceled(e):
+            logging.debug('Connection deletion aborted: error=%s', e)
+        else:
+            mainloop.quit('Connection deletion failed: error={}'.format(e))
+        return
+
+    devname = src_object.get_interface_name()
+    if success:
+        logging.debug('Connection deletion succeeded: dev=%s', devname)
+        mainloop.execute_next_action()
+    else:
+        mainloop.quit(
+            'Connection deletion failed: '
+            'dev={}, error=unknown'.format(devname))
 
 
 def get_device_by_name(devname):

--- a/libnmstate/nmclient.py
+++ b/libnmstate/nmclient.py
@@ -16,16 +16,22 @@
 #
 from __future__ import absolute_import
 
+from collections import deque
+import logging
+
 try:
     import gi                           # pylint: disable=import-error
     gi.require_version('NM', '1.0')     # NOQA: F402
-    from gi.repository import NM        # pylint: disable=import-error
+    from gi.repository import Gio, GLib, NM  # pylint: disable=import-error
 except ImportError:
     # Allow the error to pass in case we are running in a unit test context
     g = None
+    Gio = None
+    GLib = None
     NM = None
 
 
+_mainloop = None
 _nmclient = None
 
 
@@ -36,3 +42,87 @@ def client(refresh=False):
     if _nmclient is None or refresh:
         _nmclient = NM.Client.new(None)
     return _nmclient
+
+
+def mainloop():
+    global _mainloop
+    if _mainloop is None:
+        _mainloop = _MainLoop()
+    return _mainloop
+
+
+class _MainLoop(object):
+    SUCCESS = True
+    FAIL = False
+
+    def __init__(self):
+        self._action_queue = deque()
+        self._mainloop = GLib.MainLoop()
+        self._cancellable = Gio.Cancellable.new()
+
+    def execute_next_action(self):
+        action = self.pop_action()
+        if action:
+            func, args, kwargs = action
+            func(*args, **kwargs)
+        else:
+            logging.debug('NM action queue exhausted, quiting mainloop')
+            self._mainloop.quit()
+
+    def push_action(self, func, *args, **kwargs):
+        action = (func, args, kwargs)
+        self._action_queue.append(action)
+
+    def pop_action(self):
+        try:
+            action = self._action_queue.popleft()
+        except IndexError:
+            return None
+
+        return action if action[0] else None
+
+    def actions_exists(self):
+        return bool(self._action_queue)
+
+    def run(self, timeout):
+        if timeout is None:
+            self._mainloop.run()
+            return _MainLoop.SUCCESS
+
+        timeout_result = []
+        data = (self._mainloop, timeout_result)
+        timeout_id = GLib.timeout_add(
+            int(timeout * 1000),
+            _MainLoop._timeout_cb,
+            data
+        )
+        self._mainloop.run()
+
+        if timeout_result:
+            self._cancellable.cancel()
+            return _MainLoop.FAIL
+
+        GLib.source_remove(timeout_id)
+        return _MainLoop.SUCCESS
+
+    @property
+    def cancellable(self):
+        return self._cancellable
+
+    def quit(self, reason):
+        logging.error('NM main-loop aborted: %s', reason)
+        self._mainloop.quit()
+        self._cancellable.cancel()
+
+    def is_action_canceled(self, err):
+        return (isinstance(err, GLib.GError) and
+                err.domain == 'g-io-error-quark' and
+                err.code == Gio.IOErrorEnum.CANCELLED)
+
+    @staticmethod
+    def _timeout_cb(data):
+        mainloop, result = data
+        result.append(1)
+        logging.warning('NM main-loop timed out.')
+        mainloop.quit()
+        return _MainLoop.FAIL

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -30,12 +30,6 @@ OVS_NAME = 'ovs-br99'
 
 
 @pytest.fixture(scope='module', autouse=True)
-def zero_sleep():
-    with mock.patch.object(netapplier.time, 'sleep'):
-        yield
-
-
-@pytest.fixture(scope='module', autouse=True)
 def nmclient_mock():
     client_mock = mock.patch.object(netapplier.nmclient, 'client')
     mainloop_mock = mock.patch.object(netapplier.nmclient, 'mainloop')
@@ -82,7 +76,7 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     desired_config['interfaces'][0]['state'] = 'down'
     netapplier.apply(desired_config)
 
-    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_called_with(
+    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_called_once_with(
         desired_config['interfaces'])
 
 
@@ -109,10 +103,10 @@ def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_with([])
+    m_prepare.assert_called_once_with([])
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
-    m_prepare.assert_called_with(desired_config['interfaces'])
+    m_prepare.assert_called_once_with(desired_config['interfaces'])
 
 
 def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
@@ -156,10 +150,10 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_with(desired_config['interfaces'])
+    m_prepare.assert_called_once_with(desired_config['interfaces'])
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
-    m_prepare.assert_called_with([])
+    m_prepare.assert_called_once_with([])
 
 
 class TestDesiredStateMetadata(object):

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -37,7 +37,9 @@ def zero_sleep():
 
 @pytest.fixture(scope='module', autouse=True)
 def nmclient_mock():
-    with mock.patch.object(netapplier.nmclient, 'client'):
+    client_mock = mock.patch.object(netapplier.nmclient, 'client')
+    mainloop_mock = mock.patch.object(netapplier.nmclient, 'mainloop')
+    with client_mock, mainloop_mock:
         yield
 
 


### PR DESCRIPTION
The NM provider is executing libnm async funtions.
For proper operation and in order to serialize the actions, GLib
main-loop use has been embedded through a mainloop object.

The async funtions against libnm are registered to the mainloop object
and then executed one after the other from that queue.
The callback functions for each async command are responsible to execute
the next action in the mainloop object queue.
