### PR TITLE
nm: Do not raise explcitly within the checkpoint context

### DIFF
--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -88,7 +88,6 @@ class CheckPoint(object):
             self.destroy()
         else:
             self.rollback()
-            raise
 
     def create(self):
         devs = []


### PR DESCRIPTION
In case an exception occurs in a contextmanager, python will re-raise
the exception automatically after the __exit__ method is processed.
Raising from within __exit__ is not required in this case.