### PR TITLE
Canonicalize ip subtree

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -54,6 +54,7 @@ class State(object):
     def __init__(self, state):
         self._state = copy.deepcopy(state)
         self._ifaces_state = State._index_interfaces_state_by_name(self._state)
+        self._complement_interface_empty_ip_subtrees()
 
     def __eq__(self, other):
         return self.state == other.state
@@ -79,6 +80,13 @@ class State(object):
     def interfaces(self):
         """ Indexed interfaces state """
         return self._ifaces_state
+
+    def _complement_interface_empty_ip_subtrees(self):
+        """ Complement the interfaces states with empty IPv4/IPv6 subtrees. """
+        for iface_state in six.viewvalues(self.interfaces):
+            for family in (Interface.IPV4, Interface.IPV6):
+                if family not in iface_state:
+                    iface_state[family] = {}
 
     def sanitize_ethernet(self, other_state):
         """

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -117,7 +117,7 @@ class State(object):
         """
         for iface_state in six.viewvalues(self.interfaces):
             for family in ('ipv4', 'ipv6'):
-                ip = iface_state.get(family, {})
+                ip = iface_state[family]
                 if ip.get('enabled') and (
                         ip.get('dhcp') or ip.get('autoconf')):
                     ip['address'] = []
@@ -226,8 +226,7 @@ class State(object):
     def _sort_ip_addresses(self):
         for ifstate in six.viewvalues(self.interfaces):
             for family in ('ipv4', 'ipv6'):
-                ifstate.get(family, {}).get('address', []).sort(
-                    key=itemgetter('ip'))
+                ifstate[family].get('address', []).sort(key=itemgetter('ip'))
 
     def _capitalize_mac(self):
         for ifstate in six.viewvalues(self.interfaces):

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -109,7 +109,9 @@ def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
                     'options': {
                         'miimon': 200,
                     }
-                }
+                },
+                'ipv4': {},
+                'ipv6': {}
             }
         ]
     }

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -33,20 +33,16 @@ class TestAssertIfaceState(object):
     def test_desired_is_partial_to_current(self):
         desired_state = self._base_state
         current_state = self._base_state
-        current_state.interfaces.update({
-            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
-        })
+        extra_state = self._extra_state
+        current_state.interfaces.update(extra_state.interfaces)
 
         desired_state.verify_interfaces(current_state)
 
     def test_current_is_partial_to_desired(self):
         desired_state = self._base_state
         current_state = self._base_state
-        desired_state.interfaces.update({
-            'eth0': {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
-            'eth1': {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
-        })
+        extra_state = self._extra_state
+        desired_state.interfaces.update(extra_state.interfaces)
 
         with pytest.raises(NmstateVerificationError):
             desired_state.verify_interfaces(current_state)
@@ -131,5 +127,14 @@ class TestAssertIfaceState(object):
                         ]
                     }
                 }
+            ]
+        })
+
+    @property
+    def _extra_state(self):
+        return state.State({
+            Interface.KEY: [
+                {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+                {'name': 'eth1', 'state': 'up', 'type': 'unknown'}
             ]
         })


### PR DESCRIPTION
Complement IPv{4,6} keys in the interface state and assume they are there when processing the state.
The same question should not be asked multiple times.