### PR TITLE
Relicense last files to LGPL2.1+

### DIFF
--- a/automation/open_container_shell.sh
+++ b/automation/open_container_shell.sh
@@ -2,17 +2,19 @@
 #
 # Copyright 2019 Red Hat, Inc.
 #
+# This file is part of nmstate
+#
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesse General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 

--- a/libnmstate/ipaddress_extender.py
+++ b/libnmstate/ipaddress_extender.py
@@ -4,17 +4,19 @@
 #
 # Copyright 2019 Red Hat, Inc.
 #
+# This file is part of nmstate
+#
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 

--- a/packaging/build-container.sh
+++ b/packaging/build-container.sh
@@ -2,17 +2,19 @@
 #
 # Copyright 2019 Red Hat, Inc.
 #
+# This file is part of nmstate
+#
 # This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 2 of the License, or
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Lesser General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 


### PR DESCRIPTION
IIUC, the subnet_of function was added *only* in python 3.7, which means we'll need to stick to using the `ipaddress_extender` for a bit longer (RHEL 8 is fedora 28 based, which ships py3.6).

If we don't care about that - e.g. we want to only run on py3.7, we should update the spec file to require py3.7. 