### PR TITLE
nm/state: Treat empty DNS state as DNS removal

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -341,7 +341,7 @@ class State(object):
         If DNS is not mentioned in the self state, overwrite it with the other
         DNS entries.
         """
-        if not self._state.get(DNS.KEY):
+        if DNS.KEY not in self._state:
             self._state[DNS.KEY] = {
                 DNS.CONFIG: copy.deepcopy(other_state.config_dns)
             }

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -697,6 +697,15 @@ class TestAssertDnsState(object):
 
         assert desire_state.config_dns == dns_config[DNS.CONFIG]
 
+    def test_merge_dns_empty_config_with_non_empty_state(self):
+        dns_config = self._get_test_dns_config()
+        current_state = state.State({DNS.KEY: dns_config})
+        desire_state = state.State({DNS.KEY: {}})
+
+        desire_state.merge_dns(current_state)
+
+        assert desire_state.config_dns == {DNS.SERVER: [], DNS.SEARCH: []}
+
     def test_state_verify_dns_same(self):
         dns_config = self._get_test_dns_config()
         desire_state = state.State({DNS.KEY: dns_config})


### PR DESCRIPTION
Treat state `{DNS.KEY: {}}` as remove all static DNS configurations