### PR TITLE
Cleanup RPM and python dependencies

### DIFF
--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -24,7 +24,6 @@ provider support on the southbound.
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
 Requires:       NetworkManager-libnm
-Requires:       python3-gobject-base
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
 Recommends:     NetworkManager

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -12,7 +12,6 @@ Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{s
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
-Requires:       python3-setuptools
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 
 %description

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@
 jsonschema
 PyGObject
 PyYAML
+setuptools
 six


### PR DESCRIPTION
- setuptools dependency was missing in requirements.txt
- python-gobject-base dependency can now be auto-generated from requirements.txt since #248