### PR TITLE
Add option for ignoring auto DNS and routes

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -165,12 +165,19 @@ def sanitize_dhcp_state(ifaces_state):
     If dynamic IP is enabled and IP address is missing, set an empty address
     list. This assures that the desired state is not complemented by the
     current state address values.
+    If dynamic IP is disabled, all dynamic IP options should be removed.
     """
     for iface_state in six.viewvalues(ifaces_state):
         for family in ('ipv4', 'ipv6'):
             ip = iface_state.get(family, {})
             if ip.get('enabled') and (ip.get('dhcp') or ip.get('autoconf')):
                 ip['address'] = []
+            else:
+                for dhcp_option in ('auto-routes',
+                                    'auto-gateway',
+                                    'auto-dns'):
+                    ip.pop(dhcp_option, None)
+
     return ifaces_state
 
 

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -27,6 +27,9 @@ def create_setting(config, base_con_profile):
         if setting_ipv4:
             setting_ipv4 = setting_ipv4.duplicate()
             setting_ipv4.clear_addresses()
+            setting_ipv4.props.ignore_auto_routes = False
+            setting_ipv4.props.never_default = False
+            setting_ipv4.props.ignore_auto_dns = False
 
     if not setting_ipv4:
         setting_ipv4 = nmclient.NM.SettingIP4Config.new()
@@ -37,6 +40,12 @@ def create_setting(config, base_con_profile):
         if config.get('dhcp'):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO)
+            setting_ipv4.props.ignore_auto_routes = (
+                not config.get('auto-routes', True))
+            setting_ipv4.props.never_default = (
+                not config.get('auto-gateway', True))
+            setting_ipv4.props.ignore_auto_dns = (
+                not config.get('auto-dns', True))
         elif config.get('address'):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL)
@@ -67,6 +76,10 @@ def get_info(active_connection):
     if ip_profile:
         info['dhcp'] = ip_profile.get_method() == (
             nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO)
+        if info['dhcp']:
+            info['auto-routes'] = not ip_profile.props.ignore_auto_routes
+            info['auto-gateway'] = not ip_profile.props.never_default
+            info['auto-dns'] = not ip_profile.props.ignore_auto_dns
     else:
         info['dhcp'] = False
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -40,6 +40,11 @@ def get_info(active_connection):
             info['dhcp'] = True
             info['autoconf'] = False
 
+        if info['dhcp'] or info['autoconf']:
+            info['auto-routes'] = not ip_profile.props.ignore_auto_routes
+            info['auto-gateway'] = not ip_profile.props.never_default
+            info['auto-dns'] = not ip_profile.props.ignore_auto_dns
+
     ipconfig = active_connection.get_ip6_config()
     if ipconfig is None:
         # When DHCP is enable, it might be possible, the active_connection does
@@ -75,6 +80,9 @@ def create_setting(config, base_con_profile):
         if setting_ip:
             setting_ip = setting_ip.duplicate()
             setting_ip.clear_addresses()
+            setting_ip.props.ignore_auto_routes = False
+            setting_ip.props.never_default = False
+            setting_ip.props.ignore_auto_dns = False
 
     if not setting_ip:
         setting_ip = nmclient.NM.SettingIP6Config.new()
@@ -90,6 +98,12 @@ def create_setting(config, base_con_profile):
 
     if is_dhcp or is_autoconf:
         _set_dynamic(setting_ip, is_dhcp, is_autoconf)
+        setting_ip.props.ignore_auto_routes = (
+            not config.get('auto-routes', True))
+        setting_ip.props.never_default = (
+            not config.get('auto-gateway', True))
+        setting_ip.props.ignore_auto_dns = (
+            not config.get('auto-dns', True))
     elif ip_addresses:
         _set_static(setting_ip, ip_addresses)
     else:

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -301,6 +301,12 @@ definitions:
               type: boolean
             dhcp:
               type: boolean
+            auto-routes:
+              type: boolean
+            auto-gateway:
+              type: boolean
+            auto-dns:
+              type: boolean
             address:
               type: array
               items:
@@ -331,6 +337,12 @@ definitions:
             autoconf:
               type: boolean
             dhcp:
+              type: boolean
+            auto-routes:
+              type: boolean
+            auto-gateway:
+              type: boolean
+            auto-dns:
               type: boolean
             address:
               type: array

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 import os
+import re
+import time
 
 import pytest
 
@@ -31,20 +33,59 @@ IPV4_ADDRESS1 = '192.0.2.251'
 IPV4_ADDRESS2 = '192.0.2.252'
 IPV6_ADDRESS1 = '2001:db8:1::1'
 IPV6_ADDRESS2 = '2001:db8:2::1'
+IPV4_CLASSLESS_ROUTE_DST_NET1 = '198.51.100.0/24'
+IPV4_CLASSLESS_ROUTE_NEXT_HOP1 = '192.0.2.1'
+IPV6_CLASSLESS_ROUTE_DST_NET1 = '2001:db8:f::/64'
 
 DHCP_SRV_NIC = 'dhcpsrv'
 DHCP_CLI_NIC = 'dhcpcli'
+DHCP_SRV_IP4 = IPV4_ADDRESS1
+DHCP_SRV_IP6 = IPV6_ADDRESS1
+DHCP_SRV_IP4_PREFIX = '192.0.2'
+DHCP_SRV_IP6_PREFIX = '2001:db8:1'
+DHCP_SRV_IP6_NETWORK = '{}::/64'.format(DHCP_SRV_IP6_PREFIX)
 
 DNSMASQ_CONF_STR = """
