### PR TITLE
Integration test: Change ipv4.dad-timeout.

### DIFF
--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -25,7 +25,7 @@ from .testlib import cmd as libcmd
 from .testlib.statelib import INTERFACES
 
 _IPV4_EXTRA_CONFIG = 'ipv4.dad-timeout'
-_IPV4_EXTRA_VALUE = '1000'
+_IPV4_EXTRA_VALUE = '0'
 _IPV6_EXTRA_CONFIG = 'ipv6.dhcp-hostname'
 _IPV6_EXTRA_VALUE = 'libnmstate.example.com'
 


### PR DESCRIPTION
* Issue:
    The integration test case `test_reapply_preserve_ip_config` will
    fail showing ipv4 is disabled.

* Root cause
    After commit 4e34009a828ded98e2a7b14b8cb009c7f0b6cf08, nmstate
    will goes to verification stage once network manager indicate a
    profile is activated. The NetworkManager does not wait on
    ipv4.dad-timeout for marking a profile is activated. This makes
    nmstate got no IPv4 address during duplicate address detection
    stage, which then mark ipv4 as disabled.

* Fix
    Change ipv4.dad-timeout in `test_reapply_preserve_ip_config` to 0
    which is no wait on duplicate address detection.

