### PR TITLE
nm.applier: Prioritize base iface activation before the vlan

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -88,6 +88,7 @@ class InterfaceType(object):
     KEY = Interface.TYPE
 
     BOND = 'bond'
+    DUMMY = 'dummy'
     ETHERNET = 'ethernet'
     LINUX_BRIDGE = 'linux-bridge'
     OVS_BRIDGE = 'ovs-bridge'
@@ -98,6 +99,7 @@ class InterfaceType(object):
 
     VIRT_TYPES = (
         BOND,
+        DUMMY,
         LINUX_BRIDGE,
         OVS_BRIDGE,
         OVS_PORT,


### PR DESCRIPTION
When both the base interface and the VLAN interface are created in one
transaction, the base interface must be activated before the vlan one,
otherwise the VLAN activation fails.

The new VLAN interfaces are now activated after all other new
interfaces.

Solves #461 