### PR TITLE
Delete master without slave

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -132,6 +132,7 @@ def _generate_link_master_metadata(
         (ifname, ifstate)
         for ifname, ifstate in six.viewitems(ifaces_desired_state)
         if ifstate.get('type') == master_type
+        and ifstate.get('state') not in ('down', 'absent')
     ]
     for master_name, master_state in desired_masters:
         desired_slaves = get_slaves_func(master_state)
@@ -168,19 +169,20 @@ def _generate_link_master_metadata(
         for slave in current_slaves:
             if slave in ifaces_desired_state:
                 iface_state = ifaces_desired_state.get(master_name, {})
-                master_has_no_slaves_specified_in_desired = (
-                    get_slaves_func(iface_state, None) is None
-                )
-                slave_has_no_master_specified_in_desired = (
-                    ifaces_desired_state[slave].get(MASTER) is None
-                )
-                if (
-                    slave_has_no_master_specified_in_desired
-                    and master_has_no_slaves_specified_in_desired
-                ):
-                    set_metadata_func(
-                        master_state, ifaces_desired_state[slave]
+                if iface_state.get('state') not in ('down', 'absent'):
+                    master_has_no_slaves_specified_in_desired = (
+                        get_slaves_func(iface_state, None) is None
                     )
+                    slave_has_no_master_specified_in_desired = (
+                        ifaces_desired_state[slave].get(MASTER) is None
+                    )
+                    if (
+                        slave_has_no_master_specified_in_desired
+                        and master_has_no_slaves_specified_in_desired
+                    ):
+                        set_metadata_func(
+                            master_state, ifaces_desired_state[slave]
+                        )
 
 
 def _generate_route_metadata(desired_state, current_state):

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -283,6 +283,39 @@ class TestDesiredStateBondMetadata(object):
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
 
+    def test_remove_bond_while_keeping_slave(self):
+        desired_state = state.State(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: BOND_NAME,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    },
+                    {
+                        Interface.NAME: 'eth0',
+                        Interface.STATE: InterfaceState.UP,
+                        Interface.TYPE: InterfaceType.UNKNOWN,
+                    },
+                ]
+            }
+        )
+        current_state = state.State(
+            {
+                Interface.KEY: [
+                    create_bond_state_dict(BOND_NAME, ['eth0', 'eth1']),
+                    {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
+                    {'name': 'eth1', 'state': 'up', 'type': 'unknown'},
+                ]
+            }
+        )
+        expected_dstate = state.State(desired_state.state)
+        expected_cstate = state.State(current_state.state)
+
+        metadata.generate_ifaces_metadata(desired_state, current_state)
+
+        assert desired_state == expected_dstate
+        assert current_state == expected_cstate
+
 
 def create_bond_state_dict(name, slaves=None):
     slaves = slaves or []


### PR DESCRIPTION
Support the scenario where the master interface is removed but one of its slaves is explicitly left UP.
Currently this scenario results in the deletion of the slave and therefore the transaction fails on the verification step.

The PR solves this at both the metadata level (such slaves are not updated with master metadata) and the admin state update (not removing these slaves).