### PR TITLE
metadata: Remove profile for detached slaves

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -153,7 +153,10 @@ def _generate_link_master_metadata(
             slaves2remove = set(current_slaves) - set(desired_slaves)
             for slave in slaves2remove:
                 if slave not in ifaces_desired_state:
-                    ifaces_desired_state[slave] = {'name': slave}
+                    ifaces_desired_state[slave] = {
+                        'name': slave,
+                        'state': 'down',
+                    }
 
     current_masters = (
         (ifname, ifstate)

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -190,7 +190,7 @@ class TestDesiredStateBondMetadata(object):
         expected_dstate.interfaces['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_dstate.interfaces['eth0'][metadata.MASTER] = BOND_NAME
         expected_dstate.interfaces['eth0'][metadata.MASTER_TYPE] = TYPE_BOND
-        expected_dstate.interfaces['eth1'] = {'name': 'eth1'}
+        expected_dstate.interfaces['eth1'] = {'name': 'eth1', 'state': 'down'}
 
         metadata.generate_ifaces_metadata(desired_state, current_state)
 
@@ -501,7 +501,7 @@ class TestDesiredStateOvsMetadata(object):
         expected_dstate.interfaces['eth0'] = {'name': 'eth0', 'state': 'up'}
         expected_dstate.interfaces['eth0'][metadata.MASTER] = OVS_NAME
         expected_dstate.interfaces['eth0'][metadata.MASTER_TYPE] = TYPE_OVS_BR
-        expected_dstate.interfaces['eth1'] = {'name': 'eth1'}
+        expected_dstate.interfaces['eth1'] = {'name': 'eth1', 'state': 'down'}
         expected_dstate.interfaces['eth0'][
             metadata.BRPORT_OPTIONS
         ] = desired_state.interfaces[OVS_NAME]['bridge']['port'][0]


### PR DESCRIPTION
When a slave is removed from a master, it needs to be marked as `down`
in order to remove its configuration completly.
In case of the NM provider, its profile is removed.