### PR TITLE
schema: Add constants for IP subtree

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -25,6 +25,7 @@ from libnmstate.error import NmstateValueError
 from libnmstate import nm
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceState
 
 
@@ -342,7 +343,7 @@ def _dns_config_not_changed(desired_state, current_state):
             return False
         for family in six.viewkeys(iface_dns_config):
             if family in iface_state and not iface_state[family].get(
-                'enabled'
+                InterfaceIP.ENABLED
             ):
                 return False
     return True

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -106,6 +106,25 @@ class InterfaceType(object):
     )
 
 
+class InterfaceIP(object):
+    ENABLED = 'enabled'
+    ADDRESS = 'address'
+    ADDRESS_IP = 'ip'
+    ADDRESS_PREFIX_LENGTH = 'prefix-length'
+    DHCP = 'dhcp'
+    AUTO_DNS = 'auto-dns'
+    AUTO_GATEWAY = 'auto-gateway'
+    AUTO_ROUTES = 'auto-routes'
+
+
+class InterfaceIPv4(InterfaceIP):
+    pass
+
+
+class InterfaceIPv6(InterfaceIP):
+    AUTOCONF = 'autoconf'
+
+
 class Bond(object):
     KEY = InterfaceType.BOND
     CONFIG_SUBTREE = 'link-aggregation'

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -27,6 +27,8 @@ from . import nm
 from . import schema
 from .schema import Constants
 from libnmstate.schema import DNS
+from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
@@ -111,9 +113,11 @@ def validate_dhcp(state):
         for family in ('ipv4', 'ipv6'):
             ip = iface_state.get(family, {})
             if (
-                ip.get('enabled')
-                and ip.get('address')
-                and (ip.get('dhcp') or ip.get('autoconf'))
+                ip.get(InterfaceIP.ENABLED)
+                and ip.get(InterfaceIP.ADDRESS)
+                and (
+                    ip.get(InterfaceIP.DHCP) or ip.get(InterfaceIPv6.AUTOCONF)
+                )
             ):
                 logging.warning(
                     '%s addresses are ignored when ' 'dynamic IP is enabled',
@@ -200,12 +204,12 @@ def _assert_iface_ip_enabled(desired_iface_state, current_iface_state, ipkey):
     if desired_iface_state:
         ip_state = desired_iface_state.get(ipkey)
         if ip_state is not None:
-            ip_enabled = ip_state.get('enabled')
+            ip_enabled = ip_state.get(InterfaceIP.ENABLED)
             if ip_enabled is True:
                 return
             elif ip_enabled is False:
                 raise NmstateRouteWithNoIPInterfaceError(desired_iface_state)
     if current_iface_state:
         ip_state = current_iface_state.get(ipkey)
-        if not ip_state.get('enabled'):
+        if not ip_state.get(InterfaceIP.ENABLED):
             raise NmstateRouteWithNoIPInterfaceError(current_iface_state)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -29,6 +29,8 @@ from libnmstate.schema import BondMode
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -175,9 +177,12 @@ def test_add_bond_with_slaves_and_ipv4(eth1_up, eth2_up, setup_remove_bond99):
                 Interface.TYPE: InterfaceType.BOND,
                 Interface.STATE: InterfaceState.UP,
                 Interface.IPV4: {
-                    'enabled': True,
-                    'address': [
-                        {'ip': '192.168.122.250', 'prefix-length': 24}
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: '192.168.122.250',
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
                     ],
                 },
                 Bond.CONFIG_SUBTREE: {
@@ -206,9 +211,12 @@ def test_rollback_for_bond(eth1_up, eth2_up):
                 Interface.TYPE: InterfaceType.BOND,
                 Interface.STATE: InterfaceState.UP,
                 Interface.IPV4: {
-                    'enabled': True,
-                    'address': [
-                        {'ip': '192.168.122.250', 'prefix-length': 24}
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: '192.168.122.250',
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
                     ],
                 },
                 Bond.CONFIG_SUBTREE: {
@@ -349,7 +357,11 @@ def test_reordering_the_slaves_does_not_change_the_mac(bond99_with_2_slaves):
 
 def test_bond_with_empty_ipv6_static_address(eth1_up):
     extra_iface_state = {
-        Interface.IPV6: {'enabled': True, 'autoconf': False, 'dhcp': False}
+        Interface.IPV6: {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.AUTOCONF: False,
+            InterfaceIPv6.DHCP: False,
+        }
     }
     with bond_interface(
         name='bond99', slaves=['eth1'], extra_iface_state=extra_iface_state

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,7 @@ import logging
 import pytest
 
 import libnmstate
+from libnmstate.schema import InterfaceIPv6
 
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
@@ -79,7 +80,9 @@ def _set_eth_admin_state(ifname, state):
         }
         # FIXME: On most systems, IPv6 cannot be disabled by Nmstate/NM.
         if state == 'up':
-            desired_state[INTERFACES][0].update({'ipv6': {'enabled': True}})
+            desired_state[INTERFACES][0].update(
+                {'ipv6': {InterfaceIPv6.ENABLED: True}}
+            )
         libnmstate.apply(desired_state)
 
 

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -24,6 +24,8 @@ from libnmstate import netinfo
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
@@ -205,15 +207,25 @@ def _get_test_iface_states():
             Interface.STATE: InterfaceState.UP,
             Interface.TYPE: InterfaceType.ETHERNET,
             Interface.IPV4: {
-                'address': [{'ip': '192.0.2.251', 'prefix-length': 24}],
-                'dhcp': False,
-                'enabled': True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: '192.0.2.251',
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ENABLED: True,
             },
             Interface.IPV6: {
-                'address': [{'ip': '2001:db8:1::1', 'prefix-length': 64}],
-                'dhcp': False,
-                'autoconf': False,
-                'enabled': True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: '2001:db8:1::1',
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+                InterfaceIPv6.DHCP: False,
+                InterfaceIPv6.AUTOCONF: False,
+                InterfaceIPv6.ENABLED: True,
             },
         },
         {
@@ -221,15 +233,25 @@ def _get_test_iface_states():
             Interface.STATE: InterfaceState.UP,
             Interface.TYPE: InterfaceType.ETHERNET,
             Interface.IPV4: {
-                'address': [{'ip': '198.51.100.1', 'prefix-length': 24}],
-                'dhcp': False,
-                'enabled': True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: '198.51.100.1',
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ENABLED: True,
             },
             Interface.IPV6: {
-                'address': [{'ip': '2001:db8:2::1', 'prefix-length': 64}],
-                'dhcp': False,
-                'autoconf': False,
-                'enabled': True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: '2001:db8:2::1',
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+                InterfaceIPv6.DHCP: False,
+                InterfaceIPv6.AUTOCONF: False,
+                InterfaceIPv6.ENABLED: True,
             },
         },
     ]

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -24,6 +24,8 @@ import yaml
 
 import libnmstate
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge
@@ -114,8 +116,8 @@ def test_remove_bridge_and_keep_slave_up(bridge0_with_port0, port0_up):
             {
                 Interface.NAME: port_name,
                 Interface.STATE: InterfaceState.UP,
-                Interface.IPV4: {'enabled': False},
-                Interface.IPV6: {'enabled': False},
+                Interface.IPV4: {InterfaceIPv4.ENABLED: False},
+                Interface.IPV6: {InterfaceIPv6.ENABLED: False},
             }
         ]
     }
