### PR TITLE
make_rpm.sh: Fix trivial syntax error.

### DIFF
--- a/packaging/make_rpm.sh
+++ b/packaging/make_rpm.sh
@@ -14,21 +14,20 @@ fi
 
 trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
 
-VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || :)
-if [ -z $VERSION ];then
-    VERSION="0.0.1git$(git rev-parse --short HEAD)"
-else
-    VERSION="$(VERSION)git$(git rev-parse --short HEAD)"
-fi
+cd $SRC_DIR
+
+VERSION=$(python setup.py --version)
+COMMIT_COUNT=$(git rev-list --count HEAD --)
+VERSION="${VERSION}dev${COMMIT_COUNT}git$(git rev-parse --short HEAD)"
 
 if [ -n "$(rpm -E %{?fedora} 2>/dev/null)" ] ||
    [ -n "$(rpm -E %{?el8} 2>/dev/null)" ] ;then
-    cp $SRC_DIR/packaging/nmstate.py3.spec.in $SPEC_FILE
+    cp packaging/nmstate.py3.spec.in $SPEC_FILE
     sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
     $SUDO dnf install -y rpm-build
     $SUDO dnf builddep -y $SPEC_FILE
 elif [ -n "$(rpm -E %{?el7} 2>/dev/null)" ];then
-    cp $SRC_DIR/packaging/nmstate.py2.spec.in $SPEC_FILE
+    cp packaging/nmstate.py2.spec.in $SPEC_FILE
     sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
     $SUDO yum install -y rpm-build yum-utils
     $SUDO yum-builddep -y $SPEC_FILE
@@ -39,7 +38,6 @@ fi
 
 TAR_FILE="$TMP_DIR/nmstate-$VERSION.tar"
 
-cd $SRC_DIR
 git archive --prefix=nmstate-$VERSION/ --format=tar -o $TAR_FILE HEAD
 tar --append --file=$TAR_FILE $SPEC_FILE 1>/dev/null 2>/dev/null
 


### PR DESCRIPTION
When we have tagged version, the generated VERSION is incorrect.
It should be ${VERSION} instead of $(VERSION).