### PR TITLE
Integration tests: Set G_DEBUG=fatal-warnings

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -62,6 +62,7 @@ function install_nmstate {
 function run_tests {
     docker_exec '
       cd /workspace/nmstate &&
+      G_DEBUG=fatal-warnings
       pytest \
         --log-level=DEBUG \
         --durations=5 \


### PR DESCRIPTION
Thomas Haller recommended this in #169

Signed-off-by: Till Maas <opensource@till.name>