### PR TITLE
Provide requirements for ubuntu (on travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
     - libgirepository1.0-dev
+    - gir1.2-networkmanager-1.0
 
 install:
   - pip install tox


### PR DESCRIPTION
With this addition, `gi.require_version('NM', '1.0')` should not fail.
However, it is questionable if this is needed at all, because for unit tests, we do not need it on the system.

In addition, we need to be able and fail with a meaningful error so the user can take actions (installing the relevant packages).