### PR TITLE
yaml.load: Explicitly set yaml loader to SafeLoader

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -22,7 +22,9 @@ import yaml
 
 def load(schema_name):
     return yaml.load(
-        pkgutil.get_data('libnmstate', 'schemas/' + schema_name + '.yaml'))
+        pkgutil.get_data('libnmstate', 'schemas/' + schema_name + '.yaml'),
+        Loader=yaml.SafeLoader
+    )
 
 
 ifaces_schema = load('operational-state')

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -151,7 +151,7 @@ def apply_state(statedata, verify_change):
     if statedata[0] == '{':
         state = json.loads(statedata)
     else:
-        state = yaml.load(statedata)
+        state = yaml.load(statedata, Loader=yaml.SafeLoader)
         use_yaml = True
     netapplier.apply(state, verify_change)
     print('Desired state applied: ')
@@ -219,7 +219,7 @@ def _parse_state(txtstate, parse_yaml):
     state = {}
     if parse_yaml:
         try:
-            state = yaml.load(txtstate)
+            state = yaml.load(txtstate, Loader=yaml.SafeLoader)
         except yaml.parser.ParserError as e:
             error = 'Invalid YAML syntax: %s\n' % e
         except yaml.parser.ScannerError as e:

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -90,7 +90,7 @@ def bond_interface(name, slaves):
 
 
 def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
-    state = yaml.load(BOND99_YAML_BASE)
+    state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
     netapplier.apply(state)
 
     assertlib.assert_state(state)
@@ -104,7 +104,7 @@ def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
 
 
 def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
-    state = yaml.load(BOND99_YAML_BASE)
+    state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
     netapplier.apply(state)
 
     remove_bond_state = {

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -82,6 +82,6 @@ def load_example(name):
     examples = find_examples_dir()
 
     with open(os.path.join(examples, name)) as yamlfile:
-        state = yaml.load(yamlfile)
+        state = yaml.load(yamlfile, Loader=yaml.SafeLoader)
 
     return state

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -53,8 +53,8 @@ port:
 
 def test_create_and_remove_linux_bridge_with_one_port(eth1_up):
     bridge_name = 'linux-br0'
-    bridge_state = yaml.load(BRIDGE_OPTIONS_YAML)
-    port_state = yaml.load(BRIDGE_PORT_ETH1_YAML)
+    bridge_state = yaml.load(BRIDGE_OPTIONS_YAML, Loader=yaml.SafeLoader)
+    port_state = yaml.load(BRIDGE_PORT_ETH1_YAML, Loader=yaml.SafeLoader)
     bridge_state.update(port_state)
 
     with linux_bridge(bridge_name, bridge_state) as desired_state:
@@ -104,9 +104,9 @@ def linux_bridge(name, bridge_state):
 
 def test_create_and_remove_linux_bridge_with_two_ports(eth1_up, eth2_up):
     bridge_name = 'linux-br0'
-    bridge_state = yaml.load(BRIDGE_OPTIONS_YAML)
-    port1_state = yaml.load(BRIDGE_PORT_ETH1_YAML)
-    port2_state = yaml.load(BRIDGE_PORT_ETH1_YAML)
+    bridge_state = yaml.load(BRIDGE_OPTIONS_YAML, Loader=yaml.SafeLoader)
+    port1_state = yaml.load(BRIDGE_PORT_ETH1_YAML, Loader=yaml.SafeLoader)
+    port2_state = yaml.load(BRIDGE_PORT_ETH1_YAML, Loader=yaml.SafeLoader)
     port2_state[LinuxBridge.PORT_SUBTREE][0][LinuxBridge.PORT_NAME] = 'eth2'
     bridge_state.update(port1_state)
     bridge_state[LinuxBridge.PORT_SUBTREE].append(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -38,7 +38,7 @@ interfaces:
 
 
 def test_create_and_remove_ovs_bridge_with_a_system_port(eth1_up):
-    state = yaml.load(OVS_BRIDGE_YAML_BASE)
+    state = yaml.load(OVS_BRIDGE_YAML_BASE, Loader=yaml.SafeLoader)
     state[INTERFACES][0]['bridge']['port'] = [
         {
             'name': 'eth1',
@@ -88,7 +88,7 @@ def test_create_and_remove_ovs_bridge_with_min_desired_state():
 
 
 def test_create_and_remove_ovs_bridge_with_an_internal_port():
-    state = yaml.load(OVS_BRIDGE_YAML_BASE)
+    state = yaml.load(OVS_BRIDGE_YAML_BASE, Loader=yaml.SafeLoader)
     state[INTERFACES][0]['bridge']['port'] = [
         {
             'name': 'ovs0',


### PR DESCRIPTION
PyYaml 5.1 has deprecated the usage of yaml.load(input) with the default
loader. It has been accompanied by a message warning.

As the usage of yaml in nmstate is for external input, the loader has
been explicitly set to SafeLoader.

Ref: https://msg.pyyaml.org/load
https://github.com/yaml/pyyaml/commit/0cedb2a0697b2bc49e4f3841b8d4590b6b15657e