### PR TITLE
fedora container: Pin to Fedora 29

### DIFF
--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,7 +2,7 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM fedora
+FROM fedora:29
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 


### PR DESCRIPTION
Since Fedora 30 was released recently and we did not test it, yet, just
use Fedora 29 for now.

Signed-off-by: Till Maas <opensource@till.name>

I did a quick manual test, F30 will break the CI:
- The python2 dbus package seems to have gone (at least the lint tests fail because they cannot compile the pypi dbus package)
- The integration tests just failed (aborted after 7 tests)