### PR TITLE
Revert back to CentOS 7.5 due to CI failure

### DIFF
--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -1,7 +1,7 @@
 # This Dockerfile is based on the recommendations provided in the
 # Centos official repository (https://hub.docker.com/_/centos/).
 # It enables systemd to be operational.
-FROM centos:7
+FROM centos:7.5.1804
 
 ENV container docker
 


### PR DESCRIPTION
The NetworkManager cannot manager any interfaces when using CentOS 7.6
docker image.