### PR TITLE
nmstatectl provides an error if NetworkManager is not running

### DIFF
--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -57,6 +57,15 @@ def client(refresh=False):
     if _nmclient is None or refresh:
         if NM:
             _nmclient = NM.Client.new(None)
+            if not _nmclient.get_nm_running():
+                logging.error(
+                    'NetworkManager is not running, please make sure'
+                    'it is installed and running prior to running nmstate.\n'
+                    'Check the documentation for more information.'
+                )
+                raise error.NmstateDependencyError(
+                    'NetworkManager is not running'
+                )
         else:
             logging.error(
                 'Missing introspection data for libnm'


### PR DESCRIPTION
As per issue 'NMSTATE-78', nmstatectl should provide an error that NetworkManager is required.
I left a TODO comment as probably documentation has to be edited accordingly.

I quickly tested it on my RHEL8 VM with NM not running (libnm package installed):
[root@fastvm-rhel-8-0-175 nm]# systemctl stop NetworkManager
[root@fastvm-rhel-8-0-175 nm]# 
[root@fastvm-rhel-8-0-175 nm]# nmstatectl show
2019-08-22 11:26:08,198 root         ERROR    NetworkManager is in unknown state, please make sure NetworkManager is installed and running.
Check the documentation for more information.
Traceback (most recent call last):
  File "/usr/local/bin/nmstatectl", line 11, in <module>
    load_entry_point('nmstate==0.0.8', 'console_scripts', 'nmstatectl')()
  File "/usr/local/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 62, in main
    return args.func(args)
  File "/usr/local/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 206, in show
    state = _filter_state(libnmstate.show(), args.only)
  File "/usr/local/lib/python3.6/site-packages/libnmstate/netinfo.py", line 41, in show
    client = nm.nmclient.client(refresh=True)
  File "/usr/local/lib/python3.6/site-packages/libnmstate/nm/nmclient.py", line 63, in client
    'NetworkManager is in unknown state'
libnmstate.error.NmstateDependencyError: NetworkManager is in unknown state


I hope it's fine and useful.