### PR TITLE
Integration tests: Allow passing extra arguments to pytest

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -68,8 +68,8 @@ function run_tests {
         --cov=libnmstate \
         --cov=nmstatectl \
         --cov-report=html:htmlcov-py27 \
-        tests/integration
-    '
+        tests/integration \
+    '"${nmstate_pytest_extra_args}"
 }
 
 function collect_artifacts {


### PR DESCRIPTION
This allows to pass extra arguments to pytest via the
`nmstate_pytest_extra_args` variable:

nmstate_pytest_extra_args="--pdb -x" ./automation/run-integration-tests.sh

Signed-off-by: Till Maas <opensource@till.name>