### PR TITLE
Docker CI image: Add python2-ipaddress package

### DIFF
--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -16,6 +16,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    python3-pyyaml python3-jsonschema python3-setuptools \
                    NetworkManager-ovs openvswitch libibverbs python36 \
                    python3-gobject-base dnsmasq radvd python3-tox python2 \
+                   python2-ipaddress \
                    # Below packages for pip (used by tox) to build
                    # python-gobject
                    glib2-devel cairo-devel gobject-introspection-devel \

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -25,6 +25,7 @@ RUN yum -y upgrade && \
         python-gobject-base \
         python-jsonschema \
         python-setuptools \
+        python-ipaddress \
     && \
     yum clean all && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config -f


### PR DESCRIPTION
The python2-ipaddress will be need by route support.
For Python 3, the ipaddress module is included in CPython 3.3+.