### PR TITLE
 Add support of querying DNS client settings

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -19,7 +19,9 @@ from operator import itemgetter
 
 from libnmstate import nm
 from libnmstate import validator
+from libnmstate.nm import dns as nm_dns
 from libnmstate.schema import Constants
+from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
 
@@ -43,6 +45,11 @@ def show(include_status_data=False):
                         nm.ipv6.get_route_running()),
         Route.CONFIG: (nm.ipv4.get_route_config() +
                        nm.ipv6.get_route_config()),
+    }
+
+    report[Constants.DNS] = {
+        DNS.RUNNING: nm_dns.get_running(),
+        DNS.CONFIG: nm_dns.get_config(),
     }
 
     validator.verify(report)

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -1,0 +1,102 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+from operator import itemgetter
+
+from libnmstate import iplib
+from libnmstate.error import NmstateInternalError
+from libnmstate.nm import nmclient
+from libnmstate.nm import ipv4 as nm_ipv4
+from libnmstate.nm import ipv6 as nm_ipv6
+from libnmstate.schema import DNS
+
+
+DNS_DEFAULT_PRIORITY_VPN = 50
+DNS_DEFAULT_PRIORITY_OTHER = 100
+
+IPV6_ADDRESS_LENGTH = 128
+
+
+def get_running():
+    dns_state = {
+        DNS.SERVER: [],
+        DNS.SEARCH: []
+    }
+    client = nmclient.client()
+    for dns_conf in client.get_dns_configuration():
+        iface_name = dns_conf.get_interface()
+        for ns in dns_conf.get_nameservers():
+            if iplib.is_ipv6_link_local_addr(ns, IPV6_ADDRESS_LENGTH):
+                if not iface_name:
+                    # For IPv6 link local address, the interface name should be
+                    # appended also.
+                    raise NmstateInternalError(
+                        'Missing interface for IPv6 link-local DNS server '
+                        'entry {}'.format(ns))
+                ns_addr = '{}%{}'.format(ns, iface_name)
+            else:
+                ns_addr = ns
+            dns_state[DNS.SERVER].append(ns_addr)
+        dns_state[DNS.SEARCH].extend(dns_conf.get_domains())
+    if not dns_state[DNS.SERVER] and not dns_state[DNS.SEARCH]:
+        dns_state = {}
+    return dns_state
+
+
+def get_config():
+    dns_conf = {
+        DNS.SERVER: [],
+        DNS.SEARCH: []
+    }
+    tmp_dns_confs = []
+    client = nmclient.client()
+    for ac in client.get_active_connections():
+        # NM prefers IPv6 over IPv4 DNS.
+        for ip_profile in (nm_ipv6.get_ip_profile(ac),
+                           nm_ipv4.get_ip_profile(ac)):
+            if not ip_profile:
+                continue
+            if not ip_profile.props.dns and not ip_profile.props.dns_search:
+                continue
+            priority = ip_profile.props.dns_priority
+            if priority == 0:
+                # ^ The dns_priority in 'NetworkManager.conf' is been ignored
+                #   due to the lacking of query function in libnm API.
+                if ac.get_vpn():
+                    priority = DNS_DEFAULT_PRIORITY_VPN
+                else:
+                    priority = DNS_DEFAULT_PRIORITY_OTHER
+
+            tmp_dns_confs.append(
+                {
+                    'server': ip_profile.props.dns,
+                    'priority': priority,
+                    'search': ip_profile.props.dns_search,
+                }
+            )
+    # NetworkManager sorts the DNS entries based on various criteria including
+    # which profile was activated first when profiles are activated. Therefore
+    # the configuration does not completely define the order. To define the
+    # order in a declarative way, Nmstate only uses the priority to order the
+    # entries. Reference:
+    # https://developer.gnome.org/NetworkManager/stable/nm-settings.html#nm-settings.property.ipv4.dns-priority
+    tmp_dns_confs.sort(key=itemgetter('priority'))
+    for e in tmp_dns_confs:
+        dns_conf[DNS.SERVER].extend(e['server'])
+        dns_conf[DNS.SEARCH].extend(e['search'])
+    if not dns_conf[DNS.SERVER] and dns_conf[DNS.SEARCH]:
+        return {}
+    return dns_conf

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -56,9 +56,18 @@ class Route(object):
     METRIC = 'metric'
 
 
+class DNS(object):
+    KEY = 'dns-resolver'
+    RUNNING = 'running'
+    CONFIG = 'config'
+    SERVER = 'server'
+    SEARCH = 'search'
+
+
 class Constants(object):
     INTERFACES = Interface.KEY
     ROUTES = Route.KEY
+    DNS = DNS.KEY
 
 
 class InterfaceState(object):

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -35,6 +35,15 @@ properties:
         type: array
         items:
           $ref: "#/definitions/route"
