### PR TITLE
Integration test: Explicitly set DHCP CLI NIC as managed by NM

### DIFF
--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -531,6 +531,12 @@ def _setup_dhcp_nics():
         )[0]
         == 0
     )
+    assert (
+        libcmd.exec_cmd(
+            ['nmcli', 'device', 'set', DHCP_CLI_NIC, 'managed', 'yes']
+        )[0]
+        == 0
+    )
     # This stop dhcp server NIC get another IPv6 address from dnsmasq.
     with open(SYSFS_DISABLE_RA_SRV, 'w') as fd:
         fd.write('0')


### PR DESCRIPTION
Since NetworkManager 1.20, veth interface will be marked as
unmanaged by default, need explicitly set it as managed via command:

    sudo nmcli device set <nic_name> managed yes
