### PR TITLE
netapplier: Sort LAG slaves on verification

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -314,6 +314,8 @@ def assert_ifaces_state(ifaces_desired_state, ifaces_current_state):
 
         iface_dstate, iface_cstate = _cleanup_iface_ethernet_state_sanitize(
             iface_dstate, iface_cstate)
+        iface_dstate, iface_cstate = _sort_lag_slaves(
+            iface_dstate, iface_cstate)
 
         if iface_dstate != iface_cstate:
             raise DesiredStateIsNotCurrentError(
@@ -333,4 +335,10 @@ def _cleanup_iface_ethernet_state_sanitize(desired_state, current_state):
         if not ethernet_desired_state:
             desired_state.pop('ethernet', None)
             current_state.pop('ethernet', None)
+    return desired_state, current_state
+
+
+def _sort_lag_slaves(desired_state, current_state):
+    for state in (desired_state, current_state):
+        state.get('link-aggregation', {}).get('slaves', []).sort()
     return desired_state, current_state

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -26,8 +26,10 @@ def assert_state(desired_state_data):
     current_state_data = netinfo.show()
     current_state = statelib.State(current_state_data)
     current_state.filter(desired_state_data)
+    current_state.normalize()
 
     full_desired_state = statelib.State(current_state.state)
     full_desired_state.update(desired_state_data)
+    full_desired_state.normalize()
 
     assert full_desired_state.state == current_state.state

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -95,6 +95,13 @@ class State(object):
 
         self._state = other_state
 
+    def normalize(self):
+        self._sort_iface_lag_slaves()
+
+    def _sort_iface_lag_slaves(self):
+        for ifstate in self._state[INTERFACES]:
+            ifstate.get('link-aggregation', {}).get('slaves', []).sort()
+
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):
     for iface_state in interfaces_state:


### PR DESCRIPTION
The link-aggregation slaves are now sorted (by name) in order to pass
the verification step (comparison between the desired and current
state).

This should fix now bond creation.