### PR TITLE
Mainloop run: Unify run/s and remove execute_last_action

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -128,8 +128,6 @@ def _apply_ifaces_state(
         ) as checkpoint:
             with _setup_providers():
                 _add_interfaces(new_interfaces, desired_state)
-            with _setup_providers():
-                current_state = state.State(netinfo.show())
                 state2edit = _create_editable_desired_state(
                     desired_state, current_state, new_interfaces
                 )

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -188,7 +188,7 @@ class ConnectionProfile(object):
                     act_object,
                 )
                 self._reset_profile()
-                self._mainloop.execute_last_action()
+                self.safe_activate_async()
             else:
                 self._mainloop.quit(
                     'Connection activation failed on {} {}: error={}'.format(

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -88,23 +88,16 @@ class _MainLoop(object):
         self._cancellables = []
         self.new_cancellable()
         self._error = ''
-        self._last_action = None
 
     def execute_next_action(self):
         action = self.pop_action()
         if action:
-            self._last_action = action
             func, args, kwargs = action
             logging.debug('Executing NM action: func=%s', func.__name__)
             func(*args, **kwargs)
         else:
             logging.debug('NM action queue exhausted, quiting mainloop')
             self._mainloop.quit()
-
-    def execute_last_action(self):
-        func, args, kwargs = self._last_action
-        logging.debug('Executing last NM action: func=%s', func.__name__)
-        func(*args, **kwargs)
 
     def push_action(self, func, *args, **kwargs):
         action = (func, args, kwargs)


### PR DESCRIPTION
netapplier: Unify the two mainloop runs into one

On apply, two mainloop runs are currently executed: One for adding new
interfaces and another for editing existing ones.
The original reasoning for the separation was the assumption that once
the new interfaces are created, there is a need to refresh the current
state with the new information, serving the editation step.

It seems that the current state refresh is not needed, at least based on
the current test coverage.
Therefore, this change unifies the two mainloop runs into a single one.

In addition, the nmclient.mainloop method that executes the last action is removed
in favour of a simplified recall of the action directly.

