### PR TITLE
drop OVS port's "type" attribute

### DIFF
--- a/examples/ovsbridge_create.yml
+++ b/examples/ovsbridge_create.yml
@@ -22,6 +22,4 @@ interfaces:
         stp: true
       port:
         - name: eth1
-          type: system
         - name: ovs0
-          type: internal

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -21,7 +21,6 @@ import six
 
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import OVSBridge as OB
-from libnmstate.schema import OVSBridgePortType as OBPortType
 
 from . import connection
 from . import device
@@ -184,15 +183,7 @@ def _get_bridge_port_info(port_profile, devices_info):
 
     if port_slave_names:
         iface_slave_name = port_slave_names[0]
-        iface_device = device.get_device_by_name(iface_slave_name)
-
-        if is_ovs_interface_type_id(iface_device.props.device_type):
-            port_type = OBPortType.INTERNAL
-        else:
-            port_type = OBPortType.SYSTEM
-
         port_info['name'] = iface_slave_name
-        port_info['type'] = port_type
         if vlan_mode:
             port_info['vlan-mode'] = vlan_mode
             port_info['access-tag'] = port_setting.props.tag

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -214,11 +214,5 @@ class OVSBridge(object):
 
     PORT_SUBTREE = 'port'
     PORT_NAME = 'name'
-    PORT_TYPE = 'type'
     PORT_VLAN_MODE = 'vlan-mode'
     PORT_ACCESS_TAG = 'access-tag'
-
-
-class OVSBridgePortType(object):
-    SYSTEM = 'system'
-    INTERNAL = 'internal'

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -283,8 +283,6 @@ definitions:
                 properties:
                   name:
                     type: string
-                  type:
-                    type: string
                   vlan-mode:
                     type: string
                   access-tag:

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -25,10 +25,9 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge
-from libnmstate.schema import OVSBridgePortType
 
 
-class Bridge:
+class Bridge(object):
     def __init__(self, name):
         self._name = name
         self._ifaces = [
@@ -46,10 +45,10 @@ class Bridge:
         ] = options
 
     def add_system_port(self, name):
-        self._add_port(name, OVSBridgePortType.SYSTEM)
+        self._add_port(name)
 
     def add_internal_port(self, name, ipv4_state):
-        self._add_port(name, OVSBridgePortType.INTERNAL)
+        self._add_port(name)
         self._ifaces.append(
             {
                 Interface.NAME: name,
@@ -58,10 +57,10 @@ class Bridge:
             }
         )
 
-    def _add_port(self, name, _type):
+    def _add_port(self, name):
         self._bridge_iface[OVSBridge.CONFIG_SUBTREE].setdefault(
             OVSBridge.PORT_SUBTREE, []
-        ).append({OVSBridge.PORT_NAME: name, OVSBridge.PORT_TYPE: _type})
+        ).append({OVSBridge.PORT_NAME: name})
 
     @contextmanager
     def create(self):

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -30,7 +30,6 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
-from libnmstate.schema import OVSBridgePortType as OBPortType
 from libnmstate.schema import Route
 
 
@@ -339,10 +338,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth0', 'type': 'unknown'},
@@ -378,10 +374,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     }
                 ]
@@ -431,10 +424,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth0', 'type': 'unknown'},
@@ -459,10 +449,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth1', 'state': 'up', 'type': 'unknown'},
@@ -503,11 +490,7 @@ class TestDesiredStateOvsMetadata(object):
                         'name': OVS_NAME,
                         'type': TYPE_OVS_BR,
                         'state': 'up',
-                        'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM}
-                            ]
-                        },
+                        'bridge': {'port': [{'name': 'eth0'}]},
                     }
                 ]
             }
@@ -520,10 +503,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth0', 'state': 'up', 'type': 'unknown'},
@@ -562,10 +542,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth0', 'type': 'unknown'},
@@ -595,11 +572,7 @@ class TestDesiredStateOvsMetadata(object):
                         'name': OVS2_NAME,
                         'type': TYPE_OVS_BR,
                         'state': 'up',
-                        'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM}
-                            ]
-                        },
+                        'bridge': {'port': [{'name': 'eth0'}]},
                     }
                 ]
             }
@@ -612,10 +585,7 @@ class TestDesiredStateOvsMetadata(object):
                         'type': TYPE_OVS_BR,
                         'state': 'up',
                         'bridge': {
-                            'port': [
-                                {'name': 'eth0', 'type': OBPortType.SYSTEM},
-                                {'name': 'eth1', 'type': OBPortType.SYSTEM},
-                            ]
+                            'port': [{'name': 'eth0'}, {'name': 'eth1'}]
                         },
                     },
                     {'name': 'eth0', 'state': 'up', 'type': 'unknown'},

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -122,7 +122,6 @@ def test_get_ovs_info_with_ports_with_interfaces(
 
     assert len(info['port']) == 1
     assert 'name' in info['port'][0]
-    assert 'type' in info['port'][0]
     assert 'vlan-mode' in info['port'][0]
     assert 'access-tag' in info['port'][0]
 


### PR DESCRIPTION
OVS port "type" attribute is redundant. It can be currently set to "system" or "internal", but these can be easily deduced from desired and current state. I propose we drop this attribute from the API, so we don't keep redundant information and make schema more streamlined.

No other nmstate interface type requires users to specify slave type (both bond and linux-bridge require the name only).

OVS bridge schema would change from:

```yaml
interfaces:
- name: ovs-br0
  type: ovs-bridge
  state: up
  bridge:
    port:
    - name: eth3
      type: system
```

To:

```yaml
interfaces:
- name: ovs-br0
  type: ovs-bridge
  state: up
  bridge:
    port:
    - name: eth3
```

https://nmstate.atlassian.net/browse/NMSTATE-248

Note that no changes were needed to implement this, apart from dropping the "type" from reporting, schema and tests.

Signed-off-by: Petr Horacek <phoracek@redhat.com>