### PR TITLE
DEMO: Change from dict based to object based

### DIFF
--- a/libnmstate/base_iface.py
+++ b/libnmstate/base_iface.py
@@ -1,0 +1,332 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import copy
+
+import libnmstate.nm.device as nm_device
+import libnmstate.nm.connection as nm_connection
+import libnmstate.nm.ipv4 as nm_ipv4
+import libnmstate.nm.ipv6 as nm_ipv6
+import libnmstate.nm.nmclient as nmclient
+from libnmstate.nm.translator import Nm2Api
+import libnmstate.nm.wired as nm_wired
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPV4
+from libnmstate.schema import InterfaceIPV6
+from libnmstate.schema import InterfaceState
+import libnmstate.iplib as iplib
+
+
+class BaseStateObject(object):
+    def __init__(self):
+        self.default = {}
+        self.name = None
+
+    def set_default(self):
+        for key, default_value in self.default.items():
+            if getattr(self, key) is None:
+                setattr(self, key, default_value)
+
+    def merge_config(self, other):
+        for key in self.default.keys():
+            other_value = getattr(other, key)
+            self_value = getattr(self, key)
+            if self_value is None and other_value is not None:
+                setattr(self, key, other_value)
+
+
+class BaseInterface(BaseStateObject):
+    def __init__(self, iface_info=None, iface_name=None):
+        if iface_name:
+            iface_info = BaseInterface._get(iface_name)
+
+        self.name = iface_info[Interface.NAME]
+        self.type = iface_info.get(Interface.TYPE)
+        self.state = iface_info.get(Interface.STATE)
+        ipv4_info = iface_info.get(Interface.IPV4)
+        self.ipv4 = BaseInterfaceIPV4(ipv4_info) if ipv4_info else None
+        ipv6_info = iface_info.get(Interface.IPV6)
+        self.ipv6 = BaseInterfaceIPV6(ipv6_info) if ipv6_info else None
+        self.mtu = iface_info.get(Interface.MTU)
+        self.mac = iface_info.get(Interface.MAC)
+        self.verify_skip_mac = False
+        self.master_name = None
+        self.slave_type = None
+        self.master_type = None
+        self.nm_setting_name = None
+        self.slaves = []
+        ipv4_default = BaseInterfaceIPV4({})
+        ipv4_default.set_default()
+        ipv6_default = BaseInterfaceIPV6({})
+        ipv6_default.set_default()
+        self.default = {
+            'name': 'unknown',
+            'type': 'unknown',
+            'state': InterfaceState.UP,
+            'mtu': -1,
+            'mac': '00:00:00:00:00:00',
+            'ipv4': ipv4_default,
+            'ipv6': ipv6_default,
+            'master_name': None,
+            'slave_type': None,
+        }
+        self.merge_keys = ['name', 'type', 'state', 'mtu', 'mac']
+
+    @staticmethod
+    def _get(iface_name):
+        dev = nm_device.get_device_by_name(iface_name)
+        devinfo = nm_device.get_device_common_info(dev)
+        iface_info = Nm2Api.get_common_device_info(devinfo)
+        active_connection = nm_connection.get_device_active_connection(dev)
+        iface_info[Interface.IPV4] = nm_ipv4.get_info(active_connection)
+        iface_info[Interface.IPV6] = nm_ipv6.get_info(active_connection)
+        nm_dev = nm_device.get_device_by_name(iface_name)
+        wire_info = nm_wired.get_info(nm_dev)
+        iface_info[Interface.MTU] = wire_info.get(Interface.MTU)
+        iface_info[Interface.MAC] = wire_info.get(Interface.MAC)
+        return iface_info
+
+    def dump(self):
+        return {
+            Interface.NAME: self.name,
+            Interface.TYPE: self.type or self.default['type'],
+            Interface.STATE: self.state or self.default['state'],
+            Interface.MTU: self.mtu or self.default['mtu'],
+            Interface.MAC: self.mac or self.default['mac'],
+            Interface.IPV4: self.ipv4.dump() if self.ipv4 else {},
+            Interface.IPV6: self.ipv6.dump() if self.ipv6 else {},
+        }
+
+    @property
+    def metadata(self):
+        return (
+            {'master': self.master_name, 'slave_type': self.slave_type}
+            if self.master_name
+            else {}
+        )
+
+    @property
+    def is_up(self):
+        return self.state == InterfaceState.UP
+
+    @property
+    def is_down(self):
+        return self.state == InterfaceState.DOWN
+
+    @property
+    def is_absent(self):
+        return self.state == InterfaceState.ABSENT
+
+    def __str__(self):
+        return "{}: {} {}".format(
+            type(self).__name__, self.dump().__str__(), self.metadata
+        )
+
+    @property
+    def _verify_keys(self):
+        # TODO: handle state absent vs down
+        keys = [self.name, self.type, self.state]
+        if self.is_up:
+            keys.extend(
+                [
+                    self.mtu,
+                    self.ipv4.verify_keys,
+                    self.ipv6.verify_keys,
+                    self.master_name,
+                    self.slave_type,
+                ]
+            )
+
+        if not self.verify_skip_mac:
+            keys.append(self.mac)
+        return keys
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+
+        return self._verify_keys == other._verify_keys
+
+    def generate_metadata(self):
+        pass
+
+    def merge_config(self, other):
+        super(BaseInterface, self).merge_config(other)
+        self.ipv4.merge_config(other.ipv4)
+        self.ipv6.merge_config(other.ipv6)
+
+    def generate_settings(self, base_con_profile=None):
+        con_setting = nm_connection.ConnectionSetting()
+        if base_con_profile and base_con_profile.profile:
+            con_setting.import_by_profile(base_con_profile)
+        else:
+            con_setting.create(
+                con_name=self.name,
+                iface_name=self.name,
+                iface_type=self.nm_setting_name,
+            )
+        if self.master_name:
+            con_setting.set_master(self.master_name, self.slave_type)
+
+        profile = base_con_profile.profile if base_con_profile else None
+
+        return [
+            con_setting.setting,
+            nm_ipv4.create_setting(self.ipv4.dump(), profile),
+            nm_ipv6.create_setting(self.ipv6.dump(), profile),
+        ]
+
+    def pre_merge_validate(self, iface_state):
+        pass
+
+    def sanitize(self):
+        self.set_default()
+        self.ipv4.sanitize()
+        self.ipv6.sanitize()
+
+
+class IPAddr(object):
+    def __init__(self, addr):
+        self.ip = addr[InterfaceIP.ADDRESS_IP]
+        self.prefix_length = addr[InterfaceIP.ADDRESS_PREFIX_LENGTH]
+
+    @property
+    def verify_keys(self):
+        return (self.ip, self.prefix_length)
+
+    def dump(self):
+        return {
+            InterfaceIP.ADDRESS_IP: self.ip,
+            InterfaceIP.ADDRESS_PREFIX_LENGTH: self.prefix_length,
+        }
+
+    def __hash__(self):
+        return hash(self.verify_keys)
+
+    def __eq__(self, other):
+        return self.verify_keys == other.verify_keys
+
+    def __lt__(self, other):
+        return self.verify_keys < other.verify_keys
+
+    @property
+    def is_ipv6(self):
+        return iplib.is_ipv6_address(self.ip)
+
+    @property
+    def is_ipv6_link_local(self):
+        return self.is_ipv6 and iplib.is_ipv6_link_local_addr(
+            self.ip, self.prefix_length
+        )
+
+
+class BaseInterfaceIP(BaseStateObject):
+    def __init__(self, ip_info):
+        super(BaseInterfaceIP, self).__init__()
+        self.enabled = ip_info.get(InterfaceIP.ENABLED)
+        self.address = (
+            sorted(
+                set(
+                    [
+                        IPAddr(addr)
+                        for addr in ip_info.get(InterfaceIP.ADDRESS, [])
+                    ]
+                )
+            )
+            if InterfaceIP.ADDRESS
+            else None
+        )
+        self.dhcp = ip_info.get(InterfaceIP.DHCP)
+        self.auto_dns = ip_info.get(InterfaceIP.AUTO_DNS)
+        self.auto_gateway = ip_info.get(InterfaceIP.AUTO_GATEWAY)
+        self.auto_routes = ip_info.get(InterfaceIP.AUTO_ROUTES)
+        self.default = {
+            'enabled': False,
+            'address': [],
+            'dhcp': False,
+            'auto_dns': True,
+            'auto_gateway': True,
+            'auto_routes': True,
+        }
+
+    def __str__(self):
+        return "{}: {}".format(type(self).__name__, self.dump().__str__())
+
+    def dump(self, skip_ipv6_link_local=False):
+        tmp = copy.deepcopy(self)
+        tmp.set_default()
+
+        if not tmp.enabled:
+            return {InterfaceIP.ENABLED: False}
+
+        info = {InterfaceIP.ENABLED: True}
+
+        info[InterfaceIP.DHCP] = tmp.dhcp
+        if tmp.dhcp:
+            info[InterfaceIP.AUTO_DNS] = tmp.auto_dns
+            info[InterfaceIP.AUTO_GATEWAY] = tmp.auto_gateway
+            info[InterfaceIP.AUTO_ROUTES] = tmp.auto_routes
+
+        info[InterfaceIP.ADDRESS] = [
+            addr.dump()
+            for addr in tmp.address
+            if not (skip_ipv6_link_local and addr.is_ipv6_link_local)
+        ]
+
+        return info
+
+    @property
+    def verify_keys(self):
+        return self.dump(skip_ipv6_link_local=True)
+
+    def sanitize(self):
+        self.set_default()
+        if self.dhcp:
+            self.address = []
+
+
+class BaseInterfaceIPV4(BaseInterfaceIP):
+    def __init__(self, ip_info):
+        super(BaseInterfaceIPV4, self).__init__(ip_info)
+
+
+class BaseInterfaceIPV6(BaseInterfaceIP):
+    def __init__(self, ip_info):
+        super(BaseInterfaceIPV6, self).__init__(ip_info)
+        self.autoconf = ip_info.get(InterfaceIPV6.AUTOCONF)
+        self.default['autoconf'] = False
+
+    def dump(self, skip_ipv6_link_local=False):
+        info = super(BaseInterfaceIPV6, self).dump(skip_ipv6_link_local)
+        tmp = copy.deepcopy(self)
+        tmp.set_default()
+        if tmp.enabled:
+            info[InterfaceIPV6.AUTOCONF] = tmp.autoconf
+            if tmp.autoconf:
+                info[InterfaceIP.AUTO_DNS] = tmp.auto_dns
+                info[InterfaceIP.AUTO_GATEWAY] = tmp.auto_gateway
+                info[InterfaceIP.AUTO_ROUTES] = tmp.auto_routes
+        return info
+
+    def sanitize(self):
+        super(BaseInterfaceIPV6, self).sanitize()
+        self.set_default()
+        if self.autoconf:
+            self.address = []
+        self.address = [
+            addr for addr in self.address if not addr.is_ipv6_link_local
+        ]

