### PR TITLE
Show interface name first

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -30,6 +30,7 @@ import yaml
 
 from libnmstate import netapplier
 from libnmstate import netinfo
+from nmstatectl.prettystate import PrettyState
 
 
 def main():
@@ -95,12 +96,14 @@ def edit(args):
         sys.stderr.write('ERROR: No such interface\n')
         return os.EX_USAGE
 
+    pretty_state = PrettyState(state)
+
     if args.yaml:
         suffix = '.yaml'
-        txtstate = _make_pretty_yaml(state)
+        txtstate = pretty_state.yaml
     else:
         suffix = '.json'
-        txtstate = _make_pretty_json(state)
+        txtstate = pretty_state.json
 
     new_state = _get_edited_state(txtstate, suffix, args.yaml)
     if not new_state:
@@ -160,14 +163,6 @@ def _filter_interfaces(state, patterns):
                 showinterfaces.append(interface)
                 break
     return showinterfaces
-
-
-def _make_pretty_yaml(state):
-    return yaml.dump(state, default_flow_style=False)
-
-
-def _make_pretty_json(state):
-    return json.dumps(state, indent=4, sort_keys=True, separators=(',', ': '))
 
 
 def _get_edited_state(txtstate, suffix, use_yaml):
@@ -244,7 +239,8 @@ def _try_edit_again(error):
 
 
 def print_state(state, use_yaml=False):
+    state = PrettyState(state)
     if use_yaml:
-        print(_make_pretty_yaml(state))
+        print(state.yaml)
     else:
-        print(_make_pretty_json(state))
+        print(state.json)

--- a/nmstatectl/prettystate.py
+++ b/nmstatectl/prettystate.py
@@ -69,7 +69,11 @@ def order_state(state):
 def order_iface_state(iface_state):
     ordered_state = OrderedDict()
 
-    ordered_state['name'] = iface_state.pop('name')
+    for setting in ('name', 'type', 'state'):
+        try:
+            ordered_state[setting] = iface_state.pop(setting)
+        except KeyError:
+            pass
 
     for key, value in order_dict(iface_state).items():
         ordered_state[key] = value

--- a/nmstatectl/prettystate.py
+++ b/nmstatectl/prettystate.py
@@ -1,0 +1,87 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from collections import OrderedDict
+import json
+from operator import itemgetter
+
+
+import yaml
+
+
+class PrettyState(object):
+    def __init__(self, state):
+
+        yaml.add_representer(OrderedDict, represent_ordereddict)
+        self.state = order_state(state)
+
+    @property
+    def yaml(self):
+        return yaml.dump(self.state, default_flow_style=False)
+
+    @property
+    def json(self):
+        return json.dumps(self.state, indent=4, separators=(',', ': '))
+
+
+def represent_ordereddict(dumper, data):
+    """
+    Represent OrderedDict as regular dictionary
+
+    Source: https://stackoverflow.com/questions/16782112/can-pyyaml-dump-dict-items-in-non-alphabetical-order
+    """  # noqa: E501
+    value = []
+
+    for item_key, item_value in data.items():
+        node_key = dumper.represent_data(item_key)
+        node_value = dumper.represent_data(item_value)
+
+        value.append((node_key, node_value))
+
+    return yaml.nodes.MappingNode(u'tag:yaml.org,2002:map', value)
+
+
+def order_state(state):
+    iface_states = state.pop('interfaces', [])
+    state['interfaces'] = [
+        order_iface_state(iface_state) for iface_state in sorted(
+            iface_states, key=itemgetter('name')
+        )
+    ]
+
+    return state
+
+
+def order_iface_state(iface_state):
+    ordered_state = OrderedDict()
+
+    ordered_state['name'] = iface_state.pop('name')
+
+    for key, value in order_dict(iface_state).items():
+        ordered_state[key] = value
+
+    return ordered_state
+
+
+def order_dict(dict_):
+    ordered_dict = OrderedDict()
+    for key, value in sorted(dict_.items()):
+        if isinstance(value, dict):
+            value = order_dict(value)
+        ordered_dict[key] = value
+
+    return ordered_dict

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -29,8 +29,8 @@ LO_JSON_STATE = """{
     "interfaces": [
         {
             "name": "lo",
-            "state": "down",
-            "type": "unknown"
+            "type": "unknown",
+            "state": "down"
         }
     ]
 }

--- a/tests/integration/nmstatectl_show_test.py
+++ b/tests/integration/nmstatectl_show_test.py
@@ -26,29 +26,27 @@ SHOW_CMD = ['nmstatectl', 'show']
 RC_SUCCESS = 0
 RC_FAIL2 = 2
 
-LOOPBACK_JSON_CONFIG = b"""
-        {
+LOOPBACK_JSON_CONFIG = b"""        {
             "name": "lo",
+            "type": "unknown",
+            "state": "down",
             "ipv4": {
                 "enabled": false
             },
             "ipv6": {
                 "enabled": false
             },
-            "mtu": 65536,
-            "state": "down",
-            "type": "unknown"
+            "mtu": 65536
         }"""
 
-LOOPBACK_YAML_CONFIG = b"""
-- name: lo
+LOOPBACK_YAML_CONFIG = b"""- name: lo
+  type: unknown
+  state: down
   ipv4:
     enabled: false
   ipv6:
     enabled: false
-  mtu: 65536
-  state: down
-  type: unknown"""
+  mtu: 65536"""
 
 
 def test_missing_operation():

--- a/tests/integration/nmstatectl_show_test.py
+++ b/tests/integration/nmstatectl_show_test.py
@@ -28,6 +28,7 @@ RC_FAIL2 = 2
 
 LOOPBACK_JSON_CONFIG = b"""
         {
+            "name": "lo",
             "ipv4": {
                 "enabled": false
             },
@@ -35,18 +36,17 @@ LOOPBACK_JSON_CONFIG = b"""
                 "enabled": false
             },
             "mtu": 65536,
-            "name": "lo",
             "state": "down",
             "type": "unknown"
         }"""
 
 LOOPBACK_YAML_CONFIG = b"""
-- ipv4:
+- name: lo
+  ipv4:
     enabled: false
   ipv6:
     enabled: false
   mtu: 65536
-  name: lo
   state: down
   type: unknown"""
 


### PR DESCRIPTION
When showing or editing a state, show the interface name first. This makes it easier to find a specific interface state or to edit the state in yaml, since the interface name now appears after the dash instead of other options that one might want to remove.