### PR TITLE
add OVS bonding support

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -43,12 +43,15 @@ function add_extra_networks {
     container_exec '
       ip link add eth1 type veth peer eth1peer && \
       ip link add eth2 type veth peer eth2peer && \
+      ip link add eth3 type veth peer eth3peer && \
       ip link set eth1peer up && \
-      ip link set eth2peer up
+      ip link set eth2peer up && \
+      ip link set eth3peer up
       # Due to https://nmstate.atlassian.net/browse/NMSTATE-279
       # Mandually set test NICs as managed by NetworkManager.
       nmcli device set eth1 managed yes
       nmcli device set eth2 managed yes
+      nmcli device set eth3 managed yes
     '
 }
 

--- a/examples/ovsbridge_bond_create.yml
+++ b/examples/ovsbridge_bond_create.yml
@@ -1,0 +1,15 @@
+---
+interfaces:
+  - name: ovs-br0
+    type: ovs-bridge
+    state: up
+    bridge:
+      options:
+        stp: false
+      port:
+        - name: ovs-bond1
+          link-aggregation:
+            mode: balance-slb
+            slaves:
+              - name: eth1
+              - name: eth2

--- a/examples/ovsbridge_bond_delete.yml
+++ b/examples/ovsbridge_bond_delete.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+  - name: ovs-br0
+    type: ovs-bridge
+    state: absent

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -285,8 +285,9 @@ def _get_ovs_bridge_port_devices(iface_state):
         OvsB.PORT_SUBTREE, []
     ):
         ports.append(ovs.PORT_PROFILE_PREFIX + port[OvsB.Port.NAME])
