### PR TITLE
make_srpm.sh: Fix script error on EL7

### DIFF
--- a/packaging/make_srpm.sh
+++ b/packaging/make_srpm.sh
@@ -9,15 +9,15 @@ OLD_PWD=$(pwd)
 
 for candidate in python3 python2 python
 do
-    python="$(command -v "${candidate}")"
-    if [[ -v python ]]
+    python="$(command -v "${candidate}" || true)"
+    if [[ -n "${python}" ]]
     then
         break
     fi
 done
 
 
-if [[ ! -v python ]]
+if [[ -z "${python}" ]]
 then
     echo >/dev/stderr "ERROR: No python command found."
     exit 127


### PR DESCRIPTION
In RHEL/CentOS 7, the `make_srpm.sh` will fail for two reasons:

    1. The `set -e` will quit script when `command -v python3` failed.
    2. The `[[ -v python ]]` will be true even when `$python` is empty
       string.

The fix would be:

    1. Add `|| true` to silent the failure.
    2. Changed to `[ -n "$python" ]`.