### PR TITLE
Introduce nm.device.reapply

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -151,7 +151,7 @@ class ConnectionProfile(object):
                 logging.debug(
                     'Connection activation in progress: dev=%s, state=%s',
                     ac.devname, ac.state)
-                self._waitfor_active_connection_async(ac)
+                self.waitfor_active_connection_async(ac)
                 return
 
         specific_object = None
@@ -205,7 +205,7 @@ class ConnectionProfile(object):
             if ac.is_active:
                 self._mainloop.execute_next_action()
             elif ac.is_activating:
-                self._waitfor_active_connection_async(ac)
+                self.waitfor_active_connection_async(ac)
             else:
                 self._mainloop.quit(
                     'Connection activation failed on {}: reason={}'.format(
@@ -230,7 +230,7 @@ class ConnectionProfile(object):
 
         return activation_type, activation_object
 
-    def _waitfor_active_connection_async(self, ac):
+    def waitfor_active_connection_async(self, ac):
         ac.handlers.add(
             ac.nm_active_connection.connect(
                 'state-changed', self._waitfor_active_connection_callback, ac)

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -49,6 +49,68 @@ def delete(dev):
         con_profile.delete()
 
 
+def reapply(dev, connection_profile):
+    mainloop = nmclient.mainloop()
+    mainloop.push_action(_safe_reapply_async, dev, connection_profile)
+
+
+def _safe_reapply_async(dev, connection_profile):
+    mainloop = nmclient.mainloop()
+    cancellable = mainloop.new_cancellable()
+
+    if _wait_for_active_connection_async(dev, connection_profile):
+        return
+
+    version_id = 0
+    flags = 0
+    user_data = mainloop, dev, cancellable
+    dev.reapply_async(
+        connection_profile,
+        version_id,
+        flags,
+        cancellable,
+        _reapply_callback,
+        user_data,
+    )
+
+
+def _wait_for_active_connection_async(dev, connection_profile):
+    active_conn = connection.get_device_active_connection(dev)
+    if active_conn:
+        act_conn = ac.ActiveConnection(active_conn)
+        if act_conn.is_activating:
+            logging.debug(
+                'Connection activation in progress: dev=%s, state=%s',
+                act_conn.devname, act_conn.state)
+            conn = connection.ConnectionProfile(connection_profile)
+            conn.waitfor_active_connection_async(act_conn)
+            return True
+    return False
+
+
+def _reapply_callback(src_object, result, user_data):
+    mainloop, nmdev, cancellable = user_data
+    mainloop.drop_cancellable(cancellable)
+
+    devname = src_object.get_iface()
+    try:
+        success = src_object.reapply_finish(result)
+    except Exception as e:
+        if mainloop.is_action_canceled(e):
+            logging.debug('Device reapply aborted on %s: error=%s', devname, e)
+        else:
+            mainloop.quit(
+                'Device reapply failed on {}: error={}'.format(devname, e))
+        return
+
+    if success:
+        logging.debug('Device reapply succeeded: dev=%s', devname)
+        mainloop.execute_next_action()
+    else:
+        mainloop.quit(
+            'Device reapply failed: dev={}, error=unknown'.format(devname))
+
+
 def delete_device(nmdev):
     mainloop = nmclient.mainloop()
     mainloop.push_action(_safe_delete_device_async, nmdev)

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -59,9 +59,17 @@ def client(refresh=False):
     return _nmclient
 
 
-def mainloop():
+def mainloop(refresh=False):
+    """
+    Create a singleton (global) mainloop object.
+
+    When the refresh flag is set, the existing mainloop object is re-created.
+    Use the refresh flag in scenarios where the mainloop is needed but
+    the existing object is no longer usable (in an undefined state),
+    e.g. the mainloop exited with failure.
+    """
     global _mainloop
-    if _mainloop is None:
+    if _mainloop is None or refresh:
         _mainloop = _MainLoop()
     return _mainloop
 

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -1,0 +1,82 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate import nm
+
+from .testlib import mainloop
+
+
+TEST_IFACE = 'eth1'
+
+IPV4_ADDRESS1 = '192.0.2.251'
+
+
+def test_interface_ipv4_change(eth1_up):
+    with mainloop():
+        _modify_interface(
+            ipv4_state={
+                'enabled': True,
+                'dhcp': False,
+                'address': [
+                    {'ip': IPV4_ADDRESS1, 'prefix-length': 24}
+                ]
+            }
+        )
+
+    nm.nmclient.client(refresh=True)
+    ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
+
+    ip4_expected_state = {
+        'enabled': True,
+        'dhcp': False,
+        'address': [
+            {'ip': IPV4_ADDRESS1, 'prefix-length': 24}
+        ]
+    }
+    assert ip4_expected_state == ipv4_current_state
+
+
+def _modify_interface(ipv4_state):
+    conn = nm.connection.ConnectionProfile()
+    conn.import_by_id(TEST_IFACE)
+    settings = _create_iface_settings(ipv4_state, conn)
+    new_conn = nm.connection.ConnectionProfile()
+    new_conn.create(settings)
+    conn.update(new_conn)
+    conn.commit(save_to_disk=False)
+
+    nmdev = nm.device.get_device_by_name(TEST_IFACE)
+    nm.device.reapply(nmdev, conn.profile)
+
+
+def _get_ipv4_current_state(ifname):
+    nmdev = nm.device.get_device_by_name(ifname)
+    active_connection = nm.connection.get_device_active_connection(nmdev)
+    return nm.ipv4.get_info(active_connection)
+
+
+def _create_iface_settings(ipv4_state, con_profile):
+    con_setting = nm.connection.ConnectionSetting()
+    con_setting.import_by_profile(con_profile)
+
+    # Wired is required due to https://bugzilla.redhat.com/1703960
+    wired_setting = con_profile.profile.get_setting_wired()
+
+    ipv4_setting = nm.ipv4.create_setting(ipv4_state, con_profile.profile)
+    ipv6_setting = nm.ipv6.create_setting({}, None)
+
+    return con_setting.setting, wired_setting, ipv4_setting, ipv6_setting

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -20,12 +20,18 @@ import functools
 from libnmstate import nm
 
 
+class TestMainloopError(Exception):
+    pass
+
+
 @contextmanager
 def mainloop():
     mloop = nm.nmclient.mainloop()
     yield
     success = mloop.run(timeout=5)
-    assert success, 'Mainloop error: ' + mloop.error
+    if not success:
+        nm.nmclient.mainloop(refresh=True)
+        raise TestMainloopError(mloop.error)
 
 
 def mainloop_run(func):


### PR DESCRIPTION
Reapply operation is introduced in the nm provider.
It includes a fallback to a profile activation in case the reapply fails.

Integration into nmstate core is planned in a separate PR.

Dependent on PR #325 