### PR TITLE
nm/ovs: Remove port when interface removed

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -249,6 +249,11 @@ def _get_affected_devices(iface_state):
         iface_type = iface_state[Interface.TYPE]
         if iface_type == ovs.BRIDGE_TYPE:
             devs += _get_ovs_bridge_port_devices(iface_state)
+        elif ovs.is_ovs_interface(nmdev):
+            port_name = ovs.PORT_PROFILE_PREFIX + iface_state[Interface.NAME]
+            port_dev = device.get_device_by_name(port_name)
+            if port_dev:
+                devs.append(port_dev)
         elif iface_type == LB.TYPE:
             devs += bridge.get_slaves(nmdev)
         elif iface_type == bond.BOND_TYPE:

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -219,3 +219,15 @@ def _get_slave_profiles(master_device, devices_info):
             if master and (master.get_iface() == master_device.get_iface()):
                 slave_profiles.append(active_con.props.connection)
     return slave_profiles
+
+
+def is_ovs_interface(nmdev):
+    active_con = connection.get_device_active_connection(nmdev)
+    if active_con:
+        master = active_con.get_master()
+        if (
+            master
+            and master.get_device_type() == nmclient.NM.DeviceType.OVS_PORT
+        ):
+            return True
+    return False


### PR DESCRIPTION
When removing OVS internal interface or system interface,
its port should also be removed alongside.

Test cases are included.