### PR TITLE
Support manual state verification

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -32,6 +32,20 @@ from libnmstate.schema import Constants
 
 
 def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
+    """
+    Apply the desired state
+
+    :param verify_change: Check if the outcome state matches the desired state
+        and rollback if not.
+    :param commit: Commit the changes after verification if the state matches.
+    :param rollback_timeout: Revert the changes if they are not commited within
+        this timeout (specified in seconds).
+    :type verify_change: bool
+    :type commit: bool
+    :type rollback_timeout: int (seconds)
+    :returns: Checkpoint identifier
+    :rtype: str
+    """
     desired_state = copy.deepcopy(desired_state)
     validator.verify(desired_state)
     validator.verify_capabilities(desired_state, netinfo.capabilities())

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -68,7 +68,10 @@ def commit(checkpoint=None):
     """
 
     nmcheckpoint = _choose_checkpoint(checkpoint)
-    nmcheckpoint.destroy()
+    try:
+        nmcheckpoint.destroy()
+    except nm.checkpoint.NMCheckPointError as e:
+        raise NmstateValueError(str(e))
 
 
 def rollback(checkpoint=None):
@@ -81,7 +84,10 @@ def rollback(checkpoint=None):
     """
 
     nmcheckpoint = _choose_checkpoint(checkpoint)
