### PR TITLE
state: Allow copying current interface to desire

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -316,6 +316,17 @@ class State(object):
         self._config_iface_routes = State._index_routes_by_iface(
             self._config_routes)
 
+    def include_changed_interfaces(self, other, changed_iface_names):
+        """
+        Add copy interface state from other.interfaces if not found in
+        self.interfaces
+        """
+        for iface_name in changed_iface_names:
+            if iface_name not in self.interfaces and \
+               iface_name in other.interfaces:
+                self.interfaces[iface_name] = \
+                    copy.deepcopy(other.interfaces[iface_name])
+
     def _remove_absent_interfaces(self):
         ifaces = {}
         for ifname, ifstate in six.viewitems(self.interfaces):

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -119,6 +119,25 @@ class TestAssertIfaceState(object):
 
         desired_state.verify_interfaces(current_state)
 
+    def test_include_changed_ifaces(self):
+        current_state = self._base_state
+        desired_state = state.State({})
+        iface_names = current_state.interfaces.keys()
+        desired_state.include_changed_interfaces(current_state, iface_names)
+        assert desired_state.interfaces == current_state.interfaces
+
+    def test_include_changed_ifaces_but_not_in_current(self):
+        current_state = self._base_state
+        desired_state = state.State({})
+        desired_state.include_changed_interfaces(current_state, ['not-exists'])
+        assert desired_state.interfaces == {}
+
+    def test_include_changed_ifaces_with_empty_current(self):
+        desired_state = state.State({})
+        current_state = state.State({})
+        desired_state.include_changed_interfaces(current_state, ['foo-name'])
+        assert desired_state.interfaces == {}
+
     @property
     def _base_state(self):
         return state.State({


### PR DESCRIPTION
The DNS editing might save DNS configurations to interface not listed in
desired state. Adding `State.include_changed_interfaces()` to copy
current interface to desire if not found.

Unit test cases are included.