### PR TITLE
API: Move public staff to libnmstate module top level

### DIFF
--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -16,5 +16,16 @@
 #
 from __future__ import absolute_import
 
-from . import validator
-validator
+from . import error
+from . import schema
+
+from .netapplier import apply
+from .netapplier import commit
+from .netapplier import rollback
+from .netinfo import show
+
+from .prettystate import PrettyState
+
+
+__all__ = ['show', 'apply', 'commit', 'rollback', 'error', 'schema',
+           'PrettyState']

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -68,7 +68,7 @@ interfaces:
 
 
 @mock.patch('sys.argv', ['nmstatectl', 'set', 'mystate.json'])
-@mock.patch.object(nmstatectl.netapplier, 'apply',
+@mock.patch.object(nmstatectl.libnmstate, 'apply',
                    lambda state, verify_change, commit, timeout: None)
 @mock.patch.object(nmstatectl, 'open', mock.mock_open(read_data='{}'),
                    create=True)
@@ -77,14 +77,14 @@ def test_run_ctl_directly_set():
 
 
 @mock.patch('sys.argv', ['nmstatectl', 'show'])
-@mock.patch.object(nmstatectl.netinfo, 'show', lambda: {})
+@mock.patch.object(nmstatectl.libnmstate, 'show', lambda: {})
 def test_run_ctl_directly_show_empty():
     nmstatectl.main()
 
 
 @mock.patch('sys.argv', ['nmstatectl', 'show', 'non_existing_interface'])
 @mock.patch.object(
-    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+    nmstatectl.libnmstate, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_only_empty(mock_stdout):
     nmstatectl.main()
@@ -93,7 +93,7 @@ def test_run_ctl_directly_show_only_empty(mock_stdout):
 
 @mock.patch('sys.argv', ['nmstatectl', 'show', 'lo'])
 @mock.patch.object(
-    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+    nmstatectl.libnmstate, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_only(mock_stdout):
     nmstatectl.main()
@@ -103,7 +103,7 @@ def test_run_ctl_directly_show_only(mock_stdout):
 @mock.patch('sys.argv', ['nmstatectl', 'show', '--json',
                          'non_existing_interface'])
 @mock.patch.object(
-    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+    nmstatectl.libnmstate, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_json_only_empty(mock_stdout):
     nmstatectl.main()
@@ -112,7 +112,7 @@ def test_run_ctl_directly_show_json_only_empty(mock_stdout):
 
 @mock.patch('sys.argv', ['nmstatectl', 'show', '--json', 'lo'])
 @mock.patch.object(
-    nmstatectl.netinfo, 'show', lambda: json.loads(LO_JSON_STATE))
+    nmstatectl.libnmstate, 'show', lambda: json.loads(LO_JSON_STATE))
 @mock.patch('nmstatectl.nmstatectl.sys.stdout', new_callable=six.StringIO)
 def test_run_ctl_directly_show_json_only(mock_stdout):
     nmstatectl.main()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,7 @@ import logging
 
 import pytest
 
-from libnmstate import netapplier
+import libnmstate
 
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
@@ -67,4 +67,4 @@ def _set_eth_admin_state(ifname, state):
         # FIXME: On most systems, IPv6 cannot be disabled by Nmstate/NM.
         if state == 'up':
             desired_state[INTERFACES][0].update({'ipv6': {'enabled': True}})
-        netapplier.apply(desired_state)
+        libnmstate.apply(desired_state)

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -19,8 +19,7 @@ import time
 
 import pytest
 
-from libnmstate import netapplier
-from libnmstate import netinfo
+import libnmstate
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Route as RT
@@ -132,7 +131,7 @@ def setup_remove_bond99():
             }
         ]
     }
-    netapplier.apply(remove_bond)
+    libnmstate.apply(remove_bond)
 
 
 @pytest.fixture
@@ -147,7 +146,7 @@ def setup_remove_dhcpcli():
             }
         ]
     }
-    netapplier.apply(remove_bond)
+    libnmstate.apply(remove_bond)
 
 
 def test_ipv4_dhcp(dhcp_env):
