### PR TITLE
nm: Add support of DNS editing

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -27,6 +27,8 @@ BRPORT_OPTIONS = '_brport_options'
 MASTER = '_master'
 MASTER_TYPE = '_master_type'
 ROUTES = '_routes'
+DNS_METADATA = '_dns'
+DNS_METADATA_PRIORITY = '_priority'
 
 
 def generate_ifaces_metadata(desired_state, current_state):

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -19,6 +19,7 @@ import socket
 
 from . import nmclient
 from libnmstate import metadata
+from libnmstate.nm import dns as nm_dns
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import Route
 
@@ -37,6 +38,9 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.route_table = Route.USE_DEFAULT_ROUTE_TABLE
             setting_ipv4.props.route_metric = Route.USE_DEFAULT_METRIC
             setting_ipv4.clear_routes()
+            setting_ipv4.clear_dns()
+            setting_ipv4.clear_dns_searches()
+            setting_ipv4.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ipv4:
         setting_ipv4 = nmclient.NM.SettingIP4Config.new()
@@ -58,6 +62,7 @@ def create_setting(config, base_con_profile):
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL)
             _add_addresses(setting_ipv4, config['address'])
         nm_route.add_routes(setting_ipv4, config.get(metadata.ROUTES, []))
+        nm_dns.add_dns(setting_ipv4, config.get(nm_dns.DNS_METADATA, {}))
     return setting_ipv4
 
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -22,6 +22,7 @@ from libnmstate import iplib
 from libnmstate import metadata
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import nmclient
+from libnmstate.nm import dns as nm_dns
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import Route
 
@@ -94,6 +95,9 @@ def create_setting(config, base_con_profile):
             setting_ip.props.gateway = None
             setting_ip.props.route_table = Route.USE_DEFAULT_ROUTE_TABLE
             setting_ip.props.route_metric = Route.USE_DEFAULT_METRIC
+            setting_ip.clear_dns()
+            setting_ip.clear_dns_searches()
+            setting_ip.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ip:
         setting_ip = nmclient.NM.SettingIP6Config.new()
@@ -122,6 +126,7 @@ def create_setting(config, base_con_profile):
             nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
 
     nm_route.add_routes(setting_ip, config.get(metadata.ROUTES, []))
+    nm_dns.add_dns(setting_ip, config.get(nm_dns.DNS_METADATA, {}))
     return setting_ip
 
 

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate.schema import DNS
+import libnmstate.nm.connection as nm_connection
+import libnmstate.nm.dns as nm_dns
+import libnmstate.nm.ipv4 as nm_ipv4
+import libnmstate.nm.ipv6 as nm_ipv6
+
+
+def _get_test_dns_v4():
+    return {
+        nm_dns.DNS_METADATA_PRIORITY: 40,
+        DNS.SERVER: ['8.8.8.8', '1.1.1.1'],
+        DNS.SEARCH: ['example.org', 'example.com']
+    }
+
+
+def _get_test_dns_v6():
+    return {
+        nm_dns.DNS_METADATA_PRIORITY: 40,
+        DNS.SERVER: ['2001:4860:4860::8888', '2606:4700:4700::1111'],
+        DNS.SEARCH: ['example.net', 'example.edu']
+    }
+
+
+parametrize_ip_ver = pytest.mark.parametrize(
+    'nm_ip',
+    [(nm_ipv4), (nm_ipv6)],
+    ids=['ipv4', 'ipv6'])
+
+
+parametrize_ip_ver_dns = pytest.mark.parametrize(
+    'nm_ip, get_test_dns_func',
+    [(nm_ipv4, _get_test_dns_v4),
+     (nm_ipv6, _get_test_dns_v6)],
+    ids=['ipv4', 'ipv6'])
+
+
+@parametrize_ip_ver
+def test_add_dns_empty(nm_ip):
+    dns_conf = {}
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns_duplicate_server(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0], dns_conf[DNS.SERVER][0]]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0]]
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns_duplicate_search(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0], dns_conf[DNS.SEARCH][0]]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0]]
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_clear_dns(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+    con_profile = nm_connection.ConnectionProfile()
+    con_profile.create([setting_ip])
+    new_setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        nm_dns.DNS_METADATA: {}
+    }, base_con_profile=con_profile.profile)
+
+    _assert_dns(new_setting_ip, {})
+
+
+def _assert_dns(setting_ip, dns_conf):
+    assert setting_ip.props.dns == dns_conf.get(DNS.SERVER, [])
+    assert setting_ip.props.dns_search == dns_conf.get(DNS.SEARCH, [])
+    priority = dns_conf.get(nm_dns.DNS_METADATA_PRIORITY,
+                            nm_dns.DEFAULT_DNS_PRIORITY)
+    assert setting_ip.props.dns_priority == priority


### PR DESCRIPTION
The DNS configuration will be saved in `metadata.DNS_METADATA` key.
Additional key `metadata.DNS_PRIORITY` is introduced to enforce the DNS
server order(for example, [8.8.8.8, 2606:4700:4700::1111] need DNS
priority to enforce IPv4 server is listed before IPv6 server).