### PR TITLE
Integ tests: Move deepcopy of desired state into the apply func

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -42,6 +42,7 @@ class DesiredStateIsNotCurrentError(Exception):
 
 
 def apply(desired_state, verify_change=True):
+    desired_state = copy.deepcopy(desired_state)
     validator.verify(desired_state)
     validator.verify_capabilities(desired_state, netinfo.capabilities())
 

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-import copy
-
 import pytest
 import yaml
 
@@ -57,13 +55,13 @@ def setup_remove_bond99():
 
 def test_add_and_remove_bond_with_two_slaves():
     state = yaml.load(BOND99_YAML_BASE)
-    netapplier.apply(copy.deepcopy(state))
+    netapplier.apply(state)
 
     assertlib.assert_state(state)
 
     state[INTERFACES][0]['state'] = 'absent'
 
-    netapplier.apply(copy.deepcopy(state))
+    netapplier.apply(state)
 
     state = statelib.show_only((state[INTERFACES][0]['name'],))
     assert not state[INTERFACES]
@@ -71,7 +69,7 @@ def test_add_and_remove_bond_with_two_slaves():
 
 def test_remove_bond_with_minimum_desired_state():
     state = yaml.load(BOND99_YAML_BASE)
-    netapplier.apply(copy.deepcopy(state))
+    netapplier.apply(state)
 
     remove_bond_state = {
         INTERFACES: [
@@ -105,7 +103,7 @@ def test_add_bond_without_slaves():
             ]
         }
 
-    netapplier.apply(copy.deepcopy(desired_bond_state))
+    netapplier.apply(desired_bond_state)
 
     assertlib.assert_state(desired_bond_state)
 
@@ -133,6 +131,6 @@ def test_add_bond_with_slaves_and_ipv4(setup_remove_bond99):
                 ]
             }
 
-    netapplier.apply(copy.deepcopy(desired_bond_state))
+    netapplier.apply(desired_bond_state)
 
     assertlib.assert_state(desired_bond_state)

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -33,7 +33,7 @@ def test_increase_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1900
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -43,7 +43,7 @@ def test_decrease_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1400
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -53,7 +53,7 @@ def test_upper_limit_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 9000
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -63,7 +63,7 @@ def test_increase_more_than_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 10000
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -75,7 +75,7 @@ def test_decrease_to_zero_iface_mtu():
     eth1_desired_state['mtu'] = 0
 
     with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
-        netapplier.apply(copy.deepcopy(desired_state))
+        netapplier.apply(desired_state)
     assert '-mtu: 0' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.
     time.sleep(2)
@@ -89,7 +89,7 @@ def test_decrease_to_negative_iface_mtu():
     eth1_desired_state['mtu'] = -1
 
     with pytest.raises(js.ValidationError) as err:
-        netapplier.apply(copy.deepcopy(desired_state))
+        netapplier.apply(desired_state)
     assert '-1' in err.value.args[0]
     assertlib.assert_state(origin_desired_state)
 
@@ -99,7 +99,7 @@ def test_decrease_to_ipv6_min_ethernet_frame_size_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1280
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -111,7 +111,7 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu():
     eth1_desired_state['mtu'] = 1279
 
     with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
-        netapplier.apply(copy.deepcopy(desired_state))
+        netapplier.apply(desired_state)
     assert '1279' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.
     time.sleep(2)

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-import copy
-
 import pytest
 
 from libnmstate import netapplier
@@ -35,10 +33,10 @@ def test_set_a_down_iface_down():
             }
         ]
     }
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
     assertlib.assert_state(desired_state)
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -55,6 +53,6 @@ def test_removing_a_non_removable_iface():
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-import copy
-
 import pytest
 
 from libnmstate import netapplier
@@ -89,7 +87,7 @@ def test_add_static_ipv4_with_full_state():
     eth1_desired_state['ipv4']['address'] = [
         {'ip': IPV4_ADDRESS3, 'prefix-length': 24}
     ]
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -110,7 +108,7 @@ def test_add_static_ipv4_with_min_state():
             }
         ]
     }
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -128,7 +126,7 @@ def test_remove_static_ipv4(setup_eth1_ipv4):
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -150,7 +148,7 @@ def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -183,7 +181,7 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction():
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -204,7 +202,7 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(setup_eth1_ipv4):
             }
         ]
     }
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -219,7 +217,7 @@ def test_add_static_ipv6_with_full_state():
         # This sequence is intentionally made for IP address sorting.
         {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
     ]
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
     assertlib.assert_state(desired_state)
 
 
@@ -233,7 +231,7 @@ def test_add_static_ipv6_with_link_local():
         {'ip': IPV6_ADDRESS1, 'prefix-length': 64}
     ]
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     # Make sure only the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
@@ -254,7 +252,7 @@ def test_add_static_ipv6_with_link_local_only():
         {'ip': IPV6_LINK_LOCAL_ADDRESS2, 'prefix-length': 64},
     ]
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     # Make sure the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
@@ -271,7 +269,7 @@ def test_add_static_ipv6_with_no_address():
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     cur_state = statelib.show_only(('eth1',))
     eth1_cur_state = cur_state[INTERFACES][0]
@@ -295,7 +293,7 @@ def test_add_static_ipv6_with_min_state():
             }
         ]
     }
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -314,7 +312,7 @@ def test_disable_static_ipv6(setup_eth1_ipv6):
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -337,7 +335,7 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
     eth1_desired_state = desired_state[INTERFACES][0]
     current_state = statelib.show_only(('eth1',))
 
@@ -378,7 +376,7 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction():
         ]
     }
 
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -399,6 +397,6 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(setup_eth1_ipv6):
             }
         ]
     }
-    netapplier.apply(copy.deepcopy(desired_state))
+    netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)


### PR DESCRIPTION
Copying the dict in apply function assures that the caller data is not
modified by nmstate.

Signed-off-by: Sveta Haas <sveta.haas@gmail.com>