### PR TITLE
pylint: Fix a false alarm

### DIFF
--- a/libnmstate/prettystate.py
+++ b/libnmstate/prettystate.py
@@ -58,7 +58,7 @@ class PrettyState(object):
         yaml.add_representer(OrderedDict, represent_ordereddict)
 
         if six.PY2:
-            yaml.add_representer(unicode, represent_unicode)
+            yaml.add_representer(six.text_type, represent_unicode)
         self.state = order_state(deepcopy(state))
 
     @property


### PR DESCRIPTION
With python3 pylint 2.3.1, it will complain about unicode not defined
in `libnmstate/prettystate.py`.

It's a false alarm as when using unicode, the code already checked with
`if six.PY2:`.

To fix this false alarm, just change it to `six.text_type`.