### PR TITLE
stdci: Sync runtime slave distribution with the mock

### DIFF
--- a/.stdci.yml
+++ b/.stdci.yml
@@ -2,5 +2,7 @@
 Architectures:
   - x86_64:
       Distributions: ["el7"]
+      runtime-requirements:
+        host-distro: same
 script:
     from-file: automation/run-integration-tests.sh


### PR DESCRIPTION
stdci is using `mock` (using chroot) to deploy the distribution. The
runtime OS may be a totally different distribution which may cause
issues when the tests touch OS related services.

Marking the stdci configuration to make sure and run both the mock and
the slave with the same distribution.

We are seeing recently some crashes on the CI and suspect this is the problem (seen on VDSM tests as well a week back).