-        if OvsB.Port.LINK_AGGREGATION_SUBTREE in port:
-            for slave in port[OvsB.Port.LINK_AGGREGATION_SUBTREE].get(
+        la_subtree = port.get(OvsB.Port.LINK_AGGREGATION_SUBTREE)
+        if la_subtree:
+            for slave in la_subtree.get(
                 OvsB.Port.LinkAggregation.SLAVES_SUBTREE, []
             ):
                 ifaces.append(slave[OvsB.Port.LinkAggregation.Slave.NAME])
@@ -318,22 +319,21 @@ def prepare_proxy_ifaces_desired_state(ifaces_desired_state):
     new_ifaces_desired_state = []
     for iface_desired_state in ifaces_desired_state:
         master_type = iface_desired_state.get(MASTER_TYPE_METADATA)
-        if master_type is not None:
-            if master_type == ovs.BRIDGE_TYPE:
-                _prepare_proxy_ovs_ifaces(
-                    iface_desired_state, new_ifaces_desired_state
-                )
+        if master_type == ovs.BRIDGE_TYPE:
+            _prepare_proxy_ovs_ifaces(
+                iface_desired_state, new_ifaces_desired_state
+            )
 
     return new_ifaces_desired_state
 
 
 def _prepare_proxy_ovs_ifaces(iface_desired_state, new_ifaces_desired_state):
-    bridge_port_state = iface_desired_state.get(BRPORT_OPTIONS_METADATA)
-    if bridge_port_state is None:
+    bridge_port_options = iface_desired_state.get(BRPORT_OPTIONS_METADATA)
+    if bridge_port_options is None:
         return
 
     port_desired_state = _create_ovs_port_desired_state(
-        iface_desired_state, bridge_port_state
+        iface_desired_state, bridge_port_options
     )
 
     # Bond port need to be added only once per all their slaves

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -105,10 +105,10 @@ def translate_bridge_options(iface_state):
     return br_opts
 
 
-def translate_port_options(bridge_port_state):
+def translate_port_options(port_state):
     port_opts = {}
 
-    bond_mode = bridge_port_state.get("link-aggregation", {}).get("mode")
+    bond_mode = port_state.get("link-aggregation", {}).get("mode")
     if bond_mode:
         port_opts["bond-mode"] = bond_mode
 

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -32,8 +32,6 @@ from functools import total_ordering
 from ipaddress import ip_address
 from operator import itemgetter
 
-import six
-
 from libnmstate import iplib
 from libnmstate import metadata
 from libnmstate.error import NmstateNotImplementedError
@@ -581,7 +579,7 @@ class State:
             ifstate.get("link-aggregation", {}).get("slaves", []).sort()
 
     def _sort_ovs_lag_slaves(self):
-        for ifstate in six.viewvalues(self.interfaces):
+        for ifstate in self.interfaces.values():
             for port in ifstate.get(OVSBridge.CONFIG_SUBTREE, {}).get(
                 OVSBridge.PORT_SUBTREE, []
             ):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,7 @@ def logging_setup():
 @pytest.fixture(scope="session", autouse=True)
 def ethx_init(diff_initial_state):
     """ Remove any existing definitions on the ethX interfaces. """
-    ifacelib.ifaces_init("eth1", "eth2")
+    ifacelib.ifaces_init("eth1", "eth2", "eth3")
 
 
 @pytest.fixture(scope="function")
@@ -59,8 +59,15 @@ def eth2_up():
         yield ifstate
 
 
+@pytest.fixture(scope="function")
+def eth3_up():
+    with ifacelib.iface_up("eth3") as ifstate:
+        yield ifstate
+
+
 port0_up = eth1_up
 port1_up = eth2_up
+port2_up = eth3_up
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -55,6 +55,19 @@ def test_add_remove_ovs_bridge(eth1_up):
     assertlib.assert_absent("ovs-br0")
 
 
+@pytest.mark.xfail(
+    raises=NmstateLibnmError, reason="https://bugzilla.redhat.com/1724901"
+)
+def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
+    with example_state(
+        "ovsbridge_bond_create.yml", cleanup="ovsbridge_bond_delete.yml"
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    assertlib.assert_absent("ovs-br0")
+    assertlib.assert_absent("ovs-bond1")
+
+
 def test_add_remove_linux_bridge(eth1_up):
     with example_state(
         "linuxbrige_eth1_up.yml", cleanup="linuxbrige_eth1_absent.yml"

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -51,7 +51,10 @@ class Bridge:
         self._add_port(name)
         port = self._get_port(name)
         port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE] = {
-            OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: slaves
+            OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: [
+                {OVSBridge.Port.LinkAggregation.Slave.NAME: slave}
+                for slave in slaves
+            ]
         }
         if mode:
             port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
@@ -83,6 +86,18 @@ class Bridge:
         return next(
             (port for port in ports if port[OVSBridge.Port.NAME] == name), None
         )
+
+    def del_port(self, name):
+        new_ports = [
+            port
+            for port in self._bridge_iface[OVSBridge.CONFIG_SUBTREE][
+                OVSBridge.PORT_SUBTREE
+            ]
+            if port[OVSBridge.Port.NAME] != name
+        ]
+        self._bridge_iface[OVSBridge.CONFIG_SUBTREE][
+            OVSBridge.PORT_SUBTREE
+        ] = new_ports
 
     @contextmanager
     def create(self):

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -122,8 +122,6 @@ def test_get_ovs_info_with_ports_with_interfaces(
 
     assert len(info["port"]) == 1
     assert "name" in info["port"][0]
-    assert "vlan-mode" in info["port"][0]
-    assert "access-tag" in info["port"][0]
 
 
 def test_create_bridge_setting(NM_mock):
@@ -146,7 +144,6 @@ def test_create_bridge_setting(NM_mock):
 def test_create_port_setting(NM_mock):
     options = {
         "tag": 101,
-        "vlan-mode": "voomode",
         "bond-mode": "boomode",
         "lacp": "yes",
         "bond-updelay": 0,
@@ -155,7 +152,6 @@ def test_create_port_setting(NM_mock):
     port_setting = nm.ovs.create_port_setting(options)
 
     assert port_setting.props.tag == options["tag"]
-    assert port_setting.props.vlan_mode == options["vlan-mode"]
     assert port_setting.props.bond_mode == options["bond-mode"]
     assert port_setting.props.lacp == options["lacp"]
     assert port_setting.props.bond_updelay == options["bond-updelay"]


### PR DESCRIPTION
**Work in progress, don't bother reading the code**

This PR adds support for OVS bonding.

Note that removal of slaves is not supported yet.

https://bugzilla.redhat.com/show_bug.cgi?id=1730341

## Proposed API

```yaml
name: br1
type: ovs-bridge
state: up
bridge:
  port:
  - name: bond1
    link-aggregation:
      mode: balance-slb
      slaves:
      - name: eth0
      - name: eth1
```

Single-slave bond is indistinguishable from system interface port, therefore at least 2 slaves are mandatory. 

## Current state

When there is a port attached to a bridge with multiple underlying interfaces, only one of them is shown.

### Port with single iface

```yaml
- name: bridge0
  type: ovs-bridge
  state: up
  bridge:
    options:
      fail-mode: ''
      mcast-snooping-enable: false
      rstp: false
      stp: false
    port:
    - name: v1a
      type: system
```

```
ff3015ae-ba93-48c7-8a43-d4f99399841c
    Bridge "bridge0"
        Port "bond0"
            Interface "v1a"
                type: system
    ovs_version: "2.10.1"
```

### Port after attaching second iface

```yaml
- name: bridge0
  type: ovs-bridge
  state: up
  bridge:
    options:
      fail-mode: ''
      mcast-snooping-enable: false
      rstp: false
      stp: false
    port:
    - name: v2a
      type: system
```

```
ff3015ae-ba93-48c7-8a43-d4f99399841c
    Bridge "bridge0"
        Port "bond0"
            Interface "v2a"
                type: system
            Interface "v1a"
                type: system
    ovs_version: "2.10.1"
```

OVS NM tests refactoring: https://github.com/nmstate/nmstate/pull/524
OVS functional tests refactoring: https://github.com/nmstate/nmstate/pull/513