### PR TITLE
nm: Expose device connection profile only if active

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -134,7 +134,9 @@ def set_master_setting(con_setting, master, slave_type):
 
 def get_device_connection(nm_device):
     act_connection = get_device_active_connection(nm_device)
-    if act_connection:
+    if (act_connection and
+            act_connection.props.state ==
+            nmclient.NM.ActiveConnectionState.ACTIVATED):
         return act_connection.props.connection
     return None
 

--- a/tests/lib/nm/connection_test.py
+++ b/tests/lib/nm/connection_test.py
@@ -125,8 +125,10 @@ def test_set_master_setting():
     assert con_setting_mock.props.slave_type == 'slave-type'
 
 
-def test_get_device_connection():
+def test_get_device_connection(NM_mock):
     dev_mock = mock.MagicMock()
+    NM_mock.ActiveConnectionState.ACTIVATED = (
+        dev_mock.get_active_connection.return_value.props.state)
 
     con = nm.connection.get_device_connection(dev_mock)
 


### PR DESCRIPTION
Fetching a device connection profile based on the device should only
consider activated connection profiles and not in transient ones.

The caller code is usually not expecting the returned connection profile
to be in between states. In a transient state, the connection profile
may miss several expected properties, like the interfaces it is bound
to.