### PR TITLE
integ tests: Skip route versification while testing bonds

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -187,7 +187,7 @@ def test_rollback_for_bond(eth1_up, eth2_up):
     time.sleep(5)
 
     current_state_after_apply = netinfo.show()
-    assert current_state == current_state_after_apply
+    assert current_state[INTERFACES] == current_state_after_apply[INTERFACES]
 
 
 def test_add_slave_to_bond_without_slaves(eth1_up):


### PR DESCRIPTION
The bond rollback test is set to create a bond successfully and then
fail at the verification step on an unsupported parameter.

The test first reads the current state, applies the desired state and
then checks that the new current state is equal to the old current
state.

With the addition of the routes entries, this test now fails frequently
on the default IPv6 route metric change [1].

1. https://nmstate.atlassian.net/browse/NMSTATE-162