### PR TITLE
netapplier: Initialize mainloop global object on failure

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -182,6 +182,7 @@ def _setup_providers():
     yield
     success = mainloop.run(timeout=20)
     if not success:
+        nmclient.mainloop(refresh=True)
         raise NmstateLibnmError(
             'Unexpected failure of libnm when running the mainloop: {}'.format(
                 mainloop.error


### PR DESCRIPTION
The mainloop object is a singletone.
When libnmstate is used by an application which calls it multiple times
(e.g. running as a daemon), on mainloop (run) failure, the instance is kept
and reused in the following calls. Unfortunately, when the mainloop run fails,
its state may no longer be usable and may require initialization.

Therefore, to support such usages, the mainloop singletone is initialize
in case a mainloop failure is detected.