### PR TITLE
Package nmstate for CentOS7 as container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ The `export` command can be used to add it for the current session:
 export PATH="${HOME}/.local/bin:${PATH}"
 ```
 
+### Container Image
+
+Nmstate also provides a container image based on CentOS 7 to try it:
+
+```shell
+CONTAINER_ID=$(sudo docker run --privileged -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro nmstate/centos7-nmstate)
+sudo docker exec -ti "${CONTAINER_ID}" /bin/bash
+# now play with nmstatectl in the container
+nmstatectl show
+# remove the container at the end
+sudo docker stop "${CONTAINER_ID}"
+sudo docker rm "${CONTAINER_ID}"
+```
 
 ## Basic Operations
 

--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -1,22 +1,16 @@
-# This Dockerfile is based on the recommendations provided in the
-# Centos official repository (https://hub.docker.com/_/centos/).
-# It enables systemd to be operational.
-FROM centos:7.5.1804
-ENV container docker
-COPY docker_enable_systemd.sh docker_sys_config.sh ./
-RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+FROM nmstate/centos7-nmstate-base
 
-# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
-RUN yum -y upgrade && \
-    yum -y install epel-release && \
-    yum -y install python2-pip iproute NetworkManager \
-                   rpm-build git python2-devel python2-six \
-                   python2-pyyaml python-jsonschema python-setuptools \
-                   NetworkManager-ovs openvswitch libibverbs \
-                   python-gobject-base dnsmasq radvd && \
+RUN yum -y install \
+        python2-pip \
+        rpm-build \
+        git \
+        python2-devel \
+        dnsmasq \
+        iproute \
+        radvd \
+    && \
     pip install -U pip pytest==4.2.1 pytest-cov==2.6.1 python-coveralls && \
-    yum clean all && \
-    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+    yum clean all
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/packaging/Dockerfile.centos7-nmstate
+++ b/packaging/Dockerfile.centos7-nmstate
@@ -1,0 +1,15 @@
+FROM nmstate/centos7-nmstate-base
+
+ARG SOURCE_COMMIT
+
+RUN yum -y install \
+        python2-pip \
+        git \
+    && \
+    yum clean all
+
+RUN pip install git+https://github.com/nmstate/nmstate@${SOURCE_COMMIT:-master}
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -1,0 +1,30 @@
+# This Dockerfile is based on the recommendations provided in the
+# Centos official repository (https://hub.docker.com/_/centos/).
+# It enables systemd to be operational.
+FROM centos:7.5.1804
+
+ENV container docker
+
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
+
+# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
+RUN yum -y upgrade && \
+    yum -y install \
+        libibverbs \
+        NetworkManager \
+        NetworkManager-libnm \
+        NetworkManager-ovs \
+        openvswitch \
+    && \
+    yum -y install epel-release && \
+    yum -y install \\
+        python2-pyyaml \
+        python2-six \
+        python-gobject-base \
+        python-jsonschema \
+        python-setuptools \
+    && \
+    yum clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config -f

--- a/packaging/README-dockerhub.md
+++ b/packaging/README-dockerhub.md
@@ -1,0 +1,41 @@
+## Docker Hub
+
+The images are automatically rebuilt on new GIT tags or pushes to the master branch:
+
+`Dockerfile.centos7-nmstate` by https://cloud.docker.com/u/nmstate/repository/docker/nmstate/centos7-nmstate
+`Dockerfile.centos7-nmstate-base` by https://cloud.docker.com/u/nmstate/repository/docker/nmstate/centos7-nmstate-base
+
+The base image contains a common base that is used both for the development
+image and for the distributed image.
+
+Configuration (here for `centos7-nmstate-base`, the other build just specifies
+a different container spec (Dockerfile location):
+
+Source repo: nmstate/nmstate
+Autotest: Off
+Repository Links: Off
+Build rules:
+Branch:
+Source:master
+Docker Tag:latest
+Dockerfile location:Dockerfile.centos7-nmstate-base
+Build Context:/packaging
+Autobuild:on
+Build Caching:off
+
+Tag:
+Source: /^v[0-9.]+$/
+Docker Tag:{sourceref}
+Dockerfile location:Dockerfile.centos7-nmstate-base
+Build Context:/packaging
+Autobuild:on
+Build Caching:off
+
+## Manual Building
+
+The Nmstate user image builds the master master branch by default. To specify a
+different commit or tag, specify the `SOURCE_COMMIT` build argument:
+
+```shell
+sudo docker build --no-cache --build-arg SOURCE_COMMIT=v0.0.4 -t nmstate/centos7-nmstate -f Dockerfile.centos7-nmstate .
+```

--- a/packaging/docker_enable_systemd.sh
+++ b/packaging/docker_enable_systemd.sh
@@ -1,0 +1,11 @@
+cd /lib/systemd/system/sysinit.target.wants/;
+for i in *; do
+    [ $i == systemd-tmpfiles-setup.service ] || rm -f $i;
+done;
+rm -f /lib/systemd/system/multi-user.target.wants/*;
+rm -f /etc/systemd/system/*.wants/*;
+rm -f /lib/systemd/system/local-fs.target.wants/*;
+rm -f /lib/systemd/system/sockets.target.wants/*udev*;
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*;
+rm -f /lib/systemd/system/basic.target.wants/*;
+rm -f /lib/systemd/system/anaconda.target.wants/*;

--- a/packaging/docker_sys_config.sh
+++ b/packaging/docker_sys_config.sh
@@ -1,0 +1,10 @@
+install -o root -g root -d /etc/sysconfig/network-scripts
+echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
+sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/' \
+    /etc/systemd/journald.conf
+sed -i 's/#RateLimitBurst=1000/RateLimitBurst=0/' \
+    /etc/systemd/journald.conf
+systemctl enable openvswitch.service


### PR DESCRIPTION
This is based on the feedback from #241 but limited to CentOS7 for now to avoid the complexity for the several Fedora releases. Before it can be merged we need to setup the builds in docker hub to avoid breaking the CI image.