### PR TITLE
tox: Output coverage data also to terminal

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
         --cov=libnmstate \
         --cov=nmstatectl \
         --cov-report=html:htmlcov-py27 \
+        --cov-report=term \
         {posargs} \
         integration
 
@@ -38,6 +39,7 @@ commands =
         --cov=libnmstate \
         --cov=nmstatectl \
         --cov-report=html:htmlcov-py36 \
+        --cov-report=term \
         {posargs} \
         integration
 
@@ -56,6 +58,7 @@ commands =
         --cov=libnmstate \
         --cov=nmstatectl \
         --cov-report=html:htmlcov-py27 \
+        --cov-report=term \
         {posargs} \
         lib \
         ctl
@@ -74,6 +77,7 @@ commands =
         --cov=libnmstate \
         --cov=nmstatectl \
         --cov-report=html:htmlcov-py36 \
+        --cov-report=term \
         {posargs} \
         lib \
         ctl


### PR DESCRIPTION
Currently, CI requires an extra service to make the coverage data
humanly readable. By outputting the coverage data to the terminal, it
is directly available in the logs.

Signed-off-by: Till Maas <opensource@till.name>