+  dns-resolver:
+    type: object
+    properties:
+      config:
+        items:
+          $ref: "#/definitions/dns"
+      running:
+        items:
+          $ref: "#/definitions/dns"
 
 definitions:
   types:
@@ -437,3 +446,14 @@ definitions:
         type: string
       next-hop-address:
         type: string
+  dns:
+    type: object
+    properties:
+      server:
+        type: array
+        items:
+          type: string
+      search:
+        type: array
+        items:
+          type: string

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 import os
-import re
 import time
 
 import pytest
@@ -23,6 +22,7 @@ import pytest
 from libnmstate import netapplier
 from libnmstate import netinfo
 from libnmstate.schema import Constants
+from libnmstate.schema import DNS
 from libnmstate.schema import Route as RT
 
 from libnmstate.error import NmstateNotImplementedError
@@ -638,14 +638,8 @@ def _get_nameservers():
     """
     Return a list of name server string configured in RESOLV_CONF_PATH.
     """
-    ret = []
-    regex = re.compile('^nameserver +([0-9\.a-f:]+)$')
-    with open(RESOLV_CONF_PATH, 'r') as fd:
-        for line in fd:
-            match = regex.match(line)
-            if match:
-                ret.append(match.group(1))
-    return ret
+    return netinfo.show().get(
+        Constants.DNS, {}).get(DNS.RUNNING, {}).get(DNS.SERVER, [])
 
 
 def _get_running_routes():

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -20,6 +20,7 @@ from .compat import mock
 
 from libnmstate import netinfo
 from libnmstate.schema import Constants
+from libnmstate.schema import DNS
 
 
 INTERFACES = Constants.INTERFACES
@@ -32,8 +33,18 @@ def nm_mock():
         yield m
 
 
-def test_netinfo_show_generic_iface(nm_mock):
+@pytest.fixture
+def nm_dns_mock():
+    with mock.patch.object(netinfo, 'nm_dns') as m:
+        yield m
+
+
+def test_netinfo_show_generic_iface(nm_mock, nm_dns_mock):
     current_config = {
+        DNS.KEY: {
+            DNS.RUNNING: {},
+            DNS.CONFIG: {}
+        },
         ROUTES: {
             'config': [],
             'running': []
@@ -65,14 +76,20 @@ def test_netinfo_show_generic_iface(nm_mock):
     nm_mock.ipv4.get_route_config.return_value = []
     nm_mock.ipv6.get_route_running.return_value = []
     nm_mock.ipv6.get_route_config.return_value = []
+    nm_dns_mock.get_running.return_value = current_config[DNS.KEY][DNS.RUNNING]
+    nm_dns_mock.get_config.return_value = current_config[DNS.KEY][DNS.CONFIG]
 
     report = netinfo.show()
 
     assert current_config == report
 
 
-def test_netinfo_show_bond_iface(nm_mock):
+def test_netinfo_show_bond_iface(nm_mock, nm_dns_mock):
     current_config = {
+        DNS.KEY: {
+            DNS.RUNNING: {},
+            DNS.CONFIG: {}
+        },
         ROUTES: {
             'config': [],
             'running': []
@@ -117,6 +134,8 @@ def test_netinfo_show_bond_iface(nm_mock):
     nm_mock.ipv4.get_route_config.return_value = []
     nm_mock.ipv6.get_route_running.return_value = []
     nm_mock.ipv6.get_route_config.return_value = []
+    nm_dns_mock.get_running.return_value = current_config[DNS.KEY][DNS.RUNNING]
+    nm_dns_mock.get_config.return_value = current_config[DNS.KEY][DNS.CONFIG]
 
     report = netinfo.show()
 

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -24,6 +24,7 @@ import jsonschema as js
 
 import libnmstate
 from libnmstate.schema import Constants
+from libnmstate.schema import DNS
 
 
 INTERFACES = Constants.INTERFACES
@@ -83,6 +84,28 @@ COMMON_DATA = {
                 'next-hop-address': 'fe80::1'
             }
         ]
+    },
+    DNS.KEY: {
+        DNS.RUNNING: {
+            DNS.SERVER: [
+                "2001:db8::1",
+                "192.0.2.1"
+            ],
+            DNS.SEARCH: [
+                "example.com",
+                "example.org"
+            ]
+        },
+        DNS.CONFIG: {
+            DNS.SERVER: [
+                "2001:db8::1",
+                "192.0.2.1"
+            ],
+            DNS.SEARCH: [
+                "example.com",
+                "example.org"
+            ]
+        }
     }
 }
 


### PR DESCRIPTION
 Add support of querying DNS client settings

The example output would be:

```yaml
---
dns-resolver:
  config:
    server:
    - 2001::8
    - 8.8.8.8
    search:
    - example.com
    - example.org
  running:
    servers:
    - 2001::8
    - 8.8.8.8
    search:
    - example.com
    - example.org
```