-interface={}
-dhcp-range=192.0.2.200,192.0.2.250,255.255.255.0,48h
+interface={iface}
+dhcp-range={ipv4_prefix}.200,{ipv4_prefix}.250,255.255.255.0,48h
 enable-ra
-dhcp-range=2001:db8:1::100,2001:db8:1::fff,64,480h
-""".format(DHCP_SRV_NIC)
+dhcp-range={ipv6_prefix}::100,{ipv6_prefix}::fff,ra-names,slaac,64,480h
+dhcp-option=option:classless-static-route,{classless_rt},{classless_rt_dst}
+dhcp-option=option:dns-server,{v4_dns_server}
+""".format(**{
+        'iface': DHCP_SRV_NIC,
+        'ipv4_prefix': DHCP_SRV_IP4_PREFIX,
+        'ipv6_prefix': DHCP_SRV_IP6_PREFIX,
+        'classless_rt': IPV4_CLASSLESS_ROUTE_DST_NET1,
+        'classless_rt_dst': IPV4_CLASSLESS_ROUTE_NEXT_HOP1,
+        'v4_dns_server': DHCP_SRV_IP4
+    })
 
+RADVD_CONF_STR = """
+interface {}
+{{
+    AdvSendAdvert on;
+    MinRtrAdvInterval 30;
+    MaxRtrAdvInterval 100;
+    prefix {} {{
+        AdvOnLink on;
+        AdvAutonomous on;
+        AdvRouterAddr off;
+    }};
+    route {} {{
+    }};
+}};
+""".format(DHCP_SRV_NIC, DHCP_SRV_IP6_NETWORK, IPV6_CLASSLESS_ROUTE_DST_NET1)
+
+RADVD_CONF_PATH = '/etc/radvd.conf'
 DNSMASQ_CONF_PATH = '/etc/dnsmasq.d/nmstate.conf'
+# Docker does not allow NetworkManager to edit /etc/resolv.conf.
+# Have to read NetworkManager internal resolv.conf
+RESOLV_CONF_PATH = '/var/run/NetworkManager/resolv.conf'
 
 SYSFS_DISABLE_IPV6_FILE = '/proc/sys/net/ipv6/conf/{}/disable_ipv6'.format(
+    DHCP_SRV_NIC)
+SYSFS_DISABLE_RA_SRV = '/proc/sys/net/ipv6/conf/{}/accept_ra'.format(
     DHCP_SRV_NIC)
 
 # Python 2 does not have FileNotFoundError and treat file not exist as IOError