--- a/libnmstate/bond_iface.py
+++ b/libnmstate/bond_iface.py
@@ -1,0 +1,93 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import six
+
+import libnmstate.nm.device as nm_device
+import libnmstate.nm.nmclient as nmclient
+import libnmstate.nm.bond as nm_bond
+import libnmstate.nm.translator as nm_translator
+from libnmstate.base_iface import BaseInterface
+from libnmstate.schema import Interface
+from libnmstate.schema import Bond
+from libnmstate.schema import BondMode
+from libnmstate.error import NmstateValueError
+
+
+class BondInterface(BaseInterface):
+    NM_DEV_TYPES = (nmclient.NM.DeviceType.BOND,)
+
+    def __init__(self, iface_info=None, iface_name=None):
+        super(BondInterface, self).__init__(
+            iface_info=iface_info, iface_name=iface_name
+        )
+        if iface_name:
+            iface_info = BondInterface._get(iface_name)
+        bond_info = iface_info.get(Bond.CONFIG_SUBTREE, {})
+        self.slaves = (
+            sorted(set(bond_info.get(Bond.SLAVES)))
+            if bond_info.get(Bond.SLAVES)
+            else None
+        )
+        self.mode = bond_info.get(Bond.MODE)
+        self.options = bond_info.get(Bond.OPTIONS_SUBTREE)
+        self.nm_setting_name = nmclient.NM.SETTING_BOND_SETTING_NAME
+        self.master_type = 'bond'
+        self.default.update(
+            {'mode': BondMode.ROUND_ROBIN, 'options': {}, 'slaves': []}
+        )
+
+    @staticmethod
+    def _get(iface_name):
+        dev = nm_device.get_device_by_name(iface_name)
+        bond_info = nm_bond.get_bond_info(dev)
+        return nm_translator.Nm2Api.get_bond_info(bond_info)
+
+    def dump(self):
+        info = super(BondInterface, self).dump()
+
+        info[Bond.CONFIG_SUBTREE] = {
+            Bond.MODE: self.mode or self.default['mode'],
+            Bond.SLAVES: self.slaves or self.default['slaves'],
+            Bond.OPTIONS_SUBTREE: self.options or self.default['options'],
+        }
+        return info
+
+    def _dump_bond_options(self):
+        bond_option = {Bond.MODE: self.mode or BondMode.ROUND_ROBIN}
+        bond_option.update(self.options or {})
+        return bond_option
+
+    def generate_settings(self, base_con_profile=None):
+        settings = super(BondInterface, self).generate_settings(
+            base_con_profile
+        )
+        settings.append(nm_bond.create_setting(self._dump_bond_options()))
+        return settings
+
+    def pre_merge_validate(self, iface_state):
+        super(BondInterface, self).pre_merge_validate(iface_state)
+
+        if self.is_up and self.slaves:
+            # Check slave state
+            for slave_iface_name in self.slaves:
+                slave_iface_obj = iface_state.get(slave_iface_name)
+                if slave_iface_obj and not slave_iface_obj.is_up:
+                    raise NmstateValueError(
+                        "Bond slave interface %s should be in %s state",
+                        slave_iface_name,
+                        InterfaceState.UP,
+                    )

