### PR TITLE
NM: Refresh NM client before querying devices

### DIFF
--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -163,7 +163,7 @@ def _delete_connection_callback(src_object, result, user_data):
 
 
 def get_device_by_name(devname):
-    client = nmclient.client()
+    client = nmclient.client(refresh=True)
     return client.get_device_by_iface(devname)
 
 


### PR DESCRIPTION
This create a segmentation fault locally but might be a good thing to do to fix problems with the vlan test, since the vlan device seems to be cached by the client even when it is already gone and cannot be retrieved in a different nmclient instance. I guess ideally the mainloop would run for longer to take care of this.

Signed-off-by: Till Maas <opensource@till.name>