### PR TITLE
tox: Explicitly define pytest log level to DEBUG

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
     pytest \
+        --log-level=DEBUG \
         --durations=5 \
         --cov=libnmstate \
         --cov=nmstatectl \
@@ -32,6 +33,7 @@ basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
     pytest \
+        --log-level=DEBUG \
         --durations=5 \
         --cov=libnmstate \
         --cov=nmstatectl \
@@ -49,6 +51,7 @@ basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
     pytest \
+        --log-level=DEBUG \
         --durations=5 \
         --cov=libnmstate \
         --cov=nmstatectl \
@@ -66,6 +69,7 @@ basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
     pytest \
+        --log-level=DEBUG \
         --durations=5 \
         --cov=libnmstate \
         --cov=nmstatectl \


### PR DESCRIPTION
When running the tests using pytest, debug level logging helps debug
failing tests.
With this patch, when tests fail, the debug logs are included in the
report.