### PR TITLE
wired: Do not report speed 0

### DIFF
--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -69,7 +69,9 @@ def get_info(device):
 
     ethernet = {}
     try:
-        ethernet['speed'] = int(device.get_speed())
+        speed = int(device.get_speed())
+        if speed > 0:
+            ethernet['speed'] = speed
     except AttributeError:
         pass
 


### PR DESCRIPTION
It seems to be reported when speed setting is not supported.