### PR TITLE
PoC for docker packaging and using a base image

### DIFF
--- a/packaging/Dockerfile.centos_7_base
+++ b/packaging/Dockerfile.centos_7_base
@@ -1,0 +1,14 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM centos:7.5.1804
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
+    yum -y install epel-release && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f

--- a/packaging/Dockerfile.centos_7_git_rpm
+++ b/packaging/Dockerfile.centos_7_git_rpm
@@ -1,0 +1,20 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM centos:7.5.1804
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
+    yum -y install epel-release yum-utils && \
+    yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-git-el7/repo/epel-7/nmstate-nmstate-git-el7-epel-7.repo && \
+    yum -y install nmstate && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.centos_7_git_rpm
+++ b/packaging/Dockerfile.centos_7_git_rpm
@@ -1,19 +1,9 @@
-# This Dockerfile is based on the recommendations provided in the
-# Centos official repository (https://hub.docker.com/_/centos/).
-# It enables systemd to be operational.
-FROM centos:7.5.1804
-ENV container docker
-COPY docker_enable_systemd.sh docker_sys_config.sh ./
-RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+FROM nmstate/centos_7_base
 
-# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
-RUN yum -y upgrade && \
-    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
-    yum -y install epel-release yum-utils && \
+RUN yum -y install yum-utils && \
     yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-git-el7/repo/epel-7/nmstate-nmstate-git-el7-epel-7.repo && \
     yum -y install nmstate && \
-    yum clean all && \
-    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+    yum clean all
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/Dockerfile.centos_7_stable_rpm
+++ b/packaging/Dockerfile.centos_7_stable_rpm
@@ -1,0 +1,19 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM centos:7.5.1804
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
+    yum -y install epel-release && \
+    yum -y --enablerepo epel-testing install nmstate && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.fedora_29_git_rpm
+++ b/packaging/Dockerfile.fedora_29_git_rpm
@@ -1,0 +1,20 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM fedora:29
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
+    yum -y install dnf-utils && \
+    yum-config-manager --add-repo=https://copr.fedorainfracloud.org/coprs/nmstate/nmstate-git-fedora/repo/fedora-29/nmstate-nmstate-git-fedora-fedora-29.repo && \
+    yum -y install nmstate && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.fedora_29_stable_rpm
+++ b/packaging/Dockerfile.fedora_29_stable_rpm
@@ -1,0 +1,18 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM fedora:29
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install NetworkManager NetworkManager-ovs openvswitch libibverbs && \
+    yum -y install nmstate && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/docker_enable_systemd.sh
+++ b/packaging/docker_enable_systemd.sh
@@ -1,0 +1,11 @@
+cd /lib/systemd/system/sysinit.target.wants/;
+for i in *; do
+    [ $i == systemd-tmpfiles-setup.service ] || rm -f $i;
+done;
+rm -f /lib/systemd/system/multi-user.target.wants/*;
+rm -f /etc/systemd/system/*.wants/*;
+rm -f /lib/systemd/system/local-fs.target.wants/*;
+rm -f /lib/systemd/system/sockets.target.wants/*udev*;
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*;
+rm -f /lib/systemd/system/basic.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*;

--- a/packaging/docker_sys_config.sh
+++ b/packaging/docker_sys_config.sh
@@ -1,0 +1,10 @@
+install -o root -g root -d /etc/sysconfig/network-scripts
+echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/' \
+    /etc/systemd/journald.conf
+sed -i 's/#RateLimitBurst=1000/RateLimitBurst=0/' \
+    /etc/systemd/journald.conf
+systemctl enable openvswitch.service


### PR DESCRIPTION
We need to figure out an idea for which image names and tags to use, we have at least the following:

- docker base image for CentOS 7, Fedora 28, 29, Rawhide
- docker images with the stable releases built from RPM (do we also want them built from pip?)
    - ideally there would also be a simple test to check that the dependencies work, the current integration tests clobber missing dependencies (i.e. for python-setuptools as shown in #240).
- docker images with the development RPMs (to be able to test and correct problems with the docker images quicker) and to allow users to test unreleased bug fixes


TODO:
[ ] Make the integration tests use the base image(s)
[ ] Add base image for Fedora

This is intendend to replace #154 eventually