### PR TITLE
RPM packaging: Sync back changes from Fedora packaging

### DIFF
--- a/packaging/nmstate.py2.spec
+++ b/packaging/nmstate.py2.spec
@@ -5,17 +5,13 @@ Name:           nmstate
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
-Group:          System Environment/Libraries
 License:        GPLv2+
 URL:            https://github.com/%{srcname}/%{srcname}
 Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
 BuildArch:      noarch
 BuildRequires:  python2-devel
-BuildRequires:  python2-six
-BuildRequires:  python2-pyyaml
-BuildRequires:  python-jsonschema
 BuildRequires:  python-setuptools
-Requires:       python2-%{libname}
+Requires:       python2-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
 NMState is a library with an accompanying command line tool that manages host
@@ -26,8 +22,6 @@ provider support on the southbound.
 
 %package -n python2-%{libname}
 Summary:        nmstate Python 2 API library
-Group:          System Environment/Libraries
-License:        GPLv2+
 Requires:       NetworkManager-libnm
 Requires:       python-gobject-base
 Requires:       python2-six
@@ -48,11 +42,11 @@ This package contains the Python 2 library for nmstate.
 
 %files
 %doc README.md
-%license LICENSE
 %{python2_sitelib}/nmstatectl
 %{_bindir}/nmstatectl
 
 %files -n python2-%{libname}
+%license LICENSE
 %{python2_sitelib}/%{libname}
 %{python2_sitelib}/%{srcname}-*.egg-info/
 

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -1,3 +1,4 @@
+%?python_enable_dependency_generator
 %define srcname nmstate
 %define libname libnmstate
 
@@ -5,17 +6,13 @@ Name:           nmstate
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
-Group:          System Environment/Libraries
 License:        GPLv2+
 URL:            https://github.com/%{srcname}/%{srcname}
 Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
 BuildArch:      noarch
 BuildRequires:  python3-devel
-BuildRequires:  python3-six
-BuildRequires:  python3-jsonschema
-BuildRequires:  python3-PyYAML
 BuildRequires:  python3-setuptools
-Requires:       python3-%{libname}
+Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description
 NMState is a library with an accompanying command line tool that manages host
@@ -26,14 +23,9 @@ provider support on the southbound.
 
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
-Group:          System Environment/Libraries
-License:        GPLv2+
 Requires:       NetworkManager-libnm
-Recommends:     NetworkManager
 Requires:       python3-gobject-base
-Requires:       python3-six
-Requires:       python3-jsonschema
-Requires:       python3-PyYAML
+Recommends:     NetworkManager
 
 %description -n python3-%{libname}
 This package contains the Python 3 library for nmstate.
@@ -49,11 +41,11 @@ This package contains the Python 3 library for nmstate.
 
 %files
 %doc README.md
-%license LICENSE
 %{python3_sitelib}/nmstatectl
 %{_bindir}/nmstatectl
 
 %files -n python3-%{libname}
+%license LICENSE
 %{python3_sitelib}/%{libname}
 %{python3_sitelib}/%{srcname}-*.egg-info/
 


### PR DESCRIPTION
Signed-off-by: Till Maas <opensource@till.name>

@cathay4t I noticed that the Fedora spec uses Suggests instead of Recommends for NetworkManager. IMHO Recommends is better since by default nmstate needs to run on the same system as NetworkManager and Suggests are currently ignored by DNF.