### PR TITLE
Nm deactivate device

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -87,14 +87,15 @@ def set_ifaces_admin_state(ifaces_desired_state):
     for iface_desired_state in ifaces_desired_state:
         devs = _get_affected_devices(iface_desired_state)
         if iface_desired_state['state'] == 'up':
-            devs_actions.update({dev: device.activate for dev in devs})
+            devs_actions.update({dev: (device.activate,) for dev in devs})
         elif iface_desired_state['state'] in ('down', 'absent'):
-            devs_actions.update({dev: device.delete for dev in devs})
+            devs_actions.update({dev: (device.delete,) for dev in devs})
         else:
             raise UnsupportedIfaceStateError(iface_desired_state)
 
-    for dev, action in six.viewitems(devs_actions):
-        action(dev)
+    for dev, actions in six.viewitems(devs_actions):
+        for action in actions:
+            action(dev)
 
 
 def _get_affected_devices(iface_state):

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -89,7 +89,8 @@ def set_ifaces_admin_state(ifaces_desired_state):
         if iface_desired_state['state'] == 'up':
             devs_actions.update({dev: (device.activate,) for dev in devs})
         elif iface_desired_state['state'] in ('down', 'absent'):
-            devs_actions.update({dev: (device.delete,) for dev in devs})
+            devs_actions.update(
+                {dev: (device.deactivate, device.delete) for dev in devs})
         else:
             raise UnsupportedIfaceStateError(iface_desired_state)
 

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -211,6 +211,8 @@ class TestIfaceAdminStateControl(object):
         ]
         nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
+        nm_device_mock.deactivate.assert_called_once_with(
+            nm_device_mock.get_device_by_name.return_value)
         nm_device_mock.delete.assert_called_once_with(
             nm_device_mock.get_device_by_name.return_value)
 
@@ -224,6 +226,8 @@ class TestIfaceAdminStateControl(object):
         ]
         nm.applier.set_ifaces_admin_state(ifaces_desired_state)
 
+        nm_device_mock.deactivate.assert_called_once_with(
+            nm_device_mock.get_device_by_name.return_value)
         nm_device_mock.delete.assert_called_once_with(
             nm_device_mock.get_device_by_name.return_value)
 


### PR DESCRIPTION
When the iface state is set to `down` or `absent` it is not enough to delete the connection profile. The device needs to be deactivated so NM will not re-trigger an auto connection creation.