### PR TITLE
automation: Add support for getopts

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -48,8 +48,8 @@ or running the scripts:
 
 `debug_exit_shell=1 ./automation/run-integration-tests.sh`
 
-
-After closing the shell, the container will be removed.
+After closing the shell, the container will be removed. Alternatively it is
+possible to provide the `--debug-shell` command-line option.
 
 To specify a different container image for the tests, specify it with the
 `DOCKER_IMAGE` variable:
@@ -57,8 +57,14 @@ To specify a different container image for the tests, specify it with the
 `DOCKER_IMAGE=local/centos7-nmstate-dev debug_exit_shell=1 ./automation/run-integration-tests.sh`
 
 It is also possible to pass extra arguments to PDB using the
-`nmstate_pytest_extra_args` variable, for example:
+`nmstate_pytest_extra_args` variable or via `--pytest-args` command-line
+option, for example:
+
 `nmstate_pytest_extra_args="--pdb -x" ./automation/run-integration-tests.sh`
+
+or:
+
+`./automation/run-integration-tests.sh --pytest-args "--pdb -x"`
 
 
 Alternatively, the following commands start the container manually:

--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -105,7 +105,30 @@ function open_shell {
     run_exit
 }
 
-cd $EXEC_PATH 
+options=$(getopt --options "" --long pytest-args:,help,debug-shell -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --pytest-args)
+        shift
+        nmstate_pytest_extra_args="$1"
+        ;;
+    --debug-shell)
+        debug_exit_shell="1"
+        ;;
+    --help)
+        echo "$0 [--pytest-args=...] [--help] [--debug-shell]"
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+cd $EXEC_PATH
 docker --version && cat /etc/resolv.conf
 
 mkdir -p $EXPORT_DIR


### PR DESCRIPTION
Introduce --pytest-args and --debug-shell to run-integration-tests.sh to
make it easier to use these features with sudo since sudo does not pass
untrusted environment variables.

Signed-off-by: Till Maas <opensource@till.name>