### PR TITLE
tests, integ, dhcp: add tests exposing that dhcp on a bridge whose port is a vlan is buggy

### DIFF
--- a/tests/integration/testlib/vlan.py
+++ b/tests/integration/testlib/vlan.py
@@ -24,7 +24,7 @@ from .statelib import INTERFACES
 
 
 @contextmanager
-def vlan_interface(ifname, vlan_id, base_iface):
+def vlan_interface(ifname, vlan_id, base_iface, create=True):
     desired_state = {
         INTERFACES: [
             {
@@ -35,7 +35,10 @@ def vlan_interface(ifname, vlan_id, base_iface):
             }
         ]
     }
-    libnmstate.apply(desired_state)
+
+    if create:
+        libnmstate.apply(desired_state)
+
     try:
         yield desired_state
     finally:


### PR DESCRIPTION
On more complex scenarios, involving VLANs, NetworkManager hangs while assigning an IP address via DHCP to the linux bridge.

This is examplified when creating a VLAN on top of a bond, on top of an ethernet interface. That VLAN is in turn set as a port to a linux bridge.

The 2 added tests show that NM hangs when the linux bridge has a dynamic IP configuration on top of a VLAN - in the first test, this happens within a single transaction, while on the last, it manifests
when multiple transactions are used.

The NM main loop aborts since the interfaces are not assigned a dynamic IP address - since the DHCP server configured in the dynamic IP module is not being ran behind a VLAN interface, and as
such, the L2 traffic (untagged) is discarded before reaching the bridge.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1755542