### PR TITLE
Use an existing docker image

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -2,6 +2,7 @@
 
 EXEC_PATH=$(dirname "$(realpath "$0")")
 PROJECT_PATH="$(dirname $EXEC_PATH)"
+DOCKER_IMAGE="nmstate/centos7-nmstate-dev"
 
 test -t 1 && USE_TTY="-t"
 
@@ -19,9 +20,7 @@ function pyclean {
 
 cd "$EXEC_PATH"
 
-docker build --rm -t local/centos7-nmstate-base .
-
-CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate local/centos7-nmstate-base)"
+CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate $DOCKER_IMAGE)"
 trap remove_container EXIT
 
 pyclean


### PR DESCRIPTION
automation: Run the integration tests from an existing image

In order to stabilize the running tests and enable faster execution,
the docker image is pulled from the hub instead of recreating it
every execution.

Locally the execution takes several seconds now.
