### PR TITLE
RPMs: Require python-setuptools

### DIFF
--- a/packaging/nmstate.py2.spec
+++ b/packaging/nmstate.py2.spec
@@ -10,7 +10,8 @@ URL:            https://github.com/%{srcname}/%{srcname}
 Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
 BuildArch:      noarch
 BuildRequires:  python2-devel
-BuildRequires:  python-setuptools
+BuildRequires:  python2-setuptools
+Requires:       python2-setuptools
 Requires:       python2-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -12,6 +12,7 @@ Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{s
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
+Requires:       python3-setuptools
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description


### PR DESCRIPTION
nmstatectl needs python-setuptools to import `pkg_resources`:
```
Traceback (most recent call last):
  File "/usr/bin/nmstatectl", line 5, in <module>
    from pkg_resources import load_entry_point
ImportError: No module named pkg_resources
```

Signed-off-by: Till Maas <opensource@till.name>