### PR TITLE
Travis CI: coverall should never fail the test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,8 @@ install:
   - pip install tox
 
 script:
-  - tox -e flake8,pylint,check-py27,check-py36,coveralls
+  - tox -e flake8,pylint,check-py27,check-py36
+
+after_success:
+  - pip install python-coveralls
+  - cd tests && coveralls


### PR DESCRIPTION
Remove coverall from tox test and execute it using travis
`after_success` section.