### PR TITLE
nm: Fix incorrect error string.

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -33,7 +33,7 @@ def create_setting(options):
         success = bond_setting.add_option(option_name, option_value)
         if not success:
             raise NmstateValueError(
-                'Invalid bond option: \{}\=\'{}\''.format(
+                'Invalid bond option: \'{}\'=\'{}\''.format(
                     option_name, option_value
                 )
             )

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -70,7 +70,7 @@ def create_bridge_setting(options):
             bridge_setting.props.stp_enable = option_value
         else:
             raise NmstateValueError(
-                'Invalid OVS bridge option: \{}\=\'{}\''.format(
+                'Invalid OVS bridge option: \'{}\'=\'{}\''.format(
                     option_name, option_value
                 )
             )
@@ -95,7 +95,7 @@ def create_port_setting(options):
             port_setting.props.bond_downdelay = option_value
         else:
             raise NmstateValueError(
-                'Invalid OVS port option: \{}\=\'{}\''.format(
+                'Invalid OVS port option: \'{}\'=\'{}\''.format(
                     option_name, option_value
                 )
             )


### PR DESCRIPTION
Change from

    \{}\

to

    \'{}\'