### PR TITLE
Integration test: don't require network access.

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -22,7 +22,10 @@ RUN yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/nmstat
     yum-config-manager --enable nmstate-nmstate-test-env-el
 
 RUN yum -y upgrade && \
-    yum -y install iproute git python2-pytest python2-pytest-cov NetworkManager && \
+    yum -y install iproute python2-pytest python2-pytest-cov NetworkManager \
+                   rpm-build git python2-devel python2-six \
+                   python2-pyyaml python-jsonschema python-setuptools \
+                   python-gobject-base && \
     yum clean all && \
     install -o root -g root -d /etc/sysconfig/network-scripts && \
     echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > /etc/NetworkManager/conf.d/97-docker-build.conf && \

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -54,7 +54,7 @@ function dump_network_info {
 function install_nmstate {
     docker_exec '
       cd /workspace/nmstate &&
-      yum install -y `./packaging/make_rpm.sh|tail -1 || exit 1`
+      rpm -ivh `./packaging/make_rpm.sh|tail -1 || exit 1`
     '
 }
 

--- a/packaging/make_rpm.sh
+++ b/packaging/make_rpm.sh
@@ -6,11 +6,6 @@ SRC_DIR="$(dirname "$0")/.."
 TMP_DIR=$(mktemp -d)
 SPEC_FILE="$TMP_DIR/nmstate.spec"
 OLD_PWD=$(pwd)
-if [ $EUID -ne 0 ]; then
-    SUDO="sudo"
-else
-    SUDO=""
-fi
 
 trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
 
@@ -25,14 +20,10 @@ if [ -n "$(rpm -E %{?fedora} 2>/dev/null)" ] ||
     cp packaging/nmstate.py3.spec.in $SPEC_FILE
     sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
     sed -i -e "s/@SRC_VERSION@/$MAIN_VERSION/" $SPEC_FILE
-    $SUDO dnf install -y rpm-build
-    $SUDO dnf builddep -y $SPEC_FILE
 elif [ -n "$(rpm -E %{?el7} 2>/dev/null)" ];then
     cp packaging/nmstate.py2.spec.in $SPEC_FILE
     sed -i -e "s/@VERSION@/$VERSION/" $SPEC_FILE
     sed -i -e "s/@SRC_VERSION@/$MAIN_VERSION/" $SPEC_FILE
-    $SUDO yum install -y rpm-build yum-utils
-    $SUDO yum-builddep -y $SPEC_FILE
 else
     echo "Not supported"
     exit 1


### PR DESCRIPTION
By pre-installing all required rpms in docker image, the
integration test does not require network access anymore,
This also save a lot of test time as `run-integration-tests.sh`
does not depend on any yum/dnf command anymore.