### PR TITLE
Misc fixes for applying IPv6  static address.

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -36,9 +36,7 @@ function add_extra_networks {
     docker network connect $NET1 $CONTAINER_ID
     docker_exec '
       ip addr flush eth1 && \
-      ip addr flush eth2 && \
-      echo 1 > /proc/sys/net/ipv6/conf/eth1/disable_ipv6 || true \
-      echo 1 > /proc/sys/net/ipv6/conf/eth2/disable_ipv6 || true
+      ip addr flush eth2
     '
 }
 

--- a/libnmstate/iplib.py
+++ b/libnmstate/iplib.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+_IPV6_LINK_LOCAL_NETWORK_PREFIXES = ['fe8', 'fe9', 'fea', 'feb']
+_IPV6_LINK_LOCAL_NETWORK_PREFIX_LENGTH = 10
+
+
+def is_ipv6_link_local_addr(ip, prefix):
+    return (ip[:len(_IPV6_LINK_LOCAL_NETWORK_PREFIXES[0])]
+            in _IPV6_LINK_LOCAL_NETWORK_PREFIXES and
+            prefix >= _IPV6_LINK_LOCAL_NETWORK_PREFIX_LENGTH)

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -26,12 +26,15 @@ from .testlib import assertlib
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
 
+# FIXME: Once IPv6 disabling is supported, below IPv6 codes should be removed.
+
 
 def test_increase_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['mtu'] = 1900
+    eth1_desired_state['ipv6']['enabled'] = True
 
     netapplier.apply(copy.deepcopy(desired_state))
 
@@ -54,6 +57,7 @@ def test_upper_limit_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['mtu'] = 9000
+    eth1_desired_state['ipv6']['enabled'] = True
 
     netapplier.apply(copy.deepcopy(desired_state))
 
@@ -65,6 +69,7 @@ def test_increase_more_than_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['mtu'] = 10000
+    eth1_desired_state['ipv6']['enabled'] = True
 
     netapplier.apply(copy.deepcopy(desired_state))
 
@@ -77,6 +82,7 @@ def test_decrease_to_zero_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['mtu'] = 0
+    eth1_desired_state['ipv6']['enabled'] = True
 
     with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
         netapplier.apply(copy.deepcopy(desired_state))
@@ -90,6 +96,7 @@ def test_decrease_to_negative_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['mtu'] = -1
+    eth1_desired_state['ipv6']['enabled'] = True
 
     with pytest.raises(js.ValidationError) as err:
         netapplier.apply(copy.deepcopy(desired_state))
@@ -104,6 +111,7 @@ def test_decrease_to_min_ethernet_frame_size_iface_mtu():
     eth1_desired_state['state'] = 'up'
     # the min is 64 - 18 = 46
     eth1_desired_state['mtu'] = 40
+    eth1_desired_state['ipv6']['enabled'] = True
 
     with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
         netapplier.apply(copy.deepcopy(desired_state))

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -195,6 +195,8 @@ def test_add_static_ipv6_with_full_state():
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['ipv6']['enabled'] = True
     eth1_desired_state['ipv6']['address'] = [
+        {'ip': IPV6_ADDRESS2, 'prefix-length': 64},
+        # This sequence is intentionally made for IP address sorting.
         {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
     ]
     netapplier.apply(copy.deepcopy(desired_state))

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -17,6 +17,7 @@
 
 import collections
 import copy
+from operator import itemgetter
 import six
 
 from libnmstate import netinfo
@@ -99,6 +100,7 @@ class State(object):
         self._sort_iface_lag_slaves()
         self._ipv6_skeleton_canonicalization()
         self._ignore_ipv6_link_local()
+        self._sort_ip_addresses()
 
     def remove_absent_entries(self):
         self._state[INTERFACES] = [
@@ -122,6 +124,12 @@ class State(object):
                 addr for addr in iface_state['ipv6']['address']
                 if not _is_ipv6_link_local(addr['ip'],
                                            addr['prefix-length']))
+
+    def _sort_ip_addresses(self):
+        for iface_state in self._state.get(INTERFACES, []):
+            for family in ('ipv4', 'ipv6'):
+                iface_state.get(family, {}).get('address', []).sort(
+                    key=itemgetter('ip'))
 
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -699,6 +699,64 @@ class TestAssertIfaceState(object):
         with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
             netapplier.assert_ifaces_state(desired_state, current_state)
 
+    def test_sort_multiple_ip(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        desired_state['foo-name']['ipv4'] = {
+            'address': [
+                {
+                    'ip': '192.168.122.10',
+                    'prefix-length': 24
+                },
+                {
+                    'ip': '192.168.121.10',
+                    'prefix-length': 24
+                },
+            ],
+            'enabled': True
+        }
+        current_state['foo-name']['ipv4'] = {
+            'address': [
+                {
+                    'ip': '192.168.121.10',
+                    'prefix-length': 24
+                },
+                {
+                    'ip': '192.168.122.10',
+                    'prefix-length': 24
+                },
+            ],
+            'enabled': True
+        }
+        desired_state['foo-name']['ipv6'] = {
+            'address': [
+                {
+                    'ip': '2001::2',
+                    'prefix-length': 64
+                },
+                {
+                    'ip': '2001::1',
+                    'prefix-length': 64
+                }
+            ],
+            'enabled': True
+        }
+        current_state['foo-name']['ipv6'] = {
+            'address': [
+                {
+                    'ip': '2001::1',
+                    'prefix-length': 64
+                },
+                {
+                    'ip': '2001::2',
+                    'prefix-length': 64
+                }
+            ],
+            'enabled': True
+        }
+
+        netapplier.assert_ifaces_state(desired_state, current_state)
+
     @property
     def _base_state(self):
         return {


### PR DESCRIPTION
~~* Raise exception when user try to flip IPv6 status(enable/disable).~~
    Other Design not been chose:
     * Option A: Use sysctl to disable/enable IPv6.
        * Pros:
            * Works as expected for IPv6 disable and enable.
        * Cons:
            * Need to parse multiple localtion of sysctl.d(/run, /etc,
              /usr/lib, /user/local, ....)
            * Need to handle when user disable/enable IPv6 using their own
              file of sysctl.conf.
            * Docker does not allow sysctl inside.
     * Option B: Hide IPv6 link local address.
        * Pros:
            * No hack required to support IPv6 enable/disable via
              NetworkManager.
        * Cons
            * We does not showing the precise current network state.
 * Ordering the IP addresses before verify comparison of `netapplier.apply()`.
~~ * Raise `MissingIPv6LinkLocalAddressError` when no IPv6 link local address.~~
 * Ignore IPv6 link-local address when `netapplier.apply()`.
 * I don't add the test case for IPv6 yet. Just waiting other PR get merged.