### PR TITLE
state: Make interface type optional

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -99,7 +99,7 @@ def _set_ovs_bridge_ports_metadata(master_state, slave_state):
 
 def _set_common_slaves_metadata(master_state, slave_state):
     slave_state[MASTER] = master_state['name']
-    slave_state[MASTER_TYPE] = master_state['type']
+    slave_state[MASTER_TYPE] = master_state.get('type')
 
 
 def _get_ovs_slaves_from_state(iface_state, default=()):

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -89,8 +89,9 @@ class InterfaceType(object):
     ETHERNET = 'ethernet'
     LINUX_BRIDGE = 'linux-bridge'
     OVS_BRIDGE = 'ovs-bridge'
-    OVS_PORT = 'ovs-port'
     OVS_INTERFACE = 'ovs-interface'
+    OVS_PORT = 'ovs-port'
+    UNKNOWN = 'unknown'
     VLAN = 'vlan'
 
     VIRT_TYPES = (

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+import copy
 import logging
 import six
 
@@ -43,6 +44,10 @@ class NmstateRouteWithNoIPInterfaceError(NmstateValueError):
 
 
 def validate(data, validation_schema=schema.ifaces_schema):
+    data = copy.deepcopy(data)
+    for ifstate in data.get(schema.Interface.KEY, ()):
+        if not ifstate.get(schema.Interface.TYPE):
+            ifstate[schema.Interface.TYPE] = schema.InterfaceType.UNKNOWN
     js.validate(data, validation_schema)
 
 
@@ -51,7 +56,7 @@ def validate_capabilities(state, capabilities):
 
 
 def validate_interface_capabilities(ifaces_state, capabilities):
-    ifaces_types = [iface_state['type'] for iface_state in ifaces_state]
+    ifaces_types = [iface_state.get('type') for iface_state in ifaces_state]
     has_ovs_capability = nm.ovs.CAPABILITY in capabilities
     for iface_type in ifaces_types:
         is_ovs_type = iface_type in (

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -44,3 +44,17 @@ def test_removing_a_non_removable_iface(eth1_up):
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
+
+
+def test_set_iface_down_without_type(eth1_up):
+    desired_state = {INTERFACES: [{'name': 'eth1', 'state': 'down'}]}
+    libnmstate.apply(desired_state)
+
+    assertlib.assert_state(desired_state)
+
+
+def test_change_iface_without_type(eth1_up):
+    desired_state = {INTERFACES: [{'name': 'eth1', 'mtu': 1400}]}
+    libnmstate.apply(desired_state)
+
+    assertlib.assert_state(desired_state)


### PR DESCRIPTION
Defining a desired state for an interface required specifying its type.

When an interface is edited, there is no need to specify its type, as it
may be concluded from checking the current state.