### PR TITLE
automation: Explicitly enable IPv6 on test container

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -36,7 +36,9 @@ function add_extra_networks {
     docker network connect $NET1 $CONTAINER_ID
     docker_exec '
       ip addr flush eth1 && \
-      ip addr flush eth2
+      ip addr flush eth2 && \
+      echo 0 > /proc/sys/net/ipv6/conf/eth1/disable_ipv6 || true \
+      echo 0 > /proc/sys/net/ipv6/conf/eth2/disable_ipv6 || true
     '
 }
 


### PR DESCRIPTION
It has been seen that some containers (locally and on CI) do not come up with IPv6 enabled and it causes the tests to fail.
Basically, IPv6 is not enabled if it was never configured (the case for many tests, so it depends on test run order).