### PR TITLE
tests integ: Disable IPv6 by default on the bridge

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -224,6 +224,7 @@ def _linux_bridge(name, bridge_state, extra_iface_state=None):
                 Interface.NAME: name,
                 Interface.TYPE: InterfaceType.LINUX_BRIDGE,
                 Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {InterfaceIPv6.ENABLED: False},
             }
         ]
     }


### PR DESCRIPTION
In order to avoid a fallback from reapply to activate, disable IPv6 on a
bridge interface by default.