@@ -161,7 +160,7 @@ def test_ipv4_dhcp(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
     time.sleep(5)  # wait to get resolv.conf updated
     assert _has_ipv4_dhcp_nameserver()
@@ -180,7 +179,7 @@ def test_ipv6_dhcp_only(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-dns'] = True
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -208,7 +207,7 @@ def test_ipv6_dhcp_and_autoconf(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['auto-routes'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -224,7 +223,7 @@ def test_ipv6_autoconf_only(dhcp_env):
     dhcp_cli_desired_state['ipv6']['dhcp'] = False
     dhcp_cli_desired_state['ipv6']['autoconf'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
 
 def test_dhcp_with_addresses(dhcp_env):
@@ -255,7 +254,7 @@ def test_dhcp_with_addresses(dhcp_env):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -284,7 +283,7 @@ def test_dhcp_for_bond_with_ip_address_and_slave(dhcp_env,
         ]
     }
 
-    netapplier.apply(desired_state, verify_change=False)
+    libnmstate.apply(desired_state, verify_change=False)
     # Long story for why we doing 'dhcp=False' with 'verify_change=False'
     # above:
     #   For `dhcp=False`:
@@ -298,7 +297,7 @@ def test_dhcp_for_bond_with_ip_address_and_slave(dhcp_env,
     #       interface will result in `state:down`. As a workaround the
     #       verification is ignored.
     desired_state[INTERFACES][0]['ipv4']['dhcp'] = True
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -314,7 +313,7 @@ def test_ipv4_dhcp_ignore_gateway(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-dns'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # wait to get resolv.conf updated
@@ -333,7 +332,7 @@ def test_ipv4_dhcp_ignore_dns(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     assert not _has_ipv4_dhcp_nameserver()
@@ -352,7 +351,7 @@ def test_ipv4_dhcp_ignore_routes(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-dns'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # wait to get resolv.conf updated
@@ -371,7 +370,7 @@ def test_ipv6_dhcp_and_autoconf_ignore_gateway(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = False
     dhcp_cli_desired_state['ipv6']['auto-routes'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -390,7 +389,7 @@ def test_ipv6_dhcp_and_autoconf_ignore_dns(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['auto-routes'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -409,7 +408,7 @@ def test_ipv6_dhcp_and_autoconf_ignore_routes(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = True
     dhcp_cli_desired_state['ipv6']['auto-routes'] = False
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -429,7 +428,7 @@ def test_ipv4_dhcp_off_and_option_on(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-gateway'] = False
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
     assert not dhcp_cli_current_state['ipv4']['dhcp']
@@ -452,7 +451,7 @@ def test_ipv6_dhcp_off_and_option_on(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-dns'] = False
     dhcp_cli_desired_state['ipv6']['auto-gateway'] = False
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
     assert not dhcp_cli_current_state['ipv6']['dhcp']
@@ -475,7 +474,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcp_env):
     dhcp_cli_desired_state['ipv4']['auto-routes'] = True
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
     time.sleep(5)  # wait to get resolv.conf updated
     assert _has_ipv4_dhcp_nameserver()
@@ -490,7 +489,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcp_env):
     dhcp_cli_desired_state['ipv4']['dhcp'] = False
     dhcp_cli_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
     assert not _has_ipv4_dhcp_nameserver()
     assert not _has_ipv4_dhcp_gateway()
@@ -507,7 +506,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcp_env):
     dhcp_cli_desired_state['ipv6']['auto-dns'] = True
     dhcp_cli_desired_state['ipv6']['auto-routes'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
@@ -522,7 +521,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcp_env):
     dhcp_cli_desired_state['ipv6']['dhcp'] = False
     dhcp_cli_desired_state['ipv6']['autoconf'] = False
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
     assert not _has_ipv6_auto_gateway()
@@ -585,7 +584,7 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     current_state = statelib.show_only(('dhcpcli',))
     client_current_state = current_state[INTERFACES][0]
@@ -630,7 +629,7 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
         ]
     }
 
-    netapplier.apply(bridge_desired_state)
+    libnmstate.apply(bridge_desired_state)
     assertlib.assert_state(bridge_desired_state)
 
 
@@ -638,7 +637,7 @@ def _get_nameservers():
     """
     Return a list of name server string configured in RESOLV_CONF_PATH.
     """
-    return netinfo.show().get(
+    return libnmstate.show().get(
         Constants.DNS, {}).get(DNS.RUNNING, {}).get(DNS.SERVER, [])
 
 
@@ -646,7 +645,7 @@ def _get_running_routes():
     """
     return a list of running routes
     """
-    return netinfo.show().get(Constants.ROUTES, {}).get(RT.RUNNING, [])
+    return libnmstate.show().get(Constants.ROUTES, {}).get(RT.RUNNING, [])
 
 
 def _has_ipv6_auto_gateway():

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -21,7 +21,7 @@ import time
 import pytest
 import jsonschema as js
 
-from libnmstate import netapplier
+import libnmstate
 from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
@@ -39,7 +39,7 @@ def test_increase_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1900
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -49,7 +49,7 @@ def test_decrease_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1400
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -59,7 +59,7 @@ def test_upper_limit_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 9000
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -69,7 +69,7 @@ def test_increase_more_than_jambo_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 10000
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -81,7 +81,7 @@ def test_decrease_to_zero_iface_mtu():
     eth1_desired_state['mtu'] = 0
 
     with pytest.raises(NmstateVerificationError) as err:
-        netapplier.apply(desired_state)
+        libnmstate.apply(desired_state)
     assert '-mtu: 0' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.
     time.sleep(2)
@@ -95,7 +95,7 @@ def test_decrease_to_negative_iface_mtu():
     eth1_desired_state['mtu'] = -1
 
     with pytest.raises(js.ValidationError) as err:
-        netapplier.apply(desired_state)
+        libnmstate.apply(desired_state)
     assert '-1' in err.value.args[0]
     assertlib.assert_state(origin_desired_state)
 
@@ -105,7 +105,7 @@ def test_decrease_to_ipv6_min_ethernet_frame_size_iface_mtu():
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['mtu'] = 1280
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -117,7 +117,7 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu():
     eth1_desired_state['mtu'] = 1279
 
     with pytest.raises(NmstateVerificationError) as err:
-        netapplier.apply(desired_state)
+        libnmstate.apply(desired_state)
     assert '1279' in err.value.args[0]
     # FIXME: Drop the sleep when the waiting logic is implemented.
     time.sleep(2)

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from libnmstate import netapplier
+import libnmstate
 
 from .testlib import assertlib
 from .testlib.statelib import INTERFACES
@@ -33,10 +33,10 @@ def test_set_a_down_iface_down(eth1_up):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -53,6 +53,6 @@ def test_removing_a_non_removable_iface(eth1_up):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 import pytest
 import yaml
 
-from libnmstate import netapplier
+import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
@@ -134,12 +134,12 @@ def _linux_bridge(name, bridge_state):
     if bridge_state:
         desired_state[INTERFACES][0][LinuxBridge.CONFIG_SUBTREE] = bridge_state
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     try:
         yield desired_state
     finally:
-        netapplier.apply({
+        libnmstate.apply({
             INTERFACES: [
                 {
                     Interface.NAME: name,

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -17,7 +17,7 @@
 
 import yaml
 
-from libnmstate import netapplier
+import libnmstate
 
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
@@ -45,7 +45,7 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(eth1_up):
             'type': 'system'
         }
     ]
-    netapplier.apply(state)
+    libnmstate.apply(state)
 
     setup_remove_ovs_bridge_state = {
         INTERFACES: [
@@ -56,7 +56,7 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(eth1_up):
             }
         ]
     }
-    netapplier.apply(setup_remove_ovs_bridge_state)
+    libnmstate.apply(setup_remove_ovs_bridge_state)
     state = statelib.show_only((state[INTERFACES][0]['name'],))
     assert not state[INTERFACES]
 
@@ -71,7 +71,7 @@ def test_create_and_remove_ovs_bridge_with_min_desired_state():
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     setup_remove_ovs_bridge_state = {
         INTERFACES: [
@@ -82,7 +82,7 @@ def test_create_and_remove_ovs_bridge_with_min_desired_state():
             }
         ]
     }
-    netapplier.apply(setup_remove_ovs_bridge_state)
+    libnmstate.apply(setup_remove_ovs_bridge_state)
     state = statelib.show_only((desired_state[INTERFACES][0]['name'],))
     assert not state[INTERFACES]
 
@@ -111,7 +111,7 @@ def test_create_and_remove_ovs_bridge_with_an_internal_port():
         },
     }
     state[INTERFACES].append(ovs_internal_interface_state)
-    netapplier.apply(state, verify_change=False)
+    libnmstate.apply(state, verify_change=False)
 
     setup_remove_ovs_bridge_state_and_port = {
         INTERFACES: [
@@ -127,7 +127,7 @@ def test_create_and_remove_ovs_bridge_with_an_internal_port():
             }
         ]
     }
-    netapplier.apply(setup_remove_ovs_bridge_state_and_port)
+    libnmstate.apply(setup_remove_ovs_bridge_state_and_port)
     state = statelib.show_only(
         (state[INTERFACES][0]['name'], state[INTERFACES][1]['name']))
     assert not state[INTERFACES]

--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -17,7 +17,7 @@
 
 from contextlib import contextmanager
 
-from libnmstate import netapplier
+import libnmstate
 from libnmstate.nm import nmclient
 
 from .testlib import statelib
@@ -34,7 +34,7 @@ IPV6_ADDRESS1 = '2001:db8:1::1'
 
 
 def test_reapply_preserve_ip_config(eth1_up):
-    netapplier.apply(
+    libnmstate.apply(
         {
             'interfaces': [
                 {
@@ -71,7 +71,7 @@ def test_reapply_preserve_ip_config(eth1_up):
     for key, value in ((_IPV4_EXTRA_CONFIG, _IPV4_EXTRA_VALUE),
                        (_IPV6_EXTRA_CONFIG, _IPV6_EXTRA_VALUE)):
         with _extra_ip_config(uuid, key, value):
-            netapplier.apply(cur_state)
+            libnmstate.apply(cur_state)
             _assert_extra_ip_config(uuid, key, value)
 
 

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from libnmstate import netapplier
+import libnmstate
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -53,7 +53,7 @@ def setup_eth1_ipv4(eth1_up):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
 
 @pytest.fixture
@@ -73,7 +73,7 @@ def setup_eth1_ipv6(eth1_up):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     return desired_state
 
@@ -87,7 +87,7 @@ def test_add_static_ipv4_with_full_state(eth1_up):
     eth1_desired_state['ipv4']['address'] = [
         {'ip': IPV4_ADDRESS3, 'prefix-length': 24}
     ]
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -108,7 +108,7 @@ def test_add_static_ipv4_with_min_state(eth2_up):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -126,7 +126,7 @@ def test_remove_static_ipv4(setup_eth1_ipv4):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -148,7 +148,7 @@ def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -182,7 +182,7 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(eth1_up,
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -204,7 +204,7 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(setup_eth1_ipv4,
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -219,7 +219,7 @@ def test_add_static_ipv6_with_full_state(eth1_up):
         # This sequence is intentionally made for IP address sorting.
         {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
     ]
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
 
 
@@ -233,7 +233,7 @@ def test_add_static_ipv6_with_link_local(eth1_up):
         {'ip': IPV6_ADDRESS1, 'prefix-length': 64}
     ]
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     # Make sure only the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
@@ -254,7 +254,7 @@ def test_add_static_ipv6_with_link_local_only(eth1_up):
         {'ip': IPV6_LINK_LOCAL_ADDRESS2, 'prefix-length': 64},
     ]
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     # Make sure the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
@@ -271,7 +271,7 @@ def test_add_static_ipv6_with_no_address(eth1_up):
     eth1_desired_state['state'] = 'up'
     eth1_desired_state['ipv6']['enabled'] = True
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     cur_state = statelib.show_only(('eth1',))
     eth1_cur_state = cur_state[INTERFACES][0]
@@ -295,7 +295,7 @@ def test_add_static_ipv6_with_min_state(eth2_up):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -314,7 +314,7 @@ def test_disable_static_ipv6(setup_eth1_ipv6):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -337,7 +337,7 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     eth1_desired_state = desired_state[INTERFACES][0]
     current_state = statelib.show_only(('eth1',))
 
@@ -379,7 +379,7 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(eth1_up,
         ]
     }
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
@@ -401,6 +401,6 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(setup_eth1_ipv6,
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -16,7 +16,7 @@
 #
 import copy
 
-from libnmstate import netinfo
+import libnmstate
 from libnmstate.schema import DNS
 from libnmstate.schema import Route
 
@@ -27,7 +27,7 @@ from .statelib import INTERFACES
 def assert_state(desired_state_data):
     """Given a state, assert it against the current state."""
 
-    current_state_data = netinfo.show()
+    current_state_data = libnmstate.show()
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)

--- a/tests/integration/testlib/examplelib.py
+++ b/tests/integration/testlib/examplelib.py
@@ -18,11 +18,9 @@
 from contextlib import contextmanager
 import os
 
-
 import yaml
 
-
-from libnmstate import netapplier
+import libnmstate
 
 
 PATH_MAX = 4096
@@ -36,12 +34,12 @@ def example_state(initial, cleanup=None):
 
     desired_state = load_example(initial)
 
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     try:
         yield desired_state
     finally:
         if cleanup:
-            netapplier.apply(load_example(cleanup))
+            libnmstate.apply(load_example(cleanup))
 
 
 def load_example(name):

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -20,7 +20,7 @@ import copy
 from operator import itemgetter
 import six
 
-from libnmstate import netinfo
+import libnmstate
 from libnmstate.schema import Constants
 
 
@@ -34,7 +34,7 @@ def show_only(ifnames):
     base_filter_state = {
         INTERFACES: [{'name': ifname} for ifname in ifnames]
     }
-    current_state = State(netinfo.show())
+    current_state = State(libnmstate.show())
     current_state.filter(base_filter_state)
     return current_state.state
 
@@ -200,7 +200,7 @@ def filter_current_state(desired_state):
     in the desired state.
     In case there are no entities for filtering, all are reported.
     """
-    current_state = netinfo.show()
+    current_state = libnmstate.show()
     desired_iface_names = {ifstate['name']
                            for ifstate in desired_state[INTERFACES]}
 

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -20,8 +20,7 @@ import time
 
 import pytest
 
-from libnmstate import netapplier
-from libnmstate import netinfo
+import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.error import NmstateVerificationError
 
@@ -91,21 +90,21 @@ def test_add_and_remove_two_vlans_on_same_iface(eth1_up):
 
 
 def test_rollback_for_vlans(eth1_up):
-    current_state = netinfo.show()
+    current_state = libnmstate.show()
     desired_state = TWO_VLANS_STATE
 
     desired_state[INTERFACES][1]['invalid_key'] = 'foo'
     with pytest.raises(NmstateVerificationError):
-        netapplier.apply(desired_state)
+        libnmstate.apply(desired_state)
 
     time.sleep(5)   # Give some time for NetworkManager to rollback
-    current_state_after_apply = netinfo.show()
+    current_state_after_apply = libnmstate.show()
     assert current_state == current_state_after_apply
 
 
 def test_set_vlan_iface_down(eth1_up):
     with vlan_interface(VLAN_IFNAME, 101):
-        netapplier.apply({
+        libnmstate.apply({
                 INTERFACES: [
                     {
                         'name': VLAN_IFNAME,
@@ -135,11 +134,11 @@ def vlan_interface(ifname, vlan_id):
             }
         ]
     }
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     try:
         yield desired_state
     finally:
-        netapplier.apply({
+        libnmstate.apply({
                 INTERFACES: [
                     {
                         'name': ifname,
@@ -154,11 +153,11 @@ def vlan_interface(ifname, vlan_id):
 @contextmanager
 def two_vlans_on_eth1():
     desired_state = TWO_VLANS_STATE
-    netapplier.apply(desired_state)
+    libnmstate.apply(desired_state)
     try:
         yield desired_state
     finally:
-        netapplier.apply({
+        libnmstate.apply({
                 INTERFACES: [
                     {
                         'name': VLAN_IFNAME,


### PR DESCRIPTION
Moved these public classes and functions to libnmstate module top level:
 * The 'show()' function of 'netinfo.py'.
 * The 'apply()', 'commit', 'rollback' functions of 'netapplier.py'.
 * The exception classes defined in 'error.py' as exposed as
   'libnmstate.error'
 * The 'PrettyState' class defined in 'prettystate.py' which is used by
   nmstatectl.
 * The schema classes are exposed as 'libnmstate.schema'.

The integration test cases and nmstatctl has been updated to use this
new public interface.