### PR TITLE
Skip IPv6 link-local address on setting static address.

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -15,6 +15,7 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
 
 RUN yum -y install iproute NetworkManager epel-release git cairo* && \
     yum -y install python2-pip gcc python-devel gobject-introspection-devel && \
+    yum -y isntall python-ipaddress && \
     yum clean all && \
     pip install -U pip setuptools pbr tox && \
     \

--- a/libnmstate/nm/iplib.py
+++ b/libnmstate/nm/iplib.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import ipaddress
+import six
+
+
+IPV6_LINK_LOCAL_NETWORK = "fe80::/10"
+
+
+def _is_subnet_of(a, b):
+    """
+    Copy from cpython 3.7 Lib/ipaddress.py file which is licensed under PSF,
+    copyright 2007 Google Inc.
+    """
+    try:
+        # Always false if one is v4 and the other is v6.
+        if a._version != b._version:
+            raise TypeError('{a} and {b} are not of the same version')
+        return (b.network_address <= a.network_address and
+                b.broadcast_address >= a.broadcast_address)
+    except AttributeError:
+        raise TypeError('Unable to test subnet containment '
+                        'between {a} and {b}')
+
+
+def is_subnet_of(network_a, network_b):
+    """
+    Check whether network_a is subnet of network_b.
+    """
+    a = ipaddress.ip_network(six.u(network_a), strict=False)
+    b = ipaddress.ip_network(six.u(network_b), strict=False)
+    if hasattr(a, 'subnet_of'):
+        return a.subnet_of(b)
+    else:
+        return _is_subnet_of(a, b)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     PyGObject
     pytest-cov
     pytest==3.5.1
+    ipaddress
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -47,6 +48,7 @@ deps =
     mock
     pytest-cov
     pytest==3.5.1
+    ipaddress
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -84,6 +86,7 @@ deps =
     -r{toxinidir}/requirements.txt
     pytest==3.5.1
     pylint==1.8.4
+    ipaddress
 commands =
     pylint \
         --errors-only \


### PR DESCRIPTION
 * Use ipaddress(new in python 3.3, exist externally for python2.7) module
   for checking IP network subnet calculating.

 * New file `libnmstate/nm/iplib.py` is created in order to support
   the function `subnet_of()` which only exists in python 3.

 * Even we set interface into ipv6 ignore mode, the ipv6 link local address will still be there.