--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import copy
+
+import libnmstate.nm.dns as nm_dns
+import libnmstate.nm.nmclient as nmclient
+import libnmstate.nm.ipv4 as nm_ipv4
+import libnmstate.nm.ipv6 as nm_ipv6
+from libnmstate.schema import DNS
+
+
+class DnsState(object):
+    def __init__(self, dict_state=None):
+        if dict_state is None:
+            dict_state = DnsState._get()
+
+        self._config = dict_state.get(DNS.CONFIG, {})
+        self._running = dict_state.get(DNS.RUNNING, {})
+
+    @staticmethod
+    def _get():
+        client = nmclient.client()
+        return {
+            DNS.RUNNING: nm_dns.get_running(),
+            DNS.CONFIG: nm_dns.get_config(
+                nm_ipv4.acs_and_ip_profiles(client),
+                nm_ipv6.acs_and_ip_profiles(client),
+            ),
+        }
+
+    def dump(self):
+        return {DNS.RUNNING: self._running, DNS.CONFIG: self._config}
+
+    def merge_config(self, current):
+        pass
+
+    def generate_metadata(self, iface_state):
+        pass
+
+    def verify(self, current):
+        pass
+
+    def pre_merge_validate(self):
+        pass
+
+    def post_merge_validate(self):
+        pass

