### PR TITLE
Fedora/RHEL RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ AUTHORS
 ChangeLog
 
 exported-artifacts
+*.rpm

--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -13,29 +13,21 @@ RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
     rm -f /lib/systemd/system/basic.target.wants/*;\
     rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-RUN yum -y install iproute NetworkManager epel-release git cairo* && \
-    yum -y install python2-pip gcc python-devel gobject-introspection-devel && \
+# Enable EPEL and centos-release-openstack-rocky repo for new version of pytest.
+RUN yum -y install epel-release centos-release-openstack-rocky
+
+# Enable nmstate test repo for new version of pytest-cov and NetworkManager bug
+# fix of https://bugzilla.redhat.com/show_bug.cgi?id=1642625
+RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-test-env-el/repo/epel-7/nmstate-nmstate-test-env-el-epel-7.repo && \
+    yum-config-manager --enable nmstate-nmstate-test-env-el
+
+RUN yum -y upgrade && \
+    yum -y install iproute git python2-pytest python2-pytest-cov NetworkManager && \
     yum clean all && \
-    pip install -U \
-      pip \
-      setuptools \
-      pbr \
-      tox \
-      \
-      pluggy==0.6 \
-      PyGObject \
-      pytest-cov \
-      pytest==3.5.1 && \
-    \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \
     echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> /etc/NetworkManager/conf.d/97-docker-build.conf && \
     sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/ ; s/#RateLimitBurst=1000/RateLimitBurst=0/' /etc/systemd/journald.conf
-
-# Patch with NetworkManager fix for BZ#1642625
-RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/till/nmstate-NetworkManager/repo/epel-7/till-nmstate-NetworkManager-epel-7.repo && \
-    yum-config-manager --enable till-nmstate-NetworkManager && \
-    yum -y update NetworkManager
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -55,7 +55,7 @@ function dump_network_info {
 function install_nmstate {
     docker_exec '
       cd /workspace/nmstate &&
-      pip install .
+      yum install -y `./packaging/make_rpm.sh|tail -1 || exit 1`
     '
 }
 

--- a/packaging/make_rpm.sh
+++ b/packaging/make_rpm.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+SRC_DIR="$(dirname "$0")/.."
+TMP_DIR=$(mktemp -d)
+SPEC_FILE="$TMP_DIR/nmstate.spec"
+OLD_PWD=$(pwd)
+if [ $EUID -ne 0 ]; then
+    SUDO="sudo"
+else
+    SUDO=""
+fi
+
+trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
+
+VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || :)
+if [ -z $VERSION ];then
+    VERSION="0.0.1git$(git rev-parse --short HEAD)"
+else
+    VERSION="$(VERSION)git$(git rev-parse --short HEAD)"
+fi
+
+if [ -n "$(rpm -E %{?fedora} 2>/dev/null)" ] ||
+   [ -n "$(rpm -E %{?el8} 2>/dev/null)" ] ;then
+    cp $SRC_DIR/packaging/nmstate.py3.spec.in $SPEC_FILE
+    sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
+    $SUDO dnf install -y rpm-build
+    $SUDO dnf builddep -y $SPEC_FILE
+elif [ -n "$(rpm -E %{?el7} 2>/dev/null)" ];then
+    cp $SRC_DIR/packaging/nmstate.py2.spec.in $SPEC_FILE
+    sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
+    $SUDO yum install -y rpm-build yum-utils
+    $SUDO yum-builddep -y $SPEC_FILE
+else
+    echo "Not supported"
+    exit 1
+fi
+
+TAR_FILE="$TMP_DIR/nmstate-$VERSION.tar"
+
+cd $SRC_DIR
+git archive --prefix=nmstate-$VERSION/ --format=tar -o $TAR_FILE HEAD
+tar --append --file=$TAR_FILE $SPEC_FILE 1>/dev/null 2>/dev/null
+
+rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
+    -ta $TAR_FILE
+RPMS=$(find $TMP_DIR -type f -name \*.noarch.rpm -exec basename {} \;)
+SRPM=$(find $TMP_DIR -type f -name \*.src.rpm -exec basename {} \;)
+find $TMP_DIR -type f -name \*.rpm -exec mv {} $OLD_PWD \;
+echo "SRPM CREATED:"
+echo $OLD_PWD/$SRPM
+echo "RPM CREATED:"
+for RPM in $RPMS; do
+    echo -n "$OLD_PWD/$RPM "
+done
+echo

--- a/packaging/nmstate.py2.spec.in
+++ b/packaging/nmstate.py2.spec.in
@@ -1,0 +1,61 @@
+%define srcname nmstate
+%define libname libnmstate
+
+Name:           nmstate
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Declarative network manager API
+Group:          System Environment/Libraries
+License:        GPLv2+
+URL:            https://github.com/%{srcname}/%{srcname}
+Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
+BuildArch:      noarch
+BuildRequires:  python2-devel
+BuildRequires:  python2-six
+BuildRequires:  python2-pyyaml
+BuildRequires:  python-jsonschema
+BuildRequires:  python-setuptools
+Requires:       python2-%{libname}
+
+%description
+NMState is a library with an accompanying command line tool that manages host
+networking settings in a declarative manner and aimed to satisfy enterprise
+needs to manage host networking through a northbound declarative API and multi
+provider support on the southbound.
+
+
+%package -n python2-%{libname}
+Summary:        nmstate Python 2 API library
+Group:          System Environment/Libraries
+License:        GPLv2+
+Requires:       NetworkManager-libnm
+Requires:       python-gobject-base
+Requires:       python2-six
+Requires:       python-jsonschema
+Requires:       python2-pyyaml
+
+%description -n python2-%{libname}
+This package contains the Python 2 library for nmstate.
+
+%prep
+%setup -q -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+%files
+%doc README.md
+%license LICENSE
+%{python2_sitelib}/nmstatectl
+%{_bindir}/nmstatectl
+
+%files -n python2-%{libname}
+%{python2_sitelib}/%{libname}
+%{python2_sitelib}/%{srcname}-*.egg-info/
+
+%changelog
+* Mon Nov 19 2018 Gris Ge <fge@redhat.com> - 0.0.1-0
+- Initial release.

--- a/packaging/nmstate.py3.spec.in
+++ b/packaging/nmstate.py3.spec.in
@@ -1,0 +1,62 @@
+%define srcname nmstate
+%define libname libnmstate
+
+Name:           nmstate
+Version:        @VERSION@
+Release:        1%{?dist}
+Summary:        Declarative network manager API
+Group:          System Environment/Libraries
+License:        GPLv2+
+URL:            https://github.com/%{srcname}/%{srcname}
+Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3-six
+BuildRequires:  python3-jsonschema
+BuildRequires:  python3-PyYAML
+BuildRequires:  python3-setuptools
+Requires:       python3-%{libname}
+
+%description
+NMState is a library with an accompanying command line tool that manages host
+networking settings in a declarative manner and aimed to satisfy enterprise
+needs to manage host networking through a northbound declarative API and multi
+provider support on the southbound.
+
+
+%package -n python3-%{libname}
+Summary:        nmstate Python 3 API library
+Group:          System Environment/Libraries
+License:        GPLv2+
+Requires:       NetworkManager-libnm
+Recommends:     NetworkManager
+Requires:       python3-gobject-base
+Requires:       python3-six
+Requires:       python3-jsonschema
+Requires:       python3-PyYAML
+
+%description -n python3-%{libname}
+This package contains the Python 3 library for nmstate.
+
+%prep
+%setup -q -n %{srcname}-%{version}
+
+%build
+%py3_build
+
+%install
+%py3_install
+
+%files
+%doc README.md
+%license LICENSE
+%{python3_sitelib}/nmstatectl
+%{_bindir}/nmstatectl
+
+%files -n python3-%{libname}
+%{python3_sitelib}/%{libname}
+%{python3_sitelib}/%{srcname}-*.egg-info/
+
+%changelog
+* Mon Nov 19 2018 Gris Ge <fge@redhat.com> - 0.0.1-0
+- Initial release.


### PR DESCRIPTION
 * Contains a fix for running nmstatectl in python3.
 * Contains patch for removing pbr dependent.
 * `packaging/make_rpm.sh` to make rpm for RHEL 7/8 and Fedora 28+.
 * Change the integration test to use compiled rpm instead of `pip install`.

Extra notes:
 * The script `make_rpm.sh` is designed to build rpm from git HEAD, it's not designed to release.
 * For RHEL/Centos 7, it requires EPEL repo enabled.
 * ~~RHEL 8 beta is not supported yet as we are missing `python3-pbr` there. 
   I will add patch to remove dependency of pbr in this PR soon.~~