### PR TITLE
test/dhcp: Replace the sleep with pulling

### DIFF
--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -24,6 +24,8 @@ import pytest
 import libnmstate
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import Route as RT
@@ -604,6 +606,15 @@ def _setup_dhcp_nics():
 
 
 def _clean_up():
+    remove_dhcpcli_profile = {
+        INTERFACES: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.STATE: InterfaceState.ABSENT,
+            }
+        ]
+    }
+    libnmstate.apply(remove_dhcpcli_profile, verify_change=False)
     libcmd.exec_cmd(['systemctl', 'stop', 'dnsmasq'])
     libcmd.exec_cmd(['systemctl', 'stop', 'radvd'])
     _remove_veth_pair()

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 import copy
+import time
 
 import libnmstate
 from libnmstate.schema import DNS
@@ -100,3 +101,14 @@ def assert_no_config_route_to_iface(iface_name):
         for route in current_state[Route.KEY][Route.CONFIG]
         if route[Route.NEXT_HOP_INTERFACE] == iface_name
     )
+
+
+def retry_till_true(timeout, func, *args, **kwargs):
+    ret = func(*args, **kwargs)
+    while timeout > 0:
+        if ret:
+            break
+        time.sleep(1)
+        timeout -= 1
+        ret = func(*args, **kwargs)
+    return ret


### PR DESCRIPTION
The test case for DHCP might fail as the 5 seconds wait might not be
enough for IPv6 autoconf and DHCPv6.
Instead of increase the sleep time, introduce `_retry_till_true()` to
do pulling with timeout of 10 seconds.

