### PR TITLE
automation: Disable pytest live-log

### DIFF
--- a/automation/run-integration-tests.sh
+++ b/automation/run-integration-tests.sh
@@ -71,9 +71,6 @@ function run_tests {
         --log-level=DEBUG \
         --log-date-format='%Y-%m-%d %H:%M:%S' \
         --log-format='%(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s' \
-        --log-cli-level=DEBUG \
-        --log-cli-date-format='%Y-%m-%d %H:%M:%S' \
-        --log-cli-format='%(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s' \
         --durations=5 \
         --cov=\$($PYTHON_SITE_PATH_CMD)/libnmstate \
         --cov=\$($PYTHON_SITE_PATH_CMD)/nmstatectl \


### PR DESCRIPTION
The live-log option creates a lot of noise while running the
integration tests with no special added value.

Only when a failure occurs, the logs need to be examined.