### PR TITLE
libnmstate: Fix ignore unspecified ethernet settings

### DIFF
--- a/automation/run-integration-tests.packages
+++ b/automation/run-integration-tests.packages
@@ -1,1 +1,2 @@
 docker
+iputils

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -24,6 +24,7 @@ function pyclean {
 }
 
 cd "$EXEC_PATH"
+docker --version && cat /etc/resolv.conf && ping -c 1 github.com
 
 CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate $DOCKER_IMAGE)"
 trap remove_container EXIT

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -326,3 +326,5 @@ def _cleanup_iface_ethernet_state_sanitize(desired_state, current_state):
             if ethernet_desired_state.get(key, None) is None:
                 ethernet_desired_state.pop(key, None)
                 ethernet_current_state.pop(key, None)
+        if not ethernet_desired_state:
+            desired_state.pop('ethernet', None)


### PR DESCRIPTION
If all ethernet properties are ignored, the 'ethernet' subtree needs to
be removed from the desired state.