@@ -167,7 +169,11 @@ def test_add_linux_bridge_with_empty_ipv6_static_address(port0_up):
     options_subtree[LinuxBridge.STP_SUBTREE][LinuxBridge.STP_ENABLED] = False
 
     extra_iface_state = {
-        Interface.IPV6: {'enabled': True, 'autoconf': False, 'dhcp': False}
+        Interface.IPV6: {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.AUTOCONF: False,
+            InterfaceIPv6.DHCP: False,
+        }
     }
     with _linux_bridge(
         bridge_name, bridge_state, extra_iface_state

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -18,6 +18,7 @@
 #
 
 from libnmstate import nm
+from libnmstate.schema import InterfaceIPv4
 
 from ..testlib import iproutelib
 from .testlib import mainloop
@@ -33,9 +34,14 @@ def test_interface_ipv4_change(eth1_up):
     with mainloop():
         _modify_interface(
             ipv4_state={
-                'enabled': True,
-                'dhcp': False,
-                'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+                InterfaceIPv4.ENABLED: True,
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
             }
         )
 
@@ -43,9 +49,14 @@ def test_interface_ipv4_change(eth1_up):
     ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
 
     ip4_expected_state = {
-        'enabled': True,
-        'dhcp': False,
-        'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+        InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.DHCP: False,
+        InterfaceIPv4.ADDRESS: [
+            {
+                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            }
+        ],
     }
     assert ip4_expected_state == ipv4_current_state
 
@@ -53,18 +64,22 @@ def test_interface_ipv4_change(eth1_up):
 def test_enable_dhcp_with_no_server(eth1_up):
     with mainloop():
         _modify_interface(
-            ipv4_state={'enabled': True, 'dhcp': True, 'address': []}
+            ipv4_state={
+                InterfaceIPv4.ENABLED: True,
+                InterfaceIPv4.DHCP: True,
+                InterfaceIPv4.ADDRESS: [],
+            }
         )
 
     nm.nmclient.client(refresh=True)
     ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
     expected_ipv4_state = {
-        'enabled': True,
-        'dhcp': True,
-        'address': [],
-        'auto-dns': True,
-        'auto-gateway': True,
-        'auto-routes': True,
+        InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.DHCP: True,
+        InterfaceIPv4.ADDRESS: [],
+        InterfaceIPv4.AUTO_DNS: True,
+        InterfaceIPv4.AUTO_GATEWAY: True,
+        InterfaceIPv4.AUTO_ROUTES: True,
     }
     assert ipv4_current_state == expected_ipv4_state
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -20,6 +20,7 @@
 import yaml
 
 import libnmstate
+from libnmstate.schema import InterfaceIPv4
 
 from .testlib import statelib
 from .testlib.statelib import INTERFACES
@@ -83,8 +84,13 @@ def test_create_and_remove_ovs_bridge_with_an_internal_port():
         'state': 'up',
         'mtu': 1500,
         'ipv4': {
-            'enabled': True,
-            'address': [{'ip': '192.0.2.1', 'prefix-length': 24}],
+            InterfaceIPv4.ENABLED: True,
+            InterfaceIPv4.ADDRESS: [
+                {
+                    InterfaceIPv4.ADDRESS_IP: '192.0.2.1',
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                }
+            ],
         },
     }
     state[INTERFACES].append(ovs_internal_interface_state)