-    nmcheckpoint.rollback()
+    try:
+        nmcheckpoint.rollback()
+    except nm.checkpoint.NMCheckPointError as e:
+        raise NmstateValueError(str(e))
 
 
 def _choose_checkpoint(dbuspath):

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -67,7 +67,11 @@ def commit(checkpoint=None):
     :type checkpoint: str
     """
 
-    dbuspath = checkpoint
+    nmcheckpoint = _choose_checkpoint(checkpoint)
+    nmcheckpoint.destroy()
+
+
+def _choose_checkpoint(dbuspath):
     if not dbuspath:
         candidates = nm.checkpoint.get_checkpoints()
         if candidates:
@@ -75,8 +79,8 @@ def commit(checkpoint=None):
 
     if not dbuspath:
         raise NmstateValueError("No checkpoint specified or found")
-    nmcheckpoint = nm.checkpoint.CheckPoint(dbuspath=checkpoint)
-    nmcheckpoint.destroy()
+    checkpoint = nm.checkpoint.CheckPoint(dbuspath=dbuspath)
+    return checkpoint
 
 
 def _apply_ifaces_state(desired_state, verify_change, commit,

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -25,8 +25,8 @@ from libnmstate import netinfo
 from libnmstate import nm
 from libnmstate import state
 from libnmstate import validator
-from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateConflictError
+from libnmstate.error import NmstateLibnmError
 from libnmstate.nm import nmclient
 from libnmstate.schema import Constants
 

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -71,6 +71,19 @@ def commit(checkpoint=None):
     nmcheckpoint.destroy()
 
 
+def rollback(checkpoint=None):
+    """
+    Roll back a checkpoint that was received from `apply()`.
+
+    :param checkpoint: Checkpoint to roll back. If not specified, a checkpoint
+        will be selected and rolled back.
+    :type checkpoint: str
+    """
+
+    nmcheckpoint = _choose_checkpoint(checkpoint)
+    nmcheckpoint.rollback()
+
+
 def _choose_checkpoint(dbuspath):
     if not dbuspath:
         candidates = nm.checkpoint.get_checkpoints()

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -122,3 +122,7 @@ class CheckPoint(object):
         logging.debug('Checkpoint %s rollback executed: %s', self._dbuspath,
                       result)
         return result
+
+    @property
+    def dbuspath(self):
+        return self._dbuspath

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -82,7 +82,7 @@ class CheckPoint(object):
     def __init__(self, timeout=60):
         self._manager = nmdbus_manager()
         self._timeout = timeout
-        self._checkpoint = None
+        self._dbuspath = None
 
     def __enter__(self):
         self.create()
@@ -108,17 +108,17 @@ class CheckPoint(object):
                                                                 cp_flags)
             logging.debug('Checkpoint %s created for all devices: %s',
                           dbuspath, timeout)
-            self._checkpoint = dbuspath
+            self._dbuspath = dbuspath
         except dbus.exceptions.DBusException as e:
             raise NMCheckPointCreationError(str(e))
 
     def destroy(self):
-        self._manager.interface.CheckpointDestroy(self._checkpoint)
-        logging.debug('Checkpoint %s destroyed', self._checkpoint)
+        self._manager.interface.CheckpointDestroy(self._dbuspath)
+        logging.debug('Checkpoint %s destroyed', self._dbuspath)
 
     def rollback(self):
         result = self._manager.interface.CheckpointRollback(
-            self._checkpoint)
-        logging.debug('Checkpoint %s rollback executed: %s', self._checkpoint,
+            self._dbuspath)
+        logging.debug('Checkpoint %s rollback executed: %s', self._dbuspath,
                       result)
         return result

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -31,7 +31,13 @@ CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES = 0x04
 _nmdbus_manager = None
 
 
-class NMCheckPointCreationError(Exception):
+class NMCheckPointError(Exception):
+    """ Error creating a Network Manager CheckPoint """
+
+    pass
+
+
+class NMCheckPointCreationError(NMCheckPointError):
     """ Error creating a Network Manager CheckPoint """
 
     pass
@@ -115,12 +121,19 @@ class CheckPoint(object):
             raise NMCheckPointCreationError(str(e))
 
     def destroy(self):
-        self._manager.interface.CheckpointDestroy(self._dbuspath)
+        try:
+            self._manager.interface.CheckpointDestroy(self._dbuspath)
+        except dbus.exceptions.DBusException as e:
+            raise NMCheckPointError(str(e))
+
         logging.debug('Checkpoint %s destroyed', self._dbuspath)
 
     def rollback(self):
-        result = self._manager.interface.CheckpointRollback(
-            self._dbuspath)
+        try:
+            result = self._manager.interface.CheckpointRollback(
+                self._dbuspath)
+        except dbus.exceptions.DBusException as e:
+            raise NMCheckPointError(str(e))
         logging.debug('Checkpoint %s rollback executed: %s', self._dbuspath,
                       result)
         return result

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -79,10 +79,11 @@ def get_checkpoints():
 
 class CheckPoint(object):
 
-    def __init__(self, timeout=60):
+    def __init__(self, timeout=60, autodestroy=True):
         self._manager = nmdbus_manager()
         self._timeout = timeout
         self._dbuspath = None
+        self._autodestroy = autodestroy
 
     def __enter__(self):
         self.create()
@@ -90,9 +91,10 @@ class CheckPoint(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is None:
-            # If the rollback has been explicit or implicit triggered already,
-            # this command should fail.
-            self.destroy()
+            if self._autodestroy:
+                # If the rollback has been explicit or implicit triggered
+                # already, this command should fail.
+                self.destroy()
         else:
             self.rollback()
 

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -19,8 +19,11 @@ import logging
 
 import dbus
 
+import libnmstate.nm.nmclient
+
 
 DBUS_STD_PROPERTIES_IFNAME = 'org.freedesktop.DBus.Properties'
+
 CHECKPOINT_CREATE_FLAG_DESTROY_ALL = 0x01
 CHECKPOINT_CREATE_FLAG_DELETE_NEW_CONNECTIONS = 0x02
 CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES = 0x04
@@ -66,6 +69,12 @@ class _NMDbusManager(object):
                                            _NMDbusManager.OBJ_PATH)
         self.properties = dbus.Interface(mng_proxy, DBUS_STD_PROPERTIES_IFNAME)
         self.interface = dbus.Interface(mng_proxy, _NMDbusManager.IF_NAME)
+
+
+def get_checkpoints():
+    nmclient = libnmstate.nm.nmclient.client(refresh=True)
+
+    return [c.get_path() for c in nmclient.get_checkpoints()]
 
 
 class CheckPoint(object):

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -79,10 +79,10 @@ def get_checkpoints():
 
 class CheckPoint(object):
 
-    def __init__(self, timeout=60, autodestroy=True):
+    def __init__(self, timeout=60, autodestroy=True, dbuspath=None):
         self._manager = nmdbus_manager()
         self._timeout = timeout
-        self._dbuspath = None
+        self._dbuspath = dbuspath
         self._autodestroy = autodestroy
 
     def __enter__(self):

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -45,8 +45,8 @@ def main():
 
     subparsers = parser.add_subparsers()
     setup_subcommand_edit(subparsers)
-    setup_subcommand_show(subparsers)
     setup_subcommand_set(subparsers)
+    setup_subcommand_show(subparsers)
 
     if len(sys.argv) == 1:
         parser.print_usage()
@@ -72,17 +72,6 @@ def setup_subcommand_edit(subparsers):
     )
 
 
-def setup_subcommand_show(subparsers):
-    parser_show = subparsers.add_parser('show', help='Show network state')
-    parser_show.set_defaults(func=show)
-    parser_show.add_argument('--json', help='Edit as JSON', default=True,
-                             action='store_false', dest='yaml')
-    parser_show.add_argument(
-        'only', default='*', nargs='?', metavar=Constants.INTERFACES,
-        help='Show only specified interfaces (comma-separated)'
-    )
-
-
 def setup_subcommand_set(subparsers):
     parser_set = subparsers.add_parser('set', help='Set network state')
     parser_set.add_argument('file', help='File containing desired state. '
@@ -102,6 +91,17 @@ def setup_subcommand_set(subparsers):
         help='Timeout in seconds before reverting uncommited changes.'
     )
     parser_set.set_defaults(func=apply)
+
+
+def setup_subcommand_show(subparsers):
+    parser_show = subparsers.add_parser('show', help='Show network state')
+    parser_show.set_defaults(func=show)
+    parser_show.add_argument('--json', help='Edit as JSON', default=True,
+                             action='store_false', dest='yaml')
+    parser_show.add_argument(
+        'only', default='*', nargs='?', metavar=Constants.INTERFACES,
+        help='Show only specified interfaces (comma-separated)'
+    )
 
 
 def edit(args):

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -69,7 +69,7 @@ interfaces:
 
 @mock.patch('sys.argv', ['nmstatectl', 'set', 'mystate.json'])
 @mock.patch.object(nmstatectl.netapplier, 'apply',
-                   lambda state, verify_change: None)
+                   lambda state, verify_change, commit, timeout: None)
 @mock.patch.object(nmstatectl, 'open', mock.mock_open(read_data='{}'),
                    create=True)
 def test_run_ctl_directly_set():

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -33,33 +33,33 @@ def test_add_down_remove_vlan(eth1_up):
     """
 
     vlan_ifname = 'eth1.101'
