### PR TITLE
Add support of DNS editing

### DIFF
--- a/examples/dns_edit_eth1.yml
+++ b/examples/dns_edit_eth1.yml
@@ -1,0 +1,34 @@
+---
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 8.8.8.8
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::1
+    next-hop-interface: eth1
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 192.0.2.10
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  ipv6:
+    address:
+    - ip: 2001:db8:1::a
+      prefix-length: 64
+    autoconf: false
+    dhcp: false
+    enabled: true

--- a/examples/dns_remove.yml
+++ b/examples/dns_remove.yml
@@ -1,0 +1,4 @@
+---
+dns-resolver:
+  config: {}
+interfaces: []

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -53,6 +53,7 @@ def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     validator.validate(desired_state)
     validator.validate_capabilities(desired_state, netinfo.capabilities())
     validator.validate_dhcp(desired_state)
+    validator.validate_dns(desired_state)
 
     checkpoint = _apply_ifaces_state(
         state.State(desired_state), verify_change, commit, rollback_timeout)
@@ -111,6 +112,7 @@ def _apply_ifaces_state(desired_state, verify_change, commit,
     desired_state.sanitize_ethernet(current_state)
     desired_state.sanitize_dynamic_ip()
     desired_state.merge_route_config(current_state)
+    desired_state.merge_dns(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
     validator.validate_interfaces_state(desired_state, current_state)
@@ -168,6 +170,7 @@ def _verify_change(desired_state):
     current_state = state.State(netinfo.show())
     desired_state.verify_interfaces(current_state)
     desired_state.verify_routes(current_state)
+    desired_state.verify_dns(current_state)
 
 
 @contextmanager

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ def logging_setup():
 
 
 @pytest.fixture(scope='session', autouse=True)
-def ethx_init():
+def ethx_init(preserve_old_config):
     """ Remove any existing definitions on the ethX interfaces. """
     _set_eth_admin_state('eth1', 'down')
     _set_eth_admin_state('eth2', 'down')
@@ -68,3 +68,10 @@ def _set_eth_admin_state(ifname, state):
         if state == 'up':
             desired_state[INTERFACES][0].update({'ipv6': {'enabled': True}})
         libnmstate.apply(desired_state)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def preserve_old_config():
+    old_state = libnmstate.show()
+    yield
+    libnmstate.apply(old_state, verify_change=False)

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -1,0 +1,280 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate import netapplier
+from libnmstate import netinfo
+from libnmstate.error import NmstateNotImplementedError
+from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import Route
+
+
+IPV4_DNS_NAMESERVERS = ['8.8.8.8', '1.1.1.1']
+IPV6_DNS_NAMESERVERS = ['2001:4860:4860::8888', '2606:4700:4700::1111']
+EXAMPLE_SEARCHES = ['example.org', 'example.com']
+
+parametrize_ip_ver = pytest.mark.parametrize(
+    'dns_config',
+    [({DNS.SERVER: IPV4_DNS_NAMESERVERS, DNS.SEARCH: EXAMPLE_SEARCHES}),
+     ({DNS.SERVER: IPV6_DNS_NAMESERVERS, DNS.SEARCH: EXAMPLE_SEARCHES})],
+    ids=['ipv4', 'ipv6'])
+
+
+@pytest.fixture(scope='function', autouse=True)
+def dns_test_env(eth1_up, eth2_up):
+    yield
+    # Remove DNS config as it be saved in eth1 or eth2 which might trigger
+    # failure when bring eth1/eth2 down.
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: [],
+                DNS.SEARCH: []
+            }
+        }
+    }
+    netapplier.apply(desired_state)
+
+
+@parametrize_ip_ver
+def test_dns_edit_nameserver_with_static_gateway(dns_config):
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_dns_edit_ipv4_nameserver_before_ipv6():
+    dns_config = {
+        DNS.SERVER: [IPV4_DNS_NAMESERVERS[0], IPV6_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_dns_edit_ipv6_nameserver_before_ipv4():
+    dns_config = {
+        DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+@pytest.mark.xfail(raises=NmstateNotImplementedError,
+                   reason='https://nmstate.atlassian.net/browse/NMSTATE-220',
+                   strict=True)
+def test_dns_edit_three_nameservers():
+    dns_config = {
+        DNS.SERVER: IPV6_DNS_NAMESERVERS + [IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_remove_dns_config():
+    dns_config = {
+        DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+
+    netapplier.apply({
+        Interface.KEY: [],
+        DNS.KEY: {
+            DNS.CONFIG: {}
+        }
+    })
+    current_state = netinfo.show()
+    dns_config = {
+        DNS.SERVER: [],
+        DNS.SEARCH: []
+    }
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_preserve_dns_config():
+    dns_config = {
+        DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+        DNS.SEARCH: []
+    }
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    }
+    netapplier.apply(desired_state)
+    current_state = netinfo.show()
+
+    # Remove default gateways, so that if nmstate try to find new interface
+    # for DNS profile, it will fail.
+    netapplier.apply({
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: [
+                {
+                    Route.DESTINATION: '0.0.0.0/0',
+                    Route.STATE: Route.STATE_ABSENT
+                },
+                {
+                    Route.DESTINATION: '::/0',
+                    Route.STATE: Route.STATE_ABSENT
+                },
+            ]
+        },
+    })
+
+    netapplier.apply({
+        Interface.KEY: [],
+        DNS.KEY: dns_config
+    })
+
+    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+
+
+def _get_test_iface_states():
+    return [
+        {
+            Interface.NAME: 'eth1',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '192.0.2.251',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:1::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+        {
+            Interface.NAME: 'eth2',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '198.51.100.1',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:2::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+    ]
+
+
+def _gen_default_gateway_route():
+    return [
+        {
+            Route.DESTINATION: '0.0.0.0/0',
+            Route.METRIC: 200,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 54
+        },
+        {
+            Route.DESTINATION: '::/0',
+            Route.METRIC: 201,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
+            Route.NEXT_HOP_INTERFACE: 'eth1',
+            Route.TABLE_ID: 54
+        }
+    ]

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -19,6 +19,9 @@
 from .testlib import assertlib
 from .testlib.examplelib import example_state
 
+from libnmstate import netinfo
+from libnmstate.schema import DNS
+
 
 def test_add_down_remove_vlan(eth1_up):
     """
@@ -49,3 +52,16 @@ def test_add_remove_linux_bridge(eth1_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent('linux-br0')
+
+
+def test_dns_edit(eth1_up):
+    with example_state('dns_edit_eth1.yml',
+                       cleanup='dns_remove.yml') as desired_state:
+        assertlib.assert_state(desired_state)
+
+    current_state = netinfo.show()
+    assert (current_state.get(DNS.KEY, {}).get(DNS.CONFIG, {}) ==
+            {
+                DNS.SERVER: [],
+                DNS.SEARCH: []
+            })

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -17,8 +17,11 @@
 
 from libnmstate import metadata
 from libnmstate import state
+from libnmstate.nm import dns as nm_dns
+from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import OVSBridgePortType as OBPortType
 from libnmstate.schema import Route
 
@@ -630,5 +633,205 @@ def _get_mixed_test_routes():
             Route.NEXT_HOP_INTERFACE: 'eth2',
             Route.NEXT_HOP_ADDRESS: '2001:db8:1::a',
             Route.TABLE_ID: 51
+        }
+    ]
+
+
+def test_dns_metadata_empty():
+    desired_state = state.State({
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {},
+        DNS.KEY: {}
+    })
+    current_state = state.State({})
+
+    metadata.generate_ifaces_metadata(desired_state, current_state)
+    assert (nm_dns.DNS_METADATA not in
+            desired_state.interfaces['eth1'][Interface.IPV4])
+    assert (nm_dns.DNS_METADATA not in
+            desired_state.interfaces['eth1'][Interface.IPV6])
+
+
+def test_dns_gen_metadata_static_gateway_ipv6_name_server_before_ipv4():
+    dns_config = {
+        DNS.SERVER: ['2001:4860:4860::8888', '8.8.8.8'],
+        DNS.SEARCH: ['example.org', 'example.com']
+    }
+
+    desired_state = state.State({
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route('eth1')
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    })
+    current_state = state.State({})
+
+    metadata.generate_ifaces_metadata(desired_state, current_state)
+    ipv4_dns_config = {
+        DNS.SERVER: ['8.8.8.8'],
+        DNS.SEARCH: [],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE + 1,
+     }
+    ipv6_dns_config = {
+        DNS.SERVER: ['2001:4860:4860::8888'],
+        DNS.SEARCH: ['example.org', 'example.com'],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE,
+    }
+    iface_state = desired_state.interfaces['eth1']
+    assert (ipv4_dns_config ==
+            iface_state[Interface.IPV4][nm_dns.DNS_METADATA])
+    assert (ipv6_dns_config ==
+            iface_state[Interface.IPV6][nm_dns.DNS_METADATA])
+
+
+def test_dns_gen_metadata_static_gateway_ipv6_name_server_after_ipv4():
+    dns_config = {
+        DNS.SERVER: ['8.8.8.8', '2001:4860:4860::8888'],
+        DNS.SEARCH: ['example.org', 'example.com']
+    }
+
+    desired_state = state.State({
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route('eth1')
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    })
+    current_state = state.State({})
+
+    metadata.generate_ifaces_metadata(desired_state, current_state)
+    ipv4_dns_config = {
+        DNS.SERVER: ['8.8.8.8'],
+        DNS.SEARCH: ['example.org', 'example.com'],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE
+    }
+    ipv6_dns_config = {
+        DNS.SERVER: ['2001:4860:4860::8888'],
+        DNS.SEARCH: [],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE + 1
+    }
+    iface_state = desired_state.interfaces['eth1']
+    assert (ipv4_dns_config ==
+            iface_state[Interface.IPV4][nm_dns.DNS_METADATA])
+    assert (ipv6_dns_config ==
+            iface_state[Interface.IPV6][nm_dns.DNS_METADATA])
+
+
+def test_dns_metadata_interface_not_included_in_desire():
+    dns_config = {
+        DNS.SERVER: ['2001:4860:4860::8888', '8.8.8.8'],
+        DNS.SEARCH: ['example.org', 'example.com']
+    }
+
+    desired_state = state.State({
+        Interface.KEY: [],
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route('eth1')
+        },
+        DNS.KEY: {
+            DNS.CONFIG: dns_config
+        }
+    })
+    current_state = state.State({
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route('eth1')
+        },
+    })
+    metadata.generate_ifaces_metadata(desired_state, current_state)
+    iface_state = desired_state.interfaces['eth1']
+    ipv4_dns_config = {
+        DNS.SERVER: ['8.8.8.8'],
+        DNS.SEARCH: [],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE + 1
+    }
+    ipv6_dns_config = {
+        DNS.SERVER: ['2001:4860:4860::8888'],
+        DNS.SEARCH: ['example.org', 'example.com'],
+        nm_dns.DNS_METADATA_PRIORITY: nm_dns.DNS_PRIORITY_STATIC_BASE,
+    }
+    assert (ipv4_dns_config ==
+            iface_state[Interface.IPV4][nm_dns.DNS_METADATA])
+    assert (ipv6_dns_config ==
+            iface_state[Interface.IPV6][nm_dns.DNS_METADATA])
+
+
+def _get_test_iface_states():
+    return [
+        {
+            Interface.NAME: 'eth1',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '192.0.2.251',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:1::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+        {
+            Interface.NAME: 'eth2',
+            Interface.STATE: InterfaceState.UP,
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.IPV4: {
+                'address': [
+                    {
+                        'ip': '198.51.100.1',
+                        'prefix-length': 24
+                    }
+                ],
+                'dhcp': False,
+                'enabled': True
+            },
+            Interface.IPV6: {
+                'address': [
+                    {
+                        'ip': '2001:db8:2::1',
+                        'prefix-length': 64
+                    }
+                ],
+                'dhcp': False,
+                'autoconf': False,
+                'enabled': True
+            }
+        },
+    ]
+
+
+def _gen_default_gateway_route(iface_name):
+    return [
+        {
+            Route.DESTINATION: '0.0.0.0/0',
+            Route.METRIC: 200,
+            Route.NEXT_HOP_ADDRESS: '192.0.2.1',
+            Route.NEXT_HOP_INTERFACE: iface_name,
+            Route.TABLE_ID: 54
+        },
+        {
+            Route.DESTINATION: '::/0',
+            Route.METRIC: 201,
+            Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
+            Route.NEXT_HOP_INTERFACE: iface_name,
+            Route.TABLE_ID: 54
         }
     ]


### PR DESCRIPTION
Example has been included as `examples/dns_edit_eth1.yml` and
`examples/dns_remove.yml`.

If DNS not defined in desire state, old DNS configuration will be
perceived.
If DNS defined in desire state, old DNS configuration will be fully override
with desired state.

To remove static DNS configuration, Please use this state:

```python
{
    DNS.KEY: {
        DNS.CONFIG: {
            DNS.SERVER: [],
            DNS.SEARCH: []
        }
    }
}
```

Limitation: only support saving DNS configuration to state default
gateway interfaces.

Unit and integration test cases has been included.
