### PR TITLE
packaging: Prepare automated COPR packaging

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,5 @@
+SRPM_DEPENDENCIES=python-setuptools git
+
+srpm:
+	rpm -q --whatprovides $(SRPM_DEPENDENCIES) || dnf -y install $(SRPM_DEPENDENCIES)
+	$(dir $(realpath $(firstword $(MAKEFILE_LIST))))../packaging/make_srpm.sh

--- a/packaging/get_version.sh
+++ b/packaging/get_version.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+set -e
+
+OLD_PWD=$(pwd)
+SRC_DIR="$(dirname "$0")/.."
+
+cd "$SRC_DIR"
+
+VERSION="$(python setup.py --version)"
+DATE="$(date +%Y%m%d)"
+
+COMMIT_COUNT="$(git rev-list --count HEAD --)"
+GIT_REVISION="$(git rev-parse --short HEAD)"
+
+TAR_VERSION="${VERSION}dev${COMMIT_COUNT}git${GIT_REVISION}"
+
+RPM_VERSION="${VERSION}"
+RPM_RELEASE="0.${DATE}.${COMMIT_COUNT}git${GIT_REVISION}"
+
+RPM_DATE="$(LANG=C date +"%a %b %d %Y")"
+
+RPM_CHANGELOG="* ${RPM_DATE} N. N. - ${RPM_VERSION}-${RPM_RELEASE}"
+
+echo VERSION="${VERSION}"
+echo RPM_VERSION="${RPM_VERSION}"
+echo RPM_RELEASE="${RPM_RELEASE}"
+echo RPM_CHANGELOG="'${RPM_CHANGELOG}'"
+cd "$OLD_PWD"

--- a/packaging/make_rpm.sh
+++ b/packaging/make_rpm.sh
@@ -4,48 +4,23 @@ set -e
 
 SRC_DIR="$(dirname "$0")/.."
 TMP_DIR=$(mktemp -d)
-SPEC_FILE="$TMP_DIR/nmstate.spec"
 OLD_PWD=$(pwd)
 
 trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
 
 cd $SRC_DIR
 
-MAIN_VERSION=$(python setup.py --version)
-COMMIT_COUNT=$(git rev-list --count HEAD --)
-VERSION="${MAIN_VERSION}dev${COMMIT_COUNT}git$(git rev-parse --short HEAD)"
-TAR_FILE="$TMP_DIR/nmstate-$VERSION.tar"
+eval "$(./packaging/get_version.sh)"
 
-if [ -n "$(rpm -E %{?fedora} 2>/dev/null)" ] ||
-   [ -n "$(rpm -E %{?el8} 2>/dev/null)" ] ;then
-    pysuffix=.py3
-elif [ -n "$(rpm -E %{?el7} 2>/dev/null)" ];then
-    pysuffix=.py2
-else
-    echo "Not supported"
-    exit 1
-fi
+SRPM_FILE="$(./packaging/make_srpm.sh)"
 
-sed -n \
-    -e "s/@VERSION@/$VERSION/" \
-    -e "s/@SRC_VERSION@/$MAIN_VERSION/" \
-    -e "w $SPEC_FILE" \
-    "packaging/nmstate${pysuffix}.spec.in"
-
-
-python setup.py sdist --format tar --dist-dir $TMP_DIR
-mv $TMP_DIR/nmstate*.tar $TAR_FILE
-tar --append --file=$TAR_FILE $SPEC_FILE 1>/dev/null 2>/dev/null
-
-rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
-    -ta $TAR_FILE
+TAR_FILE="${TMP_DIR}/nmstate-${VERSION}.tar"
+(
+    rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
+    --rebuild "${SRPM_FILE}"
+) > /dev/null
 RPMS=$(find $TMP_DIR -type f -name \*.noarch.rpm -exec basename {} \;)
-SRPM=$(find $TMP_DIR -type f -name \*.src.rpm -exec basename {} \;)
 find $TMP_DIR -type f -name \*.rpm -exec mv {} $OLD_PWD \;
-echo "SRPM CREATED:"
-echo $OLD_PWD/$SRPM
-echo "RPM CREATED:"
 for RPM in $RPMS; do
     echo -n "$OLD_PWD/$RPM "
 done
-echo

