### PR TITLE
packaging, centos7: Fix dhclient package name

### DIFF
--- a/packaging/Dockerfile.centos7-nmstate-dev
+++ b/packaging/Dockerfile.centos7-nmstate-dev
@@ -8,7 +8,7 @@ RUN yum -y install \
         python2-pip \
         python36-pip \
         rpm-build \
-        dhcp-client \
+        dhclient \
     && yum clean all
 
 RUN pip install --upgrade pip pytest==4.2.1 pytest-cov==2.6.1


### PR DESCRIPTION
On CentOS7, the dhclient package name is `dhclient`.