### PR TITLE
libnmstate: Refresh current state before the edit step

### DIFF
--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -40,6 +40,7 @@ def nmclient_mock():
 @pytest.fixture
 def netapplier_nm_mock():
     with mock.patch.object(netapplier, 'nm') as m:
+        m.applier.prepare_proxy_ifaces_desired_state.return_value = []
         yield m
 
 
@@ -76,8 +77,12 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     desired_config['interfaces'][0]['state'] = 'down'
     netapplier.apply(desired_config)
 
-    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_called_once_with(
-        desired_config['interfaces'])
+    netapplier_nm_mock.applier.set_ifaces_admin_state.assert_has_calls(
+        [
+            mock.call([]),
+            mock.call(desired_config['interfaces'])
+        ]
+    )
 
 
 def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):


### PR DESCRIPTION
The mainloop is run in two steps, once for addition and a second time
for editing.
The split is introduced because after the addition, the current state
needs to be refreshed and be based on the addition step. This implies
that the addition should finish completely (running all the actions).

It is now possible to create a new master (ovs-bridge) to use a slave
that is already used by a different master. The slave will "move" to the
new master correctly.