### PR TITLE
Drop tox from the integ tests

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -16,7 +16,16 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 RUN yum -y install iproute NetworkManager epel-release git cairo* && \
     yum -y install python2-pip gcc python-devel gobject-introspection-devel && \
     yum clean all && \
-    pip install -U pip setuptools pbr tox && \
+    pip install -U \
+      pip \
+      setuptools \
+      pbr \
+      tox \
+      \
+      pluggy==0.6 \
+      PyGObject \
+      pytest-cov \
+      pytest==3.5.1 && \
     \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -37,4 +37,14 @@ docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'ip addr flush eth1 && ip add
 docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'nmcli dev; nmcli con; ip addr; ip route; cat /etc/resolv.conf; ping -c 3 github.com || true'
 
 pyclean
-docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'cd /workspace/nmstate && tox -e check-integ-py27'
+docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c '
+  cd /workspace/nmstate &&
+  pip install . &&
+  pytest \
+    --log-level=DEBUG \
+    --durations=5 \
+    --cov=libnmstate \
+    --cov=nmstatectl \
+    --cov-report=html:htmlcov-py27 \
+    tests/integration
+'


### PR DESCRIPTION
automation: Drop tox usage

Instead of using tox, install all the dependencies
in the container image.

This approach should reduce the instability due to dns connectivity
problems from inside the container to the outside world.

Depends on #100 