### PR TITLE
Add support of DNS editing

### DIFF
--- a/examples/dns_edit_eth1.yml
+++ b/examples/dns_edit_eth1.yml
@@ -1,0 +1,34 @@
+---
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 8.8.8.8
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::1
+    next-hop-interface: eth1
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 192.0.2.10
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  ipv6:
+    address:
+    - ip: 2001:db8:1::a
+      prefix-length: 64
+    autoconf: false
+    dhcp: false
+    enabled: true

--- a/examples/dns_remove.yml
+++ b/examples/dns_remove.yml
@@ -1,0 +1,6 @@
+---
+dns-resolver:
+  config:
+    search: []
+    server: []
+interfaces: []

--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -14,12 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+import copy
 
 import six
 
 from libnmstate import iplib
 from libnmstate.appliers import linux_bridge
+from libnmstate.error import NmstateNotImplementedError
+from libnmstate.error import NmstateValueError
+from libnmstate.nm import dns as nm_dns
+from libnmstate.nm.route import IPV4_DEFAULT_GATEWAY_DESTINATION
+from libnmstate.nm.route import IPV6_DEFAULT_GATEWAY_DESTINATION
+from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route
 
 
@@ -29,6 +37,12 @@ MASTER_TYPE = '_master_type'
 ROUTES = '_routes'
 DNS_METADATA = '_dns'
 DNS_METADATA_PRIORITY = '_priority'
+
+# The 40 is chose as default DNS priority of VPN is 50.
+DNS_ORDERING_IPV4_PRIORITY = 40
+DNS_ORDERING_IPV6_PRIORITY = 41
+# Ensuring static DNS config takes priority over DHCP/autoconf
+DNS_DEFAULT_PRIORITY_FOR_STATIC = 42
 
 
 def generate_ifaces_metadata(desired_state, current_state):
@@ -65,6 +79,13 @@ def generate_ifaces_metadata(desired_state, current_state):
         get_slaves_func=linux_bridge.get_slaves_from_state,
         set_metadata_func=linux_bridge.set_bridge_ports_metadata
     )
+    # The DNS metadata should be generated before route as DNS metadata could
+    # add include more changed interfaces which route entry should be
+    # preserved from current state. For example:
+    #   desire_state wants to change DNS on eth1 but not containing any
+    #   route config, this need routes copied from current state and saved to
+    #   eth1 route metadata.
+    _generate_dns_metadata(desired_state, current_state)
     _generate_route_metadata(desired_state)
 
 
@@ -75,6 +96,8 @@ def remove_ifaces_metadata(ifaces_state):
         iface_state.pop(BRPORT_OPTIONS, None)
         iface_state.get(Interface.IPV4, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV6, {}).pop(ROUTES, None)
+        iface_state.get(Interface.IPV4, {}).pop(DNS_METADATA, None)
+        iface_state.get(Interface.IPV6, {}).pop(DNS_METADATA, None)
 
 
 def _get_bond_slaves_from_state(iface_state, default=()):
@@ -181,3 +204,143 @@ def _generate_route_metadata(desired_state):
                 iface_state[Interface.IPV6][ROUTES].append(route)
             else:
                 iface_state[Interface.IPV4][ROUTES].append(route)