--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -21,6 +21,8 @@ from contextlib import contextmanager
 
 import libnmstate
 from libnmstate.nm import nmclient
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 from .testlib import statelib
 from .testlib import cmd as libcmd
@@ -44,16 +46,22 @@ def test_reapply_preserve_ip_config(eth1_up):
                     'type': 'ethernet',
                     'state': 'up',
                     'ipv4': {
-                        'address': [
-                            {'ip': IPV4_ADDRESS1, 'prefix-length': 24}
+                        InterfaceIPv4.ADDRESS: [
+                            {
+                                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                            }
                         ],
-                        'enabled': True,
+                        InterfaceIPv4.ENABLED: True,
                     },
                     'ipv6': {
-                        'address': [
-                            {'ip': IPV6_ADDRESS1, 'prefix-length': 64}
+                        InterfaceIPv6.ADDRESS: [
+                            {
+                                InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                                InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                            }
                         ],
-                        'enabled': True,
+                        InterfaceIPv6.ENABLED: True,
                     },
                     'mtu': 1500,
                 }

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -23,6 +23,8 @@ import pytest
 import libnmstate
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
@@ -36,15 +38,25 @@ ETH1_INTERFACE_STATE = {
     Interface.STATE: InterfaceState.UP,
     Interface.TYPE: InterfaceType.ETHERNET,
     Interface.IPV4: {
-        'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
-        'dhcp': False,
-        'enabled': True,
+        InterfaceIPv4.ADDRESS: [
+            {
+                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            }
+        ],
+        InterfaceIPv4.DHCP: False,
+        InterfaceIPv4.ENABLED: True,
     },
     Interface.IPV6: {
-        'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
-        'dhcp': False,
-        'autoconf': False,
-        'enabled': True,
+        InterfaceIPv6.ADDRESS: [
+            {
+                InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+            }
+        ],
+        InterfaceIPv6.DHCP: False,
+        InterfaceIPv6.AUTOCONF: False,
+        InterfaceIPv6.ENABLED: True,
     },
 }
 
@@ -393,7 +405,7 @@ def test_disable_ipv4_with_routes_in_current(eth1_up):
     )
 
     eth1_state = copy.deepcopy(ETH1_INTERFACE_STATE)
-    eth1_state[Interface.IPV4] = {'enabled': False}
+    eth1_state[Interface.IPV4] = {InterfaceIPv4.ENABLED: False}
 
     libnmstate.apply({Interface.KEY: [eth1_state]})
 

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -20,6 +20,8 @@
 import pytest
 
 import libnmstate
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -47,8 +49,13 @@ def setup_eth1_ipv4(eth1_up):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
                 },
             }
         ]
@@ -65,8 +72,13 @@ def setup_eth1_ipv6(eth1_up):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             }
         ]
@@ -84,7 +96,7 @@ def setup_eth1_ipv6_disable(eth1_up):
                 'name': 'eth1',
                 'type': 'ethernet',
                 'state': 'up',
-                'ipv6': {'enabled': False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
             }
         ]
     }
@@ -98,9 +110,12 @@ def test_add_static_ipv4_with_full_state(eth1_up):
     eth1_desired_state = desired_state[INTERFACES][0]
 
     eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv4']['enabled'] = True
-    eth1_desired_state['ipv4']['address'] = [
-        {'ip': IPV4_ADDRESS3, 'prefix-length': 24}
+    eth1_desired_state['ipv4'][InterfaceIPv4.ENABLED] = True
+    eth1_desired_state['ipv4'][InterfaceIPv4.ADDRESS] = [
+        {
+            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS3,
+            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+        }
     ]
     libnmstate.apply(desired_state)
 
@@ -115,8 +130,13 @@ def test_add_static_ipv4_with_min_state(eth2_up):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS4, 'prefix-length': 24}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS4,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
                 },
             }
         ]
@@ -129,7 +149,11 @@ def test_add_static_ipv4_with_min_state(eth2_up):
 def test_remove_static_ipv4(setup_eth1_ipv4):
     desired_state = {
         INTERFACES: [
-            {'name': 'eth1', 'type': 'ethernet', 'ipv4': {'enabled': False}}
+            {
+                'name': 'eth1',
+                'type': 'ethernet',
+                'ipv4': {InterfaceIPv4.ENABLED: False},
+            }
         ]
     }
 
@@ -146,8 +170,13 @@ def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS2, 'prefix-length': 30}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS2,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 30,
+                        }
+                    ],
                 },
             }
         ]
@@ -168,8 +197,13 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
                 },
             },
             {
@@ -177,8 +211,13 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
                 },
             },
         ]
