### PR TITLE
Centos CI docker image: Upgrade pytest to 4.2.1

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -14,7 +14,7 @@ RUN yum -y upgrade && \
                    python2-pyyaml python-jsonschema python-setuptools \
                    NetworkManager-ovs openvswitch libibverbs \
                    python-gobject-base dnsmasq && \
-    pip install -U pip pytest==4.1.0 pytest-cov==2.6.1 python-coveralls && \
+    pip install -U pip pytest==4.2.1 pytest-cov==2.6.1 python-coveralls && \
     yum clean all && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config -f
 

--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -13,7 +13,7 @@ RUN yum -y upgrade && \
                    rpm-build git python2-devel python2-six \
                    python2-pyyaml python-jsonschema python-setuptools \
                    NetworkManager-ovs openvswitch libibverbs \
-                   python-gobject-base dnsmasq && \
+                   python-gobject-base dnsmasq radvd && \
     pip install -U pip pytest==4.2.1 pytest-cov==2.6.1 python-coveralls && \
     yum clean all && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config -f

--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -15,7 +15,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    rpm-build git python3-devel python3-dbus python3-coveralls \
                    python3-pyyaml python3-jsonschema python3-setuptools \
                    NetworkManager-ovs openvswitch libibverbs python36 \
-                   python3-gobject-base dnsmasq python3-tox python2 && \
+                   python3-gobject-base dnsmasq radvd python3-tox python2 && \
     alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \


### PR DESCRIPTION
This is Gris' commit from #254 to fix the docker image and thus the CI by merging this. I amended the commit message a little bit to add missing words.