### PR TITLE
Preserve other existing IP configurations when apply()

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -226,8 +226,8 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
                                         iface_desired_state['name'])
 
     settings = [
-        ipv4.create_setting(iface_desired_state.get('ipv4')),
-        ipv6.create_setting(iface_desired_state.get('ipv6')),
+        ipv4.create_setting(iface_desired_state.get('ipv4'), base_con_profile),
+        ipv6.create_setting(iface_desired_state.get('ipv6'), base_con_profile),
     ]
     if base_con_profile:
         con_setting = connection.duplicate_settings(base_con_profile)

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -20,8 +20,17 @@ import socket
 from . import nmclient
 
 
-def create_setting(config):
-    setting_ipv4 = nmclient.NM.SettingIP4Config.new()
+def create_setting(config, base_con_profile):
+    setting_ipv4 = None
+    if base_con_profile:
+        setting_ipv4 = base_con_profile.get_setting_ip4_config()
+        if setting_ipv4:
+            setting_ipv4 = setting_ipv4.duplicate()
+            setting_ipv4.clear_addresses()
+
+    if not setting_ipv4:
+        setting_ipv4 = nmclient.NM.SettingIP4Config.new()
+
     if config and config.get('enabled') and config.get('address'):
         setting_ipv4.props.method = (
             nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL)

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -46,8 +46,16 @@ def get_info(active_connection):
     return info
 
 
-def create_setting(config):
-    setting_ip = nmclient.NM.SettingIP6Config.new()
+def create_setting(config, base_con_profile):
+    setting_ip = None
+    if base_con_profile:
+        setting_ip = base_con_profile.get_setting_ip6_config()
+        if setting_ip:
+            setting_ip = setting_ip.duplicate()
+            setting_ip.clear_addresses()
+
+    if not setting_ip:
+        setting_ip = nmclient.NM.SettingIP6Config.new()
     if config and config.get('enabled'):
         for address in config.get('address', ()):
             if iplib.is_ipv6_link_local_addr(address['ip'],

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -61,8 +61,8 @@ def _create_vlan(vlan_desired_state):
     )
     vlan_setting = nm.vlan.create_setting(vlan_desired_state,
                                           base_con_profile=None)
-    ipv4_setting = nm.ipv4.create_setting({})
-    ipv6_setting = nm.ipv6.create_setting({})
+    ipv4_setting = nm.ipv4.create_setting({}, None)
+    ipv6_setting = nm.ipv6.create_setting({}, None)
     with mainloop():
         con_profile = nm.connection.create_profile(
             (con_setting, vlan_setting, ipv4_setting, ipv6_setting))

--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -1,0 +1,117 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+
+from libnmstate import netapplier
+from libnmstate.nm import nmclient
+
+from .testlib import statelib
+from .testlib import cmd as libcmd
+from .testlib.statelib import INTERFACES
+
+_IPV4_EXTRA_CONFIG = 'ipv4.dad-timeout'
+_IPV4_EXTRA_VALUE = '1000'
+_IPV6_EXTRA_CONFIG = 'ipv6.dhcp-hostname'
+_IPV6_EXTRA_VALUE = 'libnmstate.example.com'
+
+IPV4_ADDRESS1 = '192.0.2.251'
+IPV6_ADDRESS1 = '2001:db8:1::1'
+
+
+def test_reapply_preserve_ip_config(eth1_up):
+    netapplier.apply(
+        {
+            'interfaces': [
+                {
+                    'name': 'eth1',
+                    'type': 'ethernet',
+                    'state': 'up',
+                    'ipv4': {
+                        'address': [
+                            {
+                                'ip': IPV4_ADDRESS1,
+                                'prefix-length': 24
+                            }
+                        ],
+                        'enabled': True
+                    },
+                    'ipv6': {
+                        'address': [
+                            {
+                                'ip': IPV6_ADDRESS1,
+                                'prefix-length': 64
+                            }
+                        ],
+                        'enabled': True
+                    },
+                    'mtu': 1500
+                },
+            ]
+        })
+    cur_state = statelib.show_only(('eth1',))
+    iface_name = cur_state[INTERFACES][0]['name']
+
+    uuid = _get_nm_profile_uuid(iface_name)
+
+    for key, value in ((_IPV4_EXTRA_CONFIG, _IPV4_EXTRA_VALUE),
+                       (_IPV6_EXTRA_CONFIG, _IPV6_EXTRA_VALUE)):
+        with _extra_ip_config(uuid, key, value):
+            netapplier.apply(cur_state)
+            _assert_extra_ip_config(uuid, key, value)
+
+
+def _get_nm_profile_uuid(iface_name):
+    nmcli = nmclient.client()
+    cur_dev = None
+    for dev in nmcli.get_all_devices():
+        if dev.get_iface() == iface_name:
+            cur_dev = dev
+            break
+
+    active_conn = cur_dev.get_active_connection()
+    return active_conn.get_uuid()
+
+
+def _get_cur_extra_ip_config(uuid, key):
+    rc, output, _ = libcmd.exec_cmd(['nmcli', '--get-values', key,
+                                     'connection', 'show', uuid])
+    assert rc == 0
+    return output.split('\n')[0]
+
+
+@contextmanager
+def _extra_ip_config(uuid, key, value):
+    old_value = _get_cur_extra_ip_config(uuid, key)
+    _apply_extra_ip_config(uuid, key, value)
+    try:
+        yield
+    finally:
+        _apply_extra_ip_config(uuid, key, old_value)
+
+
+def _apply_extra_ip_config(uuid, key, value):
+    assert libcmd.exec_cmd(['nmcli', 'connection', 'modify', uuid,
+                            key, value])[0] == 0
+
+
+def _assert_extra_ip_config(uuid, key, value):
+    """
+    Check whether extra config is touched by libnmstate.
+    """
+    cur_value = _get_cur_extra_ip_config(uuid, key)
+    assert cur_value == value


### PR DESCRIPTION
* With this fix `netapplier.apply()` will not discard all IP configurations(DNS, route, etc) but keep existing  one except IP addresses.

~~This PR is based on #107 , please review it first.~~