-    with yaml_state('vlan101_eth1_up.yml',
-                    cleanup='vlan101_eth1_absent.yml') as desired_state:
+    with example_state('vlan101_eth1_up.yml',
+                       cleanup='vlan101_eth1_absent.yml') as desired_state:
         assertlib.assert_state(desired_state)
-        with yaml_state('vlan101_eth1_down.yml') as desired_state:
+        with example_state('vlan101_eth1_down.yml') as desired_state:
             assertlib.assert_absent(vlan_ifname)
 
     assertlib.assert_absent(vlan_ifname)
 
 
 def test_add_remove_ovs_bridge(eth1_up):
-    with yaml_state('ovsbridge_create.yml',
-                    cleanup='ovsbridge_delete.yml') as desired_state:
+    with example_state('ovsbridge_create.yml',
+                       cleanup='ovsbridge_delete.yml') as desired_state:
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent('ovs-br0')
 
 
 def test_add_remove_linux_bridge(eth1_up):
-    with yaml_state('linuxbrige_eth1_up.yml',
-                    cleanup='linuxbrige_eth1_absent.yml') as desired_state:
+    with example_state('linuxbrige_eth1_up.yml',
+                       cleanup='linuxbrige_eth1_absent.yml') as desired_state:
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent('linux-br0')
 
 
 @contextmanager
-def yaml_state(initial, cleanup=None):
+def example_state(initial, cleanup=None):
     """
     Apply the initial state and optionally the cleanup state at the end
     """

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -16,15 +16,8 @@
 #
 """ Test the nmstate example files """
 
-from contextlib import contextmanager
-import os.path
-
-import yaml
-
-from libnmstate import netapplier
-
 from .testlib import assertlib
-from .testlib.examplelib import find_examples_dir
+from .testlib.examplelib import example_state
 
 
 def test_add_down_remove_vlan(eth1_up):
