### PR TITLE
automation: Refactor the deploy script and change oper orders

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -23,29 +23,62 @@ function pyclean {
         find . -type d -name "__pycache__" -delete
 }
 
-cd "$EXEC_PATH"
+function docker_exec {
+    docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c "$1"
+}
+
+function add_extra_networks {
+    docker network create $NET0 || true
+    docker network create $NET1 || true
+    docker network connect $NET0 $CONTAINER_ID
+    docker network connect $NET1 $CONTAINER_ID
+    docker_exec '
+      ip addr flush eth1 && \
+      ip addr flush eth2
+    '
+}
+
+function dump_network_info {
+    docker_exec '
+      nmcli dev; \
+      nmcli con; \
+      ip addr; \
+      ip route; \
+      cat /etc/resolv.conf; \
+      ping -c 1 github.com || true
+    '
+}
+
+function install_nmstate {
+    docker_exec '
+      cd /workspace/nmstate &&
+      pip install .
+    '
+}
+
+function run_tests {
+    docker_exec '
+      cd /workspace/nmstate &&
+      pytest \
+        --log-level=DEBUG \
+        --durations=5 \
+        --cov=libnmstate \
+        --cov=nmstatectl \
+        --cov-report=html:htmlcov-py27 \
+        tests/integration
+    '
+}
+
+cd $EXEC_PATH 
 docker --version && cat /etc/resolv.conf && ping -c 1 github.com
 
 CONTAINER_ID="$(docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v $PROJECT_PATH:/workspace/nmstate $DOCKER_IMAGE)"
 trap remove_container EXIT
-docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'systemctl start dbus.socket'
-
-docker network create $NET0 || true
-docker network create $NET1 || true
-docker network connect $NET0 $CONTAINER_ID
-docker network connect $NET1 $CONTAINER_ID
-docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'ip addr flush eth1 && ip addr flush eth2'
-docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c 'nmcli dev; nmcli con; ip addr; ip route; cat /etc/resolv.conf; ping -c 3 github.com || true'
-
+docker_exec 'systemctl start dbus.socket'
 pyclean
-docker exec $USE_TTY -i $CONTAINER_ID /bin/bash -c '
-  cd /workspace/nmstate &&
-  pip install . &&
-  pytest \
-    --log-level=DEBUG \
-    --durations=5 \
-    --cov=libnmstate \
-    --cov=nmstatectl \
-    --cov-report=html:htmlcov-py27 \
-    tests/integration
-'
+
+dump_network_info
+install_nmstate
+add_extra_networks
+dump_network_info
+run_tests


### PR DESCRIPTION
DNS instability still exists when running the test script in CI.
It has been observed that the docker container changes the resolv.conf
when additional networks are added. Therefore, this patch changes the
steps taken in the deploy script such that nmstate is installed from
source *before* the additional networks are added.

In addition, for modularity and ease of reading, a refactoring has been
applied, mainly by extracting commands into functions.