@@ -63,6 +104,10 @@ def dhcp_env():
         with open(DNSMASQ_CONF_PATH, 'w') as fd:
             fd.write(DNSMASQ_CONF_STR)
         assert libcmd.exec_cmd(['systemctl', 'restart', 'dnsmasq'])[0] == 0
+
+        with open(RADVD_CONF_PATH, 'w') as fd:
+            fd.write(RADVD_CONF_STR)
+        assert libcmd.exec_cmd(['systemctl', 'restart', 'radvd'])[0] == 0
         yield
     finally:
         _clean_up()
@@ -104,10 +149,17 @@ def test_ipv4_dhcp(dhcp_env):
     dhcp_cli_desired_state['state'] = 'up'
     dhcp_cli_desired_state['ipv4']['enabled'] = True
     dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv4']['auto-routes'] = True
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
     netapplier.apply(desired_state)
     assertlib.assert_state(desired_state)
+    time.sleep(5)  # wait to get resolv.conf updated
+    assert _has_ipv4_dhcp_nameserver()
+    assert _has_ipv4_dhcp_gateway()
+    assert _has_ipv4_classless_route()
 
 
 def test_ipv6_dhcp_only(dhcp_env):
@@ -117,22 +169,45 @@ def test_ipv6_dhcp_only(dhcp_env):
     dhcp_cli_desired_state['ipv6']['enabled'] = True
     dhcp_cli_desired_state['ipv6']['dhcp'] = True
     dhcp_cli_desired_state['ipv6']['autoconf'] = False
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
 
     netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    current_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_current_state = current_state[INTERFACES][0]
