### PR TITLE
spec files: Require libnm 1.12 or newer

### DIFF
--- a/packaging/nmstate.py2.spec
+++ b/packaging/nmstate.py2.spec
@@ -23,7 +23,7 @@ provider support on the southbound.
 
 %package -n python2-%{libname}
 Summary:        nmstate Python 2 API library
-Requires:       NetworkManager-libnm
+Requires:       NetworkManager-libnm >= 1:1.12
 Requires:       python-gobject-base
 Requires:       python2-six
 Requires:       python-jsonschema

--- a/packaging/nmstate.py3.spec
+++ b/packaging/nmstate.py3.spec
@@ -24,7 +24,7 @@ provider support on the southbound.
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
 Requires:       python3-dbus
-Requires:       NetworkManager-libnm
+Requires:       NetworkManager-libnm >= 1:1.12
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
 Recommends:     NetworkManager


### PR DESCRIPTION
Nmstate needs at least libnm 1.12 for checkpoint support.

Signed-off-by: Till Maas <opensource@till.name>