### PR TITLE
[stable_v0.0.8] nm: Support disabling IPv6 via libnm

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -145,7 +145,8 @@ def _apply_ifaces_state(
                     ifaces2add + ifaces2edit,
                     con_profiles=ifaces_add_configs + ifaces_edit_configs,
                 )
-            _disable_ipv6(desired_state)
+            if not nmclient.can_disable_ipv6():
+                _disable_ipv6(desired_state)
             if verify_change:
                 _verify_change(desired_state)
         if not commit:
@@ -160,7 +161,8 @@ def _apply_ifaces_state(
         # finish before proceeding with other actions.
         # TODO: https://nmstate.atlassian.net/browse/NMSTATE-103
         time.sleep(5)
-        _disable_ipv6(current_state)
+        if not nmclient.can_disable_ipv6():
+            _disable_ipv6(current_state)
         raise
 
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -119,7 +119,16 @@ def create_setting(config, base_con_profile):
     setting_ip.props.dhcp_duid = 'll'
 
     if not config or not config.get(InterfaceIPv6.ENABLED):
-        setting_ip.props.method = nmclient.NM.SETTING_IP6_CONFIG_METHOD_IGNORE
+        try:
+            # pylint: disable=no-member
+            setting_ip.props.method = (
+                nmclient.NM.SETTING_IP6_CONFIG_METHOD_DISABLED
+            )
+            # pylint: enable=no-member
+        except AttributeError:
+            setting_ip.props.method = (
+                nmclient.NM.SETTING_IP6_CONFIG_METHOD_IGNORE
+            )
         return setting_ip
 
     is_dhcp = config.get(InterfaceIPv6.DHCP, False)

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -43,6 +43,12 @@ GObject
 _mainloop = None
 _nmclient = None
 
+_can_disable_ipv6 = hasattr(NM, 'SETTING_IP6_CONFIG_METHOD_DISABLED')
+
+
+def can_disable_ipv6():
+    return _can_disable_ipv6
+
 
 def client(refresh=False):
     global _nmclient

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -27,4 +27,4 @@ RUN yum -y upgrade && \
         python-ipaddress \
     && \
     yum clean all && \
-    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+    bash ./docker_sys_config.sh && rm ./docker_sys_config.sh -f

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -9,7 +9,9 @@ COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
 
-RUN yum -y upgrade && \
+RUN yum -y install yum-plugin-copr && \
+    yum -y copr enable nmstate/ovs-el7 && \
+    yum -y upgrade && \
     yum -y install \
         NetworkManager \
         NetworkManager-libnm \

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -30,7 +30,7 @@ class TestMainloopError(Exception):
 def mainloop():
     mloop = nm.nmclient.mainloop()
     yield
-    success = mloop.run(timeout=5)
+    success = mloop.run(timeout=15)
     if not success:
         nm.nmclient.mainloop(refresh=True)
         raise TestMainloopError(mloop.error)

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -38,25 +38,27 @@ def NM_mock():
 
 def test_create_setting_without_config(NM_mock):
     NM_mock.SettingIP6Config.new().props.addresses = []
+    NM_mock.NM.SETTING_IP6_CONFIG_METHOD_DISABLED = 'disabled'
 
     ipv6_setting = nm.ipv6.create_setting(config=None, base_con_profile=None)
 
     assert ipv6_setting == NM_mock.SettingIP6Config.new.return_value
-    assert (
-        ipv6_setting.props.method == NM_mock.SETTING_IP6_CONFIG_METHOD_IGNORE
-    )
+    disable_method = NM_mock.SETTING_IP6_CONFIG_METHOD_DISABLED
+    assert ipv6_setting.props.method == disable_method
 
 
 def test_create_setting_with_ipv6_disabled(NM_mock):
     NM_mock.SettingIP6Config.new().props.addresses = []
+    NM_mock.NM.SETTING_IP6_CONFIG_METHOD_DISABLED = 'disabled'
 
     ipv6_setting = nm.ipv6.create_setting(
         config={InterfaceIPv6.ENABLED: False}, base_con_profile=None
     )
 
-    assert (
-        ipv6_setting.props.method == NM_mock.SETTING_IP6_CONFIG_METHOD_IGNORE
-    )
+    assert ipv6_setting == NM_mock.SettingIP6Config.new.return_value
+    disable_method = NM_mock.SETTING_IP6_CONFIG_METHOD_DISABLED
+
+    assert ipv6_setting.props.method == disable_method
 
 
 def test_create_setting_without_addresses(NM_mock):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ basepython = python2.7
 deps =
     -r{toxinidir}/requirements.txt
     pytest-cov==2.6.1
-    pytest==4.1.0
+    pytest==4.6.5
 pytest_args =
     --log-level=DEBUG
     --durations=5


### PR DESCRIPTION
Use the SETTING_IP6_CONFIG_METHOD_DISABLED to disable IPv6.
That is only available for NM 1.19.3+.