### PR TITLE
libnmstate: Process OVS only if the capability exists

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -28,6 +28,7 @@ from libnmstate import validator
 
 def apply(desired_state):
     validator.verify(desired_state)
+    validator.verify_capabilities(desired_state, netinfo.capabilities())
 
     interfaces_current_state = netinfo.interfaces()
 

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -27,6 +27,7 @@ BRIDGE_TYPE = 'ovs-bridge'
 INTERNAL_INTERFACE_TYPE = 'ovs-interface'
 PORT_TYPE = 'ovs-port'
 PORT_PROFILE_PREFIX = 'ovs-port-'
+CAPABILITY = 'openvswitch'
 
 
 _BRIDGE_OPTION_NAMES = [
@@ -45,6 +46,14 @@ _PORT_OPTION_NAMES = [
     'bond-updelay',
     'bond-downdelay'
 ]
+
+
+def has_ovs_capability():
+    try:
+        nmclient.NM.DeviceType.OVS_BRIDGE
+        return True
+    except AttributeError:
+        return False
 
 
 def create_bridge_setting(options):


### PR DESCRIPTION
Introduce the OVS capability in the report and avoid processing the OVS
interface types when it is missing.

Capabilities are now reported at the top level report under
'capabilities'.
By default, it is not included in the 'nmstatectl show' report, just
used internally.