--- a/packaging/make_spec.sh
+++ b/packaging/make_spec.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+SRC_DIR="$(dirname "$0")/.."
+
+eval "$(${SRC_DIR}/packaging/get_version.sh)"
+
+# spec variable is used by COPR as well: https://docs.pagure.org/copr.copr/user_documentation.html
+if [ -z "${spec}" ]; then
+    if [ -n "$(rpm -E %{?fedora} 2>/dev/null)" ] ||
+       [ -n "$(rpm -E %{?el8} 2>/dev/null)" ]; then
+        pysuffix=.py3
+    elif [ -n "$(rpm -E %{?el7} 2>/dev/null)" ]; then
+        pysuffix=.py2
+    else
+        echo "Not supported" >&2
+        exit 1
+    fi
+    spec="${SRC_DIR}/packaging/nmstate${pysuffix}.spec"
+fi
+
+
+sed \
+    -e "s/@VERSION@/${RPM_VERSION}/" \
+    -e "s/@RELEASE@/${RPM_RELEASE}/" \
+    -e "s/@CHANGELOG@/${RPM_CHANGELOG}/" \
+    "${spec}"

--- a/packaging/make_srpm.sh
+++ b/packaging/make_srpm.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+SRC_DIR="$(dirname "$0")/.."
+TMP_DIR=$(mktemp -d)
+SPEC_FILE="$TMP_DIR/nmstate.spec"
+OLD_PWD=$(pwd)
+
+# outdir is used by COPR as well: https://docs.pagure.org/copr.copr/user_documentation.html
+: ${outdir:=${OLD_PWD}}
+
+trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
+
+cd $SRC_DIR
+
+eval "$(./packaging/get_version.sh)"
+
+
+TAR_FILE="${TMP_DIR}/nmstate-${VERSION}.tar"
+(
+    python setup.py sdist --format tar --dist-dir $TMP_DIR
+
+    ./packaging/make_spec.sh > "${SPEC_FILE}"
+    tar --append --file=$TAR_FILE $SPEC_FILE
+
+    rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
+    -ts $TAR_FILE
+) &> /dev/null
+
+SRPM=$(find $TMP_DIR -type f -name \*.src.rpm -exec basename {} \;)
+find $TMP_DIR -type f -name \*.rpm -exec mv {} "${outdir}" \;
+echo ${outdir}/$SRPM

--- a/packaging/nmstate.py2.spec
+++ b/packaging/nmstate.py2.spec
@@ -3,7 +3,7 @@
 
 Name:           nmstate
 Version:        @VERSION@
-Release:        1%{?dist}
+Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
 Group:          System Environment/Libraries
 License:        GPLv2+
@@ -38,7 +38,7 @@ Requires:       python2-pyyaml
 This package contains the Python 2 library for nmstate.
 
 %prep
-%setup -q -n %{srcname}-@SRC_VERSION@
+%setup -q
 
 %build
 %py2_build
@@ -57,5 +57,5 @@ This package contains the Python 2 library for nmstate.
 %{python2_sitelib}/%{srcname}-*.egg-info/
 
 %changelog
-* Mon Nov 19 2018 Gris Ge <fge@redhat.com> - 0.0.1-0
-- Initial release.
+@CHANGELOG@
+- snapshot build

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -3,7 +3,7 @@
 
 Name:           nmstate
 Version:        @VERSION@
-Release:        1%{?dist}
+Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
 Group:          System Environment/Libraries
 License:        GPLv2+
@@ -39,7 +39,7 @@ Requires:       python3-PyYAML
 This package contains the Python 3 library for nmstate.
 
 %prep
-%setup -q -n %{srcname}-@SRC_VERSION@
+%setup -q
 
 %build
 %py3_build
@@ -58,5 +58,5 @@ This package contains the Python 3 library for nmstate.
 %{python3_sitelib}/%{srcname}-*.egg-info/
 
 %changelog
-* Mon Nov 19 2018 Gris Ge <fge@redhat.com> - 0.0.1-0
-- Initial release.
+@CHANGELOG@
+- snapshot build


### PR DESCRIPTION
Break up the rpm building process in individual scripts that accept the
COPR environment variables `spec` and `outdir` and add a Makefile for
COPR automated building. Rename the spec files to have a spec suffix
because COPR requires this to specify them.

Signed-off-by: Till Maas <opensource@till.name>

I suggest to create two new COPRs for this for the nmstate user:

nmstate-git-python2 (for EPEL7)
nmstate-git-python3 (for Fedora and EPEL8 eventually)

They would be automatically rebuilt as soon as changes are pushed to master. I tested it with my branch here:
https://copr.fedorainfracloud.org/coprs/till/tyll-nmstate-fedora/builds/