### PR TITLE
nmstatectl: Output yaml by default

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2018-2019 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -74,8 +74,8 @@ def setup_subcommand_edit(subparsers):
 def setup_subcommand_show(subparsers):
     parser_show = subparsers.add_parser('show', help='Show network state')
     parser_show.set_defaults(func=show)
-    parser_show.add_argument('--yaml', help='Output as yaml', default=False,
-                             action='store_true')
+    parser_show.add_argument('--json', help='Edit as JSON', default=True,
+                             action='store_false', dest='yaml')
     parser_show.add_argument(
         'only', default='*', nargs='?', metavar=Constants.INTERFACES,
         help='Show only specified interfaces (comma-separated)'

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Red Hat, Inc.
+# Copyright 2018-2019 Red Hat, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,6 +41,17 @@ EMPTY_JSON_STATE = """{
 }
 """
 
+EMPTY_YAML_STATE = """---
+interfaces: []
+"""
+
+LO_YAML_STATE = """---
+interfaces:
+- name: lo
+  type: unknown
+  state: down
+"""
+
 
 @mock.patch('sys.argv', ['nmstatectl', 'set', 'mystate.json'])
 @mock.patch.object(nmstatectl.netapplier, 'apply',
@@ -57,13 +68,13 @@ def test_run_ctl_directly_show_empty():
     nmstatectl.main()
 
 
-@mock.patch('sys.argv', ['nmstatectl', 'show', 'eth1'])
+@mock.patch('sys.argv', ['nmstatectl', 'show', 'non_existing_interface'])
 @mock.patch.object(
     nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_only_empty(mock_stdout):
     nmstatectl.main()
-    assert mock_stdout.getvalue() == EMPTY_JSON_STATE
+    assert mock_stdout.getvalue() == EMPTY_YAML_STATE
 
 
 @mock.patch('sys.argv', ['nmstatectl', 'show', 'lo'])
@@ -71,6 +82,25 @@ def test_run_ctl_directly_show_only_empty(mock_stdout):
     nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_only(mock_stdout):
+    nmstatectl.main()
+    assert mock_stdout.getvalue() == LO_YAML_STATE
+
+
+@mock.patch('sys.argv', ['nmstatectl', 'show', '--json',
+                         'non_existing_interface'])
+@mock.patch.object(
+    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+@mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
+def test_run_ctl_directly_show_json_only_empty(mock_stdout):
+    nmstatectl.main()
+    assert mock_stdout.getvalue() == EMPTY_JSON_STATE
+
+
+@mock.patch('sys.argv', ['nmstatectl', 'show', '--json', 'lo'])
+@mock.patch.object(
+    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+@mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
+def test_run_ctl_directly_show_json_only(mock_stdout):
     nmstatectl.main()
     assert mock_stdout.getvalue() == LO_JSON_STATE
 

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -74,8 +74,8 @@ def test_missing_operation():
     assert "nmstatectl: error: invalid choice: 'no-such-oper'" in err
 
 
-def test_show_command_with_no_flags():
-    ret = libcmd.exec_cmd(SHOW_CMD)
+def test_show_command_with_json():
+    ret = libcmd.exec_cmd(SHOW_CMD + ['--json'])
     rc, out, err = ret
 
     assert rc == RC_SUCCESS, format_exec_cmd_result(ret)
@@ -86,15 +86,15 @@ def test_show_command_with_no_flags():
 
 
 def test_show_command_with_yaml_format():
-    ret = libcmd.exec_cmd(SHOW_CMD + ['--yaml'])
+    ret = libcmd.exec_cmd(SHOW_CMD)
     rc, out, err = ret
 
     assert rc == RC_SUCCESS, format_exec_cmd_result(ret)
     assert LOOPBACK_YAML_CONFIG in out
 
 
-def test_show_command_only_lo():
-    ret = libcmd.exec_cmd(SHOW_CMD + ['lo'])
+def test_show_command_json_only_lo():
+    ret = libcmd.exec_cmd(SHOW_CMD + ['--json', 'lo'])
     rc, out, err = ret
 
     assert rc == RC_SUCCESS, format_exec_cmd_result(ret)
@@ -105,7 +105,7 @@ def test_show_command_only_lo():
 
 
 def test_show_command_only_non_existing():
-    ret = libcmd.exec_cmd(SHOW_CMD + ['non_existing_interface'])
+    ret = libcmd.exec_cmd(SHOW_CMD + ['--json', 'non_existing_interface'])
     rc, out, err = ret
 
     assert rc == RC_SUCCESS, format_exec_cmd_result(ret)


### PR DESCRIPTION
YAML output is more concise and easier to edit, therefore prefer it.

Signed-off-by: Till Maas <opensource@till.name>