### PR TITLE
tox: update pytest version to fix unit tests w/ html code coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ basepython = python2.7
 deps =
     -r{toxinidir}/requirements.txt
     pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest==4.6.5
 pytest_args =
     --log-level=DEBUG
     --durations=5


### PR DESCRIPTION
As can be seen in the following builds, the unit tests w/ code
coverage ran with the currently defined pytest version - 4.1.0 -
are failing.
  - https://travis-ci.org/nmstate/nmstate/builds/592672701
  - https://travis-ci.org/nmstate/nmstate/builds/592993079

Updating the pytest version to 4.3.0 makes the unit tests pass.

The error thrown by the unit test framework is:
check-py36 runtests: commands[0] | pytest --log-level=DEBUG --durations=5 --cov=libnmstate --cov=nmstatectl --cov-report=term --cov-report=html:htmlcov-py36 lib ctl
Traceback (most recent call last):
  File "/tmp/nmstate/.tox/check-py36/bin/pytest", line 10, in <module>
    sys.exit(main())
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/config/__init__.py", line 61, in main
    config = _prepareconfig(args, plugins)
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/config/__init__.py", line 182, in _prepareconfig
    config = get_config()
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/config/__init__.py", line 156, in get_config
    pluginmanager.import_plugin(spec)
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/config/__init__.py", line 530, in import_plugin
    __import__(importspec)
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/tmpdir.py", line 25, in <module>
    class TempPathFactory(object):
  File "/tmp/nmstate/.tox/check-py36/lib/python3.6/site-packages/_pytest/tmpdir.py", line 35, in TempPathFactory
    lambda p: Path(os.path.abspath(six.text_type(p)))
TypeError: attrib() got an unexpected keyword argument 'convert'
ERROR: InvocationError for command '/tmp/nmstate/.tox/check-py36/bin/pytest --log-level=DEBUG --durations=5 --cov=libnmstate --cov=nmstatectl --cov-report=term --cov-report=html:htmlcov-py36 lib ctl' (exited with code 1)