### PR TITLE
Revert "tox: Pin and update pytest* versions"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     -r{toxinidir}/requirements.txt
     PyGObject
     pytest-cov
-    pytest==3.5.1
+    pytest>=3.5.1
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -28,7 +28,7 @@ deps =
     -r{toxinidir}/requirements.txt
     PyGObject
     pytest-cov
-    pytest==3.5.1
+    pytest>=3.5.1
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
@@ -46,7 +46,7 @@ deps =
     -r{toxinidir}/requirements.txt
     mock
     pytest-cov
-    pytest==3.5.1
+    pytest>=3.5.1
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -64,7 +64,7 @@ commands =
 deps =
     -r{toxinidir}/requirements.txt
     pytest-cov
-    pytest==3.5.1
+    pytest>=3.5.1
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
@@ -82,8 +82,8 @@ commands =
 skip_install = true
 deps =
     -r{toxinidir}/requirements.txt
-    pytest==3.5.1
-    pylint==1.8.4
+    pytest>=3.5.1
+    pylint>=1.8.4
 commands =
     pylint \
         --errors-only \
@@ -98,7 +98,7 @@ commands =
 [testenv:flake8]
 skip_install = true
 deps =
-    flake8==3.5
+    flake8>=3.5
 commands =
     flake8 \
         --statistics {posargs} \
@@ -110,7 +110,7 @@ commands =
 [testenv:coveralls]
 passenv = TRAVIS TRAVIS_*
 deps =
-    urllib3==1.23
+    urllib3>=1.23
     coveralls
 changedir = {toxinidir}/tests
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ basepython = python2.7
 deps =
     -r{toxinidir}/requirements.txt
     PyGObject
-    pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest-cov
+    pytest==3.5.1
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -27,8 +27,8 @@ commands =
 deps =
     -r{toxinidir}/requirements.txt
     PyGObject
-    pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest-cov
+    pytest==3.5.1
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
@@ -45,8 +45,8 @@ commands =
 deps =
     -r{toxinidir}/requirements.txt
     mock
-    pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest-cov
+    pytest==3.5.1
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
@@ -63,8 +63,8 @@ commands =
 [testenv:check-py36]
 deps =
     -r{toxinidir}/requirements.txt
-    pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest-cov
+    pytest==3.5.1
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
@@ -82,7 +82,7 @@ commands =
 skip_install = true
 deps =
     -r{toxinidir}/requirements.txt
-    pytest==4.1.0
+    pytest==3.5.1
     pylint==1.8.4
 commands =
     pylint \


### PR DESCRIPTION
This reverts commit e4a0765892df76323fc2da9b0c07d56c53a7adc2 in order
to make stand-ci works again.

And another patch for remove hard version dependency in `tox.ini`.