### PR TITLE
Don't copy existing config when disabling IPv4/v6

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -22,7 +22,7 @@ from . import nmclient
 
 def create_setting(config, base_con_profile):
     setting_ipv4 = None
-    if base_con_profile:
+    if base_con_profile and config and config.get('enabled'):
         setting_ipv4 = base_con_profile.get_setting_ip4_config()
         if setting_ipv4:
             setting_ipv4 = setting_ipv4.duplicate()

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -48,7 +48,7 @@ def get_info(active_connection):
 
 def create_setting(config, base_con_profile):
     setting_ip = None
-    if base_con_profile:
+    if base_con_profile and config and config.get('enabled'):
         setting_ip = base_con_profile.get_setting_ip6_config()
         if setting_ip:
             setting_ip = setting_ip.duplicate()


### PR DESCRIPTION
Only preserving existing IP configurations when IPv4/6 is enabled.

Fixes: #188