--- a/libnmstate/eth_iface.py
+++ b/libnmstate/eth_iface.py
@@ -1,0 +1,70 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import six
+
+import libnmstate.nm.device as nm_device
+import libnmstate.nm.nmclient as nmclient
+import libnmstate.nm.wired as nm_wired
+from libnmstate.base_iface import BaseInterface
+from libnmstate.schema import Interface
+from libnmstate.schema import Ethernet
+
+
+class EthernetInterface(BaseInterface):
+    NM_DEV_TYPES = (
+        nmclient.NM.DeviceType.ETHERNET,
+        nmclient.NM.DeviceType.VETH,
+    )
+
+    def __init__(self, iface_info=None, iface_name=None):
+        super(EthernetInterface, self).__init__(
+            iface_info=iface_info, iface_name=iface_name
+        )
+        if iface_name:
+            iface_info = EthernetInterface._get(iface_name)
+        ethernet = iface_info.get(Ethernet.CONFIG_SUBTREE, {})
+        self.speed = ethernet.get(Ethernet.SPEED)
+        self.duplex = ethernet.get(Ethernet.DUPLEX)
+        self.auto_negotiation = ethernet.get(Ethernet.AUTO_NEGOTIATION)
+        self.nm_setting_name = nmclient.NM.SETTING_WIRED_SETTING_NAME
+
+    @staticmethod
+    def _get(iface_name):
+        dev = nm_device.get_device_by_name(iface_name)
+        return nm_wired.get_info(dev)
+
+    def dump(self):
+        info = super(EthernetInterface, self).dump()
+        if self.speed and self.speed != 0:
+            info[Ethernet.CONFIG_SUBTREE] = {
+                Ethernet.SPEED: self.speed,
+                Ethernet.DUPLEX: self.duplex or 'unknown',
+                Ethernet.AUTO_NEGOTIATION: self.auto_negotiation or 'unknown',
+            }
+        return info
+
+    def generate_settings(self, base_con_profile=None):
+        settings = super(EthernetInterface, self).generate_settings(
+            base_con_profile
+        )
+        profile = base_con_profile.profile if base_con_profile else None
+        settings.append(
+            nm_wired.create_setting(
+                self.dump(), base_con_profile=profile
+            )
+        )
+        return settings

