### PR TITLE
automation: Container image for CentOS7 unit tests

### DIFF
--- a/automation/run-local-utests.sh
+++ b/automation/run-local-utests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PROJECT=${PROJECT:-${PWD##*/}}
+TOXWORKDIR="$HOME/.cache/.tox-$PROJECT"
+CONTAINER_IMAGE="localhost/$PROJECT/centos7-$PROJECT-utest"
+
+mkdir -p "$TOXWORKDIR"
+
+podman run \
+       --rm \
+       -ti \
+       -v $PWD:/workspace/$PROJECT:Z \
+       -v $TOXWORKDIR:$TOXWORKDIR:Z \
+       $CONTAINER_IMAGE \
+       /bin/bash -c " \
+         cp -rf /workspace/$PROJECT /tmp/ \
+         && \
+         cd /tmp/$PROJECT \
+         && \
+         tox --workdir $TOXWORKDIR"

--- a/packaging/Dockerfile.centos7-nmstate-utest
+++ b/packaging/Dockerfile.centos7-nmstate-utest
@@ -1,0 +1,25 @@
+# This image definition is defining
+# a container image on which unit and lint tests
+# can be run locally through `tox`.
+
+FROM centos:7
+
+RUN yum -y upgrade \
+    && \
+    yum -y install \
+        NetworkManager \
+        NetworkManager-libnm \
+    && \
+    yum -y install epel-release \
+    && \
+    yum -y install \
+        python2-pip \
+        make \
+    && \
+    yum-builddep -y \
+        python-gobject \
+        dbus-python \
+    && \
+    yum clean all \
+    && \
+    pip install tox


### PR DESCRIPTION
The unit tests with the lint check can be executed locally
as follow: sudo ./automation/run-local-utests.sh