### PR TITLE
NM/device: Handle activation failures for connections

### DIFF
--- a/tests/lib/nm/device_test.py
+++ b/tests/lib/nm/device_test.py
@@ -52,7 +52,7 @@ def test_activate(client_mock, mainloop_mock):
         None,
         cancellable,
         nm.device._active_connection_callback,
-        (mainloop_mock, dev, cancellable),
+        (mainloop_mock, dev, None, cancellable),
     )
 
 


### PR DESCRIPTION
When a connection is activated, the user data for the active connection
callback does not contain a device object. Therefore report the
connection ID instead of the device instead.

Signed-off-by: Till Maas <opensource@till.name>

fixes #198 