### PR TITLE
libnmstate: Interface desire state sanitize adjustment

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -310,6 +310,19 @@ def assert_ifaces_state(ifaces_desired_state, ifaces_current_state):
         iface_cstate = ifaces_current_state[ifname]
         iface_dstate = _canonicalize_desired_state(
             ifaces_desired_state[ifname], iface_cstate)
+
+        _cleanup_iface_ethernet_state_sanitize(iface_dstate, iface_cstate)
+
         if iface_dstate != iface_cstate:
             raise DesiredStateIsNotCurrentError(
                 'desired: {}\ncurrent: {}'.format(iface_dstate, iface_cstate))
+
+
+def _cleanup_iface_ethernet_state_sanitize(desired_state, current_state):
+    ethernet_desired_state = desired_state.get('ethernet')
+    if ethernet_desired_state:
+        ethernet_current_state = current_state.get('ethernet', {})
+        for key in ('auto-negotiation', 'speed', 'duplex'):
+            if ethernet_desired_state.get(key, None) is None:
+                ethernet_desired_state.pop(key, None)
+                ethernet_current_state.pop(key, None)

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -84,6 +84,15 @@ def get_info(device):
     except AttributeError:
         pass
 
+    if device.get_device_type() == nmclient.NM.DeviceType.ETHERNET:
+        ethernet = _get_ethernet_info(device, iface)
+        if ethernet:
+            info['ethernet'] = ethernet
+
+    return info
+
+
+def _get_ethernet_info(device, iface):
     ethernet = {}
     try:
         speed = int(device.get_speed())
@@ -91,20 +100,13 @@ def get_info(device):
             ethernet['speed'] = speed
     except AttributeError:
         pass
-
     ethtool_results = minimal_ethtool(iface)
     auto_setting = ethtool_results['auto-negotiation']
-
     if auto_setting is True:
         ethernet['auto-negotiation'] = True
     elif auto_setting is False:
         ethernet['auto-negotiation'] = False
-
     duplex_setting = ethtool_results['duplex']
     if duplex_setting != 'unknown':
         ethernet['duplex'] = duplex_setting
-
-    if ethernet:
-        info['ethernet'] = ethernet
-
-    return info
+    return ethernet


### PR DESCRIPTION
nmstate is processing the desired state of an interface and adds base
information for the 'ethernet' properties (auto-negotiation, speed and
duplex).
The 'ethernet' properties are relevant only for ethernet type interfaces
and not for virtual ones. In addition, the base values used in the
sanitize step may cause the post apply verification to fail.

The interface ethernet state sanitize is now limited to ethernet type
interfaces and special handling has been added in the verification step
to allow proper comparison between the desired and the current state.