### PR TITLE
nmstatectl: Fix running on Python 3.

### DIFF
--- a/libnmstate/ethtool.py
+++ b/libnmstate/ethtool.py
@@ -51,7 +51,7 @@ def minimal_ethtool(interface):
 
         ecmd = array.array('B', struct.pack('I39s', ETHTOOL_GSET, b'\x00'*39))
 
-        interface = bytes(interface).encode('utf-8')
+        interface = interface.encode('utf-8')
         ifreq = struct.pack('16sP', interface, ecmd.buffer_info()[0])
 
         fcntl.ioctl(sockfd, SIOCETHTOOL, ifreq)

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import argparse
+import errno
 import fnmatch
 import json
 import logging
@@ -46,6 +47,9 @@ def main():
     setup_subcommand_show(subparsers)
     setup_subcommand_set(subparsers)
 
+    if len(sys.argv) == 1:
+        parser.print_usage()
+        return errno.EINVAL
     args = parser.parse_args()
     return args.func(args)
 
@@ -187,7 +191,7 @@ def _run_editor(txtstate, suffix):
     editor = os.environ.get('EDITOR', 'vi')
     with tempfile.NamedTemporaryFile(suffix=suffix,
                                      prefix='nmstate-') as statefile:
-        statefile.write(txtstate)
+        statefile.write(txtstate.encode('utf-8'))
         statefile.flush()
 
         try:


### PR DESCRIPTION
 * Python 3 does not print help message any more when no sub command
   provided. Fix would be check the length of argument list.

 * Fix the string encoding.