### PR TITLE
nm: Ignore not active failure when deactivate

### DIFF
--- a/tests/lib/nm/active_connection_test.py
+++ b/tests/lib/nm/active_connection_test.py
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.nm.nmclient import NM
+from libnmstate.nm.nmclient import GLib
+
+from libnmstate.nm.active_connection import NM_MANAGER_ERROR_DOMAIN
+
+
+def test_nm_manager_error_domain_str():
+    assert NM_MANAGER_ERROR_DOMAIN == GLib.quark_to_string(
+        NM.ManagerError.quark()
+    )


### PR DESCRIPTION
Ignore the failure:

    Connection deactivation failed on nm2: error=nm-manager-error-quark: The
    connection was not active.

Even we check activate connection status before deactivating, there is
still a small chance that NM deactivated the connection after we
checked.

This patch also fix the random failure of
`test_add_bond_with_slaves_and_ipv4` test when tear down:

 * The tear down will delete bond99 and eth1/eth2.
 * After bond99 got deleted, the connections of eth1/eth2 will be
   brought down automatically by NM.
 * There is a small chance(about 1 out of 10) to trigger the problem of
   deactivating a non-active connection.