### PR TITLE
Misc fixes for running nmstatectl edit on Fedora.

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -72,6 +72,9 @@ def prepare_edited_ifaces_configuration(ifaces_desired_state):
             cur_con_profile = connection.get_device_connection(nmdev)
         new_con_profile = _build_connection_profile(
             iface_desired_state, base_con_profile=cur_con_profile)
+        if not new_con_profile.get_interface_name():
+            set_conn = new_con_profile.get_setting_connection()
+            set_conn.props.interface_name = iface_desired_state['name']
         if cur_con_profile:
             connection.update_profile(cur_con_profile, new_con_profile)
             con_profiles.append(cur_con_profile)

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -66,7 +66,7 @@ def create_setting(iface_state, base_con_profile):
     if speed:
         wired_setting.props.speed = speed
 
-    if duplex:
+    if duplex in ['half', 'full']:
         wired_setting.props.duplex = duplex
 
     return wired_setting
@@ -113,8 +113,8 @@ def _get_ethernet_info(device, iface):
         return None
 
     duplex_setting = ethtool_results['duplex']
-    if duplex_setting == 'unknown':
-        return None
-    else:
+    if duplex_setting in ['half', 'full']:
         ethernet['duplex'] = duplex_setting
+    else:
+        return None
     return ethernet

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -49,7 +49,7 @@ def test_create_setting_mtu(NM_mock):
 
 
 @mock.patch.object(nm.wired, 'minimal_ethtool',
-                   return_value={'speed': 1337, 'duplex': 'mocked',
+                   return_value={'speed': 1337, 'duplex': 'full',
                                  'auto-negotiation': 'mocked'})
 def test_create_setting_auto_negotiation_False(ethtool_mock, NM_mock):
     setting = nm.wired.create_setting(
@@ -58,7 +58,7 @@ def test_create_setting_auto_negotiation_False(ethtool_mock, NM_mock):
     assert setting == NM_mock.SettingWired.new.return_value
     assert setting.props.auto_negotiate is False
     assert setting.props.speed == 1337
-    assert setting.props.duplex == 'mocked'
+    assert setting.props.duplex == 'full'
     assert ethtool_mock.called_with('nmstate_test')
 
 
@@ -88,3 +88,19 @@ def test_create_setting_speed_duplex(NM_mock):
     assert setting == NM_mock.SettingWired.new.return_value
     assert setting.props.speed == 1000
     assert setting.props.duplex == 'full'
+
+
+@mock.patch.object(nm.wired, 'minimal_ethtool',
+                   return_value={'speed': 1500, 'duplex': 'unknown',
+                                 'auto-negotiation': True})
+def test_get_info_with_invalid_duplex(ethtool_mock, NM_mock):
+    dev_mock = mock.MagicMock()
+    dev_mock.get_iface.return_value = 'nmstate_test'
+    dev_mock.get_mtu.return_value = 1500
+    dev_mock.get_device_type.return_value = NM_mock.DeviceType.ETHERNET
+
+    info = nm.wired.get_info(dev_mock)
+
+    assert info == {
+        'mtu': dev_mock.get_mtu.return_value
+    }


### PR DESCRIPTION
 * Fix NULL interface name of NMSettingConnection.
 * Fix `unknown` duplex mode of virt-net.