### PR TITLE
NM/device: Fix AttributeError

### DIFF
--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -61,8 +61,8 @@ class ActiveConnection(object):
             if unable_to_activate:
                 self._alternative_state = AlternativeACState.FAIL
             # Use the device-state as an alternative to determine if active.
-            elif (self._nmdev <= nmclient.NM.DeviceState.DISCONNECTED or
-                    self._nmdev > nmclient.NM.DeviceState.DEACTIVATING):
+            elif (self.nmdev_state <= nmclient.NM.DeviceState.DISCONNECTED or
+                    self.nmdev_state > nmclient.NM.DeviceState.DEACTIVATING):
                 self._alternative_state = AlternativeACState.FAIL
 
     @property
@@ -74,11 +74,9 @@ class ActiveConnection(object):
                 # master connections qualify as activated once they
                 # reach IP-Config state. That is because they may
                 # wait for slave devices to attach
-                nmdev_state = (self._nmdev.get_state() if self._nmdev
-                               else nmclient.NM.DeviceState.UNKNOWN)
                 return (
                     _is_device_master_type(self._nmdev) and
-                    nmclient.NM.DeviceState.IP_CONFIG <= nmdev_state <=
+                    nmclient.NM.DeviceState.IP_CONFIG <= self.nmdev_state <=
                     nmclient.NM.DeviceState.ACTIVATED
                 )
 
@@ -107,6 +105,11 @@ class ActiveConnection(object):
     @property
     def state(self):
         return self._state
+
+    @property
+    def nmdev_state(self):
+        return (self._nmdev.get_state() if self._nmdev
+                else nmclient.NM.DeviceState.UNKNOWN)
 
 
 def activate(dev=None, connection_id=None):

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -48,12 +48,13 @@ class ActiveConnection(object):
         self._alternative_state = AlternativeACState.UNKNOWN
 
         nm_acs = nmclient.NM.ActiveConnectionState
+        nm_acsreason = nmclient.NM.ActiveConnectionStateReason
         if self._state == nm_acs.DEACTIVATED:
             unable_to_activate = (
                     not self._nmdev or
                     (
-                            self._state_reason is not None and
-                            self._state_reason != nm_acs.DEVICE_DISCONNECTED
+                        self._state_reason is not None and
+                        self._state_reason != nm_acsreason.DEVICE_DISCONNECTED
                     ) or
                     self._nmdev.get_active_connection() is not self._act_con
             )


### PR DESCRIPTION
DEVICE_DISCONNECTED is a attribute of `ActiveConnectionStateReason` (not
`ActiveConnectionState`).

Signed-off-by: Till Maas <opensource@till.name>