### PR TITLE
Adding Fedora CI docker image.

### DIFF
--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -1,0 +1,26 @@
+# This Dockerfile is based on the recommendations provided in the
+# Fedora official repository
+# (https://hub.docker.com/r/fedora/systemd-systemd/).
+# It enables systemd to be operational.
+FROM fedora
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in
+# the RPM
+RUN dnf -y install --setopt=install_weak_deps=False \
+                   iproute python3-pytest python3-pytest-cov NetworkManager \
+                   rpm-build git python3-devel python3-dbus python3-coveralls \
+                   python3-pyyaml python3-jsonschema python3-setuptools \
+                   NetworkManager-ovs openvswitch libibverbs python36 \
+                   python3-gobject-base dnsmasq python3-tox python2 && \
+    alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
+    dnf clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/automation/README.md
+++ b/automation/README.md
@@ -3,11 +3,17 @@ The automation env is serving the integration tests of nmstate.
 It may be used both locally and through CI.
 
 ## Components
-- Dockerfile: Defines a container image which includes systemd,
+- Dockerfile: Defines a Centos 7 based container image which includes systemd,
   NetworkManager and other basic build tools (e.g. tox).
 
   The image can be found at:
   https://hub.docker.com/r/nmstate/centos7-nmstate-dev/
+
+- Dockerfile.fedora: Defines a Fedora based container image for nmstate test
+  purpose.
+
+  The image can be found at:
+  https://hub.docker.com/r/nmstate/fedora-nmstate-dev/
 
 - run-integration-tests.sh: Execute the integration tests in a
   container using docker.
@@ -78,12 +84,15 @@ tox -e check-integ-py27
 
 ```
 sudo docker build --no-cache --rm -t local/centos7-nmstate-dev .
+sudo docker build --file Dockerfile.fedora --no-cache --rm \
+    -t local/fedora-nmstate-dev  .
 ```
 
 To test the image, either specify it manually as described above or tag it locally:
 
 ```
 sudo docker tag local/centos7-nmstate-dev nmstate/centos7-nmstate-dev:latest
+sudo docker tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:latest
 ```
 
 ### Push local image to the docker hub
@@ -93,4 +102,9 @@ sudo docker tag local/centos7-nmstate-dev nmstate/centos7-nmstate-dev:"${VERSION
 sudo docker tag local/centos7-nmstate-dev nmstate/centos7-nmstate-dev:latest
 sudo docker push nmstate/centos7-nmstate-dev:"${VERSION}"
 sudo docker push nmstate/centos7-nmstate-dev:latest
+
+sudo docker tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:"${VERSION}"
+sudo docker push nmstate/fedora-nmstate-dev:"${VERSION}"
+sudo docker tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:latest
+sudo docker push nmstate/fedora-nmstate-dev:latest
 ```

--- a/automation/docker_enable_systemd.sh
+++ b/automation/docker_enable_systemd.sh
@@ -1,0 +1,11 @@
+cd /lib/systemd/system/sysinit.target.wants/;
+for i in *; do
+    [ $i == systemd-tmpfiles-setup.service ] || rm -f $i;
+done;
+rm -f /lib/systemd/system/multi-user.target.wants/*;
+rm -f /etc/systemd/system/*.wants/*;
+rm -f /lib/systemd/system/local-fs.target.wants/*;
+rm -f /lib/systemd/system/sockets.target.wants/*udev*;
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*;
+rm -f /lib/systemd/system/basic.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*;

--- a/automation/docker_sys_config.sh
+++ b/automation/docker_sys_config.sh
@@ -1,0 +1,10 @@
+install -o root -g root -d /etc/sysconfig/network-scripts
+echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/' \
+    /etc/systemd/journald.conf
+sed -i 's/#RateLimitBurst=1000/RateLimitBurst=0/' \
+    /etc/systemd/journald.conf
+systemctl enable openvswitch.service


### PR DESCRIPTION
Fedora CI image has been uploaded to docker hub as `nmstate/fedora-nmstate-dev`.