### PR TITLE
test: Add CentOS 8 test container

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -1,0 +1,51 @@
+# This Dockerfile is based on the recommendations provided in the
+# Fedora official repository
+# (https://hub.docker.com/r/fedora/systemd-systemd/).
+# It enables systemd to be operational.
+FROM centos:8
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
+
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled PowerTools
+
+RUN dnf copr enable nmstate/ovs-el8 -y
+
+RUN dnf -y install --setopt=install_weak_deps=False \
+                   NetworkManager \
+                   NetworkManager-ovs \
+                   openvswitch2.11 \
+                   systemd-udev \
+                   python3-dbus \
+                   python3-gobject-base \
+                   python3-jsonschema \
+                   python3-pyyaml \
+                   python3-setuptools \
+                   python36 \
+                   dnsmasq \
+                   git \
+                   iproute \
+                   python3-pytest \
+                   rpm-build \
+                   # Below package for pip (used by tox) to build dbus-python
+                   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1654774
+                   make \
+                   python3-devel \
+                   cairo-devel \
+                   cairo-gobject-devel \
+                   glib2-devel \
+                   gobject-introspection-devel \
+                   dbus-devel && \
+
+    dnf -y group install "Development Tools" && \
+    pip3 install python-coveralls pytest-cov tox && \
+    alternatives --set python /usr/bin/python3 && \
+    ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
+    dnf clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -11,7 +11,8 @@ RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
 RUN dnf -y install dnf-plugins-core && \
     dnf config-manager --set-enabled PowerTools
 
-RUN dnf copr enable nmstate/ovs-el8 -y
+RUN dnf copr enable nmstate/ovs-el8 -y && \
+    dnf copr enable networkmanager/NetworkManager-1.20 -y
 
 RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \

--- a/packaging/build-container.sh
+++ b/packaging/build-container.sh
@@ -78,7 +78,8 @@ do
             centos7-nmstate-base \
             centos7-nmstate-dev \
             centos7-nmstate \
-            fedora-nmstate-dev
+            fedora-nmstate-dev \
+            centos8-nmstate-dev
         do
             rebuild_container "${extra_args}" "${container_name}"
         done


### PR DESCRIPTION
Added the CentOS 8 test container with NetworkManager 1.20 and
openvswitch 2.11 installed from copr repo.

The travis CI test has been explained to include tests on CentOS 8.