### PR TITLE
linting: Configure black via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true

--- a/tox.ini
+++ b/tox.ini
@@ -82,10 +82,9 @@ skip_install = true
 basepython = python3.6
 deps =
     black
+# style configured via pyproject.toml
 commands =
     black \
-        -l 79 \
-        -S \
         --check \
         {posargs} \
         ./


### PR DESCRIPTION
Use pyproject.toml for Nmstate's custom black configuration to allow to
use it to automatically to re-format files without remembering the
special options.

Reference: https://black.readthedocs.io/en/stable/pyproject_toml.html

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/536)
<!-- Reviewable:end -->
