### PR TITLE
netapplier: Reflect correctly slave master even when reused

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -161,7 +161,12 @@ def _generate_link_master_metadata(ifaces_desired_state,
         for slave in current_slaves:
             if slave in ifaces_desired_state:
                 iface_state = ifaces_desired_state.get(master_name, {})
-                if get_slaves_func(iface_state, None) is None:
+                master_has_no_slaves_specified_in_desired = (
+                    get_slaves_func(iface_state, None) is None)
+                slave_has_no_master_specified_in_desired = (
+                    ifaces_desired_state[slave].get('_master') is None)
+                if (slave_has_no_master_specified_in_desired and
+                        master_has_no_slaves_specified_in_desired):
                     set_metadata_func(
                         master_state, ifaces_desired_state[slave])
 


### PR DESCRIPTION
In a scenario where an existing slave is specified under a new master in
the desired state, but not removed from the current master, the outcome
desired state (through the metadata) should point to the new master.

This patch fixes a bug where such slaves pointed to the previous master
in the calculated desired state.