### PR TITLE
nm.applier: Prioritize master interfaces activaction

### DIFF
--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -27,7 +27,7 @@ from libnmstate.schema import InterfaceType
 
 
 @contextmanager
-def bond_interface(name, slaves, extra_iface_state=None):
+def bond_interface(name, slaves, extra_iface_state=None, create=True):
     desired_state = {
         Interface.KEY: [
             {
@@ -44,7 +44,9 @@ def bond_interface(name, slaves, extra_iface_state=None):
     if extra_iface_state:
         desired_state[Interface.KEY][0].update(extra_iface_state)
 
-    libnmstate.apply(desired_state)
+    if create:
+        libnmstate.apply(desired_state)
+
     try:
         yield desired_state
     finally:

--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -28,7 +28,9 @@ from libnmstate.schema import LinuxBridge
 
 
 @contextmanager
-def linux_bridge(name, bridge_subtree_state, extra_iface_state=None):
+def linux_bridge(
+    name, bridge_subtree_state, extra_iface_state=None, create=True
+):
     desired_state = {
         Interface.KEY: [
             {
@@ -44,7 +46,8 @@ def linux_bridge(name, bridge_subtree_state, extra_iface_state=None):
     if extra_iface_state:
         desired_state[Interface.KEY][0].update(extra_iface_state)
 
-    libnmstate.apply(desired_state)
+    if create:
+        libnmstate.apply(desired_state)
 
     try:
         yield desired_state


### PR DESCRIPTION
The master interfaces must be activated first, otherwise
NetworkManager fails with errors such as:

"""
NetworkManager[858]: <debug>
[1565960861.2223] manager: Activation of <slave> requires master
device <master device>
"""

Depends on: #491 
Fixes: https://bugzilla.redhat.com/1749314