### PR TITLE
nm/ovs test: Allow OVS test cases to be fail

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -26,6 +26,7 @@ from libnmstate.schema import OVSBridge as OB
 from libnmstate.schema import OVSBridgePortType as OBPortType
 
 from .testlib import mainloop
+from .testlib import TestMainloopError
 
 
 BRIDGE0 = 'brtest0'
@@ -52,6 +53,9 @@ def bridge_default_config():
     }
 
 
+@pytest.mark.xfail(
+    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+)
 def test_create_and_remove_minimum_config_bridge(
     bridge_minimum_config, bridge_default_config
 ):
@@ -65,6 +69,9 @@ def test_create_and_remove_minimum_config_bridge(
     assert not _get_bridge_current_state()
 
 
+@pytest.mark.xfail(
+    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+)
 def test_bridge_with_system_port(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
 
@@ -85,6 +92,9 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
     assert not _get_bridge_current_state()
 
 
+@pytest.mark.xfail(
+    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+)
 def test_bridge_with_internal_interface(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
 


### PR DESCRIPTION
Due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1724901 ,
the NetworkManager OVS is not stable enough for CI test,
hence marking OVS nm tests xfail(allowed to fail).