### PR TITLE
libnmstate.apply: Introduce verify-change flag

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -60,6 +60,10 @@ def setup_subcommand_set(subparsers):
     parser_set.add_argument('file', help='File containing desired state. '
                             'stdin is used when no file is specified.',
                             nargs='?')
+    parser_set.add_argument(
+        '--verify', action='store_true',
+        help='Verify that the desired state is now part of the current state.'
+    )
     parser_set.set_defaults(func=apply)
 
 
@@ -113,6 +117,6 @@ def apply(args):
     else:
         state = yaml.load(statedata)
         use_yaml = True
-    netapplier.apply(state)
+    netapplier.apply(state, verify_change=args.verify)
     print('Desired state applied: ')
     print_state(state, use_yaml=use_yaml)

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -43,7 +43,8 @@ EMPTY_JSON_STATE = """{
 
 
 @mock.patch('sys.argv', ['nmstatectl', 'set', 'mystate.json'])
-@mock.patch.object(nmstatectl.netapplier, 'apply', lambda state: None)
+@mock.patch.object(nmstatectl.netapplier, 'apply',
+                   lambda state, verify_change: None)
 @mock.patch.object(nmstatectl, 'open', mock.mock_open(read_data='{}'),
                    create=True)
 def test_run_ctl_directly_set():

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -648,3 +648,56 @@ class TestDesiredStateOvsMetadata(object):
 
         assert desired_state == expected_desired_state
         assert current_state == expected_current_state
+
+
+class TestAssertIfaceState(object):
+
+    def test_desired_is_identical_to_current(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+
+        netapplier.assert_ifaces_state(desired_state, current_state)
+
+    def test_desired_is_partial_to_current(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        current_state.update({
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
+        })
+
+        netapplier.assert_ifaces_state(desired_state, current_state)
+
+    def test_current_is_partial_to_desired(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        desired_state.update({
+            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
+        })
+
+        with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+            netapplier.assert_ifaces_state(desired_state, current_state)
+
+    def test_desired_is_not_equal_to_current(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        current_state['foo-name']['state'] = 'down'
+
+        with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+            netapplier.assert_ifaces_state(desired_state, current_state)
+
+    @property
+    def _base_state(self):
+        return {
+            'foo-name': {
+                'name': 'foo-name',
+                'type': 'foo-type',
+                'state': 'up',
+                'bridge': {
+                    'port': [
+                        {'name': 'eth0', 'type': 'system'}
+                    ]
+                }
+            }
+        }


### PR DESCRIPTION
The verify-change flag is introduced, causing an assertion between the
desired and current state to occur at the end of the transaction.
In case the desired state is not (fully) part of the current state, the
transaction fails and the configuration is reverted to the original
state.