### PR TITLE
Do not merge duplex and speed for auto-negotiation

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -47,6 +47,7 @@ def _apply_ifaces_state(interfaces_desired_state, verify_change):
     ifaces_desired_state = _index_by_name(interfaces_desired_state)
     ifaces_current_state = _index_by_name(netinfo.interfaces())
 
+    ifaces_desired_state = sanitize_ethernet_state(ifaces_desired_state)
     generate_ifaces_metadata(ifaces_desired_state, ifaces_current_state)
 
     with _transaction():
@@ -117,6 +118,22 @@ def generate_ifaces_metadata(ifaces_desired_state, ifaces_current_state):
         get_slaves_func=_get_ovs_slaves_from_state,
         set_metadata_func=_set_ovs_bridge_ports_metadata
     )
+
+
+def sanitize_ethernet_state(ifaces_desired_state):
+    """
+    If auto-negotiation, speed and duplex settings are not provided, they need
+    to be set to None to not override them with the values from the current
+    settings since the current settings are read from the device state and not
+    from the actual configuration.  This makes it possible to distiguish
+    whether a user specified these values in the later configuration step.
+    """
+    for iface_state in six.viewvalues(ifaces_desired_state):
+        ethernet = iface_state.setdefault("ethernet", {})
+        ethernet.setdefault("auto-negotiation", None)
+        ethernet.setdefault("speed", None)
+        ethernet.setdefault("duplex", None)
+    return ifaces_desired_state
 
 
 def remove_ifaces_metadata(ifaces_state):

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -44,14 +44,24 @@ def create_setting(iface_state, base_con_profile):
 
     if auto_negotiation:
         wired_setting.props.auto_negotiate = True
-        if not speed:
+        if not speed and not duplex:
             wired_setting.props.speed = 0
-
-        if not duplex:
             wired_setting.props.duplex = None
+
+        elif not speed:
+            ethtool_results = minimal_ethtool(str(iface_state['name']))
+            speed = ethtool_results['speed']
+        elif not duplex:
+            ethtool_results = minimal_ethtool(str(iface_state['name']))
+            duplex = ethtool_results['duplex']
 
     elif auto_negotiation is False:
         wired_setting.props.auto_negotiate = False
+        ethtool_results = minimal_ethtool(str(iface_state['name']))
+        if not speed:
+            speed = ethtool_results['speed']
+        if not duplex:
+            duplex = ethtool_results['duplex']
 
     if speed:
         wired_setting.props.speed = speed

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -48,11 +48,18 @@ def test_create_setting_mtu(NM_mock):
     assert setting.props.mtu == 1500
 
 
-def test_create_setting_auto_negotiation_False(NM_mock):
+@mock.patch.object(nm.wired, 'minimal_ethtool',
+                   return_value={'speed': 1337, 'duplex': 'mocked',
+                                 'auto-negotiation': 'mocked'})
+def test_create_setting_auto_negotiation_False(ethtool_mock, NM_mock):
     setting = nm.wired.create_setting(
-        {'ethernet': {'auto-negotiation': False}}, None)
+        {'name': 'nmstate_test', 'ethernet': {'auto-negotiation': False}},
+        None)
     assert setting == NM_mock.SettingWired.new.return_value
     assert setting.props.auto_negotiate is False
+    assert setting.props.speed == 1337
+    assert setting.props.duplex == 'mocked'
+    assert ethtool_mock.called_with('nmstate_test')
 
 
 def test_create_setting_only_auto_negotiation_True(NM_mock):


### PR DESCRIPTION
When auto-negotiation is enabled, duplex and speed ethernet settings
should not be merged from the current state to be able to distinguish
whether a user specified the settings or not.