### PR TITLE
tests integ: MAC address assert helper function

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -31,6 +31,7 @@ from .testlib import assertlib
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.statelib import show_only
 from .testlib.statelib import INTERFACES
+from .testlib.assertlib import assert_mac_address
 
 TEST_BRIDGE0 = 'linux-br0'
 
@@ -118,12 +119,10 @@ def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
 
 def test_linux_bridge_uses_the_port_mac(port0_up, bridge0_with_port0):
     port0_name = port0_up[Interface.KEY][0][Interface.NAME]
-    prev_port_mac = port0_up[Interface.KEY][0][Interface.MAC]
     current_state = show_only((TEST_BRIDGE0, port0_name))
-    curr_iface0_mac = current_state[Interface.KEY][0][Interface.MAC]
-    curr_iface1_mac = current_state[Interface.KEY][1][Interface.MAC]
-
-    assert prev_port_mac == curr_iface0_mac == curr_iface1_mac
+    assert_mac_address(
+        current_state, port0_up[Interface.KEY][0][Interface.MAC]
+    )
 
 
 def _add_port_to_bridge(bridge_state, ifname):

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -19,6 +19,7 @@ import copy
 import libnmstate
 from libnmstate.schema import DNS
 from libnmstate.schema import Route
+from libnmstate.schema import Interface
 
 from . import statelib
 from .statelib import INTERFACES
@@ -53,3 +54,17 @@ def assert_absent(*ifnames):
 
     current_state = statelib.show_only(ifnames)
     assert not current_state[INTERFACES]
+
+
+def assert_mac_address(state, expected_mac=None):
+    """ Asserts that all MAC addresses of ifaces in a state are the same """
+    macs = _iface_macs(state)
+    if not expected_mac:
+        expected_mac = next(macs)
+    for mac in macs:
+        assert expected_mac.upper() == mac
+
+
+def _iface_macs(state):
+    for ifstate in state[Interface.KEY]:
+        yield ifstate[Interface.MAC]

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -21,12 +21,12 @@ import time
 import pytest
 
 import libnmstate
-from libnmstate.schema import Interface
 from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
+from .testlib.assertlib import assert_mac_address
 
 VLAN_IFNAME = 'eth1.101'
 VLAN2_IFNAME = 'eth1.102'
@@ -66,11 +66,7 @@ def vlan_on_eth1(eth1_up):
 
 
 def test_vlan_iface_uses_the_mac_of_base_iface(vlan_on_eth1):
-    base_iface_state = vlan_on_eth1[INTERFACES][0]
-    vlan_iface_state = vlan_on_eth1[INTERFACES][1]
-    base_iface_mac = base_iface_state[Interface.MAC]
-    vlan_iface_mac = vlan_iface_state[Interface.MAC]
-    assert base_iface_mac == vlan_iface_mac
+    assert_mac_address(vlan_on_eth1)
 
 
 def test_add_and_remove_two_vlans_on_same_iface(eth1_up):


### PR DESCRIPTION
Adding helper function assertMacAddress(), which takes
state and a MAC-address as paramters, and internally
asserts the MAC-address against the state iface's MACs
using a generator.

Signed-off-by: Nandan Kulkarni <nakulkar@redhat.com>