### PR TITLE
nm test: Workaround of MTU bug of NM 1.20

### DIFF
--- a/tests/integration/nm/wired_test.py
+++ b/tests/integration/nm/wired_test.py
@@ -29,7 +29,7 @@ from .testlib import MainloopTestError
 ETH1 = 'eth1'
 
 MAC0 = '02:FF:FF:FF:FF:00'
-MTU0 = 1200
+MTU0 = 1290
 
 
 @pytest.mark.xfail(reason='https://bugzilla.redhat.com/1702657', strict=True)

--- a/tests/integration/testlib/nm.py
+++ b/tests/integration/testlib/nm.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import gi  # pylint: disable=import-error
+
+gi.require_version('NM', '1.0')  # NOQA: F402
+from gi.repository import NM  # pylint: disable=no-name-in-module
+
+
+def nm_version(major, minor, micro):
+    return major * 10000 + minor * 100 + micro
+
+
+def current_nm_version():
+    return nm_version(NM.MAJOR_VERSION, NM.MINOR_VERSION, NM.MICRO_VERSION)


### PR DESCRIPTION
Duo to bug https://bugzilla.redhat.com/show_bug.cgi?id=1753128 ,
NM will always set MTU to 1280 if requested MTU is lower than 1280.
This cause the failure of
`nm/wired_test.py::test_interface_mtu_change_with_modify` test on NM
1.20. The workaround is increase testing MTU to 1290.