### PR TITLE
automation: Fix Fedora29 dev image

### DIFF
--- a/automation/Dockerfile.fedora
+++ b/automation/Dockerfile.fedora
@@ -12,6 +12,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
                    openvswitch \
+                   systemd-udev \
                    \
                    python2-dbus \
                    python2-ipaddress \

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -258,8 +258,11 @@ then
 fi
 
 docker_exec 'while ! systemctl is-active dbus; do sleep 1; done'
+docker_exec 'systemctl start systemd-udevd
+             while ! systemctl is-active systemd-udevd; do sleep 1; done
+'
 docker_exec '
-    systemctl start NetworkManager
+    systemctl restart NetworkManager
     while ! systemctl is-active NetworkManager; do sleep 1; done
 '
 pyclean


### PR DESCRIPTION
Udev has stopped working in the Fedora dev image.
It seems that the source is related to a missing systemd-udev package.

The container dockerfile has been updated to include systemd-udev.
In addition, an update has been included to confirm with the systemd
container enablement instructions:
https://hub.docker.com/r/fedora/systemd-systemd/

systemd-udevd is also being started when the container is run and NM is
restarted in order to confirm it loads with udev activated already.