### PR TITLE
nm: Choose interface with default gateway for DNS configuration

### DIFF
--- a/libnmstate/nm/route.py
+++ b/libnmstate/nm/route.py
@@ -18,11 +18,14 @@
 from operator import itemgetter
 import socket
 
+import six
+
 from libnmstate import iplib
 from libnmstate.error import NmstateInternalError
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import nmclient
 from libnmstate.nm import active_connection as nm_ac
+from libnmstate.schema import Interface
 from libnmstate.schema import Route
 
 NM_ROUTE_TABLE_ATTRIBUTE = 'table'
@@ -178,3 +181,18 @@ def _add_route_gateway(setting_ip, route):
                                              Route.USE_DEFAULT_ROUTE_TABLE)
     setting_ip.props.route_metric = route.get(Route.METRIC,
                                               Route.USE_DEFAULT_METRIC)
+
+
+def get_static_gateway_iface(family, iface_routes):
+    """
+    Return one interface with gateway for given IP family.
+    Return None if not found.
+    """
+    destination = (IPV6_DEFAULT_GATEWAY_DESTINATION
+                   if family == Interface.IPV6
+                   else IPV4_DEFAULT_GATEWAY_DESTINATION)
+    for iface_name, routes in six.viewitems(iface_routes):
+        for route in routes:
+            if route[Route.DESTINATION] == destination:
+                return iface_name
+    return None

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -17,11 +17,17 @@
 
 import pytest
 
-from libnmstate.schema import DNS
 import libnmstate.nm.connection as nm_connection
 import libnmstate.nm.dns as nm_dns
 import libnmstate.nm.ipv4 as nm_ipv4
 import libnmstate.nm.ipv6 as nm_ipv6
+from libnmstate.schema import DNS
+from libnmstate.schema import Route
+
+
+TEST_IPV4_GATEWAY_IFACE = 'eth1'
+TEST_IPV6_GATEWAY_IFACE = 'eth2'
+TEST_STATIC_ROUTE_IFACE = 'eth3'
 
 
 def _get_test_dns_v4():
@@ -124,3 +130,88 @@ def _assert_dns(setting_ip, dns_conf):
     priority = dns_conf.get(nm_dns.DNS_METADATA_PRIORITY,
                             nm_dns.DEFAULT_DNS_PRIORITY)
     assert setting_ip.props.dns_priority == priority
+
+
+def test_find_interfaces_for_dns_with_ipv6_and_ipv4_static_gateways():
+    iface_routes = _get_test_iface_routes()
+    assert ((TEST_IPV4_GATEWAY_IFACE, TEST_IPV6_GATEWAY_IFACE) ==
+            nm_dns.find_interfaces_for_name_servers(iface_routes))
+
+
+def test_find_interfaces_for_dns_with_ipv6_static_gateway_only():
+    iface_routes = {
+        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
+        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes()
+    }
+    assert ((None, TEST_IPV6_GATEWAY_IFACE) ==
+            nm_dns.find_interfaces_for_name_servers(iface_routes))
+
+
+def test_find_interfaces_for_dns_with_ipv4_static_gateway_only():
+    iface_routes = {
+        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
+        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes()
+    }
+    assert ((TEST_IPV4_GATEWAY_IFACE, None) ==
+            nm_dns.find_interfaces_for_name_servers(iface_routes))
+
+
+def test_find_interfaces_for_dns_with_no_routes():
+    iface_routes = {}
+    assert ((None, None) ==
+            nm_dns.find_interfaces_for_name_servers(iface_routes))
+
+
+def test_find_interfaces_for_dns_with_no_gateway():
+    iface_routes = {
+        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes()
+    }
+    assert ((None, None) ==
+            nm_dns.find_interfaces_for_name_servers(iface_routes))
+
+
+def _get_test_ipv4_gateway():
+    return [{
+        Route.DESTINATION: '0.0.0.0/0',
+        Route.METRIC: 200,
+        Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+        Route.NEXT_HOP_INTERFACE: TEST_IPV4_GATEWAY_IFACE,
+        Route.TABLE_ID: 54
+    }]
+
+
+def _get_test_ipv6_gateway():
+    return [{
+        Route.DESTINATION: '::/0',
+        Route.METRIC: 201,
+        Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
+        Route.NEXT_HOP_INTERFACE: TEST_IPV6_GATEWAY_IFACE,
+        Route.TABLE_ID: 54
+    }]
+
+
+def _get_test_static_routes():
+    return [
+        {
+            Route.DESTINATION: '2001:db8:3::1',
+            Route.METRIC: 201,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
+            Route.NEXT_HOP_INTERFACE: TEST_STATIC_ROUTE_IFACE,
+            Route.TABLE_ID: 54
+        },
+        {
+            Route.DESTINATION: '198.51.100.0/24',
+            Route.METRIC: 201,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: TEST_STATIC_ROUTE_IFACE,
+            Route.TABLE_ID: 54
+        }
+    ]
+
+
+def _get_test_iface_routes():
+    return {
+        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
+        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
+        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
+    }


### PR DESCRIPTION
Choose interface for IPv4/IPv6 default gateway for desired DNS configuration via `nm.dns.choose_interfaces_for_dns_conf()`.