### PR TITLE
Upgrade travis test base to Fedora 31 and CentOS 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
+          testflags="--test-type integ --pytest-args='-x'"
+        - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type format"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type lint"

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,7 +2,7 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM fedora:29
+FROM fedora:31
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
@@ -22,6 +22,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    python3-jsonschema \
                    python3-pyyaml \
                    python3-setuptools \
+                   python3-pip \
                    \
                    python2 \
                    python36 \
@@ -45,10 +46,11 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    # Below package for pip (used by tox) to build dbus-python
                    make \
                    dbus-devel && \
-    alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \
-    pip3 install --upgrade pip pytest==4.6.6 pytest-cov==2.8.1 && \
+    pip install pytest==4.6.6 pytest-cov==2.8.1 --user && \
+    # Below line is workaround for
+    #   https://src.fedoraproject.org/rpms/rootfiles/pull-request/1
+    ln -s /root/.local/bin/pytest /usr/bin/pytest && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
 
 VOLUME [ "/sys/fs/cgroup" ]

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -39,6 +39,7 @@ from .testlib import cmd as libcmd
 from .testlib import bondlib
 from .testlib import ifacelib
 from .testlib import statelib
+from .testlib.ifacelib import get_mac_address
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
@@ -496,6 +497,7 @@ def test_dhcp_on_bridge0(dhcpcli_up_with_dynamic_ip):
         Interface.IPV6: create_ipv6_state(
             enabled=True, dhcp=True, autoconf=True
         ),
+        Interface.MAC: get_mac_address(DHCP_CLI_NIC),
     }
     bridge_name = TEST_BRIDGE_NIC
     with linux_bridge(bridge_name, bridge_state, bridge_iface_state) as state:

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -53,7 +53,8 @@ def bridge_default_config():
 
 
 @pytest.mark.xfail(
-    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(MainloopTestError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_create_and_remove_minimum_config_bridge(
     bridge_minimum_config, bridge_default_config
@@ -69,7 +70,8 @@ def test_create_and_remove_minimum_config_bridge(
 
 
 @pytest.mark.xfail(
-    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(MainloopTestError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_bridge_with_system_port(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
@@ -91,7 +93,8 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
 
 
 @pytest.mark.xfail(
-    raises=MainloopTestError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(MainloopTestError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_bridge_with_internal_interface(bridge_default_config):
     bridge_desired_state = bridge_default_config

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -33,7 +33,8 @@ PORT1 = 'ovs1'
 
 
 @pytest.mark.xfail(
-    raises=NmstateLibnmError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(NmstateLibnmError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_create_and_remove_ovs_bridge_with_min_desired_state():
     with Bridge(BRIDGE1).create() as state:
@@ -43,7 +44,8 @@ def test_create_and_remove_ovs_bridge_with_min_desired_state():
 
 
 @pytest.mark.xfail(
-    raises=NmstateLibnmError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(NmstateLibnmError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_create_and_remove_ovs_bridge_options_specified():
     bridge = Bridge(BRIDGE1)
@@ -63,7 +65,8 @@ def test_create_and_remove_ovs_bridge_options_specified():
 
 
 @pytest.mark.xfail(
-    raises=NmstateLibnmError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(NmstateLibnmError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_create_and_remove_ovs_bridge_with_a_system_port(port0_up):
     bridge = Bridge(BRIDGE1)
@@ -77,7 +80,8 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(port0_up):
 
 
 @pytest.mark.xfail(
-    raises=NmstateLibnmError, reason='https://bugzilla.redhat.com/1724901'
+    raises=(NmstateLibnmError, AssertionError),
+    reason='https://bugzilla.redhat.com/1724901',
 )
 def test_create_and_remove_ovs_bridge_with_internal_port_and_static_ip():
     bridge = Bridge(BRIDGE1)

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+
+
+def is_fedora():
+    return os.path.exists('/etc/fedora-release')

--- a/tests/integration/testlib/ifacelib.py
+++ b/tests/integration/testlib/ifacelib.py
@@ -54,3 +54,8 @@ def _set_eth_admin_state(ifname, state):
             ]
         }
         libnmstate.apply(desired_state)
+
+
+def get_mac_address(ifname):
+    state = statelib.show_only((ifname,))
+    return state[schema.Interface.KEY][0].get(schema.Interface.MAC)


### PR DESCRIPTION
Both Fedora 31 and CentOS 8 test image are using NetworkManager 1.20 which is the NetworkManager version we officially support.

CentOS 7 is not supported any more and hence travis CI will not run test on it.

This PR contains patches to allow CI to pass on Fedora 31 and CentOS 8 containers.