### PR TITLE
nm/state: Fix route sorting with wildcard routes

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -77,10 +77,12 @@ class RouteEntry(object):
         return self is other or self.__keys() == other.__keys()
 
     def __lt__(self, other):
-        return (
-            (self.table_id, self.next_hop_interface, self.destination) <
-            (other.table_id, other.next_hop_interface, other.destination)
-        )
+        return ((self.table_id or Route.USE_DEFAULT_ROUTE_TABLE,
+                 self.next_hop_interface or '',
+                 self.destination or '') <
+                (other.table_id or Route.USE_DEFAULT_ROUTE_TABLE,
+                 other.next_hop_interface or '',
+                 other.destination or ''))
 
     def __repr__(self):
         return str(self.to_dict())

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -277,6 +277,27 @@ class TestRouteEntry(object):
         ]
         assert expected_routes == sorted(routes)
 
+    @parametrize_route_property
+    def test_sort_routes_with_absent_route(self, route_property):
+        absent_route = _create_route('198.51.100.0/24', '192.0.1.1', 'eth0',
+                                     9, 103).to_dict()
+        absent_route[Route.STATE] = Route.STATE_ABSENT
+        del absent_route[route_property]
+        absent_route = state.RouteEntry(absent_route)
+        routes = [
+            absent_route,
+            _create_route('198.51.100.1/24', '192.0.2.1', 'eth0', 50, 103),
+            _create_route('198.51.100.0/24', '192.0.2.1', 'eth0', 50, 103),
+            _create_route('198.51.100.0/24', '192.0.2.1', 'eth1', 10, 103),
+        ]
+        expected_routes = [
+            absent_route,
+            _create_route('198.51.100.0/24', '192.0.2.1', 'eth1', 10, 103),
+            _create_route('198.51.100.0/24', '192.0.2.1', 'eth0', 50, 103),
+            _create_route('198.51.100.1/24', '192.0.2.1', 'eth0', 50, 103),
+        ]
+        assert expected_routes == sorted(routes)
+
 
 def _create_route(dest, via_addr, via_iface, table, metric):
     return state.RouteEntry(


### PR DESCRIPTION
Then sorting routes containing wildcard, python 3 will raise error:
    TypeError: '<' not supported between instances of 'int' and 'NoneType'

The fix is normalize the sorting keys.

Unit test case included.
