### PR TITLE
tox: coverall fails to run due to urllib3 new version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,7 @@ commands =
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_*
 deps =
+    urllib3==1.23
     coveralls
 changedir = {toxinidir}/tests
 commands =


### PR DESCRIPTION
Use older version of urllib3: 1.23

The error seen on CI:

File
"/home/travis/build/nmstate/nmstate/.tox/coveralls/local/lib/python2.7/
site-packages/requests/compat.py",
line 48, in <module>
    from urllib3.packages.ordered_dict import OrderedDict