### PR TITLE
Governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,182 @@
+# Overview
+
+This is a meritocratic, consensus-based community project. Anyone with an
+interest in the project can join the community, contribute to the project
+design and participate in the decision making process. This document describes
+how that participation takes place and how to set about earning merit within
+the project community.
+
+# Roles and responsibilities
+
+## Users
+
+Users are community members who have a need for the project. They are the most
+important members of the community and without them the project would have no
+purpose. Anyone can be a user; there are no special requirements.
+
+The project asks its users to participate in the project and community as much
+as possible. User contributions enable the project team to ensure that they are
+satisfying the needs of those users. Common user contributions include (but are
+not limited to):
+
+- evangelising about the project (e.g. a link on a website and word-of-mouth
+awareness raising)
+- informing developers of strengths and weaknesses from a new user perspective
+- providing moral support (a ‘thank you’ goes a long way)
+
+Users who continue to engage with the project and its community will often
+become more and more involved. Such users may find themselves becoming
+contributors, as described in the next section.
+
+## Contributors
+
+Contributors are community members who contribute in concrete ways to the
+project. Anyone can become a contributor, and contributions can take many
+forms. There is no expectation of commitment to the project, no specific skill
+requirements and no selection process.
+
+In addition to their actions as users, contributors may also find themselves
+doing one or more of the following:
+
+- supporting new users (existing users are often the best people to support
+new users)
+- reporting bugs
+- identifying requirements
+- review code contributions
+- programming
+- assisting with project infrastructure
+- writing documentation
+- fixing bugs
+- adding features
+- providing graphics and web design
+
+Contributors engage with the project through the issue tracker and mailing
+list, or by writing or editing documentation. They submit changes to the
+project itself via patches, which will be considered for inclusion in the
+project by existing maintainers (see next section). The developer mailing list
+is the most appropriate place to ask for help when making that first
+contribution.
+
+As contributors gain experience and familiarity with the project, their profile
+within, and commitment to, the community will increase.
+A contributer who shows an above-average level of contribution to the project,
+particularly with respect to its strategic direction and long-term health, may
+be nominated to become a maintainer. This role is described below.
+
+## Maintainers 
+
+Maintainers are community members who have shown that they are committed to the
+continued development of the project through ongoing engagement with the
+community.
+
+Typically, a potential maintainer will need to show that they have an
+understanding of the project, its objectives and its strategy. They will also
+have provided valuable contributions to the project over a period of time.
+
+The project maintainers consists of those individuals identified as
+‘project owners’ on the development site. The maintainers have additional
+responsibilities over and above those of a contributor. These responsibilities
+ensure the smooth running of the project. Maintainers are expected to review
+and merge code contributions, participate in strategic planning, approve
+changes to the governance model and manage the copyrights within the project
+outputs.
+
+Maintainers do not have significant authority over other members of the
+community, although they make decisions when community consensus cannot be
+reached. In addition, maintainers may interact through the project’s private
+mailing list if it exists or directly based on the maintainers list.
+This list is used for sensitive issues, such as votes for new maintainers and
+legal matters that cannot be discussed in public. It is never used for project
+management or planning.
+
+Maintainer membership is by invitation from the existing members. A nomination
+will result in discussion and then a vote by the existing maintainers on the
+project’s private list.
+Maintainer membership votes are subject to consensus approval of the current
+maintainer members.
+
+# Support
+
+All participants in the community are encouraged to provide support for new
+users within the project management infrastructure. This support is provided as
+a way of growing the community. Those seeking support should recognise that all
+support activity within the project is voluntary and is therefore provided as
+and when time allows. A user requiring guaranteed response times or results
+should therefore seek to purchase a support contract from a community member.
+However, for those willing to engage with the project on its own terms, and
+willing to help support other users, the community support channels are ideal.
+
+# Contribution process
+
+Anyone can contribute to the project, regardless of their skills, as there are
+many ways to contribute. For instance, a contributor might be active on the
+project mailing list and issue tracker, or might supply patches.
+
+# Decision making process
+
+Decisions about the future of the project are made through discussion with all
+members of the community, from the newest user to the most experienced
+maintainer member. All non-sensitive project management discussion takes place
+on the project developer mailing list. Occasionally, sensitive discussion
+occurs on a private list.
+
+In order to ensure that the project is not bogged down by endless discussion
+and continual voting, the project operates a policy of lazy consensus. This
+allows the majority of decisions to be made without resorting to a formal vote.
+
+## Lazy consensus
+
+Decision making typically involves the following steps:
+
+- Proposal
+- Discussion
+- Vote (if consensus is not reached through discussion)
+- Decision
+
+Any community member can make a proposal for consideration by the community. In
+order to initiate a discussion about a new idea, they should send an email to
+the project developer list or submit a patch implementing the idea to the
+issue tracker (or version-control system if they have commit access). This will
+prompt a review and, if necessary, a discussion of the idea. The goal of this
+review and discussion is to gain approval for the contribution. Since most
+people in the project community have a shared vision, there is often little
+need for discussion in order to reach consensus.
+
+In general, as long as nobody explicitly opposes a proposal or patch, it is
+recognised as having the support of the community. This is called lazy
+consensus - that is, those who have not stated their opinion explicitly have
+implicitly agreed to the implementation of the proposal.
+
+Lazy consensus is a very important concept within the project. It is this
+process that allows a large group of people to efficiently reach consensus, as
+someone with no objections to a proposal need not spend time stating their
+position, and others need not spend time reading such mails.
+
+For lazy consensus to be effective, it is necessary to allow at least 72 hours
+before assuming that there are no objections to the proposal. This requirement
+ensures that everyone is given enough time to read, digest and respond to the
+proposal. This time period is chosen so as to be as inclusive as possible of
+all participants, regardless of their location and time commitments.
+
+#  Voting
+
+Not all decisions can be made using lazy consensus. Issues such as those
+affecting the strategic direction or legal standing of the project must gain
+explicit approval in the form of a vote. Every member of the community is
+encouraged to express their opinions in all discussion and all votes. However,
+only project maintainer members (as defined above) have binding votes for the
+purposes of decision making.
+
+---
+
+This document is based on OSS Watch template: Meritocratic governance model by
+Ross Gardler and Gabriel Hanganu. 
+http://oss-watch.ac.uk/resources/meritocraticgovernancemodel
+
+The document has been modified to fit the needs of the Nmstate project.
+These are the main changes done from the original template:
+- Roles: The commiter role has been dropped and PMC members have been renamed
+to be called maintainers.
+  In addition, the PMC chair role has not been mentioned.
+- Providing financial support for the project has not been mentioned.
+

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,6 @@
+# Maintainers List
+(The list is sorted alphabetically)
+
+Edward Haas <edwardh@redhat.com>
+Gris Ge <fge@redhat.com>
+Till Maas <opensource@till.name>


### PR DESCRIPTION
With the increase of users and contributors to Nmstate and its cross teams membership nature, it has become obvious that documenting the decision making and the different roles in the project is needed.

This PR suggests to use the meritocratic governance, used by other big community based open source projects (e.g. the Apache Software Foundation, oVirt).

The document is based on http://oss-watch.ac.uk/resources/meritocraticgovernancemodel template with slight adjustment (main points documented inline).

In addition, the list of current maintainers has been added.