### PR TITLE
schema: Add interface subconfig: VLAN

### DIFF
--- a/libnmstate/nm/vlan.py
+++ b/libnmstate/nm/vlan.py
@@ -18,18 +18,16 @@
 #
 
 from libnmstate.nm import nmclient
-
-
-VLAN_TYPE = 'vlan'
+from libnmstate.schema import VLAN
 
 
 def create_setting(iface_state, base_con_profile):
-    vlan = iface_state.get(VLAN_TYPE)
+    vlan = iface_state.get(VLAN.TYPE)
     if not vlan:
         return None
 
-    vlan_id = vlan['id']
-    vlan_base_iface = vlan['base-iface']
+    vlan_id = vlan[VLAN.ID]
+    vlan_base_iface = vlan[VLAN.BASE_IFACE]
 
     vlan_setting = None
     if base_con_profile:
@@ -52,8 +50,8 @@ def get_info(device):
     """
     info = {}
     if device.get_device_type() == nmclient.NM.DeviceType.VLAN:
-        info['vlan'] = {
-            'id': device.props.vlan_id,
-            'base-iface': device.props.parent.get_iface(),
+        info[VLAN.CONFIG_SUBTREE] = {
+            VLAN.ID: device.props.vlan_id,
+            VLAN.BASE_IFACE: device.props.parent.get_iface(),
         }
     return info

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -179,6 +179,14 @@ class Ethernet(object):
     HALF_DUPLEX = 'half'
 
 
+class VLAN(object):
+    TYPE = InterfaceType.VLAN
+    CONFIG_SUBTREE = 'vlan'
+
+    ID = 'id'
+    BASE_IFACE = 'base-iface'
+
+
 class OVSBridge(object):
     TYPE = 'ovs-bridge'
     CONFIG_SUBTREE = 'bridge'

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -20,6 +20,7 @@
 from contextlib import contextmanager
 
 from libnmstate import nm
+from libnmstate.schema import VLAN
 
 from .testlib import mainloop
 
@@ -28,7 +29,9 @@ ETH1 = 'eth1'
 
 
 def test_create_and_remove_vlan(eth1_up):
-    vlan_desired_state = {'vlan': {'id': 101, 'base-iface': ETH1}}
+    vlan_desired_state = {
+        VLAN.CONFIG_SUBTREE: {VLAN.ID: 101, VLAN.BASE_IFACE: ETH1}
+    }
 
     with _vlan_interface(vlan_desired_state):
 
@@ -84,4 +87,8 @@ def _delete_vlan(devname):
 
 
 def _get_vlan_ifname(state):
-    return state['vlan']['base-iface'] + '.' + str(state['vlan']['id'])
+    return (
+        state[VLAN.CONFIG_SUBTREE][VLAN.BASE_IFACE]
+        + '.'
+        + str(state[VLAN.CONFIG_SUBTREE][VLAN.ID])
+    )

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -24,6 +24,7 @@ import pytest
 
 import libnmstate
 from libnmstate.error import NmstateVerificationError
+from libnmstate.schema import VLAN
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -39,13 +40,13 @@ TWO_VLANS_STATE = {
             'name': VLAN_IFNAME,
             'type': 'vlan',
             'state': 'up',
-            'vlan': {'id': 101, 'base-iface': 'eth1'},
+            VLAN.CONFIG_SUBTREE: {VLAN.ID: 101, VLAN.BASE_IFACE: 'eth1'},
         },
         {
             'name': VLAN2_IFNAME,
             'type': 'vlan',
             'state': 'up',
-            'vlan': {'id': 102, 'base-iface': 'eth1'},
+            VLAN.CONFIG_SUBTREE: {VLAN.ID: 102, VLAN.BASE_IFACE: 'eth1'},
         },
     ]
 }
@@ -62,7 +63,9 @@ def test_add_and_remove_vlan(eth1_up):
 @pytest.fixture
 def vlan_on_eth1(eth1_up):
     with vlan_interface(VLAN_IFNAME, 101) as desired_state:
-        base_iface_name = desired_state[INTERFACES][0]['vlan']['base-iface']
+        base_iface_name = desired_state[INTERFACES][0][VLAN.CONFIG_SUBTREE][
+            VLAN.BASE_IFACE
+        ]
         iface_states = statelib.show_only((base_iface_name, VLAN_IFNAME))
         yield iface_states
 
@@ -115,7 +118,10 @@ def vlan_interface(ifname, vlan_id):
                 'name': ifname,
                 'type': 'vlan',
                 'state': 'up',
-                'vlan': {'id': vlan_id, 'base-iface': 'eth1'},
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: vlan_id,
+                    VLAN.BASE_IFACE: 'eth1',
+                },
             }
         ]
     }


### PR DESCRIPTION
Add `VLAN` class to `libnmstate.schmea` with these constants:
    * `VLAN.TYPE`
    * `VLAN.CONFIG_SUBTREE`
    * `VLAN.ID`
    * `VLAN.BASE_IFACE`