### PR TITLE
nmstatectl: Remove extra newline from yaml output

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -247,6 +247,6 @@ def _try_edit_again(error):
 def print_state(state, use_yaml=False):
     state = PrettyState(state)
     if use_yaml:
-        print(state.yaml)
+        sys.stdout.write(state.yaml)
     else:
         print(state.json)


### PR DESCRIPTION
The yaml state ends with a newline, therefore print() should not be used
as is to avoid an empty line at the end of the state.

Use sys.stdout.write() for Python 2/3 compatibility.

Signed-off-by: Till Maas <opensource@till.name>