### PR TITLE
Fix DHCP enabled criteria for interfaces.

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -101,18 +101,14 @@ def get_info(active_connection):
             info['auto-routes'] = not ip_profile.props.ignore_auto_routes
             info['auto-gateway'] = not ip_profile.props.never_default
             info['auto-dns'] = not ip_profile.props.ignore_auto_dns
+            info['enabled'] = True
+            info['address'] = []
     else:
         info['dhcp'] = False
 
     ip4config = active_connection.get_ip4_config()
     if ip4config is None:
-        # When DHCP is enable, it might be possible, the active_connection does
-        # not got IP address yet. In that case, we still mark
-        # info['enabled'] as True.
-        if info['dhcp']:
-            info['enabled'] = True
-            info['address'] = []
-        else:
+        if not info['dhcp']:
             del info['dhcp']
         return info
 

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -50,6 +50,25 @@ def test_interface_ipv4_change(eth1_up):
     assert ip4_expected_state == ipv4_current_state
 
 
+def test_enable_dhcp_with_no_server(eth1_up):
+    with mainloop():
+        _modify_interface(
+            ipv4_state={'enabled': True, 'dhcp': True, 'address': []}
+        )
+
+    nm.nmclient.client(refresh=True)
+    ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
+    expected_ipv4_state = {
+        'enabled': True,
+        'dhcp': True,
+        'address': [],
+        'auto-dns': True,
+        'auto-gateway': True,
+        'auto-routes': True,
+    }
+    assert ipv4_current_state == expected_ipv4_state
+
+
 def _modify_interface(ipv4_state):
     conn = nm.connection.ConnectionProfile()
     conn.import_by_id(TEST_IFACE)


### PR DESCRIPTION
When an existent interface was setup to have DHCP enabled, its
'enabled' criteria was not correct, since it required the interface
to have been assigned an IP addresses.

This patch updates the criteria, setting the interface to enabled
as long as it reports back being configured via DHCP by
NetworkManager.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>