### PR TITLE
Enable unit test on Python 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,86 +5,69 @@ skip_missing_interpreters = True
 [testenv]
 basepython = python2.7
 
-[testenv:check-integ-py27]
+[basecfg]
 deps =
     -r{toxinidir}/requirements.txt
     pytest-cov==2.6.1
     pytest==4.1.0
+pytest_args =
+    --log-level=DEBUG
+    --durations=5
+    --cov=libnmstate
+    --cov=nmstatectl
+    --cov-report=term
+
+[testenv:check-integ-py27]
+deps = {[basecfg]deps}
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
     pytest \
-        --log-level=DEBUG \
-        --durations=5 \
-        --cov=libnmstate \
-        --cov=nmstatectl \
+        {[basecfg]pytest_args} \
         --cov-report=html:htmlcov-integ-py27 \
-        --cov-report=term \
         {posargs} \
         integration
 
 [testenv:check-integ-py36]
-deps =
-    -r{toxinidir}/requirements.txt
-    pytest-cov==2.6.1
-    pytest==4.1.0
+deps = {[basecfg]deps}
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
     pytest \
-        --log-level=DEBUG \
-        --durations=5 \
-        --cov=libnmstate \
-        --cov=nmstatectl \
+        {[basecfg]pytest_args} \
         --cov-report=html:htmlcov-integ-py36 \
-        --cov-report=term \
         {posargs} \
         integration
 
 [testenv:check-py27]
 deps =
-    -r{toxinidir}/requirements.txt
+    {[basecfg]deps}
     mock
-    pytest-cov==2.6.1
-    pytest==4.1.0
 basepython = python2.7
 changedir = {toxinidir}/tests
 commands =
     pytest \
-        --log-level=DEBUG \
-        --durations=5 \
-        --cov=libnmstate \
-        --cov=nmstatectl \
+        {[basecfg]pytest_args} \
         --cov-report=html:htmlcov-py27 \
-        --cov-report=term \
         {posargs} \
         lib \
         ctl
 
 [testenv:check-py36]
-deps =
-    -r{toxinidir}/requirements.txt
-    pytest-cov==2.6.1
-    pytest==4.1.0
+deps = {[basecfg]deps}
 basepython = python3.6
 changedir = {toxinidir}/tests
 commands =
     pytest \
-        --log-level=DEBUG \
-        --durations=5 \
-        --cov=libnmstate \
-        --cov=nmstatectl \
+        {[basecfg]pytest_args} \
         --cov-report=html:htmlcov-py36 \
-        --cov-report=term \
         {posargs} \
         lib \
         ctl
 
 [testenv:pylint]
 skip_install = true
-deps =
-    -r{toxinidir}/requirements.txt
-    pytest==4.1.0
+deps = {[basecfg]deps}
     pylint==1.8.4
 commands =
     pylint \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pylint, check-{py27,py36}
+envlist = flake8, pylint, check-{py27,py36,py37}
 skip_missing_interpreters = True
 
 [testenv]
@@ -61,6 +61,18 @@ commands =
     pytest \
         {[basecfg]pytest_args} \
         --cov-report=html:htmlcov-py36 \
+        {posargs} \
+        lib \
+        ctl
+
+[testenv:check-py37]
+deps = {[basecfg]deps}
+basepython = python3.7
+changedir = {toxinidir}/tests
+commands =
+    pytest \
+        {[basecfg]pytest_args} \
+        --cov-report=html:htmlcov-py37 \
         {posargs} \
         lib \
         ctl


### PR DESCRIPTION
Contains two patches:
 * Remove duplicate lines in `tox.ini` for requirements and pytest arguments.
 * Enable python 3.7 for unit test in `tox.ini`.