### PR TITLE
testlib: Rename TestMainloopError to MainloopTestError

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -26,7 +26,7 @@ from libnmstate.schema import OVSBridge as OB
 from libnmstate.schema import OVSBridgePortType as OBPortType
 
 from .testlib import mainloop
-from .testlib import TestMainloopError
+from .testlib import MainloopTestError
 
 
 BRIDGE0 = 'brtest0'
@@ -54,7 +54,7 @@ def bridge_default_config():
 
 
 @pytest.mark.xfail(
-    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
 )
 def test_create_and_remove_minimum_config_bridge(
     bridge_minimum_config, bridge_default_config
@@ -70,7 +70,7 @@ def test_create_and_remove_minimum_config_bridge(
 
 
 @pytest.mark.xfail(
-    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
 )
 def test_bridge_with_system_port(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
@@ -93,7 +93,7 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
 
 
 @pytest.mark.xfail(
-    raises=TestMainloopError, reason='https://bugzilla.redhat.com/1724901'
+    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
 )
 def test_bridge_with_internal_interface(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -22,7 +22,7 @@ import functools
 from libnmstate import nm
 
 
-class TestMainloopError(Exception):
+class MainloopTestError(Exception):
     pass
 
 
@@ -33,7 +33,7 @@ def mainloop():
     success = mloop.run(timeout=15)
     if not success:
         nm.nmclient.mainloop(refresh=True)
-        raise TestMainloopError(mloop.error)
+        raise MainloopTestError(mloop.error)
 
 
 def mainloop_run(func):

--- a/tests/integration/nm/wired_test.py
+++ b/tests/integration/nm/wired_test.py
@@ -23,7 +23,7 @@ from libnmstate import nm
 from libnmstate import schema
 
 from .testlib import mainloop
-from .testlib import TestMainloopError
+from .testlib import MainloopTestError
 
 
 ETH1 = 'eth1'
@@ -59,7 +59,7 @@ def _test_interface_mtu_change(apply_operation):
 
 
 def test_interface_mac_change_with_reapply_fails(eth1_up):
-    with pytest.raises(TestMainloopError):
+    with pytest.raises(MainloopTestError):
         _test_interface_mac_change(nm.device.reapply)
 
 


### PR DESCRIPTION
pytest tries collect tests from `TestMainloopError` as a test case since
it starts with `Test`, possibly resulting in warnings. Therefore rename
the Exception to avoid this.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/535)
<!-- Reviewable:end -->
