### PR TITLE
copr: Detect python version for SRPM deps

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,4 +1,5 @@
-SRPM_DEPENDENCIES=python-setuptools git
+python_major_version=$(shell command -v python3 &>/dev/null && echo 3 || echo 2)
+SRPM_DEPENDENCIES=python$(python_major_version)-setuptools git
 
 srpm:
 	rpm -q --whatprovides $(SRPM_DEPENDENCIES) || dnf -y install $(SRPM_DEPENDENCIES)


### PR DESCRIPTION
This finally fixes the Copr SRPM build, see https://copr.fedorainfracloud.org/coprs/till/nmstate-git-fedora/build/921236/

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/373)
<!-- Reviewable:end -->
