### PR TITLE
schema: add linux bridge vlan filtering

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -171,6 +171,23 @@ class LinuxBridge(object):
     PORT_STP_HAIRPIN_MODE = 'stp-hairpin-mode'
     PORT_STP_PATH_COST = 'stp-path-cost'
 
+    class Port(object):
+        VLAN_SUBTREE = 'vlan'
+
+        class Vlan(object):
+            TRUNK_TAGS = 'trunk-tags'
+            TAG = 'tag'
+            ENABLE_NATIVE = 'enable-native'
+            TYPE = 'type'
+            ACCESS_TYPE = 'access'
+            TRUNK_TYPE = 'trunk'
+
+            class TrunkTags(object):
+                ID = 'id'
+                ID_RANGE = 'id-range'
+                MIN_RANGE = 'min'
+                MAX_RANGE = 'max'
+
 
 class Ethernet(object):
     TYPE = InterfaceType.ETHERNET

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -56,6 +56,10 @@ definitions:
     mac-address:
       type: string
       pattern: "^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$"
+    bridge-vlan-tag:
+      type: integer
+      minimum: 0
+      maximum: 4095
 
   # Interface types
   interface-base:
@@ -240,6 +244,22 @@ definitions:
                     type: integer
                   stp-hairpin-mode:
                     type: boolean
+                  vlan:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - trunk
+                          - access
+                      trunk-tags:
+                        type: array
+                        items:
+                          $ref: "#/definitions/bridge-port-vlan"
+                      tag:
+                        $ref: "#/definitions/types/bridge-vlan-tag"
+                      enable-native:
+                        type: boolean
             options:
               type: object
               properties:
@@ -476,3 +496,15 @@ definitions:
         type: array
         items:
           type: string
+  bridge-port-vlan:
+    type: object
+    properties:
+      id:
+        $ref: "#/definitions/types/bridge-vlan-tag"
+      id-range:
+        type: object
+        properties:
+          min:
+            $ref: "#/definitions/types/bridge-vlan-tag"
+          max:
+            $ref: "#/definitions/types/bridge-vlan-tag"


### PR DESCRIPTION
schema: add linux bridge vlan filtering
    
The defined model allows for setting trunk and access ports.
Furthermore, it allows defining a native vlan on a trunk port.
    
It is possible to independently define the trunks/access vlans per each port, and while NM / linux bridges allows it, at the moment, we will not allow setting allowed vlans on the bridge port.
It will be hardcoded with the linux bridge default: having vlan id 1 as native vlan.
Defining the schema of the uplink port will be done in a separate subsequent PR.
    
This patch adds to the model:
  - a 'vlan' map to the bridge ports, that will hold a list trunk tag (that can be individual tags, or tag ranges), an access tag - to be used for access ports - and an 'enable-native' flag, intended to select one of the trunk tags as native vlan.
    
    An example of a bridge configuration that allows for all vlans on a trunk port:
```yaml
    - name: linux-br0
      type: linux-bridge
      state: up
      bridge:
        options:
          stp:
            enabled: true
        port:
          - name: eth1
            vlans:
              type: trunk
              trunk-tags:
                - id-range:
                    min: 1
                    max: 4095
```
An example of a bridge configuration with an access port:
```yaml
    - name: linux-br0
      type: linux-bridge
      state: up
      bridge:
        options:
          stp:
            enabled: true
        port:
          - name: eth1
            vlan:
              type: access
              tag: 101
```
An example of a bridge configuration having a port with a native vlan trunk tag:
```yaml
    - name: linux-br0
      type: linux-bridge
      state: up
      bridge:
        options:
          stp:
            enabled: true
        port:
          - name: eth1
            vlan:
              type: trunk
              trunk-tags:
                - id: 101
                - id-range:
                    min: 200
                    max: 4095
              tag: 100
              enable-native: true
```
    
The bug that tracks the feature in NetworkManager can be found at [0].
    
More information on this feature can be found in [1].
    
[0] - https://bugzilla.redhat.com/show_bug.cgi?id=1652910#c11
[1] - https://developers.redhat.com/blog/2017/09/14/vlan-filter-support-on-bridge/
    
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>
