### PR TITLE
automation: Docker - Enable no-auto-default on all devices

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -30,6 +30,7 @@ RUN yum -y install iproute NetworkManager epel-release git cairo* && \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \
     echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> /etc/NetworkManager/conf.d/97-docker-build.conf && \
+    echo -e "[main]\nno-auto-default=*\n" >> /etc/NetworkManager/conf.d/97-docker-build.conf && \
     sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/ ; s/#RateLimitBurst=1000/RateLimitBurst=0/' /etc/systemd/journald.conf
 
 VOLUME [ "/sys/fs/cgroup" ]


### PR DESCRIPTION
Do not create generated connections automatically on all devices in the
container.