### PR TITLE
Setup.py: Set content type for long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     author="Edward Haas",
     author_email="ehaas@redhat.com",
     long_description=readme(),
+    long_description_content_type='text/markdown',
     url='https://nmstate.github.io/',
     license='GPLv2+',
     packages=find_packages(),


### PR DESCRIPTION
Reference: https://packaging.python.org/guides/making-a-pypi-friendly-readme/
Signed-off-by: Till Maas <opensource@till.name>