### PR TITLE
nm: Remove ipv{4,6} module dependency on metadata module

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -18,7 +18,6 @@
 import socket
 
 from . import nmclient
-from libnmstate import metadata
 from libnmstate.nm import dns as nm_dns
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import Route
@@ -61,7 +60,8 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL)
             _add_addresses(setting_ipv4, config['address'])
-        nm_route.add_routes(setting_ipv4, config.get(metadata.ROUTES, []))
+        nm_route.add_routes(
+            setting_ipv4, config.get(nm_route.ROUTE_METADATA, []))
         nm_dns.add_dns(setting_ipv4, config.get(nm_dns.DNS_METADATA, {}))
     return setting_ipv4
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -19,7 +19,6 @@ import logging
 import socket
 
 from libnmstate import iplib
-from libnmstate import metadata
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import nmclient
 from libnmstate.nm import dns as nm_dns
@@ -125,7 +124,7 @@ def create_setting(config, base_con_profile):
         setting_ip.props.method = (
             nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL)
 
-    nm_route.add_routes(setting_ip, config.get(metadata.ROUTES, []))
+    nm_route.add_routes(setting_ip, config.get(nm_route.ROUTE_METADATA, []))
     nm_dns.add_dns(setting_ip, config.get(nm_dns.DNS_METADATA, {}))
     return setting_ip
 

--- a/libnmstate/nm/route.py
+++ b/libnmstate/nm/route.py
@@ -27,6 +27,7 @@ from libnmstate.schema import Route
 NM_ROUTE_TABLE_ATTRIBUTE = 'table'
 IPV4_DEFAULT_GATEWAY_DESTINATION = '0.0.0.0/0'
 IPV6_DEFAULT_GATEWAY_DESTINATION = '::/0'
+ROUTE_METADATA = '_routes'
 
 
 def get_running(acs_and_ip_cfgs):


### PR DESCRIPTION
The metadata module only required for route metadata string,
saving that string in `nm/route.py` will remove the metadata dependency.