### PR TITLE
Support adding non-gateway route in libnmstate.nm

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -23,6 +23,7 @@ from libnmstate.appliers import linux_bridge
 BRPORT_OPTIONS = '_brport_options'
 MASTER = '_master'
 MASTER_TYPE = '_master_type'
+ROUTES = '_routes'
 
 
 def generate_ifaces_metadata(desired_state, current_state):

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -18,6 +18,7 @@
 import socket
 
 from . import nmclient
+from libnmstate import metadata
 from libnmstate.nm import route as nm_route
 
 
@@ -31,6 +32,7 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.ignore_auto_routes = False
             setting_ipv4.props.never_default = False
             setting_ipv4.props.ignore_auto_dns = False
+            setting_ipv4.clear_routes()
 
     if not setting_ipv4:
         setting_ipv4 = nmclient.NM.SettingIP4Config.new()
@@ -51,6 +53,7 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL)
             _add_addresses(setting_ipv4, config['address'])
+        nm_route.add_routes(setting_ipv4, config.get(metadata.ROUTES, []))
     return setting_ipv4
 
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -19,6 +19,7 @@ import logging
 import socket
 
 from libnmstate import iplib
+from libnmstate import metadata
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import nmclient
 from libnmstate.nm import route as nm_route
@@ -89,6 +90,7 @@ def create_setting(config, base_con_profile):
             setting_ip.props.ignore_auto_routes = False
             setting_ip.props.never_default = False
             setting_ip.props.ignore_auto_dns = False
+            setting_ip.clear_routes()
 
     if not setting_ip:
         setting_ip = nmclient.NM.SettingIP6Config.new()
@@ -116,6 +118,7 @@ def create_setting(config, base_con_profile):
         setting_ip.props.method = (
             nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
 
+    nm_route.add_routes(setting_ip, config.get(metadata.ROUTES, []))
     return setting_ip
 
 

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -54,6 +54,8 @@ class Route(object):
     NEXT_HOP_INTERFACE = 'next-hop-interface'
     NEXT_HOP_ADDRESS = 'next-hop-address'
     METRIC = 'metric'
+    USE_DEFAULT_METRIC = -1
+    USE_DEFAULT_ROUTE_TABLE = 0
 
 
 class DNS(object):

--- a/tests/lib/nm/route_test.py
+++ b/tests/lib/nm/route_test.py
@@ -1,0 +1,136 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import copy
+
+import pytest
+
+from libnmstate import metadata
+from libnmstate.nm import ipv4 as nm_ipv4
+from libnmstate.nm import ipv6 as nm_ipv6
+from libnmstate.nm import connection as nm_connection
+from libnmstate.schema import Route
+
+IPV4_ROUTE1 = {
+    Route.DESTINATION: '198.51.100.0/24',
+    Route.METRIC: 103,
+    Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+    Route.TABLE_ID: 50
+}
+
+IPV4_ROUTE2 = {
+    Route.DESTINATION: '203.0.113.0/24',
+    Route.METRIC: 103,
+    Route.NEXT_HOP_ADDRESS: '192.0.2.2',
+    Route.TABLE_ID: 51
+}
+
+IPV6_ROUTE1 = {
+    Route.DESTINATION: '2001:db8:a::/64',
+    Route.METRIC: 103,
+    Route.NEXT_HOP_ADDRESS: '2001:db8:1::a',
+    Route.TABLE_ID: 50
+}
+
+IPV6_ROUTE2 = {
+    Route.DESTINATION: '2001:db8:b::/64',
+    Route.METRIC: 103,
+    Route.NEXT_HOP_ADDRESS: '2001:db8:1::b',
+    Route.TABLE_ID: 51
+}
+
+parametrize_ip_ver_routes = pytest.mark.parametrize(
+    'nm_ip, routes',
+    [(nm_ipv4, [IPV4_ROUTE1, IPV4_ROUTE2]),
+     (nm_ipv6, [IPV6_ROUTE1, IPV6_ROUTE2])],
+    ids=['ipv4', 'ipv6'])
+
+
+@parametrize_ip_ver_routes
+def test_add_multiple_route(nm_ip, routes):
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: routes
+    }, base_con_profile=None)
+    assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == routes
+
+
+@parametrize_ip_ver_routes
+def test_add_duplicate_routes(nm_ip, routes):
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: [routes[0], routes[0]]
+    }, base_con_profile=None)
+    assert ([_nm_route_to_dict(r) for r in setting_ip.props.routes] ==
+            [routes[0]])
+
+
+@parametrize_ip_ver_routes
+def test_clear_route(nm_ip, routes):
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: routes
+    }, base_con_profile=None)
+    con_profile = nm_connection.ConnectionProfile()
+    con_profile.create([setting_ip])
+    new_setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: []
+    }, base_con_profile=con_profile.profile)
+    assert not [_nm_route_to_dict(r) for r in new_setting_ip.props.routes]
+
+
+@parametrize_ip_ver_routes
+def test_add_route_without_metric(nm_ip, routes):
+    route_with_default_metric = copy.deepcopy(routes[0])
+    route_with_default_metric[Route.METRIC] = Route.USE_DEFAULT_METRIC
+    route_without_metric = copy.deepcopy(routes[0])
+    del route_without_metric[Route.METRIC]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: [route_without_metric]
+    }, base_con_profile=None)
+    assert ([_nm_route_to_dict(r) for r in setting_ip.props.routes] ==
+            [route_with_default_metric])
+
+
+@parametrize_ip_ver_routes
+def test_add_route_without_table_id(nm_ip, routes):
+    route_with_default_table_id = copy.deepcopy(routes[0])
+    route_with_default_table_id[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+    route_without_table_id = copy.deepcopy(routes[0])
+    del route_without_table_id[Route.TABLE_ID]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.ROUTES: [route_without_table_id]
+    }, base_con_profile=None)
+    assert ([_nm_route_to_dict(r) for r in setting_ip.props.routes] ==
+            [route_with_default_table_id])
+
+
+def _nm_route_to_dict(nm_route):
+    dst = '{ip}/{prefix}'.format(
+        ip=nm_route.get_dest(), prefix=nm_route.get_prefix())
+    next_hop = nm_route.get_next_hop() or ''
+    metric = int(nm_route.get_metric())
+    table_id_variant = nm_route.get_attribute('table')
+
+    return {
+        Route.TABLE_ID: int(table_id_variant.get_uint32()),
+        Route.DESTINATION: dst,
+        Route.NEXT_HOP_ADDRESS: next_hop,
+        Route.METRIC: metric,
+    }


### PR DESCRIPTION
Support adding non-gateway route via nm/ipv4.py and nm/ipv6.py.

Test case included.