--- a/libnmstate/iface_state.py
+++ b/libnmstate/iface_state.py
@@ -1,0 +1,184 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+import copy
+
+import libnmstate.nm.nmclient as nmclient
+import libnmstate.nm.connection as nm_connection
+import libnmstate.nm.applier as nm_applier
+import libnmstate.nm.device as nm_device
+from libnmstate.eth_iface import EthernetInterface
+from libnmstate.base_iface import BaseInterface
+from libnmstate.bond_iface import BondInterface
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+
+
+class IfaceState(object):
+    def __init__(self, ifaces=None):
+        iface_objs = []
+        if ifaces is None:
+            iface_objs = IfaceState._get()
+        else:
+            for iface in ifaces:
+                iface_type = iface[Interface.TYPE]
+                if iface_type == InterfaceType.ETHERNET:
+                    iface_objs.append(EthernetInterface(iface))
+                elif iface_type == InterfaceType.BOND:
+                    iface_objs.append(BondInterface(iface))
+                else:
+                    print(
+                        "Unknown dev type ", iface[Interface.NAME], iface_type
+                    )
+                    iface_objs.append(BaseInterface(iface))
+
+        self._iface_obj_dict = {}
+        for iface_obj in iface_objs:
+            self._iface_obj_dict[iface_obj.name] = iface_obj
+        if ifaces is None:
+            self.sanitize()
+
+    def update_slave_ifaces(self):
+        # Remove all existing master/slave information
+        for iface_obj in self:
+            iface_obj.master_name = None
+            iface_obj.slave_type = None
+        # Fill in the master/slave information
+        for iface_obj in self:
+            if iface_obj.is_up:
+                for slave in iface_obj.slaves:
+                    self[slave].master_name = iface_obj.name
+                    self[slave].slave_type = iface_obj.master_type
+
+    def __str__(self):
+        return "{}: {}".format(
+            type(self).__name__,
+            list(iface_obj.__str__() for iface_obj in self),
+        )
+
+    def __getitem__(self, iface_name):
+        return self._iface_obj_dict.get(iface_name)
+
+    def __delitem__(self, iface_name):
+        del self._iface_obj_dict[iface_name]
+
+    def get(self, iface_name):
+        return self._iface_obj_dict.get(iface_name)
+
+    def items(self):
+        return self._iface_obj_dict.items()
+
+    def keys(self):
+        return self._iface_obj_dict.keys()
+
+    def values(self):
+        return self._iface_obj_dict.values()
+
+    def __iter__(self):
+        for iface_obj in self._iface_obj_dict.values():
+            yield iface_obj
+
+    @staticmethod
+    def _get():
+        iface_objs = []
+        nmclient.client(refresh=True)
+        iface_names = sorted(
+            [dev.get_iface() for dev in nm_device.list_devices()]
+        )
+        for dev in nm_device.list_devices():
+            iface_name = dev.get_iface()
+            dev_type = dev.get_device_type()
+            if dev_type in EthernetInterface.NM_DEV_TYPES:
+                iface_objs.append(EthernetInterface(iface_name=iface_name))
+            elif dev_type in BondInterface.NM_DEV_TYPES:
+                iface_objs.append(BondInterface(iface_name=iface_name))
+            else:
+                print("Unknown dev type ", iface_name, dev_type)
+                iface_objs.append(BaseInterface(iface_name=iface_name))
+
+        return iface_objs
+
+    def dump(self):
+        return [iface_obj.dump() for iface_obj in self]
+
+    def merge_config(self, current_state):
+        current = current_state.iface_state
+        for iface_name, iface_obj in current.items():
+            if iface_name not in self.keys():
+                self._iface_obj_dict[iface_obj.name] = copy.deepcopy(iface_obj)
+
+        for iface_name, iface_obj in self.items():
+            current_iface_obj = current.get(iface_name)
+            if current_iface_obj:
+                iface_obj.merge_config(current_iface_obj)
+
+    def generate_metadata(self):
+        for iface_obj in self.values():
+            iface_obj.generate_metadata()
+
+    def remove_unchanged_iface(self, current_state):
+        current = current_state.iface_state
+        unchanged_iface_names = []
+        for iface_name, iface_obj in self.items():
+            if iface_obj == current.get(iface_name):
+                print('Interface %s is not changed' % iface_name)
+                unchanged_iface_names.append(iface_name)
+            else:
+                print('Changed interface, current: ', current.get(iface_name))
+                print('Changed interface, desired: ', iface_obj)
+        for iface_name in unchanged_iface_names:
+            del self[iface_name]
+
+    def apply(self):
+        profiles = []
+        for iface_name, iface_obj in self.items():
+            cur_profile = nm_connection.ConnectionProfile()
+            nmdev = nm_device.get_device_by_name(iface_name)
+            cur_profile.import_by_device(nmdev)
+            new_profile = nm_connection.ConnectionProfile()
+            if not cur_profile.profile:
+                # No profile exists for this device
+                settings = iface_obj.generate_settings()
+                new_profile.create(settings)
+                profiles.append(new_profile)
+            else:
+                settings = iface_obj.generate_settings(cur_profile)
+                new_profile.create(settings)
+                cur_profile.update(new_profile)
+                profiles.append(cur_profile)
+
+        nm_applier.edit_existing_ifaces(profiles)
+        nm_applier.set_ifaces_admin_state(self.dump(), profiles)
+
+    def verify(self, current):
+        pass
+
+    def pre_merge_validate(self):
+        for iface_obj in self:
+            iface_obj.pre_merge_validate(self)
+
+    def post_merge_validate(self):
+        pass
+
+    def sanitize(self):
+        for iface_obj in self:
+            iface_obj.sanitize()
+        # Change slave state to UP
+        for iface_obj in self:
+            if iface_obj.is_up:
+                for slave in iface_obj.slaves:
+                    self[slave].state = InterfaceState.UP

