### PR TITLE
packaging, tox: Upgrade pytest and pytest-cov

### DIFF
--- a/packaging/Dockerfile.centos7-nmstate-dev
+++ b/packaging/Dockerfile.centos7-nmstate-dev
@@ -11,7 +11,7 @@ RUN yum -y install \
         dhclient \
     && yum clean all
 
-RUN pip install --upgrade pip pytest==4.2.1 pytest-cov==2.6.1
+RUN pip install --upgrade pip pytest==4.6.6 pytest-cov==2.8.1
 
 RUN pip3 install --user python-coveralls
 

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -29,8 +29,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    git \
                    iproute \
                    python3-coveralls \
-                   python3-pytest \
-                   python3-pytest-cov \
                    python3-tox \
                    rpm-build \
                    \
@@ -49,6 +47,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \
+    pip3 install --upgrade pip pytest==4.6.6 pytest-cov==2.8.1 && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
 
 VOLUME [ "/sys/fs/cgroup" ]

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ basepython = python2.7
 [basecfg]
 deps =
     -r{toxinidir}/requirements.txt
-    pytest-cov==2.6.1
-    pytest==4.6.5
+    pytest-cov==2.8.1
+    pytest==4.6.6
 pytest_args =
     --log-level=DEBUG
     --durations=5


### PR DESCRIPTION
The existing pytest* packages used by the container images are broken,
therefore, they are upgraded with this change to the latest (py2
compatible) version.