+
+
+def _generate_dns_metadata(desired_state, current_state):
+    """
+    Save DNS configuration to choose interface as metadata.
+    Raise NmstateValueError if failed to find interface.
+    To handle 3 DNS name server, we need 2+ interfaces when IPv6 server been
+    placed between two IPv4 servers and it also require assigning DNS priority.
+    To simplify workflow, currently we only support at most 2 name servers.
+    """
+    servers = desired_state.config_dns.get(DNS.SERVER, [])
+    searches = desired_state.config_dns.get(DNS.SEARCH, [])
+    if len(servers) > 2:
+        raise NmstateNotImplementedError(
+            'Nmstate only support at most 2 DNS name servers')
+    # Some interfaces might old DNS configuration which is not included
+    # in desired_state, we need to add them into desired_state in order to
+    # clear its DNS configurations
+    old_dns_ifaces = nm_dns.get_dns_config_iface_names()
+    _include_name_only_iface_state(
+        desired_state, current_state, old_dns_ifaces)
+    if not servers and not searches:
+        return
+    ipv4_server = []
+    ipv6_server = []
+    for server in servers:
+        if iplib.is_ipv6_address(server):
+            ipv6_server.append(server)
+        else:
+            ipv4_server.append(server)
+
+    search_saved = False
+    ipv4_iface, ipv6_iface = _choose_iface_for_dns(desired_state,
+                                                   current_state)
+
+    # Set DNS priority in case IPv4 server is listed before IPv6 server
+    need_dns_priority = False
+    if ipv6_server and ipv4_server:
+        if servers == [ipv4_server[0], ipv6_server[0]]:
+            need_dns_priority = True
+
+    for iface, family, servers in ((ipv6_iface, Interface.IPV6, ipv6_server),
+                                   (ipv4_iface, Interface.IPV4, ipv4_server)):
+        if servers:
+            if not iface:
+                raise NmstateValueError(
+                    'Failed to find suitable interface for saving DNS '
+                    'name servers: %s' % servers)
+            if iface not in desired_state.interfaces:
+                _include_name_only_iface_state(
+                    desired_state, current_state, [iface])
+            dns_meta = {
+                DNS_METADATA_PRIORITY: DNS_DEFAULT_PRIORITY_FOR_STATIC,
+                DNS.SERVER: servers,
+                DNS.SEARCH: []
+            }
+            if need_dns_priority:
+                if family == Interface.IPV6:
+                    dns_meta[DNS_METADATA_PRIORITY] = (
+                        DNS_ORDERING_IPV6_PRIORITY)
+                else:
+                    dns_meta[DNS_METADATA_PRIORITY] = (
+                        DNS_ORDERING_IPV4_PRIORITY)
+            if not search_saved:
+                dns_meta[DNS.SEARCH] = searches
+                search_saved = True
+            iface_state = desired_state.interfaces[iface]
+            if family not in iface_state:
+                iface_state[family] = {DNS_METADATA: dns_meta}
+            else:
+                iface_state[family][DNS_METADATA] = dns_meta
+
+
+def _choose_iface_for_dns(desired_state, current_state):
+    """
+    Find out the interface to store the DNS configuration:
+        * Static gateway configured
+        * DHCP with auto-dns false
+    Return two iface_names, first is for ipv4, second for ipv6.
+    """
+    ipv6_iface = None
+    ipv4_iface = None
+    new_state = copy.deepcopy(desired_state)
+    new_state.merge_interfaces(current_state)
+    for iface_name, routes in six.viewitems(new_state.config_iface_routes):
+        for route in routes:
+            if ipv6_iface and ipv4_iface:
+                return ipv4_iface, ipv6_iface
+            if not ipv6_iface and \
+               route[Route.DESTINATION] == IPV6_DEFAULT_GATEWAY_DESTINATION:
+                ipv6_iface = iface_name
+                continue
+            if not ipv4_iface and \
+               route[Route.DESTINATION] == IPV4_DEFAULT_GATEWAY_DESTINATION:
+                ipv4_iface = iface_name
+                continue
+    if not ipv4_iface:
+        ipv4_iface = _choose_auto_iface_without_auto_dns(
+            Interface.IPV4, desired_state, current_state)
+    if not ipv6_iface:
+        ipv6_iface = _choose_auto_iface_without_auto_dns(
+            Interface.IPV6, desired_state, current_state)
+    return ipv4_iface, ipv6_iface
+
+
+def _choose_auto_iface_without_auto_dns(family, desired_state, current_state):
+    """
+    Return the interface which has DHCP/Autoconf enabled but auto_dns False.
+    """
+    # The interface is not merged yet, we have to do ourselves.
+    checked_ifaces = []
+    desired_state = copy.deepcopy(desired_state)
+    desired_state.merge_interfaces(current_state)
+    # The desired_state might only contain partial interfaces, we need to check
+    # the current state also.
+    for iface_states in (desired_state.interfaces, current_state.interfaces):
+        for iface_name, iface_state in six.viewitems(iface_states):
+            if iface_name in checked_ifaces:
+                continue
+            checked_ifaces.append(iface_name)
+            if iface_state[Interface.STATE] != InterfaceState.UP:
+                continue
+            ip_state = iface_state.get(family, {})
+            if not ip_state['enabled']:
+                continue
+            if family == Interface.IPV4:
+                if ip_state.get('dhcp') and not ip_state.get('auto-dns'):
+                    return iface_name
+            elif family == Interface.IPV6:
+                if ip_state.get('dhcp') or ip_state.get('autoconf'):
+                    if not ip_state.get('auto-dns'):
+                        return iface_name
+
+
+def _include_name_only_iface_state(desired_state, current_state, iface_names):
+    for iface_name in iface_names:
+        if iface_name not in desired_state.interfaces and \
+           iface_name in current_state.interfaces:
+            print("HAHA", iface_name)
+            desired_state.interfaces[iface_name] = {Interface.NAME: iface_name}

