### PR TITLE
Unify the exception to NmstateError

### DIFF
--- a/libnmstate/error.py
+++ b/libnmstate/error.py
@@ -1,0 +1,84 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+try:
+    PermissionError
+except NameError:
+    # Python 2 does not have PermissionError.
+    class PermissionError(Exception):
+        pass
+
+
+class NmstateError(Exception):
+    """
+    The base exception of libnmstate.
+    """
+    pass
+
+
+class NmstateDependencyError(NmstateError):
+    """
+    Nmstate requires external tools installed and/or started for desired state.
+    """
+    pass
+
+
+class NmstateValueError(NmstateError, ValueError):
+    """
+    Exception happens at pre-apply check, user should resubmit the amended
+    desired state. Example:
+        * JSON/YAML syntax issue.
+        * Nmstate schema issue.
+        * Invalid value of desired property, like bond missing slave.
+    """
+    pass
+
+
+class NmstatePermissionError(NmstateError, PermissionError):
+    """
+    Permission deny when applying the desired state.
+    """
+    pass
+
+
+class NmstateLibnmError(NmstateError):
+    """
+    Exception for unexpected libnm failure.
+    """
+    pass
+
+
+class NmstateVerificationError(NmstateError):
+    """
+    After applied desired state, current state does not match desired state for
+    unknown reason.
+    """
+    pass
+
+
+class NmstateNotImplementedError(NmstateError, NotImplementedError):
+    """
+    Desired feature is not supported by Nmstate yet.
+    """
+    pass
+
+
+class NmstateInternalError(NmstateError):
+    """
+    Unexpected behaviour happened. It is a bug of libnmstate which should be
+    fixed.
+    """
+    pass

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -18,6 +18,8 @@
 import six
 
 from libnmstate.schema import LinuxBridge as LB
+from libnmstate.error import NmstateValueError
+from libnmstate.error import NmstateNotImplementedError
 
 from . import bond
 from . import bridge
@@ -30,14 +32,6 @@ from . import translator
 from . import user
 from . import vlan
 from . import wired
-
-
-class UnsupportedIfaceStateError(Exception):
-    pass
-
-
-class UnsupportedIfaceTypeError(Exception):
-    pass
 
 
 def create_new_ifaces(con_profiles):
@@ -130,7 +124,10 @@ def set_ifaces_admin_state(ifaces_desired_state, con_profiles=()):
                 for nmdev in nmdevs:
                     devs_actions[nmdev] = (device.deactivate, device.delete)
             else:
-                raise UnsupportedIfaceStateError(iface_desired_state)
+                raise NmstateValueError(
+                    'Invalid state {} for interface {}'.format(
+                        iface_desired_state['state'],
+                        iface_desired_state['name']))
 
     for ifname in new_ifaces_to_activate:
         device.activate(dev=None, connection_id=ifname)
@@ -231,8 +228,10 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
 
     # TODO: Support ovs-interface type on setup
     if iface_type == ovs.INTERNAL_INTERFACE_TYPE:
