### PR TITLE
Integration tests: Make pytest verbose

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -63,6 +63,7 @@ function run_tests {
     docker_exec '
       cd /workspace/nmstate &&
       pytest \
+        --verbose \
         --log-level=DEBUG \
         --durations=5 \
         --cov=libnmstate \


### PR DESCRIPTION
Making pytest verbose makes it show full diffs for state comparisons.

Signed-off-by: Till Maas <opensource@till.name>