### PR TITLE
nm: Reduce noise when logging actions execution

### DIFF
--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -73,8 +73,7 @@ class _MainLoop(object):
         action = self.pop_action()
         if action:
             func, args, kwargs = action
-            logging.debug('Executing NM action: func=%s, args=%s',
-                          func.__name__, args)
+            logging.debug('Executing NM action: func=%s', func.__name__)
             func(*args, **kwargs)
         else:
             logging.debug('NM action queue exhausted, quiting mainloop')


### PR DESCRIPTION
The logging of the action function arguments is not helpful, makes it
difficult to follow the logs, therefore, they are removed.