### PR TITLE
 tests integ: Adding helper and assert functions for MAC

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -31,6 +31,8 @@ from .testlib import assertlib
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.statelib import show_only
 from .testlib.statelib import INTERFACES
+from .testlib.statelib import get_macs
+from .testlib.assertlib import assert_all_equal
 
 TEST_BRIDGE0 = 'linux-br0'
 
@@ -116,14 +118,12 @@ def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
     assertlib.assert_state(desired_state)
 
 
-def test_linux_bridge_uses_the_port_mac(port0_up, bridge0_with_port0):
+def test_linux_bridge_uses_the_port_mac(bridge0_with_port0, port0_up):
     port0_name = port0_up[Interface.KEY][0][Interface.NAME]
-    prev_port_mac = port0_up[Interface.KEY][0][Interface.MAC]
     current_state = show_only((TEST_BRIDGE0, port0_name))
-    curr_iface0_mac = current_state[Interface.KEY][0][Interface.MAC]
-    curr_iface1_mac = current_state[Interface.KEY][1][Interface.MAC]
-
-    assert prev_port_mac == curr_iface0_mac == curr_iface1_mac
+    macs = get_macs(port0_up)
+    macs += get_macs(current_state)
+    assert_all_equal(macs)
 
 
 def _add_port_to_bridge(bridge_state, ifname):

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -53,3 +53,8 @@ def assert_absent(*ifnames):
 
     current_state = statelib.show_only(ifnames)
     assert not current_state[INTERFACES]
+
+
+def assert_all_equal(items):
+    """ Assert that all the items are the same """
+    assert not items or len(set(items)) == 1

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -22,7 +22,7 @@ import six
 
 import libnmstate
 from libnmstate.schema import Constants
-
+from libnmstate.schema import Interface
 
 INTERFACES = Constants.INTERFACES
 
@@ -229,3 +229,10 @@ def _is_ipv6_link_local(ip, prefix):
     The IPv6 link local address range is fe80::/10.
     """
     return ip[:3] in ['fe8', 'fe9', 'fea', 'feb'] and prefix >= 10
+
+
+def get_macs(state):
+    """
+    Returns the MAC addresses of interfaces in the states
+    """
+    return [ifstate[Interface.MAC] for ifstate in state[Interface.KEY]]

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -21,12 +21,13 @@ import time
 import pytest
 
 import libnmstate
-from libnmstate.schema import Interface
 from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
+from .testlib.statelib import get_macs
+from .testlib.assertlib import assert_all_equal
 
 VLAN_IFNAME = 'eth1.101'
 VLAN2_IFNAME = 'eth1.102'
@@ -66,11 +67,8 @@ def vlan_on_eth1(eth1_up):
 
 
 def test_vlan_iface_uses_the_mac_of_base_iface(vlan_on_eth1):
-    base_iface_state = vlan_on_eth1[INTERFACES][0]
-    vlan_iface_state = vlan_on_eth1[INTERFACES][1]
-    base_iface_mac = base_iface_state[Interface.MAC]
-    vlan_iface_mac = vlan_iface_state[Interface.MAC]
-    assert base_iface_mac == vlan_iface_mac
+    vlan_on_eth1_iface_macs = get_macs(vlan_on_eth1)
+    assert_all_equal(vlan_on_eth1_iface_macs)
 
 
 def test_add_and_remove_two_vlans_on_same_iface(eth1_up):


### PR DESCRIPTION
Adding get_all_macs(state) helper function that returns the
MAC-address list of all the interfaces in the state. Since
the function call recreates multiple lists just to fetch one
item out of them, an assert_all_equal(items) is called
which asserts if all the MAC addresses are the same or not.

Signed-off-by: Nandan Kulkarni <nakulkar@redhat.com>