### PR TITLE
schema constants: Introduce Bond and BondMode

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -98,6 +98,25 @@ class InterfaceType(object):
     )
 
 
+class Bond(object):
+    KEY = InterfaceType.BOND
+    CONFIG_SUBTREE = 'link-aggregation'
+
+    MODE = 'mode'
+    SLAVES = 'slaves'
+    OPTIONS_SUBTREE = 'options'
+
+
+class BondMode(object):
+    ROUND_ROBIN = 'balance-rr'
+    ACTIVE_BACKUP = 'active-backup'
+    XOR = 'balance-xor'
+    BROADCAST = 'broadcast'
+    LACP = '802.3ad'
+    TLB = 'balance-tlb'
+    ALB = 'balance-alb'
+
+
 class LinuxBridge(object):
     TYPE = 'linux-bridge'
     CONFIG_SUBTREE = 'bridge'

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -18,6 +18,7 @@
 from contextlib import contextmanager
 
 from libnmstate import nm
+from libnmstate import schema
 
 from .testlib import mainloop
 
@@ -27,14 +28,17 @@ ETH1 = 'eth1'
 
 
 def test_create_and_remove_bond(eth1_up):
-    bond_options = {'mode': 'balance-rr', 'miimon': '140'}
+    bond_options = {
+        schema.Bond.MODE: schema.BondMode.ROUND_ROBIN,
+        'miimon': '140'
+    }
 
     with _bond_interface(BOND0, bond_options):
         bond_current_state = _get_bond_current_state(BOND0)
 
         bond_desired_state = {
-            'slaves': [],
-            'options': bond_options
+            schema.Bond.SLAVES: [],
+            schema.Bond.OPTIONS_SUBTREE: bond_options
         }
         assert bond_desired_state == bond_current_state
 


### PR DESCRIPTION
Use the new constants in the integration bond_test module.

Note: Bond options have not been specified in this change. It is left
for a following change.