@@ -199,8 +238,13 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv4': {
-                    'enabled': True,
-                    'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
                 },
             }
         ]
@@ -214,11 +258,17 @@ def test_add_static_ipv6_with_full_state(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6']['enabled'] = True
-    eth1_desired_state['ipv6']['address'] = [
-        {'ip': IPV6_ADDRESS2, 'prefix-length': 64},
+    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
         # This sequence is intentionally made for IP address sorting.
-        {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
     ]
     libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
@@ -228,10 +278,16 @@ def test_add_static_ipv6_with_link_local(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6']['enabled'] = True
-    eth1_desired_state['ipv6']['address'] = [
-        {'ip': IPV6_LINK_LOCAL_ADDRESS1, 'prefix-length': 64},
-        {'ip': IPV6_ADDRESS1, 'prefix-length': 64},
+    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_LINK_LOCAL_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
     ]
 
     libnmstate.apply(desired_state)
@@ -240,12 +296,12 @@ def test_add_static_ipv6_with_link_local(eth1_up):
     cur_state = statelib.show_only(('eth1',))
     eth1_cur_state = cur_state[INTERFACES][0]
     assert (
-        eth1_desired_state['ipv6']['address'][0]
-        not in eth1_cur_state['ipv6']['address']
+        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
+        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
     assert (
-        eth1_desired_state['ipv6']['address'][1]
-        in eth1_cur_state['ipv6']['address']
+        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][1]
+        in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
 
 
@@ -253,10 +309,16 @@ def test_add_static_ipv6_with_link_local_only(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6']['enabled'] = True
-    eth1_desired_state['ipv6']['address'] = [
-        {'ip': IPV6_LINK_LOCAL_ADDRESS1, 'prefix-length': 64},
-        {'ip': IPV6_LINK_LOCAL_ADDRESS2, 'prefix-length': 64},
+    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_LINK_LOCAL_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_LINK_LOCAL_ADDRESS2,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        },
     ]
 
     libnmstate.apply(desired_state)
@@ -265,12 +327,12 @@ def test_add_static_ipv6_with_link_local_only(eth1_up):
     cur_state = statelib.show_only(('eth1',))
     eth1_cur_state = cur_state[INTERFACES][0]
     assert (
-        eth1_desired_state['ipv6']['address'][0]
-        not in eth1_cur_state['ipv6']['address']
+        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
+        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
     assert (
-        eth1_desired_state['ipv6']['address'][1]
-        not in eth1_cur_state['ipv6']['address']
+        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][1]
+        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
 
 
@@ -278,14 +340,14 @@ def test_add_static_ipv6_with_no_address(eth1_up):
     desired_state = statelib.show_only(('eth1',))
     eth1_desired_state = desired_state[INTERFACES][0]
     eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6']['enabled'] = True
+    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
 
     libnmstate.apply(desired_state)
 
     cur_state = statelib.show_only(('eth1',))
     eth1_cur_state = cur_state[INTERFACES][0]
     # Should have at least 1 link-local address.
-    assert len(eth1_cur_state['ipv6']['address']) >= 1
+    assert len(eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]) >= 1
 
 
 def test_add_static_ipv6_with_min_state(eth2_up):
@@ -296,8 +358,13 @@ def test_add_static_ipv6_with_min_state(eth2_up):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 24}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             }
         ]
@@ -310,7 +377,11 @@ def test_add_static_ipv6_with_min_state(eth2_up):
 def test_disable_static_ipv6(setup_eth1_ipv6):
     desired_state = {
         INTERFACES: [
-            {'name': 'eth1', 'type': 'ethernet', 'ipv6': {'enabled': False}}
+            {
+                'name': 'eth1',
+                'type': 'ethernet',
+                'ipv6': {InterfaceIPv6.ENABLED: False},
+            }
         ]
     }
 
@@ -330,7 +401,7 @@ def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
             {
                 'name': 'eth1',
                 'type': 'ethernet',
-                'ipv6': {'enabled': False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
                 'foo': 'bad_value',
             }
         ]
@@ -349,8 +420,13 @@ def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
                 'name': 'eth1',
                 'type': 'ethernet',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
                 'foo': 'bad_value',
             }
@@ -372,8 +448,13 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS2, 'prefix-length': 24}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             }
         ]
@@ -386,13 +467,13 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
     eth1_current_state = current_state[INTERFACES][0]
 
     assert (
-        eth1_desired_state['ipv6']['address'][0]
-        in eth1_current_state['ipv6']['address']
+        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
+        in eth1_current_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
 
     assert (
-        eth1_setup['ipv6']['address'][0]
-        not in eth1_current_state['ipv6']['address']
+        eth1_setup['ipv6'][InterfaceIPv6.ADDRESS][0]
+        not in eth1_current_state['ipv6'][InterfaceIPv6.ADDRESS]
     )
 
 
@@ -406,8 +487,13 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             },
             {
@@ -415,8 +501,13 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             },
         ]