--- a/libnmstate/iplib.py
+++ b/libnmstate/iplib.py
@@ -28,6 +28,5 @@ def is_ipv6_link_local_addr(ip, prefix):
         and prefix >= _IPV6_LINK_LOCAL_NETWORK_PREFIX_LENGTH
     )
 
-
 def is_ipv6_address(addr):
     return ':' in addr

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -32,6 +32,7 @@ from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstatePermissionError
 from libnmstate.error import NmstateValueError
 from libnmstate.nm import nmclient
+from libnmstate.nmstate import NmState
 
 
 def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
@@ -49,6 +50,9 @@ def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     :returns: Checkpoint identifier
     :rtype: str
     """
+    return NmState(desired_state).apply(
+        verify_change, commit, rollback_timeout
+    )
     desired_state = copy.deepcopy(desired_state)
     validator.validate(desired_state)
     validator.validate_capabilities(desired_state, netinfo.capabilities())

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -24,6 +24,7 @@ from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
+from libnmstate.nmstate import NmState
 
 
 def show(include_status_data=False):
@@ -36,6 +37,7 @@ def show(include_status_data=False):
     When include_status_data is set, both are reported, otherwise only the
     configuration data is reported.
     """
+    return NmState().to_dict()
     report = {Constants.INTERFACES: interfaces()}
     if include_status_data:
         report['capabilities'] = capabilities()

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -1,0 +1,126 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+# Naming Schema:
+#   * iface_state: The IfaceState containing all the interfaces objects
+#   * iface_obj: The BaseInterface object or its inheritance objects
+#   * iface_name: String of interface name
+#   * conn_setting: The object of nm_connection.ConnectionSetting
+#   * profile: The NM.RemoteConnection for NM connection profile(like nmcli c)
+
+from contextlib import contextmanager
+
+from libnmstate.dns import DnsState
+from libnmstate.error import NmstateLibnmError
+from libnmstate.error import NmstatePermissionError
+from libnmstate.iface_state import IfaceState
+import libnmstate.nm.checkpoint as nm_checkpoint
+import libnmstate.nm.nmclient as nmclient
+from libnmstate.route import RouteState
+from libnmstate.schema import Interface
+from libnmstate.schema import Route
+from libnmstate.schema import DNS
+from libnmstate.validator import validate as schema_validate
+
+
+class NmState(object):
+    def __init__(self, state_dict=None):
+        if state_dict is None:
+            self._iface_state = IfaceState()
+            self._route_state = RouteState()
+            self._dns_state = DnsState()
+        else:
+            schema_validate(state_dict)
+            self._iface_state = IfaceState(
+                state_dict.get(Interface.KEY, [])
+            )
+            self._route_state = RouteState(state_dict.get(Route.KEY, {}))
+            self._dns_state = DnsState(state_dict.get(DNS.KEY, {}))
+
+    def apply(self, verify_change=True, commit=True, rollback_timeout=60):
+        current_state = NmState()
+
+        # Check whether desire state contain illegal value
+        self._iface_state.pre_merge_validate()
+        self._dns_state.pre_merge_validate()
+        self._route_state.pre_merge_validate()
+
+        self._iface_state.merge_config(current_state)
+        self._route_state.merge_config(current_state)
+        self._dns_state.merge_config(current_state)
+
+        self._iface_state.sanitize()
+
+        self._iface_state.update_slave_ifaces()
+        current_state._iface_state.update_slave_ifaces()
+
+        # Check whether desire state contain missing/invalid slaves and etc
+        self._iface_state.post_merge_validate()
+        self._dns_state.post_merge_validate()
+        self._route_state.post_merge_validate()
+
+        self._iface_state.generate_metadata()
+        self._route_state.generate_metadata(self._iface_state)
+        self._dns_state.generate_metadata(self._iface_state)
+
+        self._iface_state.remove_unchanged_iface(current_state)
+
+        if not self._iface_state.keys():
+            print("nothing changed")
+            return
+
+        try:
+            with nm_checkpoint.CheckPoint(
+                autodestroy=commit, timeout=rollback_timeout
+            ) as checkpoint:
+                with _setup_providers():
+                    self._iface_state.apply()
+                if verify_change:
+                    current_state = NmState()
+                    self._iface_state.verify(current_state)
+                    self._route_state.verify(current_state)
+                    self._dns_state.verify(current_state)
+            if not commit:
+                return checkpoint
+        except nm_checkpoint.NMCheckPointPermissionError:
+            raise NmstatePermissionError('Error creating a check point')
+        except nm_checkpoint.NMCheckPointCreationError:
+            raise NmstateConflictError('Error creating a check point')
+
+    def to_dict(self):
+        return {
+            DNS.KEY: self._dns_state.dump(),
+            Route.KEY: self._route_state.dump(),
+            Interface.KEY: self._iface_state.dump(),
+        }
+
+    @property
+    def iface_state(self):
+        return self._iface_state
+
+
+@contextmanager
+def _setup_providers():
+    mainloop = nmclient.mainloop()
+    yield
+    success = mainloop.run(timeout=20)
+    if not success:
+        raise NmstateLibnmError(
+            'Unexpected failure of libnm when running the mainloop: {}'.format(
+                mainloop.error
+            )
+        )

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import copy
+
+import libnmstate.nm.ipv4 as nm_ipv4
+import libnmstate.nm.ipv6 as nm_ipv6
+from libnmstate.schema import Route
+
+
+class RouteState(object):
+    def __init__(self, state_dict=None):
+        if state_dict is None:
+            state_dict = RouteState._get()
+        self._running = state_dict.get(Route.RUNNING)
+        self._config = state_dict.get(Route.CONFIG)
+
+    @staticmethod
+    def _get():
+        return {
+            Route.RUNNING: nm_ipv4.get_route_running()
+            + nm_ipv6.get_route_running(),
+            Route.CONFIG: nm_ipv4.get_route_config()
+            + nm_ipv6.get_route_config(),
+        }
+
+    def dump(self):
+        return {Route.RUNNING: self._running, Route.CONFIG: self._config}
+
+    def merge_config(self, current):
+        pass
+
+    def generate_metadata(self, iface_state):
+        pass
+
+    def pre_merge_validate(self):
+        pass
+
+    def post_merge_validate(self):
+        pass
+
+    def verify(self, current):
+        pass

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -44,6 +44,26 @@ class Interface(object):
     MTU = 'mtu'
 
 
