### PR TITLE
nm.applier: Activate slave interfaces last

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -96,9 +96,17 @@ def bond0(port0_up):
 
 
 @pytest.fixture
-def bond0_vlan101(bond0):
+def bond1(port0_up):
+    bond_name = 'testbond1'
+    port_name = port0_up[Interface.KEY][0][Interface.NAME]
+    with bond_interface(bond_name, [port_name], create=False) as bond1:
+        yield bond1
+
+
+@pytest.fixture
+def bond0_vlan101(bond1):
     vlan_id = 101
-    bond_name = bond0[Interface.KEY][0][Interface.NAME]
+    bond_name = bond1[Interface.KEY][0][Interface.NAME]
     vlan_port_name = '{base_iface}.{vlan_id}'.format(
         base_iface=bond_name, vlan_id=vlan_id
     )
@@ -308,7 +316,7 @@ def test_linux_bridge_over_bond_over_slave_in_one_transaction(bond0):
 
 
 def test_linux_bridge_over_vlan_over_bond_over_slave_in_one_transaction(
-    bond0, bond0_vlan101
+    bond1, bond0_vlan101
 ):
     bridge_name = TEST_BRIDGE0
     vlan_ifname = bond0_vlan101[Interface.KEY][0][Interface.NAME]
@@ -316,7 +324,7 @@ def test_linux_bridge_over_vlan_over_bond_over_slave_in_one_transaction(
     with linux_bridge(
         bridge_name, bridge_config_state, create=False
     ) as bridge0:
-        desired_state = bond0
+        desired_state = bond1
         _append_interface_state(desired_state, bond0_vlan101)
         _append_interface_state(desired_state, bridge0)
         libnmstate.apply(desired_state)

--- a/tests/integration/testlib/vlan.py
+++ b/tests/integration/testlib/vlan.py
@@ -24,7 +24,7 @@ from .statelib import INTERFACES
 
 
 @contextmanager
-def vlan_interface(ifname, vlan_id, base_iface):
+def vlan_interface(ifname, vlan_id, base_iface, create=True):
     desired_state = {
         INTERFACES: [
             {
@@ -35,7 +35,10 @@ def vlan_interface(ifname, vlan_id, base_iface):
             }
         ]
     }
-    libnmstate.apply(desired_state)
+
+    if create:
+        libnmstate.apply(desired_state)
+
     try:
         yield desired_state
     finally:


### PR DESCRIPTION
The slave interfaces - that are not masters themselves - must be
activated last, otherwise NetworkManager fails with errors such
as:

```
NetworkManager[858]: <debug>
[1565960861.2223] manager: Activation of <slave> requires master
device <master device>
```

This change addresses the scenario introduced by provisioning the
following yaml:

```yaml
---
interfaces:
  - name: bond0
    type: bond
    state: up
    link-aggregation:
      slaves:
        - eth0
        - eth1
      options:
        miimon: "100"
        xmit_hash_policy: "2"
      mode: 802.3ad
    ipv4:
      enabled: false
    ipv6:
      enabled: false
  - name: bond0.166
    type: vlan
    state: up
    vlan:
      id: 166
      base-iface: bond0
    ipv4:
      enabled: false
    ipv6:
      enabled: false
  - name: bridge0
    type: linux-bridge
    state: up
    bridge:
      port:
        - name: bond0.166
      options:
        stp:
          enabled: false
    ipv4:
      enabled: true
      dhcp: true
      auto-dns: false
      auto-gateway: false
      auto-routes: false
    ipv6:
      enabled: false
```

Provisioning the above yaml without this change fails, since it
tries to activate the eth[0|1] interfaces before the bond.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>