### PR TITLE
Nm wired return existing

### DIFF
--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -32,14 +32,14 @@ def create_setting(iface_state, base_con_profile):
     duplex = ethernet.get('duplex')
     auto_negotiation = ethernet.get('auto-negotiation')
 
-    if not (mac or mtu or speed or duplex or (auto_negotiation is not None)):
-        return None
-
     wired_setting = None
     if base_con_profile:
         wired_setting = base_con_profile.get_setting_wired()
         if wired_setting:
             wired_setting = wired_setting.duplicate()
+
+    if not (mac or mtu or speed or duplex or (auto_negotiation is not None)):
+        return wired_setting
 
     if not wired_setting:
         wired_setting = nmclient.NM.SettingWired.new()


### PR DESCRIPTION
Dependent on #325 
nm.wired: Return existing setting instead of nothing

The wired setting is affecting the reapply action when it is missing
from the connection profile [1].
In order to adjust to this behaviour, in cases where no new wired
parameters are mentioned in the desired state and an existing profile
exists, the current wired setting is returned.

1. https://bugzilla.redhat.com/1703960