+class InterfaceIP(object):
+    ENABLED = 'enabled'
+    ADDRESS = 'address'
+    ADDRESS_IP = 'ip'
+    ADDRESS_PREFIX_LENGTH = 'prefix-length'
+    DHCP = 'dhcp'
+    AUTO_DNS = 'auto-dns'
+    AUTO_GATEWAY = 'auto-gateway'
+    AUTO_ROUTES = 'auto-routes'
+
+
+class InterfaceIPV4(InterfaceIP):
+    KEY = Interface.IPV4
+
+
+class InterfaceIPV6(InterfaceIP):
+    KEY = Interface.IPV6
+    AUTOCONF = 'autoconf'
+
+
 class Route(object):
     KEY = 'routes'
 


### PR DESCRIPTION
Only support ethernet/veth interface for now.

The base layout is:

```
                NmState
                    |
        +-----------+-----------+
        |           |           |
    IfaceState  RouteState      DnsStae
        |
    ----+---------------+---------------+
    |                   |               ...
EthernetInterface    BondInterface
```

The IfaceState represents the all the interfaces and handles the all the
works required for cross interface knowledge(like master/slave,
route/dns metadata, merge config).

The EthernetInterface, BondInterface and etc are representing each
interface, and are inheriting from BaseInterface where ipv4, ipv6,
apply, merge are handled.

Both query and setting is supported.

Improvements:
```
    * Interface work has been split into:
        * BaseInterface:
            * shared functions of all interface types
        * EthernetInterface, BondInterface, OvsInterface, etc:
            * Holding extra interface information.
            * Appending data to dump()
            * Appending extra setting object for profile.

    * Work flow is clean:
        * Query:
            * Assemble IfaceState.dump(), DnsStae.dump() and
              RouteState.dump().

        * Apply:
            * pre_merge_validate
              # For invalid setting check
            * merge
              # All interfaces are self now.
            * post_merge_validate
              # For master/slave check
            * generate_metadata
              # All metadata are saved in BaseInterface or its
              # children.
              # As the whole network state is in self/desire now,
              # DNS/Route metadata could determine the their
              # owner profile without looking into current states
            * remove_unchanged_iface
              # Remove unchanged interface from self
            * apply
            * verify
```
TODO:
    * Add more interface type.
    * Add DNS, route support.
    * Generate metadata.
    * Validation and verification.
