### PR TITLE
Nm disable no auto default

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -30,7 +30,6 @@ RUN yum -y install iproute NetworkManager epel-release git cairo* && \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \
     echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> /etc/NetworkManager/conf.d/97-docker-build.conf && \
-    echo -e "[main]\nno-auto-default=*\n" >> /etc/NetworkManager/conf.d/97-docker-build.conf && \
     sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/ ; s/#RateLimitBurst=1000/RateLimitBurst=0/' /etc/systemd/journald.conf
 
 VOLUME [ "/sys/fs/cgroup" ]


### PR DESCRIPTION
This PR is all about removing the special NetworkManager.conf setting which makes sure to avoid creating a connection profile automatically on interfaces.

nmstate should be able to handle this without special config.

NOTE: Tests show (with #98 ) that it is not working as expected yet. There are from time to time timeouts on waiting for the activation callback. Further investigation is needed.
Nevertheless, the changes merit a proper review.
NOTE2: The last commit needs to be removed before merging, in parallel to the creation of a new image.