### PR TITLE
Fedora CI docker image: Add dependencies for unit test

### DIFF
--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -15,7 +15,11 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    rpm-build git python3-devel python3-dbus python3-coveralls \
                    python3-pyyaml python3-jsonschema python3-setuptools \
                    NetworkManager-ovs openvswitch libibverbs python36 \
-                   python3-gobject-base dnsmasq radvd python3-tox python2 && \
+                   python3-gobject-base dnsmasq radvd python3-tox python2 \
+                   # Below packages for pip (used by tox) to build
+                   # python-gobject
+                   glib2-devel cairo-devel gobject-introspection-devel \
+                   python2-devel python3-devel cairo-gobject-devel && \
     alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \


### PR DESCRIPTION
Since we included PyGObject into `requirements.txt`, the tox unit tests
will try to install PyGObject which will fail in Fedora docker CI image.