### PR TITLE
Reset speed and duplex when enabling auto-negotiation

### DIFF
--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -40,17 +40,24 @@ def create_setting(iface_state, base_con_profile):
         wired_setting = nmclient.NM.SettingWired.new()
 
     if mtu:
-        wired_setting.set_property(nmclient.NM.SETTING_WIRED_MTU, mtu)
+        wired_setting.props.mtu = mtu
+
+    if auto_negotiation:
+        wired_setting.props.auto_negotiate = True
+        if not speed:
+            wired_setting.props.speed = 0
+
+        if not duplex:
+            wired_setting.props.duplex = None
+
+    elif auto_negotiation is False:
+        wired_setting.props.auto_negotiate = False
 
     if speed:
-        wired_setting.set_property(nmclient.NM.SETTING_WIRED_SPEED, speed)
+        wired_setting.props.speed = speed
 
     if duplex:
-        wired_setting.set_property(nmclient.NM.SETTING_WIRED_DUPLEX, duplex)
-
-    if auto_negotiation is not None:
-        wired_setting.set_property(nmclient.NM.SETTING_WIRED_AUTO_NEGOTIATE,
-                                   auto_negotiation)
+        wired_setting.props.duplex = duplex
 
     return wired_setting
 

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -45,23 +45,33 @@ def test_create_setting_duplicate(NM_mock):
 def test_create_setting_mtu(NM_mock):
     setting = nm.wired.create_setting({'mtu': 1500}, None)
     assert setting == NM_mock.SettingWired.new.return_value
-    setting.set_property.assert_called_with(NM_mock.SETTING_WIRED_MTU, 1500)
+    assert setting.props.mtu == 1500
 
 
 def test_create_setting_auto_negotiation_False(NM_mock):
     setting = nm.wired.create_setting(
         {'ethernet': {'auto-negotiation': False}}, None)
     assert setting == NM_mock.SettingWired.new.return_value
-    setting.set_property.assert_called_with(
-        NM_mock.SETTING_WIRED_AUTO_NEGOTIATE, False)
+    assert setting.props.auto_negotiate is False
 
 
-def test_create_setting_auto_negotiation_True(NM_mock):
+def test_create_setting_only_auto_negotiation_True(NM_mock):
     setting = nm.wired.create_setting({'ethernet':
                                       {'auto-negotiation': True}}, None)
     assert setting == NM_mock.SettingWired.new.return_value
-    setting.set_property.assert_called_with(
-        NM_mock.SETTING_WIRED_AUTO_NEGOTIATE, True)
+    assert setting.props.auto_negotiate is True
+    assert setting.props.speed == 0
+    assert setting.props.duplex is None
+
+
+def test_create_setting_auto_negotiation_speed_duplex(NM_mock):
+    setting = nm.wired.create_setting({'ethernet': {'auto-negotiation': True,
+                                                    'speed': 1000, 'duplex':
+                                                    'full'}}, None)
+    assert setting == NM_mock.SettingWired.new.return_value
+    assert setting.props.auto_negotiate is True
+    assert setting.props.speed == 1000
+    assert setting.props.duplex == 'full'
 
 
 def test_create_setting_speed_duplex(NM_mock):
@@ -69,7 +79,5 @@ def test_create_setting_speed_duplex(NM_mock):
                                                     'duplex': 'full'}},
                                       None)
     assert setting == NM_mock.SettingWired.new.return_value
-    setting.set_property.assert_has_calls([
-        mock.call(NM_mock.SETTING_WIRED_SPEED, 1000),
-        mock.call(NM_mock.SETTING_WIRED_DUPLEX, 'full')],
-        any_order=True)
+    assert setting.props.speed == 1000
+    assert setting.props.duplex == 'full'


### PR DESCRIPTION
When auto-negotiation is enabled and speed/duplex are not explicitly
specified, reset them to allow them to be fully auto-negotiated. Also
use props to set the properties to match the other modules and simplify
testing.