### PR TITLE
netapplier: allow description removal

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -38,6 +38,7 @@ class Interface(object):
     NAME = 'name'
     TYPE = 'type'
     STATE = 'state'
+    DESCRIPTION = 'description'
 
     IPV4 = 'ipv4'
     IPV6 = 'ipv6'

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -284,6 +284,7 @@ class State(object):
         self._remove_iface_ipv6_link_local_addr()
         self._sort_ip_addresses()
         self._capitalize_mac()
+        self._remove_empty_description()
 
     def merge_interfaces(self, other_state):
         """
@@ -473,6 +474,11 @@ class State(object):
             mac = ifstate.get(Interface.MAC)
             if mac:
                 ifstate[Interface.MAC] = mac.upper()
+
+    def _remove_empty_description(self):
+        for ifstate in six.viewvalues(self.interfaces):
+            if ifstate.get(Interface.DESCRIPTION) == '':
+                del ifstate[Interface.DESCRIPTION]
 
     def _assert_interfaces_equal(self, current_state):
         for ifname in self.interfaces:

--- a/tests/integration/interface_common_test.py
+++ b/tests/integration/interface_common_test.py
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import libnmstate
+
+from .testlib import statelib
+from libnmstate.schema import Interface
+
+
+def test_iface_description_removal(eth1_up):
+    desired_state = eth1_up
+    desired_state[Interface.KEY][0][Interface.DESCRIPTION] = 'bar'
+    libnmstate.apply(desired_state)
+    current_state = statelib.show_only(('eth1',))
+    assert current_state[Interface.KEY][0][Interface.DESCRIPTION] == 'bar'
+
+    desired_state[Interface.KEY][0][Interface.DESCRIPTION] = ''
+    libnmstate.apply(desired_state)
+    current_state = statelib.show_only(('eth1',))
+    assert Interface.DESCRIPTION not in current_state[Interface.KEY][0]

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -132,6 +132,21 @@ class TestAssertIfaceState(object):
 
         desired_state.verify_interfaces(current_state)
 
+    def test_description_is_empty(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        desired_state.interfaces['foo-name'][Interface.DESCRIPTION] = ''
+
+        desired_state.verify_interfaces(current_state)
+
+    def test_description_is_not_empty(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        desired_state.interfaces['foo-name'][Interface.DESCRIPTION] = 'bar'
+        current_state.interfaces['foo-name'][Interface.DESCRIPTION] = 'bar'
+
+        desired_state.verify_interfaces(current_state)
+
     @property
     def _base_state(self):
         return state.State(


### PR DESCRIPTION
Allows description removal by setting an empty description. We need to
delete the description element from the desired state after being
applied.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>