### PR TITLE
tests, integ: Increase the nm test mainloop timeout

### DIFF
--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -30,7 +30,7 @@ class TestMainloopError(Exception):
 def mainloop():
     mloop = nm.nmclient.mainloop()
     yield
-    success = mloop.run(timeout=5)
+    success = mloop.run(timeout=15)
     if not success:
         nm.nmclient.mainloop(refresh=True)
         raise TestMainloopError(mloop.error)


### PR DESCRIPTION
CI tests have been failing on timeout when running the nm bridge tests.
This may be caused by slow CI slaves.