@@ -437,8 +528,13 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(
                 'type': 'ethernet',
                 'state': 'up',
                 'ipv6': {
-                    'enabled': True,
-                    'address': [{'ip': IPV6_ADDRESS1, 'prefix-length': 64}],
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
                 },
             }
         ]

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -26,6 +26,8 @@ from libnmstate import state
 from libnmstate.nm import dns as nm_dns
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import OVSBridgePortType as OBPortType
@@ -904,15 +906,25 @@ def _get_test_iface_states():
             Interface.STATE: InterfaceState.UP,
             Interface.TYPE: InterfaceType.ETHERNET,
             Interface.IPV4: {
-                'address': [{'ip': '192.0.2.251', 'prefix-length': 24}],
-                'dhcp': False,
-                'enabled': True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: '192.0.2.251',
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ENABLED: True,
             },
             Interface.IPV6: {
-                'address': [{'ip': '2001:db8:1::1', 'prefix-length': 64}],
-                'dhcp': False,
-                'autoconf': False,
-                'enabled': True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: '2001:db8:1::1',
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+                InterfaceIPv6.DHCP: False,
+                InterfaceIPv6.AUTOCONF: False,
+                InterfaceIPv6.ENABLED: True,
             },
         },
         {
@@ -920,15 +932,25 @@ def _get_test_iface_states():
             Interface.STATE: InterfaceState.UP,
             Interface.TYPE: InterfaceType.ETHERNET,
             Interface.IPV4: {
-                'address': [{'ip': '198.51.100.1', 'prefix-length': 24}],
-                'dhcp': False,
-                'enabled': True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: '198.51.100.1',
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ENABLED: True,
             },
             Interface.IPV6: {
-                'address': [{'ip': '2001:db8:2::1', 'prefix-length': 64}],
-                'dhcp': False,
-                'autoconf': False,
-                'enabled': True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: '2001:db8:2::1',
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+                InterfaceIPv6.DHCP: False,
+                InterfaceIPv6.AUTOCONF: False,
+                InterfaceIPv6.ENABLED: True,
             },
         },
     ]

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -24,6 +24,8 @@ from .compat import mock
 
 from libnmstate import netapplier
 from libnmstate.schema import Constants
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 INTERFACES = Constants.INTERFACES
 BOND_TYPE = 'bond'
@@ -57,8 +59,8 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
                 'name': 'foo',
                 'type': 'unknown',
                 'state': 'up',
-                'ipv4': {'enabled': False},
-                'ipv6': {'enabled': False},
+                'ipv4': {InterfaceIPv4.ENABLED: False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
             }
         ]
     }
@@ -144,8 +146,8 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
                     'slaves': [],
                     'options': {'miimon': '100'},
                 },
-                'ipv4': {'enabled': False},
-                'ipv6': {'enabled': False},
+                'ipv4': {InterfaceIPv4.ENABLED: False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
             }
         ]
     }

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -23,6 +23,8 @@ from .compat import mock
 from libnmstate import netinfo
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 
 INTERFACES = Constants.INTERFACES
@@ -50,8 +52,8 @@ def test_netinfo_show_generic_iface(nm_mock, nm_dns_mock):
                 'name': 'foo',
                 'type': 'unknown',
                 'state': 'up',
-                'ipv4': {'enabled': False},
-                'ipv6': {'enabled': False},
+                'ipv4': {InterfaceIPv4.ENABLED: False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
             }
         ],
     }
@@ -90,8 +92,8 @@ def test_netinfo_show_bond_iface(nm_mock, nm_dns_mock):
                     'slaves': [],
                     'options': {'miimon': '100'},
                 },
-                'ipv4': {'enabled': False},
-                'ipv6': {'enabled': False},
+                'ipv4': {InterfaceIPv4.ENABLED: False},
+                'ipv6': {InterfaceIPv6.ENABLED: False},
             }
         ],
     }

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -24,6 +24,7 @@ import libnmstate.nm.dns as nm_dns
 import libnmstate.nm.ipv4 as nm_ipv4
 import libnmstate.nm.ipv6 as nm_ipv6
 from libnmstate.schema import DNS
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import Route
 
 
@@ -64,7 +65,8 @@ parametrize_ip_ver_dns = pytest.mark.parametrize(
 def test_add_dns_empty(nm_ip):
     dns_conf = {}
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: dns_conf}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: dns_conf},
+        base_con_profile=None,
     )
 
     _assert_dns(setting_ip, dns_conf)
@@ -74,7 +76,8 @@ def test_add_dns_empty(nm_ip):
 def test_add_dns(nm_ip, get_test_dns_func):
     dns_conf = get_test_dns_func()
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: dns_conf}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: dns_conf},
+        base_con_profile=None,
     )
 
     _assert_dns(setting_ip, dns_conf)
@@ -85,7 +88,8 @@ def test_add_dns_duplicate_server(nm_ip, get_test_dns_func):
     dns_conf = get_test_dns_func()
     dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0], dns_conf[DNS.SERVER][0]]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: dns_conf}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: dns_conf},
+        base_con_profile=None,
     )
 
     dns_conf[DNS.SERVER] = [dns_conf[DNS.SERVER][0]]
@@ -97,7 +101,8 @@ def test_add_dns_duplicate_search(nm_ip, get_test_dns_func):
     dns_conf = get_test_dns_func()
     dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0], dns_conf[DNS.SEARCH][0]]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: dns_conf}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: dns_conf},
