### PR TITLE
libnmstate: Fix handling of iface edition and deletion

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -161,7 +161,8 @@ def _generate_link_master_metadata(ifaces_desired_state,
             if slave in ifaces_desired_state:
                 set_metadata_func(master_state, ifaces_desired_state[slave])
             elif slave in ifaces_current_state:
-                ifaces_desired_state[slave] = {'name': slave}
+                ifaces_desired_state[slave] = {'name': slave,
+                                               'state': master_state['state']}
                 set_metadata_func(master_state, ifaces_desired_state[slave])
 
         desired_slaves = get_slaves_func(master_state)
@@ -197,7 +198,7 @@ def _add_interfaces(ifaces_desired_state, ifaces_current_state):
     ifaces2add = [
         ifaces_desired_state[name] for name in
         six.viewkeys(ifaces_desired_state) - six.viewkeys(ifaces_current_state)
-        if ifaces_desired_state[name].get('state') != 'absent'
+        if ifaces_desired_state[name].get('state') not in ('absent', 'down')
     ]
 
     validator.verify_interfaces_state(ifaces2add, ifaces_desired_state)
@@ -220,7 +221,9 @@ def _edit_interfaces(ifaces_desired_state, ifaces_current_state):
     validator.verify_interfaces_state(ifaces2edit, ifaces_desired_state)
 
     iface2prepare = list(
-        filter(lambda state: state.get('state') != 'absent', ifaces2edit))
+        filter(lambda state: state.get('state') not in ('absent', 'down'),
+               ifaces2edit)
+    )
     proxy_ifaces = nm.applier.prepare_proxy_ifaces_desired_state(iface2prepare)
     ifaces_configs = nm.applier.prepare_edited_ifaces_configuration(
         iface2prepare + proxy_ifaces)

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -83,7 +83,7 @@ def set_ifaces_admin_state(ifaces_desired_state):
         if iface_desired_state['state'] == 'up':
             _set_dev_state(iface_desired_state, device.activate)
         elif iface_desired_state['state'] == 'down':
-            _set_dev_state(iface_desired_state, device.deactivate)
+            _set_dev_state(iface_desired_state, device.delete)
         elif iface_desired_state['state'] == 'absent':
             _set_dev_state(iface_desired_state, device.delete)
         else:

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -96,13 +96,22 @@ def _deactivate_connection_callback(src_object, result, user_data):
 
 
 def delete(dev):
+    mainloop = nmclient.mainloop()
+    mainloop.push_action(_safe_delete_async, dev)
+
+
+def _safe_delete_async(dev):
     """Removes all device profiles."""
     connections = dev.get_available_connections()
     mainloop = nmclient.mainloop()
+    if not connections:
+        # No callback is expected, so we should call the next one.
+        mainloop.execute_next_action()
+        return
+
     user_data = mainloop
     for con in connections:
-        mainloop.push_action(
-            con.delete_async,
+        con.delete_async(
             mainloop.cancellable,
             _delete_connection_callback,
             user_data,

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -218,10 +218,10 @@ class TestDesiredStateBondMetadata(object):
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = BOND_NAME
         expected_desired_state['eth0']['_master_type'] = BOND_TYPE
-        expected_desired_state['eth1'] = {'name': 'eth1'}
+        expected_desired_state['eth1'] = {'name': 'eth1', 'state': 'up'}
         expected_desired_state['eth1']['_master'] = BOND_NAME
         expected_desired_state['eth1']['_master_type'] = BOND_TYPE
 
@@ -270,14 +270,14 @@ class TestDesiredStateBondMetadata(object):
                     'slaves': ['eth0', 'eth1']
                 }
             },
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         current_state = {
             'eth0': {'name': 'eth0', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = BOND_NAME
         expected_desired_state['eth1']['_master'] = BOND_NAME
         expected_desired_state['eth0']['_master_type'] = BOND_TYPE
@@ -310,12 +310,12 @@ class TestDesiredStateBondMetadata(object):
                     'slaves': ['eth0', 'eth1']
                 }
             },
-            'eth0': {'name': 'eth0', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = BOND_NAME
         expected_desired_state['eth0']['_master_type'] = BOND_TYPE
         expected_desired_state['eth1'] = {}
@@ -379,12 +379,12 @@ class TestDesiredStateBondMetadata(object):
                     'slaves': ['eth0', 'eth1']
                 }
             },
