### PR TITLE
CI: Remove CentOS 7 copr repo tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ env:
     matrix:
         - DOCKER_IMAGE=nmstate/centos7-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
-        - DOCKER_IMAGE=nmstate/centos7-nmstate-dev
-          testflags="--test-type integ --pytest-args='-x'
-              --copr networkmanager/NetworkManager-master"
-        - DOCKER_IMAGE=nmstate/centos7-nmstate-dev
-          testflags="--test-type integ --pytest-args='-x'
-              --copr networkmanager/NetworkManager-1.18"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev


### PR DESCRIPTION
Remove the test instances of CentOS 7 using NetworkManager copr build
which turn out to be time wasting as no one is checking their failures.