### PR TITLE
test: Fix centos7-nmstate-base container

### DIFF
--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -9,7 +9,9 @@ COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh -f
 
-RUN yum -y upgrade && \
+RUN yum -y install yum-plugin-copr && \
+    yum -y copr enable nmstate/ovs-el7 && \
+    yum -y upgrade && \
     yum -y install \
         NetworkManager \
         NetworkManager-libnm \

--- a/packaging/Dockerfile.centos7-nmstate-base
+++ b/packaging/Dockerfile.centos7-nmstate-base
@@ -26,4 +26,4 @@ RUN yum -y upgrade && \
         python-setuptools \
     && \
     yum clean all && \
-    bash ./docker_sys_config.sh && rm ./docker_sys_config -f
+    bash ./docker_sys_config.sh && rm ./docker_sys_config.sh -f


### PR DESCRIPTION
Fix the incorrect script path:

    Wrong:      docker_sys_config
    Correct:    docker_sys_config.sh

Use  copr repo `nmstate/ovs-el7` for openvswitch as it has been removed from base repo since RHEL/CentOS 7.7.