### PR TITLE
tests integ: Introduce the bondlib module

### DIFF
--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -1,0 +1,62 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+from contextlib import contextmanager
+
+import libnmstate
+from libnmstate.schema import Bond
+from libnmstate.schema import BondMode
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+
+
+@contextmanager
+def bond_interface(name, slaves, extra_iface_state=None):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: name,
+                Interface.TYPE: InterfaceType.BOND,
+                Interface.STATE: InterfaceState.UP,
+                Bond.CONFIG_SUBTREE: {
+                    Bond.MODE: BondMode.ROUND_ROBIN,
+                    Bond.SLAVES: slaves,
+                },
+            }
+        ]
+    }
+    if extra_iface_state:
+        desired_state[Interface.KEY][0].update(extra_iface_state)
+
+    libnmstate.apply(desired_state)
+    try:
+        yield desired_state
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: name,
+                        Interface.TYPE: InterfaceType.BOND,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            },
+            verify_change=False,
+        )


### PR DESCRIPTION
Extract the bond creation function to a dedicated module, enabling
it to be re-used in other tests.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>