### PR TITLE
Add support of IPv4/IPv6 DHCP.

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -25,7 +25,7 @@ RUN yum -y upgrade && \
     yum -y install iproute python2-pytest python2-pytest-cov NetworkManager \
                    rpm-build git python2-devel python2-six \
                    python2-pyyaml python-jsonschema python-setuptools \
-                   python-gobject-base && \
+                   python-gobject-base dnsmasq && \
     yum clean all && \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-import socket
 import logging
+import socket
 
 from libnmstate.nm import nmclient
 from libnmstate import iplib
@@ -27,8 +27,30 @@ def get_info(active_connection):
     if active_connection is None:
         return info
 
+    info['dhcp'] = False
+    info['autoconf'] = False
+
+    ip_profile = get_ip_profile(active_connection)
+    if ip_profile:
+        method = ip_profile.get_method()
+        if method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO:
+            info['dhcp'] = True
+            info['autoconf'] = True
+        elif method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP:
+            info['dhcp'] = True
+            info['autoconf'] = False
+
     ipconfig = active_connection.get_ip6_config()
     if ipconfig is None:
+        # When DHCP is enable, it might be possible, the active_connection does
+        # not got IP address yet. In that case, we still mark
+        # info['enabled'] as True.
+        if info['dhcp'] or info['autoconf']:
+            info['enabled'] = True
+            info['address'] = []
+        else:
+            del info['dhcp']
+            del info['autoconf']
         return info
 
     addresses = [
@@ -56,25 +78,72 @@ def create_setting(config, base_con_profile):
 
     if not setting_ip:
         setting_ip = nmclient.NM.SettingIP6Config.new()
-    if config and config.get('enabled'):
-        for address in config.get('address', ()):
-            if iplib.is_ipv6_link_local_addr(address['ip'],
-                                             address['prefix-length']):
-                logging.warning('IPv6 link local address '
-                                '{a[ip]}/{a[prefix-length]} is ignored when '
-                                'applying desired state'.format(a=address))
-            else:
-                naddr = nmclient.NM.IPAddress.new(socket.AF_INET6,
-                                                  address['ip'],
-                                                  address['prefix-length'])
-                setting_ip.add_address(naddr)
-        if setting_ip.props.addresses:
-            setting_ip.props.method = (
-                nmclient.NM.SETTING_IP6_CONFIG_METHOD_MANUAL)
-        else:
-            setting_ip.props.method = (
-                nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
-    else:
+
+    if not config or not config.get('enabled'):
         setting_ip.props.method = (
             nmclient.NM.SETTING_IP6_CONFIG_METHOD_IGNORE)
+        return setting_ip
+
+    is_dhcp = config.get('dhcp', False)
+    is_autoconf = config.get('autoconf', False)
+    ip_addresses = config.get('address', ())
+
+    if is_dhcp or is_autoconf:
+        _set_dynamic(setting_ip, is_dhcp, is_autoconf)
+    elif ip_addresses:
+        _set_static(setting_ip, ip_addresses)
+    else:
+        setting_ip.props.method = (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
+
     return setting_ip
+
+
+class NoSupportDynamicIPv6OptionError(Exception):
+    pass
+
+
+def _set_dynamic(setting_ip, is_dhcp, is_autoconf):
+    if not is_dhcp and is_autoconf:
+        raise NoSupportDynamicIPv6OptionError(
+            'Autoconf without DHCP is not supported yet')
+
+    if is_dhcp and is_autoconf:
+        setting_ip.props.method = (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO)
+    elif is_dhcp and not is_autoconf:
+        setting_ip.props.method = (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP)
+
+
+def _set_static(setting_ip, ip_addresses):
+    for address in ip_addresses:
+        if iplib.is_ipv6_link_local_addr(address['ip'],
+                                         address['prefix-length']):
+            logging.warning('IPv6 link local address '
+                            '{a[ip]}/{a[prefix-length]} is ignored '
+                            'when applying desired state'
+                            .format(a=address))
+        else:
+            naddr = nmclient.NM.IPAddress.new(socket.AF_INET6,
+                                              address['ip'],
+                                              address['prefix-length'])
+            setting_ip.add_address(naddr)
+
+    if setting_ip.props.addresses:
+        setting_ip.props.method = (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_MANUAL)
+    else:
+        setting_ip.props.method = (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
+
+
+def get_ip_profile(active_connection):
+    """
+    Get NMSettingIP6Config from NMActiveConnection.
+    For any error, return None.
+    """
+    remote_conn = active_connection.get_connection()
+    if remote_conn:
+        return remote_conn.get_setting_ip6_config()
+    return None

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 
 import jsonschema as js
+import logging
 import six
 
 from . import nm
@@ -81,3 +82,13 @@ def verify_link_aggregation_state(ifaces_state, ifaces_desired_state):
                 if slaves & specified_slaves:
                     raise LinkAggregationSlavesReuseError(iface_state)
                 specified_slaves |= slaves
+
+
+def verify_dhcp(state):
+    for iface_state in state[Constants.INTERFACES]:
+        for family in ('ipv4', 'ipv6'):
+            ip = iface_state.get(family, {})
+            if ip.get('enabled') and ip.get('address') and \
+               (ip.get('dhcp') or ip.get('autoconf')):
+                logging.warning('%s addresses are ignored when '
+                                'dynamic IP is enabled', family)

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -1,0 +1,177 @@
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import os
+
+import pytest
+
+from libnmstate import netapplier
+from libnmstate import nm
+
+from .testlib import assertlib
+from .testlib import cmd as libcmd
+from .testlib import statelib
+from .testlib.statelib import INTERFACES
+
+
+IPV4_ADDRESS1 = '192.0.2.251'
+IPV4_ADDRESS2 = '192.0.2.252'
+IPV6_ADDRESS1 = '2001:db8:1::1'
+IPV6_ADDRESS2 = '2001:db8:2::1'
+
+DHCP_SRV_NIC = 'dhcpsrv'
+DHCP_CLI_NIC = 'dhcpcli'
+
+DNSMASQ_CONF_STR = """
+interface={}
+dhcp-range=192.0.2.200,192.0.2.250,255.255.255.0,48h
+enable-ra
+dhcp-range=2001:db8:1::100,2001:db8:1::fff,64,480h
+""".format(DHCP_SRV_NIC)
+
+DNSMASQ_CONF_PATH = '/etc/dnsmasq.d/nmstate.conf'
+
+SYSFS_DISABLE_IPV6_FILE = '/proc/sys/net/ipv6/conf/{}/disable_ipv6'.format(
+    DHCP_SRV_NIC)
+
+# Python 2 does not have FileNotFoundError and treat file not exist as IOError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+
+@pytest.fixture(scope='module')
+def dhcp_env(request):
+    try:
+        _create_veth_pair()
+        _setup_dhcp_nics()
+
+        with open(DNSMASQ_CONF_PATH, 'w') as fd:
+            fd.write(DNSMASQ_CONF_STR)
+        assert libcmd.exec_cmd(['systemctl', 'restart', 'dnsmasq'])[0] == 0
+        yield
+    finally:
+        _clean_up()
+
+
+def test_ipv4_dhcp(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+    assertlib.assert_state(desired_state)
+
+
+def test_ipv6_dhcp_only(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = False
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+
+
+def test_ipv6_dhcp_and_autoconf(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+
+
+@pytest.mark.xfail(raises=nm.ipv6.NoSupportDynamicIPv6OptionError)
+def test_ipv6_autoconf_only(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['ipv6']['dhcp'] = False
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+
+    netapplier.apply(desired_state)
+
+
+def test_dhcp_with_addresses(dhcp_env):
+    desired_state = {
+        INTERFACES: [
+            {
+                'name': DHCP_CLI_NIC,
+                'type': 'ethernet',
+                'state': 'up',
+                'ipv4': {
+                    'enabled': True,
+                    'dhcp': True,
+                    'address': [
+                        {'ip': IPV4_ADDRESS1, 'prefix-length': 24},
+                        {'ip': IPV4_ADDRESS2, 'prefix-length': 24}
+                    ]
+                },
+                'ipv6': {
+                    'enabled': True,
+                    'dhcp': True,
+                    'autoconf': True,
+                    'address': [
+                        {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
+                        {'ip': IPV6_ADDRESS2, 'prefix-length': 64}
+                    ]
+                }
+            }
+        ]
+    }
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+
+
+def _create_veth_pair():
+    assert libcmd.exec_cmd(['ip', 'link', 'add', DHCP_SRV_NIC, 'type', 'veth',
+                            'peer', 'name', DHCP_CLI_NIC])[0] == 0
+
+
+def _remove_veth_pair():
+    libcmd.exec_cmd(['ip', 'link', 'del', 'dev', DHCP_SRV_NIC])
+
+
+def _setup_dhcp_nics():
+    assert libcmd.exec_cmd(['ip', 'link', 'set', DHCP_SRV_NIC, 'up'])[0] == 0
+    assert libcmd.exec_cmd(['ip', 'link', 'set', DHCP_CLI_NIC, 'up'])[0] == 0
+    assert libcmd.exec_cmd(['ip', 'addr', 'add', IPV4_ADDRESS1, 'dev',
+                            DHCP_SRV_NIC])[0] == 0
+    with open(SYSFS_DISABLE_IPV6_FILE, 'w') as fd:
+        fd.write('0')
+    assert libcmd.exec_cmd(['ip', 'addr', 'add', IPV6_ADDRESS1, 'dev',
+                            DHCP_SRV_NIC])[0] == 0
+
+
+def _clean_up():
+    libcmd.exec_cmd(['systemctl', 'stop', 'dnsmasq'])
+    _remove_veth_pair()
+    try:
+        os.unlink(DNSMASQ_CONF_PATH)
+    except FileNotFoundError:
+        pass

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -98,7 +98,9 @@ class State(object):
 
     def normalize(self):
         self._sort_iface_lag_slaves()
+        self._ipv4_skeleton_canonicalization()
         self._ipv6_skeleton_canonicalization()
+        self._ignore_dhcp_manual_addr()
         self._ignore_ipv6_link_local()
         self._sort_ip_addresses()
 
@@ -117,6 +119,15 @@ class State(object):
             iface_state.setdefault('ipv6', {})
             iface_state['ipv6'].setdefault('enabled', False)
             iface_state['ipv6'].setdefault('address', [])
+            iface_state['ipv6'].setdefault('dhcp', False)
+            iface_state['ipv6'].setdefault('autoconf', False)
+
+    def _ipv4_skeleton_canonicalization(self):
+        for iface_state in self._state.get(INTERFACES, []):
+            iface_state.setdefault('ipv4', {})
+            iface_state['ipv4'].setdefault('enabled', False)
+            iface_state['ipv4'].setdefault('address', [])
+            iface_state['ipv4'].setdefault('dhcp', False)
 
     def _ignore_ipv6_link_local(self):
         for iface_state in self._state.get(INTERFACES, []):
@@ -130,6 +141,12 @@ class State(object):
             for family in ('ipv4', 'ipv6'):
                 iface_state.get(family, {}).get('address', []).sort(
                     key=itemgetter('ip'))
+
+    def _ignore_dhcp_manual_addr(self):
+        for iface_state in self._state.get(INTERFACES, []):
+            for family in ('ipv4', 'ipv6'):
+                if iface_state.get(family, {}).get('dhcp'):
+                    iface_state[family]['address'] = []
 
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -96,22 +96,30 @@ def test_get_info_with_no_connection():
 def test_get_info_with_no_ipv4_config():
     con_mock = mock.MagicMock()
     con_mock.get_ip4_config.return_value = None
+    con_mock.get_connection.return_value = None
 
     info = nm.ipv4.get_info(active_connection=con_mock)
 
     assert info == {'enabled': False}
 
 
-def test_get_info_with_ipv4_config():
+def test_get_info_with_ipv4_config(NM_mock):
     act_con_mock = mock.MagicMock()
     config_mock = act_con_mock.get_ip4_config.return_value
     address_mock = mock.MagicMock()
     config_mock.get_addresses.return_value = [address_mock]
+    remote_conn_mock = mock.MagicMock()
+    act_con_mock.get_connection().return_value = remote_conn_mock
+    set_ip_conf = mock.MagicMock()
+    remote_conn_mock.get_setting_ip4_config.return_value = set_ip_conf
+    set_ip_conf.get_method.return_value = (
+        NM_mock.SETTING_IP4_CONFIG_METHOD_MANUAL)
 
     info = nm.ipv4.get_info(active_connection=act_con_mock)
 
     assert info == {
         'enabled': True,
+        'dhcp': False,
         'address': [
             {
                 'ip': address_mock.get_address.return_value,

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -105,22 +105,31 @@ def test_get_info_with_no_connection():
 def test_get_info_with_no_ipv6_config():
     con_mock = mock.MagicMock()
     con_mock.get_ip6_config.return_value = None
+    con_mock.get_connection.return_value = None
 
     info = nm.ipv6.get_info(active_connection=con_mock)
 
     assert info == {'enabled': False}
 
 
-def test_get_info_with_ipv6_config():
+def test_get_info_with_ipv6_config(NM_mock):
     act_con_mock = mock.MagicMock()
     config_mock = act_con_mock.get_ip6_config.return_value
     address_mock = mock.MagicMock()
     config_mock.get_addresses.return_value = [address_mock]
+    remote_conn_mock = mock.MagicMock()
+    act_con_mock.get_connection().return_value = remote_conn_mock
+    set_ip_conf = mock.MagicMock()
+    remote_conn_mock.get_setting_ip6_config.return_value = set_ip_conf
+    set_ip_conf.get_method.return_value = (
+        NM_mock.SETTING_IP6_CONFIG_METHOD_MANUAL)
 
     info = nm.ipv6.get_info(active_connection=act_con_mock)
 
     assert info == {
         'enabled': True,
+        'autoconf': False,
+        'dhcp': False,
         'address': [
             {
                 'ip': address_mock.get_address.return_value,


### PR DESCRIPTION
The sample output of `nmstatectl show` for DHCP:

    "ipv4": {
        "address": [
            {
                "ip": "192.0.2.251"
                "prefix-length": 24
            }
        ],
        "dhcp": true,
        "enabled": true
    },
    "ipv6": {
        "address": [
            {
                "ip": "fe80::1",
                "prefix-length": 64
            },
            {
                "ip": "2001:db8:1::1",
                "prefix-length": 64
            }
        ],
        "autoconf": true,
        "dhcp": true,
        "enabled": true
    },

Will raise InvalidIPv6OptionError exception if user are asking
IPv6 'dhcp: false' and 'autoconf: true'.