### PR TITLE
tests integ: Adding ethernet mtu tests

### DIFF
--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -1,0 +1,111 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+import copy
+
+import pytest
+import jsonschema as js
+
+from libnmstate import netapplier
+
+from .testlib import assertlib
+from .testlib import statelib
+from .testlib.statelib import INTERFACES
+
+
+def test_increase_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = 1900
+
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)
+
+
+def test_decrease_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = 1000
+
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)
+
+
+def test_upper_limit_jambo_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = 9000
+
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)
+
+
+def test_increase_more_than_jambo_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = 10000
+
+    netapplier.apply(copy.deepcopy(desired_state))
+
+    assertlib.assert_state(desired_state)
+
+
+def test_decrease_to_zero_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    origin_desired_state = copy.deepcopy(desired_state)
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = 0
+
+    with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
+        netapplier.apply(copy.deepcopy(desired_state))
+    assert '-mtu: 0' in err.value.args[0]
+    assertlib.assert_state(origin_desired_state)
+
+
+def test_decrease_to_negative_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    origin_desired_state = copy.deepcopy(desired_state)
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    eth1_desired_state['mtu'] = -1
+
+    with pytest.raises(js.ValidationError) as err:
+        netapplier.apply(copy.deepcopy(desired_state))
+    assert '-1' in err.value.args[0]
+    assertlib.assert_state(origin_desired_state)
+
+
+def test_decrease_to_min_ethernet_frame_size_iface_mtu():
+    desired_state = statelib.show_only(('eth1',))
+    origin_desired_state = copy.deepcopy(desired_state)
+    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state['state'] = 'up'
+    # the min is 64 - 18 = 46
+    eth1_desired_state['mtu'] = 40
+
+    with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
+        netapplier.apply(copy.deepcopy(desired_state))
+    assert '-mtu: 40' in err.value.args[0]
+    assertlib.assert_state(origin_desired_state)


### PR DESCRIPTION
The following scenarios are added to the ehternet integration tests:
(Relative to the mtu default value of 1500)
    - Increase mtu
    - Decrease mtu
    - Increase mtu to the upper jambo limit
    - Increase mtu to be bigger than jambo upper limit
    - Decrease mtu to zero
    - Decrease mtu to negative value
    - Decrease mtu to lower than min limit
