### PR TITLE
nm/checkpoint: Remove dependency on python-dbus

### DIFF
--- a/README.install.md
+++ b/README.install.md
@@ -16,7 +16,6 @@ To manage OvS, Nmstate needs the packages `NetworkManager-ovs` and `openvswitch`
 ```shell
 yum -y install epel-release
 yum -y install \
-    dbus-python \
     NetworkManager \
     NetworkManager-libnm \
     NetworkManager-ovs \
@@ -26,7 +25,6 @@ yum -y install \
     python-setuptools \
     python2-pyyaml \
     python2-six
-yum-builddep -y dbus-python
 ```
 
 #### Post Package installation
@@ -63,9 +61,6 @@ pip uninstall -y nmstate; pip install nmstate
 Minimal Nmstate installation:
 ``` shell
 # install binary dependencies; The development packages are needed to build
-# python-dbus which is improperly packaged on RHEL 8:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1654774
-yum install -y dbus-devel gcc glib2-devel make python3-devel python3-gobject-base
 yum install -y python3-pip
 pip3 uninstall -y nmstate; pip3 install nmstate
 ```

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -22,7 +22,6 @@ from contextlib import contextmanager
 import copy
 import logging
 import six
-import time
 
 from libnmstate import metadata
 from libnmstate import netinfo
@@ -157,11 +156,6 @@ def _apply_ifaces_state(
     except nm.checkpoint.NMCheckPointCreationError:
         raise NmstateConflictError('Error creating a check point')
     except NmstateError:
-        # Assume rollback occured, revert IPv6 stack state.
-        # Checkpoint rollback is async, there is a need to wait for it to
-        # finish before proceeding with other actions.
-        # TODO: https://nmstate.atlassian.net/browse/NMSTATE-103
-        time.sleep(5)
         if not nmclient.can_disable_ipv6():
             _disable_ipv6(current_state)
         raise

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -20,7 +20,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager-config-server \
                    openvswitch2.11 \
                    systemd-udev \
-                   python3-dbus \
                    python3-gobject-base \
                    python3-jsonschema \
                    python3-pyyaml \
@@ -30,15 +29,11 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    git \
                    iproute \
                    rpm-build \
-                   # Below package for pip (used by tox) to build dbus-python
-                   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1654774
-                   make \
                    python3-devel \
                    cairo-devel \
                    cairo-gobject-devel \
                    glib2-devel \
-                   gobject-introspection-devel \
-                   dbus-devel && \
+                   gobject-introspection-devel && \
     dnf -y group install "Development Tools" && \
     pip3 install pytest==4.6.6 pytest-cov==2.8.1 \
         python-coveralls tox --user && \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -16,8 +16,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    openvswitch \
                    systemd-udev \
                    \
-                   python2-dbus \
-                   python3-dbus \
                    python3-gobject-base \
                    python3-jsonschema \
                    python3-pyyaml \
@@ -42,10 +40,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    gobject-introspection-devel \
                    python2-devel \
                    python3-devel \
-                   \
-                   # Below package for pip (used by tox) to build dbus-python
-                   make \
-                   dbus-devel && \
+                   make && \
     dnf clean all && \
     pip install pytest==4.6.6 pytest-cov==2.8.1 --user && \
     # Below line is workaround for

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -23,7 +23,6 @@ provider support on the southbound.
 
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
-Requires:       python3-dbus
 Requires:       NetworkManager-libnm >= 1:1.20
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
@@ -39,7 +38,6 @@ This package contains the Python 3 library for Nmstate.
 
 %prep
 %setup -q
-sed -i -e '/^dbus-python$/d' requirements.txt
 
 %build
 %py3_build

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 #packageC>=3.0.0
 #packageD!=0.13.0,<0.14,>=0.12.0
 
-dbus-python
 ipaddress;python_version<"3.3"
 jsonschema
 PyGObject

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -93,3 +93,7 @@ def test_creating_a_checkpoint_from_dbuspath():
     new_checkpoint = CheckPoint(dbuspath=initial_checkpoint.dbuspath)
     new_checkpoint.destroy()
     assert not get_checkpoints()
+
+def test_repeat_create_destory_checkpoint():
+    for _ in range(0, 1000):
+        CheckPoint()


### PR DESCRIPTION
nm/checkpoint: Remove dependency on python-dbus

Replacing current dbus checkpoint code with these libnm functions:
 * `libnm.NM.nmclient.checkpoint_create()`.
 * `libnm.NM.nmclient.checkpoint_rollback()`.
 * `libnm.NM.nmclient.checkpoint_destroy()`.

These functions only exists on libnm 1.12+(RHEL/CentOS 7.6 are shipping
libnm 1.12).
If libnm too old, raise `LibNMNotSupportCheckPoint` exception.