+    has_dhcp_ip_addr = False
+    for addr in dhcp_cli_current_state['ipv6']['address']:
+        if addr['prefix-length'] == 128 and DHCP_SRV_IP6_PREFIX in addr['ip']:
+            has_dhcp_ip_addr = True
+            break
+    assert has_dhcp_ip_addr
+    assert not _has_ipv6_auto_gateway()      # DHCPv6 does not provide routes
+    assert not _has_ipv6_auto_extra_route()  # DHCPv6 does not provide routes
+    assert _has_ipv6_auto_nameserver()
 
 
 def test_ipv6_dhcp_and_autoconf(dhcp_env):
     desired_state = statelib.show_only((DHCP_CLI_NIC,))
     dhcp_cli_desired_state = desired_state[INTERFACES][0]
     dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
     dhcp_cli_desired_state['ipv6']['dhcp'] = True
     dhcp_cli_desired_state['ipv6']['autoconf'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = True
 
     netapplier.apply(desired_state)
 
     assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    assert _has_ipv6_auto_gateway()
+    assert _has_ipv6_auto_extra_route()
+    assert _has_ipv6_auto_nameserver()
 
 
 @pytest.mark.xfail(raises=nm.ipv6.NoSupportDynamicIPv6OptionError)
@@ -207,6 +282,233 @@ def test_dhcp_for_bond_with_ip_address_and_slave(dhcp_env,
     assertlib.assert_state(desired_state)
 
 
+def test_ipv4_dhcp_ignore_gateway(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = False
+    dhcp_cli_desired_state['ipv4']['auto-routes'] = True
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # wait to get resolv.conf updated
+    assert _has_ipv4_dhcp_nameserver()
+    assert not _has_ipv4_dhcp_gateway()
+    assert _has_ipv4_classless_route()
+
+
+def test_ipv4_dhcp_ignore_dns(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = False
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    assert not _has_ipv4_dhcp_nameserver()
+    assert _has_ipv4_dhcp_gateway()
+    assert _has_ipv4_classless_route()
+
+
+def test_ipv4_dhcp_ignore_routes(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv4']['auto-routes'] = False
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # wait to get resolv.conf updated
+    assert _has_ipv4_dhcp_nameserver()
+    assert not _has_ipv4_dhcp_gateway()
+    assert not _has_ipv4_classless_route()
+
+
+def test_ipv6_dhcp_and_autoconf_ignore_gateway(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = False
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    assert not _has_ipv6_auto_gateway()
+    assert _has_ipv6_auto_extra_route()
+    assert _has_ipv6_auto_nameserver()
+
+
+def test_ipv6_dhcp_and_autoconf_ignore_dns(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = False
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    assert _has_ipv6_auto_gateway()
+    assert _has_ipv6_auto_extra_route()
+    assert not _has_ipv6_auto_nameserver()
+
+
+def test_ipv6_dhcp_and_autoconf_ignore_routes(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = False
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    assert not _has_ipv6_auto_gateway()
+    assert not _has_ipv6_auto_extra_route()
+    assert _has_ipv6_auto_nameserver()
+
+
+def test_ipv4_dhcp_off_and_option_on(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['dhcp'] = False
+    # Below options should be silently ignored.
+    dhcp_cli_desired_state['ipv4']['auto-routes'] = False
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = False
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = False
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+
+    dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
+    assert not dhcp_cli_current_state['ipv4']['dhcp']
+    assert 'auto-routes' not in dhcp_cli_current_state['ipv4']
+    assert 'auto-dns' not in dhcp_cli_current_state['ipv4']
+    assert 'auto-gateway' not in dhcp_cli_current_state['ipv4']
+    assert not _has_ipv4_dhcp_nameserver()
+    assert not _has_ipv4_dhcp_gateway()
+    assert not _has_ipv4_classless_route()
+
+
+def test_ipv6_dhcp_off_and_option_on(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = False
+    dhcp_cli_desired_state['ipv6']['autoconf'] = False
+    # Below options should be silently ignored.
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = False
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = False
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = False
+
+    netapplier.apply(desired_state)
+
+    dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
+    assert not dhcp_cli_current_state['ipv6']['dhcp']
+    assert 'auto-routes' not in dhcp_cli_current_state['ipv6']
+    assert 'auto-dns' not in dhcp_cli_current_state['ipv6']
+    assert 'auto-gateway' not in dhcp_cli_current_state['ipv6']
+    assert not _has_ipv6_auto_gateway()
+    assert not _has_ipv6_auto_extra_route()
+    assert not _has_ipv6_auto_nameserver()
+
+
+def test_ipv4_dhcp_switch_on_to_off(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = True
+    dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv4']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv4']['auto-routes'] = True
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # wait to get resolv.conf updated
+    assert _has_ipv4_dhcp_nameserver()
+    assert _has_ipv4_dhcp_gateway()
+    assert _has_ipv4_classless_route()
+
+    # disable dhcp and make sure dns, route, gone.
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv4']['enabled'] = True
+    dhcp_cli_desired_state['ipv4']['dhcp'] = False
+    dhcp_cli_desired_state['ipv6']['enabled'] = True
+
+    netapplier.apply(desired_state)
+    assertlib.assert_state(desired_state)
+    assert not _has_ipv4_dhcp_nameserver()
+    assert not _has_ipv4_dhcp_gateway()
+    assert not _has_ipv4_classless_route()
+
+
+def test_ipv6_dhcp_switch_on_to_off(dhcp_env):
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = True
+    dhcp_cli_desired_state['ipv6']['autoconf'] = True
+    dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
+    dhcp_cli_desired_state['ipv6']['auto-dns'] = True
+    dhcp_cli_desired_state['ipv6']['auto-routes'] = True
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
+    assert _has_ipv6_auto_gateway()
+    assert _has_ipv6_auto_extra_route()
+    assert _has_ipv6_auto_nameserver()
+
+    # disable dhcp and make sure dns, route, gone.
+    desired_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state['state'] = 'up'
+    dhcp_cli_desired_state['ipv6']['dhcp'] = False
+    dhcp_cli_desired_state['ipv6']['autoconf'] = False
+
+    netapplier.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+    assert not _has_ipv6_auto_gateway()
+    assert not _has_ipv6_auto_extra_route()
+    assert not _has_ipv6_auto_nameserver()
+
+
 def _create_veth_pair():
     assert libcmd.exec_cmd(['ip', 'link', 'add', DHCP_SRV_NIC, 'type', 'veth',
                             'peer', 'name', DHCP_CLI_NIC])[0] == 0
@@ -219,20 +521,30 @@ def _remove_veth_pair():
 def _setup_dhcp_nics():
     assert libcmd.exec_cmd(['ip', 'link', 'set', DHCP_SRV_NIC, 'up'])[0] == 0
     assert libcmd.exec_cmd(['ip', 'link', 'set', DHCP_CLI_NIC, 'up'])[0] == 0
-    assert libcmd.exec_cmd(['ip', 'addr', 'add', IPV4_ADDRESS1, 'dev',
-                            DHCP_SRV_NIC])[0] == 0
+    assert libcmd.exec_cmd(['ip', 'addr', 'add', "{}/24".format(DHCP_SRV_IP4),
+                            'dev', DHCP_SRV_NIC])[0] == 0
+    with open(SYSFS_DISABLE_RA_SRV, 'w') as fd:
+        fd.write('0')
+
+    # This stop dhcp server NIC get another IPv6 address from radvd.
     with open(SYSFS_DISABLE_IPV6_FILE, 'w') as fd:
         fd.write('0')
-    assert libcmd.exec_cmd(['ip', 'addr', 'add', IPV6_ADDRESS1, 'dev',
-                            DHCP_SRV_NIC])[0] == 0
+
+    assert libcmd.exec_cmd(['ip', 'addr', 'add', "{}/64".format(DHCP_SRV_IP6),
+                            'dev', DHCP_SRV_NIC])[0] == 0
 
 
 def _clean_up():
     libcmd.exec_cmd(['systemctl', 'stop', 'dnsmasq'])
+    libcmd.exec_cmd(['systemctl', 'stop', 'radvd'])
     _remove_veth_pair()
     try:
         os.unlink(DNSMASQ_CONF_PATH)
-    except FileNotFoundError:
+    except (FileNotFoundError, OSError):
+        pass
+    try:
+        os.unlink(RADVD_CONF_PATH)
+    except (FileNotFoundError, OSError):
         pass
 
 
@@ -299,3 +611,77 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
 
     netapplier.apply(bridge_desired_state)
     assertlib.assert_state(bridge_desired_state)
+
+
+def _get_nameservers():
+    """
+    Return a list of name server string configured in RESOLV_CONF_PATH.
+    """
+    ret = []
+    regex = re.compile('^nameserver +([0-9\.a-f:]+)$')
+    with open(RESOLV_CONF_PATH, 'r') as fd:
+        for line in fd:
+            match = regex.match(line)
+            if match:
+                ret.append(match.group(1))
+    return ret
+
+
+def _get_ipv4_main_routes():
+    """
+    return a list of route entry string from `ip -4 route`.
+    """
+    rc, output, _ = libcmd.exec_cmd(['ip', '-4', 'route'])
+    if rc != 0:
+        return []
+    return [line for line in output.split('\n') if line]
+
+
+def _get_ipv6_main_routes():
+    """
+    return a list of route entry string from `ip -6 route`.
+    """
+    rc, output, _ = libcmd.exec_cmd(['ip', '-6', 'route'])
+    if rc != 0:
+        return []
+    return [line for line in output.split('\n') if line]
+
+
+def _has_ipv6_auto_gateway():
+    routes = _get_ipv6_main_routes()
+    for route in routes:
+        if 'default' in route and DHCP_CLI_NIC in route:
+            return True
+    return False
+
+
+def _has_ipv6_auto_extra_route():
+    routes = _get_ipv6_main_routes()
+    for route in routes:
+        if IPV6_CLASSLESS_ROUTE_DST_NET1 in route and DHCP_CLI_NIC in route:
+            return True
+    return False
+
+
+def _has_ipv6_auto_nameserver():
+    return DHCP_SRV_IP6 in _get_nameservers()
+
+
+def _has_ipv4_dhcp_nameserver():
+    return DHCP_SRV_IP4 in _get_nameservers()
+
+
+def _has_ipv4_dhcp_gateway():
+    routes = _get_ipv4_main_routes()
+    for route in routes:
+        if 'default' in route and DHCP_CLI_NIC in route:
+            return True
+    return False
+
+
+def _has_ipv4_classless_route():
+    routes = _get_ipv4_main_routes()
+    for route in routes:
+        if IPV4_CLASSLESS_ROUTE_DST_NET1 in route and DHCP_CLI_NIC in route:
+            return True
+    return False

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -101,6 +101,7 @@ class State(object):
         self._ipv4_skeleton_canonicalization()
         self._ipv6_skeleton_canonicalization()
         self._ignore_dhcp_manual_addr()
+        self._ignore_dhcp_option_when_off()
         self._ignore_ipv6_link_local()
         self._sort_ip_addresses()
         self._sort_interfaces_by_name()
@@ -151,6 +152,17 @@ class State(object):
             for family in ('ipv4', 'ipv6'):
                 if iface_state.get(family, {}).get('dhcp'):
                     iface_state[family]['address'] = []
+
+    def _ignore_dhcp_option_when_off(self):
+        for iface_state in self._state.get(INTERFACES, []):
+            for family in ('ipv4', 'ipv6'):
+                ip = iface_state.get(family, {})
+                if not (ip.get('enabled') and
+                        (ip.get('dhcp') or ip.get('autoconf'))):
+                    for dhcp_option in ('auto-routes',
+                                        'auto-gateway',
+                                        'auto-dns'):
+                        ip.pop(dhcp_option, None)
 
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -114,6 +114,9 @@ def test_get_info_with_ipv4_config(NM_mock):
     remote_conn_mock.get_setting_ip4_config.return_value = set_ip_conf
     set_ip_conf.get_method.return_value = (
         NM_mock.SETTING_IP4_CONFIG_METHOD_MANUAL)
+    set_ip_conf.props.never_default = False
+    set_ip_conf.props.ignore_auto_dns = False
+    set_ip_conf.props.ignore_auto_routes = False
 
     info = nm.ipv4.get_info(active_connection=act_con_mock)
 

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -109,7 +109,7 @@ def test_get_info_with_ipv4_config(NM_mock):
     address_mock = mock.MagicMock()
     config_mock.get_addresses.return_value = [address_mock]
     remote_conn_mock = mock.MagicMock()
-    act_con_mock.get_connection().return_value = remote_conn_mock
+    act_con_mock.get_connection.return_value = remote_conn_mock
     set_ip_conf = mock.MagicMock()
     remote_conn_mock.get_setting_ip4_config.return_value = set_ip_conf
     set_ip_conf.get_method.return_value = (

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -118,7 +118,7 @@ def test_get_info_with_ipv6_config(NM_mock):
     address_mock = mock.MagicMock()
     config_mock.get_addresses.return_value = [address_mock]
     remote_conn_mock = mock.MagicMock()
-    act_con_mock.get_connection().return_value = remote_conn_mock
+    act_con_mock.get_connection.return_value = remote_conn_mock
     set_ip_conf = mock.MagicMock()
     remote_conn_mock.get_setting_ip6_config.return_value = set_ip_conf
     set_ip_conf.get_method.return_value = (

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -123,6 +123,9 @@ def test_get_info_with_ipv6_config(NM_mock):
     remote_conn_mock.get_setting_ip6_config.return_value = set_ip_conf
     set_ip_conf.get_method.return_value = (
         NM_mock.SETTING_IP6_CONFIG_METHOD_MANUAL)
+    set_ip_conf.props.never_default = False
+    set_ip_conf.props.ignore_auto_dns = False
+    set_ip_conf.props.ignore_auto_routes = False
 
     info = nm.ipv6.get_info(active_connection=act_con_mock)
 


### PR DESCRIPTION
Added these options to ipv4 and ipv6 section:

 * ignore-auto-routes:  Ignore all DHCP/autoconf routes(including gateway).
 * ignore-auto-gateway: Ignore the DHCP/autoconf gateway.
 * ignore-auto-dns:     Ignore the DNS provided by DHCP.