### PR TITLE
tests: Add an integ lib test for adding static IPv4

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -34,7 +34,9 @@ function add_extra_networks {
     docker network connect $NET1 $CONTAINER_ID
     docker_exec '
       ip addr flush eth1 && \
-      ip addr flush eth2
+      ip addr flush eth2 && \
+      echo 1 > /proc/sys/net/ipv6/conf/eth1/disable_ipv6 || true \
+      echo 1 > /proc/sys/net/ipv6/conf/eth2/disable_ipv6 || true
     '
 }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def logging_setup():
+    logging.basicConfig(
+        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        level=logging.DEBUG)

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import copy
+
+from libnmstate import netapplier
+
+from .testlib import assertlib
+from .testlib import statelib
+from .testlib.statelib import INTERFACES
+
+
+def test_add_static_ipv4_with_full_state():
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[INTERFACES][0]
+
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['ipv4']['enabled'] = True
+    eth1_desired_state['ipv4']['address'] = [
+        {'ip': '192.168.122.250', 'prefix-length': 24}
+    ]
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)
+
+
+def test_add_static_ipv4_with_min_state():
+    desired_state = {
+        INTERFACES: [
+            {
+                'name': 'eth2',
+                'type': 'ethernet',
+                'state': 'up',
+                'ipv4': {
+                    'enabled': True,
+                    'address': [
+                        {'ip': '192.168.122.251', 'prefix-length': 24}
+                    ]
+                }
+            }
+        ]
+    }
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)

--- a/tests/integration/testlib/__init__.py
+++ b/tests/integration/testlib/__init__.py
@@ -14,3 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
+import pytest
+
+pytest.register_assert_rewrite(__name__ + '.assertlib')

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -1,0 +1,76 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import collections
+import copy
+import six
+
+from . import statelib
+from .statelib import INTERFACES
+
+
+def assert_state(desired_state):
+    """Given a state, assert it against the current state."""
+
+    filtered_current_state = statelib.filter_current_state(desired_state)
+    normalized_desired_state = _normalize_desired_state(desired_state,
+                                                        filtered_current_state)
+
+    assert normalized_desired_state == filtered_current_state
+
+
+def _normalize_desired_state(desired_state, current_state):
+    """
+    Given the desired and current state, complement the desired state with all
+    missing properties such that it will be a "full" state description.
+    Note: It is common for the desired state to include only partial config,
+    expecting nmstate to complement the missing parts from the current state.
+    """
+    desired_state = copy.deepcopy(desired_state)
+    desired_interfaces_state = desired_state[INTERFACES]
+
+    for current_iface_state in current_state[INTERFACES]:
+        ifname = current_iface_state['name']
+        desired_iface_state = _lookup_iface_state_by_name(
+            desired_interfaces_state, ifname)
+        if desired_iface_state is not None:
+            normalized_desired_iface_state = _dict_update(
+                copy.deepcopy(current_iface_state), desired_iface_state)
+            desired_iface_state.update(normalized_desired_iface_state)
+    return desired_state
+
+
+def _lookup_iface_state_by_name(interfaces_state, ifname):
+    for iface_state in interfaces_state:
+        if iface_state['name'] == ifname:
+            return iface_state
+    return None
+
+
+def _dict_update(origin_data, to_merge_data):
+    """
+    Recursively performs a dict update (merge), taking the to_merge_data and
+    updating the origin_data.
+    The function changes the origin_data in-place.
+    """
+    for key, val in six.viewitems(to_merge_data):
+        if isinstance(val, collections.Mapping):
+            origin_data[key] = _dict_update(origin_data.get(key, {}), val)
+        else:
+            origin_data[key] = val
+
+    return origin_data

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate import netinfo
+
+
+INTERFACES = 'interfaces'
+
+
+def show_only(ifnames):
+    """
+    Report the current state, filtering based on the given interface names.
+    """
+    base_filter_state = {
+        INTERFACES: [{'name': ifname} for ifname in ifnames]
+    }
+    return filter_current_state(base_filter_state)
+
+
+def filter_current_state(desired_state):
+    """
+    Given the desired state, return a filtered version of the current state
+    which includes only entities such as interfaces that have been mentioned
+    in the desired state.
+    In case there are no entities for filtering, all are reported.
+    """
+    current_state = netinfo.show()
+    desired_iface_names = {ifstate['name']
+                           for ifstate in desired_state[INTERFACES]}
+
+    if not desired_iface_names:
+        return current_state
+
+    filtered_iface_current_state = [
+        ifstate
+        for ifstate in current_state[INTERFACES]
+        if ifstate['name'] in desired_iface_names
+    ]
+    return {INTERFACES: filtered_iface_current_state}


### PR DESCRIPTION
Configuring a static IPv4 address on an interface.

The assertion is embedded in the transaction verification,
which is on by default.