### PR TITLE
nm/checkpoint: Do not destroy other checkpoints

### DIFF
--- a/libnmstate/error.py
+++ b/libnmstate/error.py
@@ -54,6 +54,13 @@ class NmstatePermissionError(NmstateError, PermissionError):
     pass
 
 
+class NmstateConflictError(NmstateError, RuntimeError):
+    """
+    Something else is already editing the network state via Nmstate.
+    """
+    pass
+
+
 class NmstateLibnmError(NmstateError):
     """
     Exception for unexpected libnm failure.

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -47,7 +47,7 @@ def _apply_ifaces_state(desired_state, verify_change):
     desired_state.sanitize_dynamic_ip()
     metadata.generate_ifaces_metadata(desired_state, current_state)
     try:
-        with _transaction():
+        with nm.checkpoint.CheckPoint():
             with _setup_providers():
                 _add_interfaces(desired_state.interfaces,
                                 current_state.interfaces)
@@ -68,17 +68,6 @@ def _verify_change(desired_state):
 
 
 @contextmanager
-def _transaction():
-    if nm.checkpoint.has_checkpoint_capability():
-        checkpoint_ctx = nm.checkpoint.CheckPoint()
-    else:
-        checkpoint_ctx = _placeholder_ctx()
-
-    with checkpoint_ctx as checkpoint:
-        yield checkpoint
-
-
-@contextmanager
 def _setup_providers():
     mainloop = nmclient.mainloop()
     yield
@@ -87,11 +76,6 @@ def _setup_providers():
         raise NmstateLibnmError(
             'Unexpected failure of libnm when running the mainloop: {}'.format(
                 mainloop.error))
-
-
-@contextmanager
-def _placeholder_ctx():
-    yield
 
 
 def _add_interfaces(ifaces_desired_state, ifaces_current_state):

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -108,8 +108,8 @@ class CheckPoint(object):
             logging.debug('Checkpoint %s created for all devices: %s',
                           dbuspath, timeout)
             self._checkpoint = dbuspath
-        except dbus.exceptions.DBusException:
-            raise NMCheckPointCreationError()
+        except dbus.exceptions.DBusException as e:
+            raise NMCheckPointCreationError(str(e))
 
     def destroy(self):
         self._manager.interface.CheckpointDestroy(self._checkpoint)

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -93,7 +93,6 @@ class CheckPoint(object):
         devs = []
         timeout = self._timeout
         cp_flags = (
-            CHECKPOINT_CREATE_FLAG_DESTROY_ALL |
             CHECKPOINT_CREATE_FLAG_DELETE_NEW_CONNECTIONS |
             CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES
         )

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -17,11 +17,7 @@
 
 import logging
 
-try:
-    import dbus                         # pylint: disable=import-error
-except ImportError:
-    # dbus is set to None to indicate that checkpoint is not available
-    dbus = None
+import dbus
 
 
 DBUS_STD_PROPERTIES_IFNAME = 'org.freedesktop.DBus.Properties'
@@ -36,10 +32,6 @@ class NMCheckPointCreationError(Exception):
     """ Error creating a Network Manager CheckPoint """
 
     pass
-
-
-def has_checkpoint_capability():
-    return dbus is not None
 
 
 def nmdbus_manager():

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import time
+
+
+import pytest
+
+
+from libnmstate.nm.checkpoint import CheckPoint
+from libnmstate.nm.checkpoint import NMCheckPointCreationError
+
+
+def test_creating_one_checkpoint():
+    """ I can create a checkpoint """
+    with CheckPoint() as checkpoint:
+        pass
+
+    assert checkpoint is not None
+
+
+def test_creating_two_checkpoints():
+    """ I cannot create a checkpoint when a checkpoint already exists. """
+    with CheckPoint() as checkpoint:
+        with pytest.raises(NMCheckPointCreationError):
+            with CheckPoint():
+                pass
+
+    assert checkpoint is not None
+
+
+def test_checkpoint_timeout():
+    """ I can create a checkpoint that is removed after one second. """
+
+    with pytest.raises(Exception):
+        with CheckPoint(timeout=1) as checkpoint_a:
+            time.sleep(1)
+            with CheckPoint() as checkpoint_b:
+                pass
+
+    assert checkpoint_b is not None
+    assert checkpoint_a is not None


### PR DESCRIPTION
Not destroying other checkpoints will make checkpoint creation fail if
there is already a checkpoint for all devices. This prevents other users
to use another instance of Nmstate to change the state while a state
change is in progress.

Signed-off-by: Till Maas <opensource@till.name>