### PR TITLE
netapplier: Unify the profile activation/deactivation

### DIFF
--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -91,10 +91,10 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
     )
     applier_mock.set_ifaces_admin_state.assert_has_calls(
         [
-            mock.call([], con_profiles=ifaces_conf_new),
             mock.call(
-                desired_config[INTERFACES], con_profiles=ifaces_conf_edit
-            ),
+                desired_config[INTERFACES],
+                con_profiles=ifaces_conf_new + ifaces_conf_edit,
+            )
         ]
     )
 


### PR DESCRIPTION
Currently, netapplier will do two profile activation/deactivation:
one for new interfaces, another for edited interfaces. Doing so
could cause [newly bridge got no link due to missing slaves][1].

After patched, profiles is activated/deactivation after all profiles are
added and updated.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1723290