### PR TITLE
dns: Remove dns module dependency on ipv{4,6} modules

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -47,9 +47,11 @@ def show(include_status_data=False):
                        nm.ipv6.get_route_config()),
     }
 
+    client = nm.nmclient.client()
     report[Constants.DNS] = {
         DNS.RUNNING: nm_dns.get_running(),
-        DNS.CONFIG: nm_dns.get_config(),
+        DNS.CONFIG: nm_dns.get_config(nm.ipv4.acs_and_ip_profiles(client),
+                                      nm.ipv6.acs_and_ip_profiles(client)),
     }
 
     validator.validate(report)

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -134,7 +134,7 @@ def get_route_running():
 
 
 def get_route_config():
-    return nm_route.get_config(_acs_and_ip_profiles(nmclient.client()))
+    return nm_route.get_config(acs_and_ip_profiles(nmclient.client()))
 
 
 def _acs_and_ip_cfgs(client):
@@ -145,7 +145,7 @@ def _acs_and_ip_cfgs(client):
         yield ac, ip_cfg
 
 
-def _acs_and_ip_profiles(client):
+def acs_and_ip_profiles(client):
     for ac in client.get_active_connections():
         ip_profile = get_ip_profile(ac)
         if not ip_profile:

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -176,7 +176,7 @@ def get_route_running():
 
 
 def get_route_config():
-    routes = nm_route.get_config(_acs_and_ip_profiles(nmclient.client()))
+    routes = nm_route.get_config(acs_and_ip_profiles(nmclient.client()))
     for route in routes:
         if route[Route.METRIC] == 0:
             # Kernel will convert 0 to IPV6_DEFAULT_ROUTE_METRIC.
@@ -193,7 +193,7 @@ def _acs_and_ip_cfgs(client):
         yield ac, ip_cfg
 
 
-def _acs_and_ip_profiles(client):
+def acs_and_ip_profiles(client):
     for ac in client.get_active_connections():
         ip_profile = get_ip_profile(ac)
         if not ip_profile:


### PR DESCRIPTION
Use existing generators from the ip modules to fetch the DNS
configuration and by that removing the existing dependency.