### PR TITLE
Integration test: Add case for bring iface down with routes

### DIFF
--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -396,3 +396,24 @@ def test_disable_ipv4_with_routes_in_current(eth1_up):
 
     cur_state = libnmstate.show()
     _assert_routes([], cur_state)
+
+
+@parametrize_ip_ver_routes
+def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
+    libnmstate.apply({
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+        Route.KEY: {
+            Route.CONFIG: get_routes_func()
+        }
+    })
+
+    libnmstate.apply({
+        Interface.KEY: [{
+            Interface.NAME: 'eth1',
+            Interface.TYPE: InterfaceType.ETHERNET,
+            Interface.STATE: InterfaceState.DOWN
+        }]
+    })
+
+    cur_state = libnmstate.show()
+    _assert_routes([], cur_state)


### PR DESCRIPTION
New test case for bring interface down with routes in current next hop to it.