### PR TITLE
Add support of static IPv6.

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -60,6 +60,7 @@ def interfaces():
 
         act_con = nm.connection.get_device_active_connection(dev)
         iface_info['ipv4'] = nm.ipv4.get_info(act_con)
+        iface_info['ipv6'] = nm.ipv6.get_info(act_con)
         iface_info.update(nm.wired.get_info(dev))
         iface_info.update(nm.user.get_info(dev))
 

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -175,7 +175,7 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
 
     settings = [
         ipv4.create_setting(iface_desired_state.get('ipv4')),
-        ipv6.create_setting(),
+        ipv6.create_setting(iface_desired_state.get('ipv6')),
     ]
     if base_con_profile:
         con_setting = connection.duplicate_settings(base_con_profile)

--- a/tests/integration/nmstatectl_show_test.py
+++ b/tests/integration/nmstatectl_show_test.py
@@ -28,6 +28,9 @@ LOOPBACK_JSON_CONFIG = b"""
             "ipv4": {
                 "enabled": false
             },
+            "ipv6": {
+                "enabled": false
+            },
             "mtu": 65536,
             "name": "lo",
             "state": "down",
@@ -36,6 +39,8 @@ LOOPBACK_JSON_CONFIG = b"""
 
 LOOPBACK_YAML_CONFIG = b"""
 - ipv4:
+    enabled: false
+  ipv6:
     enabled: false
   mtu: 65536
   name: lo

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -60,6 +60,9 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
                 'ipv4': {
                     'enabled': False,
                 },
+                'ipv6': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -73,6 +76,8 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     netinfo_nm_mock.ovs.is_ovs_port_type_id.return_value = False
     netinfo_nm_mock.ipv4.get_info.return_value = (
         current_config['interfaces'][0]['ipv4'])
+    netinfo_nm_mock.ipv6.get_info.return_value = (
+        current_config['interfaces'][0]['ipv6'])
 
     desired_config['interfaces'][0]['state'] = 'down'
     netapplier.apply(desired_config)
@@ -131,6 +136,9 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
                 'ipv4': {
                     'enabled': False,
                 },
+                'ipv6': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -147,6 +155,8 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     }
     netinfo_nm_mock.ipv4.get_info.return_value = (
         current_config['interfaces'][0]['ipv4'])
+    netinfo_nm_mock.ipv6.get_info.return_value = (
+        current_config['interfaces'][0]['ipv6'])
 
     desired_config = copy.deepcopy(current_config)
     options = desired_config['interfaces'][0]['link-aggregation']['options']

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -37,6 +37,9 @@ def test_netinfo_show_generic_iface(nm_mock):
                 'ipv4': {
                     'enabled': False,
                 },
+                'ipv6': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -47,6 +50,8 @@ def test_netinfo_show_generic_iface(nm_mock):
     nm_mock.bond.is_bond_type_id.return_value = False
     nm_mock.ipv4.get_info.return_value = (
         current_config['interfaces'][0]['ipv4'])
+    nm_mock.ipv6.get_info.return_value = (
+        current_config['interfaces'][0]['ipv6'])
 
     report = netinfo.show()
 
@@ -70,6 +75,9 @@ def test_netinfo_show_bond_iface(nm_mock):
                 'ipv4': {
                     'enabled': False,
                 },
+                'ipv6': {
+                    'enabled': False,
+                },
             }
         ]
     }
@@ -86,6 +94,8 @@ def test_netinfo_show_bond_iface(nm_mock):
     }
     nm_mock.ipv4.get_info.return_value = (
         current_config['interfaces'][0]['ipv4'])
+    nm_mock.ipv6.get_info.return_value = (
+        current_config['interfaces'][0]['ipv6'])
 
     report = netinfo.show()
 

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -15,15 +15,105 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import pytest
+
 from lib.compat import mock
 
 from libnmstate import nm
 
 
-@mock.patch.object(nm.ipv6.nmclient, 'NM')
-def test_create_setting(NM_mock):
-    ipv6_setting = nm.ipv6.create_setting()
+@pytest.fixture
+def NM_mock():
+    with mock.patch.object(nm.ipv6.nmclient, 'NM') as m:
+        yield m
+
+
+def test_create_setting_without_config(NM_mock):
+    ipv6_setting = nm.ipv6.create_setting(config=None)
 
     assert ipv6_setting == NM_mock.SettingIP6Config.new.return_value
     assert (ipv6_setting.props.method ==
             NM_mock.SETTING_IP6_CONFIG_METHOD_IGNORE)
+
+
+def test_create_setting_with_ipv6_disabled(NM_mock):
+    ipv6_setting = nm.ipv6.create_setting(config={'enabled': False})
+
+    assert (ipv6_setting.props.method ==
+            NM_mock.SETTING_IP6_CONFIG_METHOD_IGNORE)
+
+
+def test_create_setting_without_addresses(NM_mock):
+    ipv6_setting = nm.ipv6.create_setting(
+        config={
+            'enabled': True,
+            'address': [],
+        }
+    )
+
+    assert (ipv6_setting.props.method ==
+            NM_mock.SETTING_IP6_CONFIG_METHOD_IGNORE)
+
+
+def test_create_setting_with_static_addresses(NM_mock):
+    config = {
+        'enabled': True,
+        'address': [
+            {'ip': 'fd12:3456:789a:1::1', 'prefix-length': 24},
+            {'ip': 'fd12:3456:789a:2::1', 'prefix-length': 24},
+        ],
+    }
+    ipv6_setting = nm.ipv6.create_setting(
+        config=config
+    )
+
+    assert (ipv6_setting.props.method ==
+            NM_mock.SETTING_IP6_CONFIG_METHOD_MANUAL)
+    NM_mock.IPAddress.new.assert_has_calls(
+        [
+            mock.call(nm.ipv6.socket.AF_INET6,
+                      config['address'][0]['ip'],
+                      config['address'][0]['prefix-length']),
+            mock.call(nm.ipv6.socket.AF_INET6,
+                      config['address'][1]['ip'],
+                      config['address'][1]['prefix-length'])
+        ]
+    )
+    NM_mock.SettingIP6Config.new.return_value.add_address.assert_has_calls(
+        [mock.call(NM_mock.IPAddress.new.return_value),
+         mock.call(NM_mock.IPAddress.new.return_value)]
+    )
+
+
+def test_get_info_with_no_connection():
+    info = nm.ipv6.get_info(active_connection=None)
+
+    assert info == {'enabled': False}
+
+
+def test_get_info_with_no_ipv6_config():
+    con_mock = mock.MagicMock()
+    con_mock.get_ip6_config.return_value = None
+
+    info = nm.ipv6.get_info(active_connection=con_mock)
+
+    assert info == {'enabled': False}
+
+
+def test_get_info_with_ipv6_config():
+    act_con_mock = mock.MagicMock()
+    config_mock = act_con_mock.get_ip6_config.return_value
+    address_mock = mock.MagicMock()
+    config_mock.get_addresses.return_value = [address_mock]
+
+    info = nm.ipv6.get_info(active_connection=act_con_mock)
+
+    assert info == {
+        'enabled': True,
+        'address': [
+            {
+                'ip': address_mock.get_address.return_value,
+                'prefix-length': int(address_mock.get_prefix.return_value),
+            }
+        ]
+    }


### PR DESCRIPTION
Example:

```json
{
    "interfaces": [
        {
            "ipv4": {
                "address": [
                    {
                        "ip": "192.168.32.11",
                        "prefix-length": 24
                    }
                ],
                "enabled": true
            },
            "ipv6": {
                "address": [
                    {
                        "ip": "fe80::8097:51a0:9ff4:c7a1",
                        "prefix-length": 64
                    }
                ],
                "enabled": true
            },
            "mtu": 1500,
            "name": "wlp3s0",
            "state": "up",
            "type": "unknown"
        }
    ]
}
```