### PR TITLE
Add support of route addition

### DIFF
--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1,0 +1,253 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import copy
+
+import pytest
+
+from libnmstate import netapplier
+from libnmstate import netinfo
+from libnmstate.error import NmstateNotImplementedError
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import Route
+
+IPV4_ADDRESS1 = '192.0.2.251'
+
+IPV6_ADDRESS1 = '2001:db8:1::1'
+
+ETH1_INTERFACE_STATE = {
+    Interface.NAME: 'eth1',
+    Interface.STATE: InterfaceState.UP,
+    Interface.TYPE: InterfaceType.ETHERNET,
+    Interface.IPV4: {
+        'address': [
+            {
+                'ip': IPV4_ADDRESS1,
+                'prefix-length': 24
+            }
+        ],
+        'dhcp': False,
+        'enabled': True
+    },
+    Interface.IPV6: {
+        'address': [
+            {
+                'ip': IPV6_ADDRESS1,
+                'prefix-length': 64
+            }
+        ],
+        'dhcp': False,
+        'autoconf': False,
+        'enabled': True
+    }
+}
+
+
+def test_add_static_routes(eth1_up):
+    routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    netapplier.apply({
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+        Route.KEY: {
+            Route.CONFIG: routes
+        }
+    })
+    cur_state = netinfo.show()
+    _assert_routes(routes, cur_state)
+
+
+def test_add_gateway(eth1_up):
+    routes = [_get_ipv4_gateways()[0], _get_ipv6_test_routes()[0]]
+    netapplier.apply({
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+        Route.KEY: {
+            Route.CONFIG: routes
+        }
+    })
+    cur_state = netinfo.show()
+    _assert_routes(routes, cur_state)
+
+
+def test_add_route_without_metric(eth1_up):
+    routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    for route in routes:
+        del route[Route.METRIC]
+
+    netapplier.apply({
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+        Route.KEY: {
+            Route.CONFIG: routes
+        }
+    })
+
+    cur_state = netinfo.show()
+    _assert_routes(routes, cur_state)
+
+
+def test_add_route_without_table_id(eth1_up):
+    routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    for route in routes:
+        del route[Route.TABLE_ID]
+
+    netapplier.apply({
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+        Route.KEY: {
+            Route.CONFIG: routes
+        },
+    })
+
+    cur_state = netinfo.show()
+    _assert_routes(routes, cur_state)
+
+
+@pytest.mark.xfail(raises=NmstateNotImplementedError,
+                   reason="Red Hat Bug 1707396")
+def test_multiple_gateway(eth1_up):
+    netapplier.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {
+                Route.CONFIG: _get_ipv4_gateways() + _get_ipv6_gateways()
+            }
+        })
+
+
+def _assert_routes(routes, state):
+    """
+    Assuming we are all operating eth1 routes
+    """
+    routes = copy.deepcopy(routes)
+    for route in routes:
+        if Route.METRIC not in route:
+            route[Route.METRIC] = Route.USE_DEFAULT_METRIC
+        if Route.TABLE_ID not in route:
+            route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+    routes.sort(key=_route_sort_key)
+    config_routes = []
+    for config_route in state[Route.KEY][Route.CONFIG]:
+        if config_route[Route.NEXT_HOP_INTERFACE] == 'eth1':
+            config_routes.append(config_route)
+
+    config_routes.sort(key=_route_sort_key)
+    assert routes == config_routes
+
+    # The running routes contains more route entries than desired config
+    # The running routes also has different metric and table id for
+    # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
+    running_routes = state[Route.KEY][Route.RUNNING]
+    for route in routes:
+        _assert_in_running_route(route, running_routes)
+
+
+def _assert_in_running_route(route, running_routes):
+    route_in_running_routes = False
+    for running_route in running_routes:
+        metric = route.get(Route.METRIC, Route.USE_DEFAULT_METRIC)
+        table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
+        if metric == Route.USE_DEFAULT_METRIC:
+            running_route = copy.deepcopy(running_route)
+            running_route[Route.METRIC] = Route.USE_DEFAULT_METRIC
+        if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
+            running_route = copy.deepcopy(running_route)
+            running_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+
+        if route == running_route:
+            route_in_running_routes = True
+            break
+    assert route_in_running_routes
+
+
+def _get_ipv4_test_routes():
+    return [
+        {
+            Route.DESTINATION: '198.51.100.0/24',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 50
+        },
+        {
+            Route.DESTINATION: '203.0.113.0/24',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 51
+        }
+    ]
+
+
+def _get_ipv4_gateways():
+    return [
+        {
+            Route.DESTINATION: '0.0.0.0/0',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 254
+        },
+        {
+            Route.DESTINATION: '0.0.0.0/0',
+            Route.METRIC: 101,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.2',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 254
+        }
+    ]
+
+
+def _get_ipv6_test_routes():
+    return [
+        {
+            Route.DESTINATION: '2001:db8:a::/64',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:1::a',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 50
+        },
+        {
+            Route.DESTINATION: '2001:db8:b::/64',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:1::b',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 50
+        }
+    ]
+
+
+def _get_ipv6_gateways():
+    return [
+        {
+            Route.DESTINATION: '::/0',
+            Route.METRIC: 103,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:1::f',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 254
+        },
+        {
+            Route.DESTINATION: '::/0',
+            Route.METRIC: 101,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:1::e',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 254
+        }
+    ]
+
+
+def _route_sort_key(route):
+    return (route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE),
+            route.get(Route.NEXT_HOP_INTERFACE, ''),
+            route.get(Route.DESTINATION, ''))

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -76,6 +76,10 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
         current_config[INTERFACES][0]['ipv4'])
     netinfo_nm_mock.ipv6.get_info.return_value = (
         current_config[INTERFACES][0]['ipv6'])
+    netinfo_nm_mock.ipv4.get_route_running.return_value = []
+    netinfo_nm_mock.ipv4.get_route_config.return_value = []
+    netinfo_nm_mock.ipv6.get_route_running.return_value = []
+    netinfo_nm_mock.ipv6.get_route_config.return_value = []
 
     desired_config[INTERFACES][0]['state'] = 'down'
     netapplier.apply(desired_config, verify_change=False)
@@ -96,6 +100,10 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
 
 def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
     netinfo_nm_mock.device.list_devices.return_value = []
+    netinfo_nm_mock.ipv4.get_route_running.return_value = []
+    netinfo_nm_mock.ipv4.get_route_config.return_value = []
+    netinfo_nm_mock.ipv6.get_route_running.return_value = []
+    netinfo_nm_mock.ipv6.get_route_config.return_value = []
 
     desired_config = {
         INTERFACES: [
@@ -163,6 +171,10 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
         current_config[INTERFACES][0]['ipv4'])
     netinfo_nm_mock.ipv6.get_info.return_value = (
         current_config[INTERFACES][0]['ipv6'])
+    netinfo_nm_mock.ipv4.get_route_running.return_value = []
+    netinfo_nm_mock.ipv4.get_route_config.return_value = []
+    netinfo_nm_mock.ipv6.get_route_running.return_value = []
+    netinfo_nm_mock.ipv6.get_route_config.return_value = []
 
     desired_config = copy.deepcopy(current_config)
     options = desired_config[INTERFACES][0]['link-aggregation']['options']


### PR DESCRIPTION
Allows adding route entry to existing state with limitations:
    * Not support route removal yet.
    * Any interface referred as route next hop interface should be
      defined interfaces section of desired state.

Example is included at `examples/eth1_add_route.yml`