### PR TITLE
VLAN over Linux bridge

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -158,6 +158,14 @@ def test_create_vlan_as_slave_of_linux_bridge(port0_vlan101):
         assertlib.assert_state(desired_state)
 
 
+def test_create_vlan_over_linux_bridge(bridge0_with_port0):
+    vlan_base_iface = TEST_BRIDGE0
+    vlan_id = 101
+    port_name = '{}.{}'.format(vlan_base_iface, vlan_id)
+    with vlan_interface(port_name, vlan_id, vlan_base_iface) as desired_state:
+        assertlib.assert_state(desired_state)
+
+
 @ip_monitor_assert_stable_link_up(TEST_BRIDGE0)
 def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
     desired_state = bridge0_with_port0


### PR DESCRIPTION
tests integ: Defining VLAN over Linux bridge interface
    
Test VLAN's behavior when is it defined over Linux bridge
interface.
    
Signed-off-by: Nandan Kulkarni <nakulkar@redhat.com>

Note: Only function `test_create_vlan_over_linux_bridge` is an addition in this PR,
rest of the code you see (inserted and deleted) is exactly same as PR #444. Opened a new branch for easier readability and changes than committing on the same branch. Also PR 444 should be merged by now (that way I won’t have to rebase.)

Thank you,
Nandan