### PR TITLE
tests integ: Introduce a link state monitor decorator

### DIFF
--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -26,20 +26,18 @@ TEST_IFACE = 'eth1'
 IPV4_ADDRESS1 = '192.0.2.251'
 
 
+@iproutelib.ip_monitor_assert_stable_link_up(TEST_IFACE)
 def test_interface_ipv4_change(eth1_up):
-    with iproutelib.ip_monitor(object_type='link', dev=TEST_IFACE) as result:
-        with mainloop():
-            _modify_interface(
-                ipv4_state={
-                    'enabled': True,
-                    'dhcp': False,
-                    'address': [
-                        {'ip': IPV4_ADDRESS1, 'prefix-length': 24}
-                    ]
-                }
-            )
-
-    assert len(iproutelib.get_non_up_events(result, dev='eth1')) == 0
+    with mainloop():
+        _modify_interface(
+            ipv4_state={
+                'enabled': True,
+                'dhcp': False,
+                'address': [
+                    {'ip': IPV4_ADDRESS1, 'prefix-length': 24}
+                ]
+            }
+        )
 
     nm.nmclient.client(refresh=True)
     ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)

--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -20,6 +20,8 @@ import subprocess
 import threading
 import time
 
+import six
+
 
 TIMEOUT = 10
 
@@ -29,6 +31,18 @@ class IpMonitorResult(object):
         self.out = None
         self.err = None
         self.popen = None
+
+
+def ip_monitor_assert_stable_link_up(dev, timeout=10):
+    def decorator(func):
+        @six.wraps(func)
+        def wrapper_ip_monitor(*args, **kwargs):
+            with ip_monitor('link', dev, timeout) as result:
+                func(*args, **kwargs)
+            assert len(get_non_up_events(result, dev)) == 0, ('result: ' +
+                                                              result.out)
+        return wrapper_ip_monitor
+    return decorator
 
 
 @contextmanager


### PR DESCRIPTION
Link state monitoring is used to detect link state changes while
executing apply changes. In particular, to detect links that change to
anything but UP.

In order to allow simpler usage in selected tests, a decorator is
introduced in addition to the existing context-manager.

Note: six is used to overcome functools.wraps limitations with pytest
(https://github.com/pytest-dev/pytest/issues/2782)