-            'eth0': {'name': 'eth0', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = BOND2_NAME
         expected_desired_state['eth0']['_master_type'] = BOND_TYPE
 
@@ -443,15 +443,15 @@ class TestDesiredStateOvsMetadata(object):
             }
         }
         current_state = {
-            'eth0': {'name': 'eth0', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = OVS_NAME
         expected_desired_state['eth0']['_master_type'] = OVS_BR_TYPE
-        expected_desired_state['eth1'] = {'name': 'eth1'}
+        expected_desired_state['eth1'] = {'name': 'eth1', 'state': 'up'}
         expected_desired_state['eth1']['_master'] = OVS_NAME
         expected_desired_state['eth1']['_master_type'] = OVS_BR_TYPE
         expected_desired_state['eth0']['_brport_options'] = (
@@ -508,14 +508,14 @@ class TestDesiredStateOvsMetadata(object):
                     ]
                 }
             },
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         current_state = {
-            'eth0': {'name': 'eth0', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = OVS_NAME
         expected_desired_state['eth1']['_master'] = OVS_NAME
         expected_desired_state['eth0']['_master_type'] = OVS_BR_TYPE
@@ -555,12 +555,12 @@ class TestDesiredStateOvsMetadata(object):
                     ]
                 }
             },
-            'eth0': {'name': 'eth0', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = OVS_NAME
         expected_desired_state['eth0']['_master_type'] = OVS_BR_TYPE
         expected_desired_state['eth1'] = {}
@@ -633,12 +633,12 @@ class TestDesiredStateOvsMetadata(object):
                     ]
                 }
             },
-            'eth0': {'name': 'eth0', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'type': 'unknown'}
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         }
         expected_desired_state = copy.deepcopy(desired_state)
         expected_current_state = copy.deepcopy(current_state)
-        expected_desired_state['eth0'] = {'name': 'eth0'}
+        expected_desired_state['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_desired_state['eth0']['_master'] = OVS2_NAME
         expected_desired_state['eth0']['_master_type'] = OVS_BR_TYPE
         expected_desired_state['eth0']['_brport_options'] = (

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -207,7 +207,7 @@ def test_set_ifaces_admin_state_down(nm_device_mock):
     ]
     nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-    nm_device_mock.deactivate.assert_called_with(
+    nm_device_mock.delete.assert_called_with(
         nm_device_mock.get_device_by_name.return_value)
 
 

--- a/tests/lib/nm/device_test.py
+++ b/tests/lib/nm/device_test.py
@@ -66,16 +66,16 @@ def test_deactivate(client_mock, mainloop_mock):
 def test_delete(mainloop_mock):
     dev = mock.MagicMock()
     dev.get_available_connections.return_value = [mock.MagicMock()]
+    mainloop_mock.push_action = lambda func, dev: func(dev)
     nm.device.delete(dev)
 
     dev.get_available_connections.assert_called_once()
     connections = dev.get_available_connections.return_value
 
-    mainloop_mock.push_action.assert_called_once_with(
-        connections[0].delete_async,
+    connections[0].delete_async.assert_called_once_with(
         mainloop_mock.cancellable,
         nm.device._delete_connection_callback,
-        mainloop_mock,
+        mainloop_mock
     )
 
 


### PR DESCRIPTION
This patch is handling the following points:
- A slave iface state which is not mentioned in the desired state,
  is determined based on the master state.
  This way, the state of the master can define the slaves or can remove
  them with the master.
- The 'down' state should be handled as 'absent' for the time being,
  specifically for the NM provider implementation. The current mapping
  between 'down' and 'deactivate' in NM terms causes connection profiles
  to be left on the system unused.
- The device.delete functionality is now using a safer async wrapper,
  which is handled through the mainloop. When a deletion is requested,
  it is performed only if the device still exists, otherwise it is
  skipped.
  In several cases, the deletion of a connection profile is triggered by
  more than one source. Due to the async nature of the deletion, the
  caller does not know that a previous deletion call has been issued.
  This is the case when a master is removed and its slave also is
  explicitly mentioned for removal.