### PR TITLE
automation: Connect 2 additional networks to docker

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,64 @@
+# Automation Environment
+The automation env is serving the integration tests of nmstate.
+It may be used both locally and through CI.
+
+## Components
+- Dockerfile: Defines a container image which includes systemd,
+  NetworkManager and other basic build tools (e.g. tox).
+
+  The image can be found at:
+  https://hub.docker.com/r/nmstate/centos7-nmstate-dev/
+
+- run-integration-tests.sh: Execute the integration tests in a
+  container using docker.
+
+  The following steps are executed:
+  - Run the container (defined in the Dockerfile) as a daemon.
+  - Stop NetworkManager before adding additional networks (ifaces).
+  - Add additonal networks (ifaces) to the container.
+  - Start NetworkManager.
+  - Execute the integration tests (using tox) in the container.
+
+  It also handles the cleanup of the container and nets (stop,rm).
+
+- run-integration-tests.mounts: Includes mounts to be used by the
+  oVirt CI (STDCI) worker.
+
+- run-integration-tests.packages: Includes the packages needed by
+  the oVirt CI (STDCI) worker.
+
+## Running the Tests
+Assuming *docker* is installed on the host,
+just run:
+`./automation/run-integration-tests.sh`
+
+## Development
+
+### Run the tests manually in the container
+For debugging, it is convenient to run the container and then
+connect to it in order to run the tests.
+```
+DOCKER_IMAGE="nmstate/centos7-nmstate-dev"
+NET0="nmstate-net0"
+NET1="nmstate-net1"
+
+CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PWD:/workspace/nmstate $DOCKER_IMAGE)"
+docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl stop NetworkManager'
+docker network create $NET0 || true
+docker network create $NET1 || true
+docker network connect $NET0 $CONTAINER_ID
+docker network connect $NET1 $CONTAINER_ID
+docker exec -ti $CONTAINER_ID /bin/bash
+systemctl start NetworkManager
+cd /workspace/nmstate
+tox -e check-integ-py27
+```
+
+### Build a new container image and push to the docker hub
+```
+sudo docker build --rm -t local/centos7-nmstate-dev .
+docker tag local/centos7-nmstate-dev nmstate/centos7-nmstate-dev:<ver>
+docker tag local/centos7-nmstate-dev nmstate/centos7-nmstate-dev:latest
+docker push nmstate/centos7-nmstate-dev:<ver>
+docker push nmstate/centos7-nmstate-dev:latest
+```

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -27,6 +27,7 @@ cd "$EXEC_PATH"
 
 CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate $DOCKER_IMAGE)"
 trap remove_container EXIT
+docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl start dbus.socket'
 docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl stop NetworkManager'
 
 docker network create $NET0 || true

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -4,6 +4,9 @@ EXEC_PATH=$(dirname "$(realpath "$0")")
 PROJECT_PATH="$(dirname $EXEC_PATH)"
 DOCKER_IMAGE="nmstate/centos7-nmstate-dev"
 
+NET0="nmstate-net0"
+NET1="nmstate-net1"
+
 test -t 1 && USE_TTY="-t"
 
 function remove_container {
@@ -11,6 +14,8 @@ function remove_container {
     [ "$res" -ne 0 ] && echo "*** ERROR: $res"
     docker stop $CONTAINER_ID
     docker rm $CONTAINER_ID
+    docker network rm $NET0
+    docker network rm $NET1
 }
 
 function pyclean {
@@ -22,6 +27,13 @@ cd "$EXEC_PATH"
 
 CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate $DOCKER_IMAGE)"
 trap remove_container EXIT
+docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl stop NetworkManager'
+
+docker network create $NET0 || true
+docker network create $NET1 || true
+docker network connect $NET0 $CONTAINER_ID
+docker network connect $NET1 $CONTAINER_ID
 
 pyclean
+docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl start NetworkManager'
 docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'cd /workspace/nmstate && tox -e check-integ-py27'


### PR DESCRIPTION
Adding 2 additional links to the running docker (3 in total) to allow
complex test configurations to be supported.