### PR TITLE
ovs: nm tests refactoring

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -72,16 +72,24 @@ def test_create_and_remove_minimum_config_bridge(
 @pytest.mark.xfail(
     raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
 )
+def test_bridge_without_ports(bridge_default_config):
+    bridge_desired_state = bridge_default_config
+
+    with _bridge_interface(bridge_desired_state):
+        bridge_current_state = _get_bridge_current_state()
+        assert bridge_desired_state == bridge_current_state
+        assert bridge_current_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE] == []
+
+    assert not _get_bridge_current_state()
+
+
+@pytest.mark.xfail(
+    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
+)
 def test_bridge_with_system_port(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
 
-    eth1_port = {
-        OB.PORT_NAME: 'eth1',
-        OB.PORT_TYPE: OBPortType.SYSTEM,
-        # OVS vlan/s are not yet supported.
-        # OB.PORT_VLAN_MODE: None,
-        # OB.PORT_ACCESS_TAG: 0,
-    }
+    eth1_port = {OB.PORT_NAME: 'eth1', OB.PORT_TYPE: OBPortType.SYSTEM}
 
     bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(eth1_port)
 
@@ -95,11 +103,32 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
 @pytest.mark.xfail(
     raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
 )
-def test_bridge_with_internal_interface(eth1_up, bridge_default_config):
+def test_bridge_with_internal_interface(bridge_default_config):
     bridge_desired_state = bridge_default_config
 
     ovs_port = {OB.PORT_NAME: 'ovs0', OB.PORT_TYPE: OBPortType.INTERNAL}
 
+    bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(ovs_port)
+
+    with _bridge_interface(bridge_desired_state):
+        bridge_current_state = _get_bridge_current_state()
+        assert bridge_desired_state == bridge_current_state
+
+    assert not _get_bridge_current_state()
+
+
+@pytest.mark.xfail(
+    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
+)
+def test_bridge_with_system_port_and_internal_interface(
+    eth1_up, bridge_default_config
+):
+    bridge_desired_state = bridge_default_config
+
+    eth1_port = {OB.PORT_NAME: 'eth1', OB.PORT_TYPE: OBPortType.SYSTEM}
+    ovs_port = {OB.PORT_NAME: 'ovs0', OB.PORT_TYPE: OBPortType.INTERNAL}
+
+    bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(eth1_port)
     bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(ovs_port)
 
     with _bridge_interface(bridge_desired_state):

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -30,18 +30,6 @@ def NM_mock():
         yield m
 
 
-@pytest.fixture
-def nm_connection_mock():
-    with mock.patch.object(nm.ovs, 'connection') as m:
-        yield m
-
-
-@pytest.fixture
-def nm_device_mock():
-    with mock.patch.object(nm.ovs, 'device') as m:
-        yield m
-
-
 def test_is_ovs_bridge_type_id(NM_mock):
     type_id = NM_mock.DeviceType.OVS_BRIDGE
     assert nm.ovs.is_ovs_bridge_type_id(type_id)
@@ -55,76 +43,6 @@ def test_is_ovs_port_type_id(NM_mock):
 def test_is_ovs_interface_type_id(NM_mock):
     type_id = NM_mock.DeviceType.OVS_INTERFACE
     assert nm.ovs.is_ovs_interface_type_id(type_id)
-
-
-def test_get_ovs_info_without_ports(nm_connection_mock, NM_mock):
-    bridge_device = mock.MagicMock()
-    _mock_port_profile(nm_connection_mock)
-
-    device_info = [(bridge_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
-
-    expected_info = {
-        'port': [],
-        'options': {
-            'fail-mode': '',
-            'mcast-snooping-enable': False,
-            'rstp': False,
-            'stp': False,
-        },
-    }
-    assert expected_info == info
-
-
-def test_get_ovs_info_with_ports_without_interfaces(
-    nm_connection_mock, nm_device_mock, NM_mock
-):
-    bridge_device = mock.MagicMock()
-    port_device = mock.MagicMock()
-    _mock_port_profile(nm_connection_mock)
-    active_con = nm_connection_mock.get_device_active_connection.return_value
-    active_con.props.master = bridge_device
-
-    device_info = [(bridge_device, None), (port_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
-
-    expected_info = {
-        'port': [],
-        'options': {
-            'fail-mode': '',
-            'mcast-snooping-enable': False,
-            'rstp': False,
-            'stp': False,
-        },
-    }
-    assert expected_info == info
-
-
-def test_get_ovs_info_with_ports_with_interfaces(
-    nm_connection_mock, nm_device_mock, NM_mock
-):
-    bridge_device = mock.MagicMock()
-    port_device = mock.MagicMock()
-    bridge_active_con = mock.MagicMock()
-    port_active_con = mock.MagicMock()
-    nm_device_mock.get_device_by_name.return_value = port_device
-    _mock_port_profile(nm_connection_mock)
-    nm_connection_mock.get_device_active_connection = (
-        lambda dev: bridge_active_con
-        if dev == bridge_device
-        else port_active_con
-    )
-    bridge_active_con.props.master = bridge_device
-    port_active_con.props.master = port_device
-
-    device_info = [(bridge_device, None), (port_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
-
-    assert len(info['port']) == 1
-    assert 'name' in info['port'][0]
-    assert 'type' in info['port'][0]
-    assert 'vlan-mode' in info['port'][0]
-    assert 'access-tag' in info['port'][0]
 
 
 def test_create_bridge_setting(NM_mock):
@@ -161,13 +79,3 @@ def test_create_port_setting(NM_mock):
     assert port_setting.props.lacp == options['lacp']
     assert port_setting.props.bond_updelay == options['bond-updelay']
     assert port_setting.props.bond_downdelay == options['bond-downdelay']
-
-
-def _mock_port_profile(nm_connection_mock):
-    con_prof_mock = nm_connection_mock.ConnectionProfile.return_value
-    connection_profile = con_prof_mock.profile
-    bridge_setting = connection_profile.get_setting.return_value
-    bridge_setting.props.stp_enable = False
-    bridge_setting.props.rstp_enable = False
-    bridge_setting.props.fail_mode = None
-    bridge_setting.props.mcast_snooping_enable = False


### PR DESCRIPTION
Current NetworkManager tests of OVS are rather hard to understand. It is not
clear how are NM devices built up and they can break in future when internal
implementation of either NM or nmstate changes. This patch moves these
heavy-mocked tests under integration/nm/ovs_test.py, making sure all existing
scenarios are still covered.

There is also was bug in mocking, where we set master of an interface to itself.
This issue manifests itself when we connect multiple interfaces to a port. In
the current state it works because of the way we tread OVS ports and interfaces
as 1:1.

Signed-off-by: Petr Horacek <phoracek@redhat.com>