-        raise UnsupportedIfaceTypeError(iface_type,
-                                        iface_desired_state['name'])
+        raise NmstateNotImplementedError(
+            'Interface type {} of interface {} not supported yet'.format(
+                iface_type,
+                iface_desired_state['name']))
 
     settings = [
         ipv4.create_setting(iface_desired_state.get('ipv4'), base_con_profile),

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -19,6 +19,7 @@ import six
 
 from . import connection
 from . import nmclient
+from libnmstate.error import NmstateValueError
 
 
 BOND_TYPE = 'bond'
@@ -29,7 +30,10 @@ def create_setting(options):
     for option_name, option_value in six.viewitems(options):
         success = bond_setting.add_option(option_name, option_value)
         if not success:
-            raise InvalidBondOptionError(option_name, option_value)
+            raise NmstateValueError(
+                'Invalid bond option: \{}\=\'{}\''.format(
+                    option_name, option_value))
+
     return bond_setting
 
 
@@ -54,7 +58,3 @@ def get_options(nm_device):
 
 def get_slaves(nm_device):
     return nm_device.get_slaves()
-
-
-class InvalidBondOptionError(Exception):
-    pass

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -21,10 +21,6 @@ from . import connection
 from . import nmclient
 
 
-class ActivationError(Exception):
-    pass
-
-
 class AlternativeACState(object):
     UNKNOWN = 0
     ACTIVE = 1

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -20,6 +20,7 @@ import socket
 
 from libnmstate.nm import nmclient
 from libnmstate import iplib
+from libnmstate.error import NmstateNotImplementedError
 
 
 def get_info(active_connection):
@@ -113,13 +114,9 @@ def create_setting(config, base_con_profile):
     return setting_ip
 
 
-class NoSupportDynamicIPv6OptionError(Exception):
-    pass
-
-
 def _set_dynamic(setting_ip, is_dhcp, is_autoconf):
     if not is_dhcp and is_autoconf:
-        raise NoSupportDynamicIPv6OptionError(
+        raise NmstateNotImplementedError(
             'Autoconf without DHCP is not supported yet')
 
     if is_dhcp and is_autoconf:

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -33,6 +33,9 @@ except ValueError:
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import GObject
+from libnmstate.error import NmstateValueError
+from libnmstate.error import NmstateInternalError
+
 GObject
 
 _mainloop = None
@@ -102,7 +105,8 @@ class _MainLoop(object):
 
     def run(self, timeout):
         if not isinstance(timeout, six.integer_types):
-            raise TypeError('timeout is expected to be an integer')
+            raise NmstateValueError(
+                "Invalid timeout value: should be an integer")
 
         if not self.actions_exists():
             return _MainLoop.SUCCESS
@@ -132,7 +136,7 @@ class _MainLoop(object):
     def drop_cancellable(self, c):
         idx = self._cancellables.index(c)
         if idx == 0:
-            raise MainloopCancellableDropError('Cannot drop main cancellable')
+            raise NmstateInternalError('Cannot drop main cancellable')
         del self._cancellables[idx]
 
     def _cancel_cancellables(self):
@@ -185,7 +189,3 @@ class _MainLoop(object):
     def _execute_action_once(self, _):
         self.execute_next_action()
         return False
-
-
-class MainloopCancellableDropError(Exception):
-    pass

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -17,6 +17,7 @@
 
 import six
 
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import OVSBridge as OB
 from libnmstate.schema import OVSBridgePortType as OBPortType
 
@@ -71,7 +72,9 @@ def create_bridge_setting(options):
         elif option_name == 'stp':
             bridge_setting.props.stp_enable = option_value
         else:
-            raise InvalidOvsBridgeOptionError(option_name, option_value)
+            raise NmstateValueError(
+                'Invalid OVS bridge option: \{}\=\'{}\''.format(
+                    option_name, option_value))
 
     return bridge_setting
 
@@ -92,7 +95,9 @@ def create_port_setting(options):
         elif option_name == 'bond-downdelay':
             port_setting.props.bond_downdelay = option_value
         else:
-            raise InvalidOvsPortOptionError(option_name, option_value)
+            raise NmstateValueError(
+                'Invalid OVS port option: \{}\=\'{}\''.format(
+                    option_name, option_value))
 
     return port_setting
 
@@ -211,11 +216,3 @@ def _get_slave_profiles(master_device, devices_info):
             if master and (master.get_iface() == master_device.get_iface()):
                 slave_profiles.append(active_con.props.connection)
     return slave_profiles
-
-
-class InvalidOvsBridgeOptionError(Exception):
-    pass
-
-
-class InvalidOvsPortOptionError(Exception):
-    pass

--- a/libnmstate/nm/user.py
+++ b/libnmstate/nm/user.py
@@ -20,14 +20,11 @@ does not fit somewhere else such as an interface's description.
 https://lazka.github.io/pgi-docs/#NM-1.0/classes/SettingUser.html
 """
 
+from libnmstate.error import NmstateValueError
 from libnmstate.nm import connection as nm_connection
 from libnmstate.nm import nmclient
 
 NMSTATE_DESCRIPTION = "nmstate.interface.description"
-
-
-class InvalidDescriptionError(Exception):
-    pass
 
 
 def create_setting(iface_state, base_con_profile):
@@ -37,7 +34,7 @@ def create_setting(iface_state, base_con_profile):
         return None
 
     if not nmclient.NM.SettingUser.check_val(description):
-        raise InvalidDescriptionError()
+        raise NmstateValueError('Invalid description')
 
     user_setting = None
     if base_con_profile:

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -22,6 +22,7 @@ import yaml
 
 from libnmstate import netapplier
 from libnmstate import netinfo
+from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -180,7 +181,7 @@ def test_rollback_for_bond(eth1_up, eth2_up):
 
     desired_state[INTERFACES][0]['invalid_key'] = 'foo'
 
-    with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+    with pytest.raises(NmstateVerificationError):
         netapplier.apply(desired_state)
 
     time.sleep(5)

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -21,7 +21,7 @@ import time
 import pytest
 
 from libnmstate import netapplier
-from libnmstate import nm
+from libnmstate.error import NmstateNotImplementedError
 
 from .testlib import assertlib
 from .testlib import cmd as libcmd
@@ -210,7 +210,7 @@ def test_ipv6_dhcp_and_autoconf(dhcp_env):
     assert _has_ipv6_auto_nameserver()
 
 
-@pytest.mark.xfail(raises=nm.ipv6.NoSupportDynamicIPv6OptionError)
+@pytest.mark.xfail(raises=NmstateNotImplementedError)
 def test_ipv6_autoconf_only(dhcp_env):
     desired_state = statelib.show_only((DHCP_CLI_NIC,))
     dhcp_cli_desired_state = desired_state[INTERFACES][0]

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -22,6 +22,7 @@ import pytest
 import jsonschema as js
 
 from libnmstate import netapplier
+from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -79,7 +80,7 @@ def test_decrease_to_zero_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 0
 
-    with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
+    with pytest.raises(NmstateVerificationError) as err:
         netapplier.apply(desired_state)
     assert '-mtu: 0' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.
@@ -115,7 +116,7 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1279
 
-    with pytest.raises(netapplier.DesiredStateIsNotCurrentError) as err:
+    with pytest.raises(NmstateVerificationError) as err:
         netapplier.apply(desired_state)
     assert '1279' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -22,6 +22,7 @@ import pytest
 
 from libnmstate import netapplier
 from libnmstate import netinfo
+from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -77,7 +78,7 @@ def test_rollback_for_vlans(eth1_up):
     desired_state = TWO_VLANS_STATE
 
     desired_state[INTERFACES][1]['invalid_key'] = 'foo'
-    with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+    with pytest.raises(NmstateVerificationError):
         netapplier.apply(desired_state)
 
     time.sleep(5)   # Give some time for NetworkManager to rollback

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -21,6 +21,7 @@ import pytest
 from .compat import mock
 
 from libnmstate import netapplier
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Constants
 from libnmstate.schema import OVSBridgePortType as OBPortType
 
@@ -695,7 +696,7 @@ class TestAssertIfaceState(object):
             'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
         })
 
-        with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+        with pytest.raises(NmstateVerificationError):
             netapplier.assert_ifaces_state(desired_state, current_state)
 
     def test_desired_is_not_equal_to_current(self):
@@ -703,7 +704,7 @@ class TestAssertIfaceState(object):
         current_state = self._base_state
         current_state['foo-name']['state'] = 'down'
 
-        with pytest.raises(netapplier.DesiredStateIsNotCurrentError):
+        with pytest.raises(NmstateVerificationError):
             netapplier.assert_ifaces_state(desired_state, current_state)
 
     def test_sort_multiple_ip(self):

--- a/tests/lib/nm/bond_test.py
+++ b/tests/lib/nm/bond_test.py
@@ -19,6 +19,7 @@ import pytest
 from lib.compat import mock
 
 from libnmstate import nm
+from libnmstate.error import NmstateValueError
 
 
 @pytest.fixture()
@@ -53,7 +54,7 @@ def test_create_setting_with_invalid_bond_option(NM_mock):
         'foo': '100',
     }
 
-    with pytest.raises(nm.bond.InvalidBondOptionError):
+    with pytest.raises(NmstateValueError):
         nm.bond.create_setting(options)
 
 

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -18,6 +18,7 @@
 import pytest
 
 import libnmstate
+from libnmstate.error import NmstateValueError
 
 
 class TestLinkAggregationState(object):
@@ -96,8 +97,7 @@ class TestLinkAggregationState(object):
                 },
             }
         ]
-        with pytest.raises(
-                libnmstate.validator.LinkAggregationSlavesReuseError):
+        with pytest.raises(NmstateValueError):
             libnmstate.validator.verify_link_aggregation_state(config, {})
 
     def test_bonds_with_missing_slaves(self):
@@ -117,6 +117,5 @@ class TestLinkAggregationState(object):
                 },
             }
         ]
-        with pytest.raises(
-                libnmstate.validator.LinkAggregationSlavesMissingError):
+        with pytest.raises(NmstateValueError):
             libnmstate.validator.verify_link_aggregation_state(config, {})


### PR DESCRIPTION
Moving all exceptions into 'error.py' to provide stable API on
error path -- `libnmstate.error.<Exception_Name>`.

The base exception is NmstateError which could be used by application
which want to catch all exceptions in Nmstate.