### PR TITLE
nmclient: Explicitly create a new client object only in netinfo

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -52,6 +52,8 @@ def capabilities():
 def interfaces():
     info = []
 
+    nm.nmclient.client(refresh=True)
+
     devices_info = [(dev, nm.device.get_device_common_info(dev))
                     for dev in nm.device.list_devices()]
 

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -342,7 +342,7 @@ def get_device_by_name(devname):
 
 
 def list_devices():
-    client = nmclient.client(refresh=True)
+    client = nmclient.client()
     return client.get_devices()
 
 


### PR DESCRIPTION
Usage of the NM client object should be limited in most cases to a
single instance.
In particular, during a mainloop run, only a single instance of the
client should be used due to its cached data.

This change is limited in scope, fixing issues seen with current
integration tests. A follow up change will organize the client object
lifetime in a more systematic manner.