### PR TITLE
github: Fix CODEOWNERS syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 # Default reviewers for everything
-* cathay4t EdDev ffmancera tyll
+* @cathay4t @EdDev @ffmancera @tyll


### PR DESCRIPTION
Usernames need to be prefixed with at-signs.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/541)
<!-- Reviewable:end -->