@@ -56,32 +49,3 @@ def test_add_remove_linux_bridge(eth1_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent('linux-br0')
-
-
-@contextmanager
-def example_state(initial, cleanup=None):
-    """
-    Apply the initial state and optionally the cleanup state at the end
-    """
-
-    desired_state = load_example(initial)
-
-    netapplier.apply(desired_state)
-    try:
-        yield desired_state
-    finally:
-        if cleanup:
-            netapplier.apply(load_example(cleanup))
-
-
-def load_example(name):
-    """
-    Load the state from an example yaml file
-    """
-
-    examples = find_examples_dir()
-
-    with open(os.path.join(examples, name)) as yamlfile:
-        state = yaml.load(yamlfile, Loader=yaml.SafeLoader)
-
-    return state

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -69,3 +69,16 @@ def test_getting_a_checkpoint():
 
     assert len(checkpoints) == 1
     assert checkpoints[0] == checkpoint.dbuspath
+
+
+def test_non_auto_destroying_checkpoint():
+    """ I can create a checkpoint that needs to be confirmed manually. """
+
+    with CheckPoint(autodestroy=False) as checkpoint:
+        pass
+
+    checkpoints = get_checkpoints()
+
+    assert checkpoints[0] == checkpoint.dbuspath
+    checkpoint.destroy()
+    assert not get_checkpoints()

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -64,7 +64,8 @@ def test_getting_a_checkpoint():
 
     assert len(checkpoints) == 0
 
-    with CheckPoint():
+    with CheckPoint() as checkpoint:
         checkpoints = get_checkpoints()
 
     assert len(checkpoints) == 1
+    assert checkpoints[0] == checkpoint.dbuspath

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -22,6 +22,7 @@ import pytest
 
 
 from libnmstate.nm.checkpoint import CheckPoint
+from libnmstate.nm.checkpoint import get_checkpoints
 from libnmstate.nm.checkpoint import NMCheckPointCreationError
 
 
@@ -54,3 +55,16 @@ def test_checkpoint_timeout():
 
     assert checkpoint_b is not None
     assert checkpoint_a is not None
+
+
+def test_getting_a_checkpoint():
+    """ I can get a list of all checkpoints. """
+
+    checkpoints = get_checkpoints()
+
+    assert len(checkpoints) == 0
+
+    with CheckPoint():
+        checkpoints = get_checkpoints()
+
+    assert len(checkpoints) == 1

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -82,3 +82,12 @@ def test_non_auto_destroying_checkpoint():
     assert checkpoints[0] == checkpoint.dbuspath
     checkpoint.destroy()
     assert not get_checkpoints()
+
+
+def test_creating_a_checkpoint_from_dbuspath():
+    with CheckPoint(autodestroy=False) as initial_checkpoint:
+        pass
+
+    new_checkpoint = CheckPoint(dbuspath=initial_checkpoint.dbuspath)
+    new_checkpoint.destroy()
+    assert not get_checkpoints()

--- a/tests/integration/testlib/examplelib.py
+++ b/tests/integration/testlib/examplelib.py
@@ -15,10 +15,46 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+from contextlib import contextmanager
 import os
 
 
+import yaml
+
+
+from libnmstate import netapplier
+
+
 PATH_MAX = 4096
+
+
+@contextmanager
+def example_state(initial, cleanup=None):
+    """
+    Apply the initial state and optionally the cleanup state at the end
+    """
+
+    desired_state = load_example(initial)
+
+    netapplier.apply(desired_state)
+    try:
+        yield desired_state
+    finally:
+        if cleanup:
+            netapplier.apply(load_example(cleanup))
+
+
+def load_example(name):
+    """
+    Load the state from an example yaml file
+    """
+
+    examples = find_examples_dir()
+
+    with open(os.path.join(examples, name)) as yamlfile:
+        state = yaml.load(yamlfile, Loader=yaml.SafeLoader)
+
+    return state
 
 
 def find_examples_dir():


### PR DESCRIPTION

To help other reviewer, below lines are added by @cathay4t:

This PR introduce a way to allow user commit or rollback a checkpoint manually.

API:
 * `libnmstate.netapplier.apply()` support new optional argument `commit=False`.
    If set, the function will return a checkpoint object. The checkpoint object could be used for
    `libnmstate.netapplier.commit()` or `libnmstate.netapplier.rollback()`

CLI:
 * `nmstatectl set <yaml_file> --no-commit` which will print a checkpoint dbus object path.
 *  `nmstatctl commit <checkpoint_dbus_obj_path>` or `nmstatctl rollback <checkpoint_dbus_obj_path>`