--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -27,6 +27,8 @@ BRPORT_OPTIONS = '_brport_options'
 MASTER = '_master'
 MASTER_TYPE = '_master_type'
 ROUTES = '_routes'
+DNS_METADATA = '_dns'
+DNS_METADATA_PRIORITY = '_priority'
 
 
 def generate_ifaces_metadata(desired_state, current_state):

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -111,6 +111,7 @@ def _apply_ifaces_state(desired_state, verify_change, commit,
     desired_state.sanitize_ethernet(current_state)
     desired_state.sanitize_dynamic_ip()
     desired_state.merge_route_config(current_state)
+    desired_state.merge_dns(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
     validator.validate_interfaces_state(desired_state, current_state)
@@ -168,6 +169,7 @@ def _verify_change(desired_state):
     current_state = state.State(netinfo.show())
     desired_state.verify_interfaces(current_state)
     desired_state.verify_routes(current_state)
+    desired_state.verify_dns(current_state)
 
 
 @contextmanager

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -419,3 +419,11 @@ def get_ipv6_profile(active_connection):
     if remote_conn:
         return remote_conn.get_setting_ip6_config()
     return None
+
+
+def get_iface_name(active_connection):
+    """
+    Return interface name for active_connection, return None if error.
+    """
+    devs = active_connection.get_devices()
+    return devs[0].get_iface() if devs else None

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -397,3 +397,25 @@ def get_device_active_connection(nm_device):
     if nm_device:
         active_conn = nm_device.get_active_connection()
     return active_conn
+
+
+def get_ipv4_profile(active_connection):
+    """
+    Get NMSettingIP4Config from NMActiveConnection.
+    For any error, return None.
+    """
+    remote_conn = active_connection.get_connection()
+    if remote_conn:
+        return remote_conn.get_setting_ip4_config()
+    return None
+
+
+def get_ipv6_profile(active_connection):
+    """
+    Get NMSettingIP6Config from NMActiveConnection.
+    For any error, return None.
+    """
+    remote_conn = active_connection.get_connection()
+    if remote_conn:
+        return remote_conn.get_setting_ip6_config()
+    return None

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -103,6 +103,24 @@ def get_config():
     return dns_conf
 
 
+def get_dns_config_iface_names():
+    """
+    Return a list of interface name which holds the static DNS configurations.
+    """
+    iface_names = []
+    client = nmclient.client()
+    for ac in client.get_active_connections():
+        for ip_profile in (nm_connection.get_ipv6_profile(ac),
+                           nm_connection.get_ipv4_profile(ac)):
+            if not ip_profile:
+                continue
+            if not ip_profile.props.dns and not ip_profile.props.dns_search:
+                continue
+            iface_names.append(nm_connection.get_iface_name(ac))
+    print('old_dns_config', iface_names)
+    return iface_names
+
+
 def add_dns(setting_ip, dns_state):
     priority = dns_state.get(DNS_METADATA_PRIORITY)
     if priority is not None:

--- a/libnmstate/nm/route.py
+++ b/libnmstate/nm/route.py
@@ -22,6 +22,7 @@ from libnmstate import iplib
 from libnmstate.error import NmstateInternalError
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import nmclient
+from libnmstate.nm import connection as nm_connection
 from libnmstate.schema import Route
 
 NM_ROUTE_TABLE_ATTRIBUTE = 'table'
@@ -39,7 +40,7 @@ def get_running(acs_and_ip_cfgs):
     for (active_connection, ip_cfg) in acs_and_ip_cfgs:
         if not ip_cfg.props.routes:
             continue
-        iface_name = _get_iface_name(active_connection)
+        iface_name = nm_connection.get_iface_name(active_connection)
         if not iface_name:
             raise NmstateInternalError(
                 'Got connection {} has not interface name'.format(
@@ -72,7 +73,7 @@ def get_config(acs_and_ip_profiles):
         gateway = ip_profile.props.gateway
         if not nm_routes and not gateway:
             continue
-        iface_name = _get_iface_name(active_connection)
+        iface_name = nm_connection.get_iface_name(active_connection)
         if not iface_name:
             raise NmstateInternalError(
                 'Got connection {} has not interface name'.format(
@@ -107,14 +108,6 @@ def get_config(acs_and_ip_profiles):
 def _get_per_route_table_id(nm_route, default_table_id):
     table = nm_route.get_attribute(NM_ROUTE_TABLE_ATTRIBUTE)
     return int(table.get_uint32()) if table else default_table_id
-
-
-def _get_iface_name(active_connection):
-    """
-    Return interface name for active_connection, return None if error.
-    """
-    devs = active_connection.get_devices()
-    return devs[0].get_iface() if devs else None
 
 
 def _nm_route_to_route(nm_route, table_id, iface_name):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ import logging
 import pytest
 
 from libnmstate import netapplier
+from libnmstate import netinfo
 
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
@@ -68,3 +69,10 @@ def _set_eth_admin_state(ifname, state):
         if state == 'up':
             desired_state[INTERFACES][0].update({'ipv6': {'enabled': True}})
         netapplier.apply(desired_state)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def preserve_old_config():
+    old_state = netinfo.show()
+    yield
+    netapplier.apply(old_state, verify_change=False)

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -1,0 +1,236 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate import netapplier
+from libnmstate import netinfo
+from libnmstate.error import NmstateNotImplementedError
+from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import Route
+
+
+IPV4_DNS_NAMESERVERS = ['8.8.8.8', '1.1.1.1']
+IPV6_DNS_NAMESERVERS = ['2001:4860:4860::8888', '2606:4700:4700::1111']
+EXAMPLE_SEARCHES = ['example.org', 'example.com']
+
+parametrize_ip_ver = pytest.mark.parametrize(
+    'dns_config',
+    [({DNS.SERVER: IPV4_DNS_NAMESERVERS, DNS.SEARCH: EXAMPLE_SEARCHES}),
+     ({DNS.SERVER: IPV6_DNS_NAMESERVERS, DNS.SEARCH: EXAMPLE_SEARCHES})],
+    ids=['ipv4', 'ipv6'])
+
+
+@pytest.fixture(scope='function', autouse=True)
+def dns_test_env(eth1_up, eth2_up):
+    yield
+    # Remove DNS config as it be saved in eth1 or eth2 which might trigger
+    # failure when bring eth1/eth2 down.
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: [],
+                DNS.SEARCH: []
+            }
+        }
+    }
+    netapplier.apply(desired_state)
+
+
+@parametrize_ip_ver
+def test_dns_edit_nameserver_with_static_gateway(dns_config):
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_dns_edit_ipv4_nameserver_before_ipv6():
+    dns_config = {
+        DNS.SERVER: [IPV4_DNS_NAMESERVERS[0], IPV6_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_dns_edit_ipv6_nameserver_before_ipv4():
+    dns_config = {
+        DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+@pytest.mark.xfail(raises=NmstateNotImplementedError,
+                   reason='https://nmstate.atlassian.net/browse/NMSTATE-220',
+                   strict=True)
+def test_dns_edit_three_nameservers():
+    dns_config = {
+        DNS.SERVER: IPV6_DNS_NAMESERVERS + [IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_remove_dns_config():
+    dns_config = {
+        DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+
+    dns_config = {
+        DNS.SERVER: [],
+        DNS.SEARCH: []
+    }
+    netapplier.apply({
+        Interface.KEY: [],
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    })
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+def _get_test_iface_states():
+    return [
+        {
+            Interface.NAME: 'eth1',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '192.0.2.251',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:1::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+        {
+            Interface.NAME: 'eth2',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '198.51.100.1',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:2::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+    ]
+
+
+def _gen_default_gateway_route():
+    return [
+        {
+            Route.DESTINATION: '0.0.0.0/0',
+            Route.METRIC: 200,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 54
+        },
+        {
+            Route.DESTINATION: '::/0',
+            Route.METRIC: 201,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 54
+        }
+    ]

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -19,6 +19,9 @@
 from .testlib import assertlib
 from .testlib.examplelib import example_state
 
+from libnmstate import netinfo
+from libnmstate.schema import DNS
+
 
 def test_add_down_remove_vlan(eth1_up):
     """
@@ -49,3 +52,16 @@ def test_add_remove_linux_bridge(eth1_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent('linux-br0')
+
+
+def test_dns_edit(eth1_up):
+    with example_state('dns_edit_eth1.yml',
+                       cleanup='dns_remove.yml') as desired_state:
+        assertlib.assert_state(desired_state)
+
+    current_state = netinfo.show()
+    assert (current_state.get(DNS.KEY, {}).get(DNS.CONFIG, {}) ==
+            {
+                DNS.SERVER: [],
+                DNS.SEARCH: []
+            })

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -1,0 +1,127 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate import metadata
+from libnmstate.schema import DNS
+import libnmstate.nm.connection as nm_connection
+import libnmstate.nm.dns as nm_dns
+import libnmstate.nm.ipv4 as nm_ipv4
+import libnmstate.nm.ipv6 as nm_ipv6
+
+
+def _get_test_dns_v4():
+    return {
+        metadata.DNS_METADATA_PRIORITY: 40,
+        DNS.SERVER: ['8.8.8.8', '1.1.1.1'],
+        DNS.SEARCH: ['example.org', 'example.com']
+    }
+
+
+def _get_test_dns_v6():
+    return {
+        metadata.DNS_METADATA_PRIORITY: 40,
+        DNS.SERVER: ['2001:4860:4860::8888', '2606:4700:4700::1111'],
+        DNS.SEARCH: ['example.net', 'example.edu']
+    }
+
+
+parametrize_ip_ver = pytest.mark.parametrize(
+    'nm_ip',
+    [(nm_ipv4), (nm_ipv6)],
+    ids=['ipv4', 'ipv6'])
+
+
+parametrize_ip_ver_dns = pytest.mark.parametrize(
+    'nm_ip, get_test_dns_func',
+    [(nm_ipv4, _get_test_dns_v4),
+     (nm_ipv6, _get_test_dns_v6)],
+    ids=['ipv4', 'ipv6'])
+
+
+@parametrize_ip_ver
+def test_add_dns_empty(nm_ip):
+    dns_conf = {}
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns_duplicate_server(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0], dns_conf[DNS.SERVER][0]]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0]]
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_add_dns_duplicate_search(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0], dns_conf[DNS.SEARCH][0]]
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+
+    dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0]]
+    _assert_dns(setting_ip, dns_conf)
+
+
+@parametrize_ip_ver_dns
+def test_clear_dns(nm_ip, get_test_dns_func):
+    dns_conf = get_test_dns_func()
+    setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: dns_conf
+    }, base_con_profile=None)
+    con_profile = nm_connection.ConnectionProfile()
+    con_profile.create([setting_ip])
+    new_setting_ip = nm_ip.create_setting({
+        'enabled': True,
+        metadata.DNS_METADATA: {}
+    }, base_con_profile=con_profile.profile)
+
+    _assert_dns(new_setting_ip, {})
+
+
+def _assert_dns(setting_ip, dns_conf):
+    assert setting_ip.props.dns == dns_conf.get(DNS.SERVER, [])
+    assert setting_ip.props.dns_search == dns_conf.get(DNS.SEARCH, [])
+    priority = dns_conf.get(metadata.DNS_METADATA_PRIORITY,
+                            nm_dns.DEFAULT_DNS_PRIORITY)
+    assert setting_ip.props.dns_priority == priority


### PR DESCRIPTION
Example has been included as `../examples/dns_edit_eth1.yml`.
If DNS not defined in desire state, old DNS configuration will be
perceived.
To remove static DNS configuration, Please use this state:

```python
{
    DNS.KEY: {
        DNS.CONFIG: {
            DNS.SERVER: [],
            DNS.SEARCH: []
        }
    }
}
```

Unit and integration test cases has been included.