### PR TITLE
automation: Create the ifcfg root folder

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -18,6 +18,7 @@ RUN yum -y install iproute NetworkManager epel-release git cairo* && \
     yum clean all && \
     pip install -U pip setuptools pbr tox && \
     \
+    install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \
     sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/ ; s/#RateLimitBurst=1000/RateLimitBurst=0/' /etc/systemd/journald.conf
 


### PR DESCRIPTION
When installing and running NM in a container, it does not (always)
create the ifcfg root folder.

It is now created and provided in the docker image.