### PR TITLE
validator: Only support up to two DNS name servers.

### DIFF
--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -23,7 +23,9 @@ import jsonschema as js
 from . import nm
 from . import schema
 from .schema import Constants
+from libnmstate.schema import DNS
 from libnmstate.error import NmstateDependencyError
+from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
 
 
@@ -86,3 +88,15 @@ def validate_dhcp(state):
                (ip.get('dhcp') or ip.get('autoconf')):
                 logging.warning('%s addresses are ignored when '
                                 'dynamic IP is enabled', family)
+
+
+def validate_dns(state):
+    """
+    Only support at most 2 name servers now:
+    https://nmstate.atlassian.net/browse/NMSTATE-220
+    """
+    dns_servers = state.get(
+        DNS.KEY, {}).get(DNS.CONFIG, {}).get(DNS.SERVER, [])
+    if len(dns_servers) > 2:
+        raise NmstateNotImplementedError(
+            'Nmstate only support at most 2 DNS name servers')

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -20,6 +20,8 @@ import pytest
 import libnmstate
 from libnmstate import schema
 from libnmstate import state
+from libnmstate.schema import DNS
+from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
 
 
@@ -137,6 +139,19 @@ class TestLinkAggregationState(object):
         with pytest.raises(NmstateValueError):
             libnmstate.validator.validate_link_aggregation_state(desired_state,
                                                                  empty_state())
+
+
+@pytest.mark.xfail(raises=NmstateNotImplementedError,
+                   reason='https://nmstate.atlassian.net/browse/NMSTATE-220',
+                   strict=True)
+def test_dns_three_nameservers():
+    libnmstate.validator.validate_dns({
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: ['8.8.8.8', '2001:4860:4860::8888', '8.8.4.4']
+            }
+        }
+    })
 
 
 def empty_state():


### PR DESCRIPTION
Supporting 3 name server is too complex to implement via libnm:
    https://nmstate.atlassian.net/browse/NMSTATE-220

Test case included.