### PR TITLE
netapplier: Ignore `down` state (for virt iface) in verification step

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -30,3 +30,17 @@ ifaces_schema = load('operational-state')
 
 class Constants(object):
     INTERFACES = 'interfaces'
+
+    BOND = 'bond'
+    LINUX_BRIDGE = 'linux-bridge'
+    OVS_BRIDGE = 'ovs-bridge'
+    OVS_PORT = 'ovs-port'
+    VLAN = 'vlan'
+
+    VIRT_IFACE_TYPES = (
+        BOND,
+        LINUX_BRIDGE,
+        OVS_BRIDGE,
+        OVS_PORT,
+        VLAN
+    )

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -45,6 +45,23 @@ def test_add_and_remove_two_vlans_on_same_iface(eth1_up):
     assert not current_state[INTERFACES]
 
 
+def test_set_vlan_iface_down(eth1_up):
+    with vlan_interface(VLAN_IFNAME, 101):
+        netapplier.apply({
+                INTERFACES: [
+                    {
+                        'name': VLAN_IFNAME,
+                        'type': 'vlan',
+                        'state': 'down'
+                    }
+                ]
+            }
+        )
+
+        current_state = statelib.show_only((VLAN_IFNAME,))
+        assert not current_state[INTERFACES]
+
+
 @contextmanager
 def vlan_interface(ifname, vlan_id):
     desired_state = {


### PR DESCRIPTION
Currently, when in the desired state a virtual interface is set as
`down`, it is removed (treated as `absent`).
When the verification step occurs, checking that the desired state is
included in the current state, these virtual interfaces should be
treated like the `absent` ones.