### PR TITLE
packaging: Remove libibverbs dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ existing limitations.
 yum -y install epel-release
 yum -y install \
     dbus-python \
-    libibverbs \
     NetworkManager \
     NetworkManager-libnm \
     NetworkManager-ovs \

--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -8,10 +8,7 @@ COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
 
-# libibverbs is a dependency for openvswitch that is missing as a dependency in
-# the RPM
 RUN dnf -y install --setopt=install_weak_deps=False \
-                   libibverbs \
                    NetworkManager \
                    NetworkManager-ovs \
                    openvswitch \

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -9,10 +9,8 @@ COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
 
-# libibverbs is a dependency for openvswitch that is missing as a dependency in the RPM
 RUN yum -y upgrade && \
     yum -y install \
-        libibverbs \
         NetworkManager \
         NetworkManager-libnm \
         NetworkManager-ovs \


### PR DESCRIPTION
libibverbs does not seem to be required for openvswitch anymore,
therefore do not install or mention it.

Signed-off-by: Till Maas <opensource@till.name>