### PR TITLE
ipv6: Disable the IPv6 stack when explicitly requested

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -28,6 +28,7 @@ from libnmstate import netinfo
 from libnmstate import nm
 from libnmstate import schema
 from libnmstate import state
+from libnmstate import sysctl
 from libnmstate import validator
 from libnmstate.error import NmstateConflictError
 from libnmstate.error import NmstateLibnmError
@@ -140,6 +141,7 @@ def _apply_ifaces_state(
                     ifaces2add + ifaces2edit,
                     con_profiles=ifaces_add_configs + ifaces_edit_configs,
                 )
+            _disable_ipv6(desired_state)
             if verify_change:
                 _verify_change(desired_state)
         if not commit:
@@ -232,3 +234,16 @@ def _edit_interfaces(state2edit):
 
 def _index_by_name(ifaces_state):
     return {iface['name']: iface for iface in ifaces_state}
+
+
+def _disable_ipv6(desired_state):
+    """
+    Identify in the desired state all interfaces that explicitly disable
+    the IPv6 stack and apply it through sysfs.
+
+    This is an intermediate workaround for https://bugzilla.redhat.com/1643841.
+    """
+    for ifstate in six.viewvalues(desired_state.interfaces):
+        ipv6_state = ifstate.get(schema.Interface.IPV6, {})
+        if ipv6_state.get('enabled') is False:
+            sysctl.disable_ipv6(ifstate[schema.Interface.NAME])

--- a/libnmstate/sysctl.py
+++ b/libnmstate/sysctl.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import errno
+
+from . import error
+
+
+class ChangeIpv6StateError(error.NmstateError):
+    pass
+
+
+def enable_ipv6(dev):
+    _change_ipv6_state(dev, disable=False)
+
+
+def disable_ipv6(dev):
+    _change_ipv6_state(dev, disable=True)
+
+
+def _change_ipv6_state(dev, disable):
+    try:
+        with open('/proc/sys/net/ipv6/conf/%s/disable_ipv6' % dev, 'w') as f:
+            f.write('1' if disable else '0')
+    except IOError as e:
+        if e.errno == errno.ENOENT and disable:
+            # IPv6 stack is (already) not available on this device
+            return
+        raise ChangeIpv6StateError(str(e))
+
+
+def is_disabled_ipv6(dev='default'):
+    try:
+        with open('/proc/sys/net/ipv6/conf/%s/disable_ipv6' % dev) as f:
+            return int(f.read())
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            return 1
+        else:
+            raise error.NmstateError(str(e))


### PR DESCRIPTION
NetworkManager is currently not supporting the ability to disable the
IPv6 stack on the kernel [1].

As an intermediate solution, sysfs is used to control the IPv6 stack.

[1] https://bugzilla.redhat.com/1643841