### PR TITLE
tests integ: Fix nm VLAN tests by refreshing nm client

### DIFF
--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -16,7 +16,6 @@
 #
 
 from contextlib import contextmanager
-import time
 
 from libnmstate import nm
 
@@ -34,9 +33,6 @@ def test_create_and_remove_vlan():
         vlan_current_state = _get_vlan_current_state(vlan_desired_state)
         assert vlan_desired_state == vlan_current_state
 
-    # FIXME: Remove this sleep after adding wait for state mechanism.
-    time.sleep(5)
-
     assert not _get_vlan_current_state(vlan_desired_state)
 
 
@@ -50,6 +46,7 @@ def _vlan_interface(state):
 
 
 def _get_vlan_current_state(vlan_desired_state):
+    nm.nmclient.client(refresh=True)
     ifname = _get_vlan_ifname(vlan_desired_state)
     nmdev = nm.device.get_device_by_name(ifname)
     return nm.vlan.get_info(nmdev) if nmdev else {}


### PR DESCRIPTION
Remove the sleep introduced in previous patched and add an NM client
refresh.
While outside the mainloop, the client needs to be re-created in order
to retrieve updated information form NM.