### PR TITLE
nm: Query interface names which hold DNS config

### DIFF
--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 from libnmstate import iplib
 from libnmstate.error import NmstateInternalError
 from libnmstate.nm import nmclient
+from libnmstate.nm import active_connection as nm_ac
 from libnmstate.schema import DNS
 
 
@@ -106,3 +107,14 @@ def add_dns(setting_ip, dns_state):
         setting_ip.add_dns(server)
     for search in dns_state.get(DNS.SEARCH, []):
         setting_ip.add_dns_search(search)
+
+
+def get_dns_config_iface_names(acs_and_ipv4_profiles, acs_and_ipv6_profiles):
+    """
+    Return a list of interface names which hold static DNS configuration.
+    """
+    iface_names = []
+    for ac, ip_profile in chain(acs_and_ipv6_profiles, acs_and_ipv4_profiles):
+        if ip_profile.props.dns or ip_profile.props.dns_search:
+            iface_names.append(nm_ac.ActiveConnection(ac).devname)
+    return iface_names


### PR DESCRIPTION
Add `nm.dns.get_dns_config_iface_names()` to get a list of interface
names which is currently hold static DNS configurations.