### PR TITLE
State diff: Show three lines context

### DIFF
--- a/libnmstate/prettystate.py
+++ b/libnmstate/prettystate.py
@@ -35,7 +35,7 @@ def format_desired_current_state_diff(desired_state, current_state):
         pretty_desired_state.splitlines(True),
         pretty_current_state.splitlines(True),
         fromfile='desired',
-        tofile='current', n=0))
+        tofile='current', n=3))
     return (
         '\n'
         'desired\n'


### PR DESCRIPTION
Show more context when diffing the state to make it easier to identify
differences for non-unique settings such as `enabled` which appears both
for ipv4 and ipv6.

Signed-off-by: Till Maas <opensource@till.name>