### PR TITLE
mainloop: If the last action fails, exit correctly

### DIFF
--- a/libnmstate/nmclient.py
+++ b/libnmstate/nmclient.py
@@ -118,6 +118,8 @@ class _MainLoop(object):
 
     def quit(self, reason):
         logging.error('NM main-loop aborted: %s', reason)
+        # In case it was the last action, add a sentinel to fail run.
+        self.push_action(None)
         self._mainloop.quit()
         self._cancellable.cancel()
 


### PR DESCRIPTION
Before this patch, if the last action in the mainloop queue failed, it
got ignored.
With this patch, the mainloop run exists with an error if the last
action failed and the transaction is able to kick in.