### PR TITLE
Set admin state once when master/slave interfaces are involved

### DIFF
--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -193,7 +193,7 @@ def test_set_ifaces_admin_state_up(nm_device_mock):
     ]
     nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-    nm_device_mock.activate.assert_called_with(
+    nm_device_mock.activate.assert_called_once_with(
         nm_device_mock.get_device_by_name.return_value)
 
 
@@ -207,7 +207,7 @@ def test_set_ifaces_admin_state_down(nm_device_mock):
     ]
     nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-    nm_device_mock.delete.assert_called_with(
+    nm_device_mock.delete.assert_called_once_with(
         nm_device_mock.get_device_by_name.return_value)
 
 
@@ -221,5 +221,5 @@ def test_set_ifaces_admin_state_absent(nm_device_mock):
     ]
     nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-    nm_device_mock.delete.assert_called_with(
+    nm_device_mock.delete.assert_called_once_with(
         nm_device_mock.get_device_by_name.return_value)

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -253,7 +253,6 @@ class TestIfaceAdminStateControl(object):
 
         expected_calls = [
             mock.call(bond),
-            mock.call(slaves[0]),
             mock.call(slaves[0])
         ]
         actual_calls = nm_device_mock.activate.mock_calls

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -183,43 +183,42 @@ def test_prepare_edited_ifaces_configuration(nm_device_mock,
     )
 
 
-def test_set_ifaces_admin_state_up(nm_device_mock):
-    ifaces_desired_state = [
-        {
-            'name': 'eth0',
-            'type': 'ethernet',
-            'state': 'up',
-        }
-    ]
-    nm.applier.set_ifaces_admin_state(ifaces_desired_state)
+class TestIfaceAdminStateControl(object):
+    def test_set_ifaces_admin_state_up(self, nm_device_mock):
+        ifaces_desired_state = [
+            {
+                'name': 'eth0',
+                'type': 'ethernet',
+                'state': 'up',
+            }
+        ]
+        nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-    nm_device_mock.activate.assert_called_once_with(
-        nm_device_mock.get_device_by_name.return_value)
+        nm_device_mock.activate.assert_called_once_with(
+            nm_device_mock.get_device_by_name.return_value)
 
+    def test_set_ifaces_admin_state_down(self, nm_device_mock):
+        ifaces_desired_state = [
+            {
+                'name': 'eth0',
+                'type': 'ethernet',
+                'state': 'down',
+            }
+        ]
+        nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-def test_set_ifaces_admin_state_down(nm_device_mock):
-    ifaces_desired_state = [
-        {
-            'name': 'eth0',
-            'type': 'ethernet',
-            'state': 'down',
-        }
-    ]
-    nm.applier.set_ifaces_admin_state(ifaces_desired_state)
+        nm_device_mock.delete.assert_called_once_with(
+            nm_device_mock.get_device_by_name.return_value)
 
-    nm_device_mock.delete.assert_called_once_with(
-        nm_device_mock.get_device_by_name.return_value)
+    def test_set_ifaces_admin_state_absent(self, nm_device_mock):
+        ifaces_desired_state = [
+            {
+                'name': 'eth0',
+                'type': 'ethernet',
+                'state': 'absent',
+            }
+        ]
+        nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
-
-def test_set_ifaces_admin_state_absent(nm_device_mock):
-    ifaces_desired_state = [
-        {
-            'name': 'eth0',
-            'type': 'ethernet',
-            'state': 'absent',
-        }
-    ]
-    nm.applier.set_ifaces_admin_state(ifaces_desired_state)
-
-    nm_device_mock.delete.assert_called_once_with(
-        nm_device_mock.get_device_by_name.return_value)
+        nm_device_mock.delete.assert_called_once_with(
+            nm_device_mock.get_device_by_name.return_value)


### PR DESCRIPTION
When there are bonds or OVS bridges, the current admin-state handling may execute an activation/deactivation multiple times on a single iface (on slaves in particular).

We should avoid this and perform the action once per device.