### PR TITLE
DNS: Preserve DNS config with empty state

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -307,7 +307,8 @@ def _dns_config_not_changed(desired_state, current_state):
            iface_state[Interface.STATE] != InterfaceState.UP:
             return False
         for family in six.viewkeys(iface_dns_config):
-            if not iface_state.get(family, {}).get('enabled'):
+            if family in iface_state and \
+               not iface_state[family].get('enabled'):
                 return False
     return True
 

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -204,6 +204,35 @@ def test_preserve_dns_config():
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
 
 
+@pytest.fixture
+def setup_ipv4_ipv6_name_server():
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {
+            Route.CONFIG: _gen_default_gateway_route()
+        },
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
+                DNS.SEARCH: []
+            }
+        }
+    }
+    netapplier.apply(desired_state)
+    yield desired_state
+
+
+def test_preserve_dns_config_with_empty_state(setup_ipv4_ipv6_name_server):
+    old_state = setup_ipv4_ipv6_name_server
+
+    netapplier.apply({
+        Interface.KEY: [],
+    })
+    current_state = netinfo.show()
+
+    assert old_state[DNS.KEY][DNS.CONFIG] == current_state[DNS.KEY][DNS.CONFIG]
+
+
 def _get_test_iface_states():
     return [
         {


### PR DESCRIPTION
When applying empty state, current DNS edit code will raise exception
for not finding interface. The problem is caused by
the incorrect check on IP entablement.

The integration test case is included for this use case.