### PR TITLE
automation: Enable no-auto-default on all devices

### DIFF
--- a/automation/docker_sys_config.sh
+++ b/automation/docker_sys_config.sh
@@ -3,6 +3,8 @@ echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > \
     /etc/NetworkManager/conf.d/97-docker-build.conf
 echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> \
     /etc/NetworkManager/conf.d/97-docker-build.conf
+echo -e "[main]\nno-auto-default=*\n" >> \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
 sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/' \
     /etc/systemd/journald.conf
 sed -i 's/#RateLimitBurst=1000/RateLimitBurst=0/' \

--- a/packaging/docker_sys_config.sh
+++ b/packaging/docker_sys_config.sh
@@ -3,6 +3,8 @@ echo -e "[logging]\nlevel=TRACE\ndomains=ALL\n" > \
     /etc/NetworkManager/conf.d/97-docker-build.conf
 echo -e "[device]\nmatch-device=*\nmanaged=0\n" >> \
     /etc/NetworkManager/conf.d/97-docker-build.conf
+echo -e "[main]\nno-auto-default=*\n" >> \
+    /etc/NetworkManager/conf.d/97-docker-build.conf
 sed -i 's/#RateLimitInterval=30s/RateLimitInterval=0/' \
     /etc/systemd/journald.conf
 sed -i 's/#RateLimitBurst=1000/RateLimitBurst=0/' \


### PR DESCRIPTION
Do not create generated connections automatically on all devices in the
test env.

This configuration has been re-introduced due to:
https://bugzilla.redhat.com/1687937