### PR TITLE
Enforce auto IP address to be based on MAC address.

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -47,6 +47,7 @@ def create_setting(config, base_con_profile):
     if not setting_ipv4:
         setting_ipv4 = nmclient.NM.SettingIP4Config.new()
 
+    setting_ipv4.props.dhcp_client_id = 'mac'
     setting_ipv4.props.method = nmclient.NM.SETTING_IP4_CONFIG_METHOD_DISABLED
     if config and config.get(InterfaceIPv4.ENABLED):
         if config.get(InterfaceIPv4.DHCP):

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -112,6 +112,12 @@ def create_setting(config, base_con_profile):
     if not setting_ip:
         setting_ip = nmclient.NM.SettingIP6Config.new()
 
+    # Ensure IPv6 RA and DHCPv6 is based on MAC address only
+    setting_ip.props.addr_gen_mode = (
+        nmclient.NM.SettingIP6ConfigAddrGenMode.EUI64
+    )
+    setting_ip.props.dhcp_duid = 'll'
+
     if not config or not config.get(InterfaceIPv6.ENABLED):
         setting_ip.props.method = nmclient.NM.SETTING_IP6_CONFIG_METHOD_IGNORE
         return setting_ip

--- a/packaging/Dockerfile.centos7-nmstate-dev
+++ b/packaging/Dockerfile.centos7-nmstate-dev
@@ -8,6 +8,7 @@ RUN yum -y install \
         python2-pip \
         python36-pip \
         rpm-build \
+        dhcp-client \
     && yum clean all
 
 RUN pip install --upgrade pip pytest==4.2.1 pytest-cov==2.6.1

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -11,6 +11,7 @@ RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
 RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
+                   dhcp-client \
                    openvswitch \
                    systemd-udev \
                    \

--- a/packaging/docker_sys_config.sh
+++ b/packaging/docker_sys_config.sh
@@ -23,4 +23,10 @@ cat > /etc/NetworkManager/conf.d/97-no-auto-default.conf <<EOF
 no-auto-default=*
 EOF
 
+cat > /etc/NetworkManager/conf.d/97-use-dhclient.conf <<EOF
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1749358
+[main]
+dhcp=dhclient
+EOF
+
 systemctl enable openvswitch.service

--- a/tests/integration/dhcp_test.py
+++ b/tests/integration/dhcp_test.py
@@ -549,9 +549,9 @@ def test_dhcp_on_bridge0(dhcpcli_up_with_delay_status):
         - The dynamic settings have been applied.
         - IPv4 and IPv6 addresses have been provided by the server.
         - IPv4 addresses are identical to the original ones which existed on
-        the nic (dhcpcli interface). [XFAIL]
+        the nic (dhcpcli interface).
         - IPv6 addresses are identical to the original ones which existed on
-        the nic (dhcpcli interface). [XFAIL]
+        the nic (dhcpcli interface).
     """
     origin_port_state = dhcpcli_up_with_delay_status
 
@@ -585,10 +585,8 @@ def test_dhcp_on_bridge0(dhcpcli_up_with_delay_status):
 
     origin_ipv4_state = origin_port_state[Interface.KEY][0][Interface.IPV4]
     origin_ipv6_state = origin_port_state[Interface.KEY][0][Interface.IPV6]
-    with pytest.raises(AssertionError):
-        assert origin_ipv4_state == new_ipv4_state
-    with pytest.raises(AssertionError):
-        assert origin_ipv6_state == new_ipv6_state
+    assert origin_ipv4_state == new_ipv4_state
+    assert origin_ipv6_state == new_ipv6_state
 
 
 def _create_veth_pair():


### PR DESCRIPTION
When enslave interface to linux bridge, to ensure the bridge
get the same IPv6 address from IPv6-RA and DHCPv6, change
the 'dhcp_duid' to LL(Link-layer address, RFC 3315) and
'addr_gen_mode' to EUI64.

For DHCPv4, change the DHCP client ID to the MAC address of interface.