### PR TITLE
Show with nmclient refresh

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -38,6 +38,8 @@ def show(include_status_data=False):
     When include_status_data is set, both are reported, otherwise only the
     configuration data is reported.
     """
+    client = nm.nmclient.client(refresh=True)
+
     report = {Constants.INTERFACES: interfaces()}
     if include_status_data:
         report['capabilities'] = capabilities()
@@ -51,7 +53,6 @@ def show(include_status_data=False):
         ),
     }
 
-    client = nm.nmclient.client()
     report[Constants.DNS] = {
         DNS.RUNNING: nm_dns.get_running(),
         DNS.CONFIG: nm_dns.get_config(


### PR DESCRIPTION
Refresh nmclient for each `show` call

NM client represents the interface to NM.
In most cases, it is up to date. However, immediately after the mainloop
is completed, the verification step kicks in and calls `show`, at which
point the nmclient seems to be out-of-sync.

For consistency, on each call to `show`, the NM client is refreshed
(object recreated).

Note: `show` should not be called from within the mainloop as the NM
client must remain unchanged.

Depends on #445 