+        base_con_profile=None,
     )
 
     dns_conf[DNS.SEARCH] = [dns_conf[DNS.SEARCH][0]]
@@ -108,12 +113,13 @@ def test_add_dns_duplicate_search(nm_ip, get_test_dns_func):
 def test_clear_dns(nm_ip, get_test_dns_func):
     dns_conf = get_test_dns_func()
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: dns_conf}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: dns_conf},
+        base_con_profile=None,
     )
     con_profile = nm_connection.ConnectionProfile()
     con_profile.create([setting_ip])
     new_setting_ip = nm_ip.create_setting(
-        {'enabled': True, nm_dns.DNS_METADATA: {}},
+        {InterfaceIP.ENABLED: True, nm_dns.DNS_METADATA: {}},
         base_con_profile=con_profile.profile,
     )
 

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -22,6 +22,7 @@ import pytest
 from lib.compat import mock
 
 from libnmstate import nm
+from libnmstate.schema import InterfaceIPv4
 
 IPV4_ADDRESS1 = '192.0.2.251'
 
@@ -43,7 +44,7 @@ def test_create_setting_without_config(NM_mock):
 
 def test_create_setting_with_ipv4_disabled(NM_mock):
     ipv4_setting = nm.ipv4.create_setting(
-        config={'enabled': False}, base_con_profile=None
+        config={InterfaceIPv4.ENABLED: False}, base_con_profile=None
     )
 
     assert (
@@ -53,7 +54,8 @@ def test_create_setting_with_ipv4_disabled(NM_mock):
 
 def test_create_setting_without_addresses(NM_mock):
     ipv4_setting = nm.ipv4.create_setting(
-        config={'enabled': True, 'address': []}, base_con_profile=None
+        config={InterfaceIPv4.ENABLED: True, InterfaceIPv4.ADDRESS: []},
+        base_con_profile=None,
     )
 
     assert (
@@ -63,10 +65,16 @@ def test_create_setting_without_addresses(NM_mock):
 
 def test_create_setting_with_static_addresses(NM_mock):
     config = {
-        'enabled': True,
-        'address': [
-            {'ip': '10.10.10.1', 'prefix-length': 24},
-            {'ip': '10.10.20.1', 'prefix-length': 24},
+        InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.ADDRESS: [
+            {
+                InterfaceIPv4.ADDRESS_IP: '10.10.10.1',
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            },
+            {
+                InterfaceIPv4.ADDRESS_IP: '10.10.20.1',
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            },
         ],
     }
     ipv4_setting = nm.ipv4.create_setting(config=config, base_con_profile=None)
@@ -78,13 +86,17 @@ def test_create_setting_with_static_addresses(NM_mock):
         [
             mock.call(
                 nm.ipv4.socket.AF_INET,
-                config['address'][0]['ip'],
-                config['address'][0]['prefix-length'],
+                config[InterfaceIPv4.ADDRESS][0][InterfaceIPv4.ADDRESS_IP],
+                config[InterfaceIPv4.ADDRESS][0][
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH
+                ],
             ),
             mock.call(
                 nm.ipv4.socket.AF_INET,
-                config['address'][1]['ip'],
-                config['address'][1]['prefix-length'],
+                config[InterfaceIPv4.ADDRESS][1][InterfaceIPv4.ADDRESS_IP],
+                config[InterfaceIPv4.ADDRESS][1][
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH
+                ],
             ),
         ]
     )
@@ -99,7 +111,7 @@ def test_create_setting_with_static_addresses(NM_mock):
 def test_get_info_with_no_connection():
     info = nm.ipv4.get_info(active_connection=None)
 
-    assert info == {'enabled': False}
+    assert info == {InterfaceIPv4.ENABLED: False}
 
 
 def test_get_info_with_no_ipv4_config():
@@ -109,7 +121,7 @@ def test_get_info_with_no_ipv4_config():
 
     info = nm.ipv4.get_info(active_connection=con_mock)
 
-    assert info == {'enabled': False}
+    assert info == {InterfaceIPv4.ENABLED: False}
 
 
 def test_get_info_with_ipv4_config(NM_mock):
@@ -131,12 +143,16 @@ def test_get_info_with_ipv4_config(NM_mock):
     info = nm.ipv4.get_info(active_connection=act_con_mock)
 
     assert info == {
-        'enabled': True,
-        'dhcp': False,
-        'address': [
+        InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.DHCP: False,
+        InterfaceIPv4.ADDRESS: [
             {
-                'ip': address_mock.get_address.return_value,
-                'prefix-length': int(address_mock.get_prefix.return_value),
+                InterfaceIPv4.ADDRESS_IP: (
+                    address_mock.get_address.return_value
+                ),
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: int(
+                    address_mock.get_prefix.return_value
+                ),
             }
         ],
     }
@@ -144,8 +160,13 @@ def test_get_info_with_ipv4_config(NM_mock):
 
 def test_create_setting_with_base_con_profile(NM_mock):
     config = {
-        'enabled': True,
-        'address': [{'ip': IPV4_ADDRESS1, 'prefix-length': 24}],
+        InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.ADDRESS: [
+            {
+                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            }
+        ],
     }
     base_con_profile_mock = mock.MagicMock()
     config_mock = base_con_profile_mock.get_setting_ip4_config.return_value

--- a/tests/lib/nm/route_test.py
+++ b/tests/lib/nm/route_test.py
@@ -26,6 +26,7 @@ from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import ipv4 as nm_ipv4
 from libnmstate.nm import ipv6 as nm_ipv6
 from libnmstate.nm import connection as nm_connection
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import Route
 
 IPV4_DEFAULT_GATEWAY_DESTINATION = '0.0.0.0/0'
@@ -116,7 +117,8 @@ parametrize_ip_ver_routes_gw = pytest.mark.parametrize(
 @parametrize_ip_ver_routes
 def test_add_multiple_route(nm_ip, routes):
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes},
+        base_con_profile=None,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == routes
 
@@ -124,7 +126,7 @@ def test_add_multiple_route(nm_ip, routes):
 @parametrize_ip_ver_routes
 def test_add_duplicate_routes(nm_ip, routes):
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: [routes[0], routes[0]]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: [routes[0], routes[0]]},
         base_con_profile=None,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == [
@@ -135,12 +137,13 @@ def test_add_duplicate_routes(nm_ip, routes):
 @parametrize_ip_ver_routes
 def test_clear_route(nm_ip, routes):
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes}, base_con_profile=None
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes},
+        base_con_profile=None,
     )
     con_profile = nm_connection.ConnectionProfile()
     con_profile.create([setting_ip])
     new_setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: []},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: []},
         base_con_profile=con_profile.profile,
     )
     assert not [_nm_route_to_dict(r) for r in new_setting_ip.props.routes]
