### PR TITLE
tests integ: Remove non-main table from gateway-route

### DIFF
--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -268,13 +268,11 @@ def _gen_default_gateway_route():
             Route.METRIC: 200,
             Route.NEXT_HOP_ADDRESS: '192.0.2.1',
             Route.NEXT_HOP_INTERFACE: 'eth1',
-            Route.TABLE_ID: 54
         },
         {
             Route.DESTINATION: '::/0',
             Route.METRIC: 201,
             Route.NEXT_HOP_ADDRESS: '2001:db8:2::f',
             Route.NEXT_HOP_INTERFACE: 'eth1',
-            Route.TABLE_ID: 54
         }
     ]


### PR DESCRIPTION
The DNS tests are using gateway routes with a non-main table.

On Centos/RHEL7 this is not working due to an existing kernel bug.
As the tests do not require the table ID, they are removed in order to
pass the tests on machines running Centos/RHEL7 kernels.

Ref: https://bugzilla.redhat.com/1535977