### PR TITLE
Integ tests eth1 eth2

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -53,7 +53,7 @@ def setup_remove_bond99():
     netapplier.apply(remove_bond)
 
 
-def test_add_and_remove_bond_with_two_slaves():
+def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
     state = yaml.load(BOND99_YAML_BASE)
     netapplier.apply(state)
 
@@ -67,7 +67,7 @@ def test_add_and_remove_bond_with_two_slaves():
     assert not state[INTERFACES]
 
 
-def test_remove_bond_with_minimum_desired_state():
+def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
     state = yaml.load(BOND99_YAML_BASE)
     netapplier.apply(state)
 
@@ -106,7 +106,7 @@ def test_add_bond_without_slaves():
     assertlib.assert_state(desired_bond_state)
 
 
-def test_add_bond_with_slaves_and_ipv4(setup_remove_bond99):
+def test_add_bond_with_slaves_and_ipv4(eth1_up, eth2_up, setup_remove_bond99):
     desired_bond_state = {
                 INTERFACES: [
                     {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,12 +42,12 @@ def eth2_down():
     _set_eth_admin_state('eth2', 'down')
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='function')
 def eth1_up(eth1_down):
     _set_eth_admin_state('eth1', 'up')
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(scope='function')
 def eth2_up(eth2_down):
     _set_eth_admin_state('eth2', 'up')
 

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -28,6 +28,11 @@ from .testlib import statelib
 from .testlib.statelib import INTERFACES
 
 
+@pytest.fixture(scope='function', autouse=True)
+def eth1(eth1_up):
+    pass
+
+
 def test_increase_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -23,7 +23,7 @@ from .testlib import assertlib
 from .testlib.statelib import INTERFACES
 
 
-def test_set_a_down_iface_down():
+def test_set_a_down_iface_down(eth1_up):
     desired_state = {
         INTERFACES: [
             {
@@ -42,7 +42,7 @@ def test_set_a_down_iface_down():
 
 
 @pytest.mark.xfail(reason='Some ifaces cannot be removed', strict=True)
-def test_removing_a_non_removable_iface():
+def test_removing_a_non_removable_iface(eth1_up):
     desired_state = {
         INTERFACES: [
             {

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -25,7 +25,7 @@ from .testlib import mainloop
 ETH1 = 'eth1'
 
 
-def test_create_and_remove_vlan():
+def test_create_and_remove_vlan(eth1_up):
     vlan_desired_state = {'vlan': {'id': 101, 'base-iface': ETH1}}
 
     with _vlan_interface(vlan_desired_state):

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -37,7 +37,7 @@ IPV6_LINK_LOCAL_ADDRESS2 = 'fe80::2'
 
 
 @pytest.fixture
-def setup_eth1_ipv4():
+def setup_eth1_ipv4(eth1_up):
     desired_state = {
         INTERFACES: [
             {
@@ -57,7 +57,7 @@ def setup_eth1_ipv4():
 
 
 @pytest.fixture
-def setup_eth1_ipv6():
+def setup_eth1_ipv6(eth1_up):
     desired_state = {
         INTERFACES: [
             {
@@ -78,7 +78,7 @@ def setup_eth1_ipv6():
     return desired_state
 
 
-def test_add_static_ipv4_with_full_state():
+def test_add_static_ipv4_with_full_state(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
 
@@ -92,7 +92,7 @@ def test_add_static_ipv4_with_full_state():
     assertlib.assert_state(desired_state)
 
 
-def test_add_static_ipv4_with_min_state():
+def test_add_static_ipv4_with_min_state(eth2_up):
     desired_state = {
         INTERFACES: [
             {
@@ -153,7 +153,8 @@ def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
     assertlib.assert_state(desired_state)
 
 
-def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction():
+def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(eth1_up,
+                                                                     eth2_up):
     desired_state = {
         INTERFACES: [
             {
@@ -186,7 +187,8 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction():
     assertlib.assert_state(desired_state)
 
 
-def test_add_iface_with_same_static_ipv4_address_to_existing(setup_eth1_ipv4):
+def test_add_iface_with_same_static_ipv4_address_to_existing(setup_eth1_ipv4,
+                                                             eth2_up):
     desired_state = {
         INTERFACES: [
             {
@@ -207,7 +209,7 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(setup_eth1_ipv4):
     assertlib.assert_state(desired_state)
 
 
-def test_add_static_ipv6_with_full_state():
+def test_add_static_ipv6_with_full_state(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
@@ -221,7 +223,7 @@ def test_add_static_ipv6_with_full_state():
     assertlib.assert_state(desired_state)
 
 
-def test_add_static_ipv6_with_link_local():
+def test_add_static_ipv6_with_link_local(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
@@ -242,7 +244,7 @@ def test_add_static_ipv6_with_link_local():
             eth1_cur_state['ipv6']['address'])
 
 
-def test_add_static_ipv6_with_link_local_only():
+def test_add_static_ipv6_with_link_local_only(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
@@ -263,7 +265,7 @@ def test_add_static_ipv6_with_link_local_only():
             eth1_cur_state['ipv6']['address'])
 
 
-def test_add_static_ipv6_with_no_address():
+def test_add_static_ipv6_with_no_address(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
@@ -277,7 +279,7 @@ def test_add_static_ipv6_with_no_address():
     assert len(eth1_cur_state['ipv6']['address']) >= 1
 
 
-def test_add_static_ipv6_with_min_state():
+def test_add_static_ipv6_with_min_state(eth2_up):
     desired_state = {
         INTERFACES: [
             {
@@ -348,7 +350,8 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
             eth1_current_state['ipv6']['address'])
 
 
-def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction():
+def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(eth1_up,
+                                                                     eth2_up):
     desired_state = {
         INTERFACES: [
             {
@@ -381,7 +384,8 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction():
     assertlib.assert_state(desired_state)
 
 
-def test_add_iface_with_same_static_ipv6_address_to_existing(setup_eth1_ipv6):
+def test_add_iface_with_same_static_ipv6_address_to_existing(setup_eth1_ipv6,
+                                                             eth2_up):
     desired_state = {
         INTERFACES: [
             {


### PR DESCRIPTION
Refactor integration tests global fixtures.
The final intent is to optimize the individual interface cleanup/setup by need only.

Depends on #156 