@@ -153,7 +156,7 @@ def test_add_route_without_metric(nm_ip, routes):
     route_without_metric = copy.deepcopy(routes[0])
     del route_without_metric[Route.METRIC]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: [route_without_metric]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: [route_without_metric]},
         base_con_profile=None,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == [
@@ -168,7 +171,7 @@ def test_add_route_without_table_id(nm_ip, routes):
     route_without_table_id = copy.deepcopy(routes[0])
     del route_without_table_id[Route.TABLE_ID]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: [route_without_table_id]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: [route_without_table_id]},
         base_con_profile=None,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == [
@@ -180,7 +183,7 @@ def test_add_route_without_table_id(nm_ip, routes):
 def test_change_gateway(nm_ip, routes, gateways):
     desired_routes = routes + gateways[:1]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: desired_routes},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: desired_routes},
         base_con_profile=None,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == routes
@@ -195,7 +198,7 @@ def test_change_gateway(nm_ip, routes, gateways):
 @parametrize_ip_ver_routes_gw
 def test_add_two_gateway(nm_ip, routes, gateways):
     nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes + gateways},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes + gateways},
         base_con_profile=None,
     )
 
@@ -209,7 +212,7 @@ def test_add_two_gateway(nm_ip, routes, gateways):
 def test_add_duplicate_gateways(nm_ip, routes, gateways):
     nm_ip.create_setting(
         {
-            'enabled': True,
+            InterfaceIP.ENABLED: True,
             metadata.ROUTES: routes + [gateways[0], gateways[0]],
         },
         base_con_profile=None,
@@ -220,7 +223,7 @@ def test_add_duplicate_gateways(nm_ip, routes, gateways):
 def test_change_gateway_without_metric(nm_ip, routes, gateways):
     del gateways[0][Route.METRIC]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes + [gateways[0]]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes + [gateways[0]]},
         base_con_profile=None,
     )
     gateways[0][Route.METRIC] = Route.USE_DEFAULT_METRIC
@@ -232,7 +235,7 @@ def test_change_gateway_without_metric(nm_ip, routes, gateways):
 def test_change_gateway_without_table_id(nm_ip, routes, gateways):
     del gateways[0][Route.TABLE_ID]
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes + [gateways[0]]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes + [gateways[0]]},
         base_con_profile=None,
     )
     gateways[0][Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
@@ -244,13 +247,13 @@ def test_change_gateway_without_table_id(nm_ip, routes, gateways):
 @parametrize_ip_ver_routes_gw
 def test_clear_gateway(nm_ip, routes, gateways):
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes + gateways[:1]},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes + gateways[:1]},
         base_con_profile=None,
     )
     con_profile = nm_connection.ConnectionProfile()
     con_profile.create([setting_ip])
     setting_ip = nm_ip.create_setting(
-        {'enabled': True, metadata.ROUTES: routes},
+        {InterfaceIP.ENABLED: True, metadata.ROUTES: routes},
         base_con_profile=con_profile.profile,
     )
     assert [_nm_route_to_dict(r) for r in setting_ip.props.routes] == routes

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -24,6 +24,8 @@ from libnmstate import state
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route
 
@@ -76,32 +78,56 @@ class TestAssertIfaceState(object):
         desired_state = self._base_state
         current_state = self._base_state
         desired_state.interfaces['foo-name']['ipv4'] = {
-            'address': [
-                {'ip': '192.168.122.10', 'prefix-length': 24},
-                {'ip': '192.168.121.10', 'prefix-length': 24},
+            InterfaceIPv4.ADDRESS: [
+                {
+                    InterfaceIPv4.ADDRESS_IP: '192.168.122.10',
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                },
+                {
+                    InterfaceIPv4.ADDRESS_IP: '192.168.121.10',
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                },
             ],
-            'enabled': True,
+            InterfaceIPv4.ENABLED: True,
         }
         current_state.interfaces['foo-name']['ipv4'] = {
-            'address': [
-                {'ip': '192.168.121.10', 'prefix-length': 24},
-                {'ip': '192.168.122.10', 'prefix-length': 24},
+            InterfaceIPv4.ADDRESS: [
+                {
+                    InterfaceIPv4.ADDRESS_IP: '192.168.121.10',
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                },
+                {
+                    InterfaceIPv4.ADDRESS_IP: '192.168.122.10',
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                },
             ],
-            'enabled': True,
+            InterfaceIPv4.ENABLED: True,
         }
         desired_state.interfaces['foo-name']['ipv6'] = {
-            'address': [
-                {'ip': '2001::2', 'prefix-length': 64},
-                {'ip': '2001::1', 'prefix-length': 64},
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: '2001::2',
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                },
+                {
+                    InterfaceIPv6.ADDRESS_IP: '2001::1',
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                },
             ],
-            'enabled': True,
+            InterfaceIPv6.ENABLED: True,
         }
         current_state.interfaces['foo-name']['ipv6'] = {
-            'address': [
-                {'ip': '2001::1', 'prefix-length': 64},
-                {'ip': '2001::2', 'prefix-length': 64},
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: '2001::1',
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                },
+                {
+                    InterfaceIPv6.ADDRESS_IP: '2001::2',
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                },
             ],
-            'enabled': True,
+            InterfaceIPv6.ENABLED: True,
         }
 
         desired_state.verify_interfaces(current_state)
@@ -416,7 +442,7 @@ class TestRouteStateMerge(object):
                     {
                         Interface.NAME: route0_obj.next_hop_interface,
                         Interface.STATE: InterfaceState.UP,
-                        Interface.IPV4: {'enabled': False},
+                        Interface.IPV4: {InterfaceIPv4.ENABLED: False},
                     }
                 ]
             }
@@ -430,7 +456,7 @@ class TestRouteStateMerge(object):
                 {
                     Interface.NAME: route0_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
-                    Interface.IPV4: {'enabled': False},
+                    Interface.IPV4: {InterfaceIPv4.ENABLED: False},
                     Interface.IPV6: {},
                 }
             ],
@@ -448,7 +474,7 @@ class TestRouteStateMerge(object):
                     {
                         Interface.NAME: route1_obj.next_hop_interface,
                         Interface.STATE: InterfaceState.UP,
-                        Interface.IPV6: {'enabled': False},
+                        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                     }
                 ]
             }
@@ -463,7 +489,7 @@ class TestRouteStateMerge(object):
                     Interface.NAME: route1_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
                     Interface.IPV4: {},
-                    Interface.IPV6: {'enabled': False},
+                    Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                 }
             ],
             Route.KEY: {Route.CONFIG: []},
@@ -480,7 +506,7 @@ class TestRouteStateMerge(object):
                     {
                         Interface.NAME: route0_obj.next_hop_interface,
                         Interface.STATE: InterfaceState.UP,
-                        Interface.IPV6: {'enabled': False},
+                        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                     }
                 ]
             }
@@ -495,7 +521,7 @@ class TestRouteStateMerge(object):
                     Interface.NAME: route0_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
                     Interface.IPV4: {},
-                    Interface.IPV6: {'enabled': False},
+                    Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                 }
             ],
             Route.KEY: {Route.CONFIG: [route0]},
@@ -668,8 +694,8 @@ def _gen_iface_states_for_routes(routes):
         {
             Interface.NAME: iface,
             Interface.STATE: InterfaceState.UP,
-            Interface.IPV4: {'enabled': True},
-            Interface.IPV6: {'enabled': True},
+            Interface.IPV4: {InterfaceIPv4.ENABLED: True},
+            Interface.IPV6: {InterfaceIPv6.ENABLED: True},
         }
         for iface in ifaces
     ]

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -24,6 +24,8 @@ from libnmstate import schema
 from libnmstate import state
 from libnmstate import validator
 from libnmstate.schema import DNS
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
 
@@ -295,8 +297,8 @@ def _create_interface_state(
         schema.Interface.NAME: iface_name,
         schema.Interface.TYPE: schema.InterfaceType.ETHERNET,
         schema.Interface.STATE: state,
-        schema.Interface.IPV4: {'enabled': ipv4},
-        schema.Interface.IPV6: {'enabled': ipv6},
+        schema.Interface.IPV4: {InterfaceIPv4.ENABLED: ipv4},
+        schema.Interface.IPV6: {InterfaceIPv6.ENABLED: ipv6},
     }
 
 


### PR DESCRIPTION
Three class was added:
* `schema.InterfaceIP`
* `schema.InterfaceIPv4`
* `schema.InterfaceIPv6`