### PR TITLE
Compress static IPv6 addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@
 #packageD!=0.13.0,<0.14,>=0.12.0
 
 dbus-python
+ipaddress;python_version<"3.3"
 jsonschema
 PyGObject
 PyYAML

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -20,8 +20,11 @@
 import pytest
 
 import libnmstate
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -536,4 +539,29 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(
     }
     libnmstate.apply(desired_state)
 
+    assertlib.assert_state(desired_state)
+
+
+@pytest.mark.xfail(reason='https://bugzilla.redhat.com/1760800', strict=True)
+def test_add_iface_with_static_ipv6_expanded_format(eth1_up):
+    ipv6_addr_lead_zeroes = '2001:0db8:85a3:0000:0000:8a2e:0370:7331'
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: eth1_up[Interface.KEY][0][Interface.NAME],
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: ipv6_addr_lead_zeroes,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -542,7 +542,6 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(
     assertlib.assert_state(desired_state)
 
 
-@pytest.mark.xfail(reason='https://bugzilla.redhat.com/1760800', strict=True)
 def test_add_iface_with_static_ipv6_expanded_format(eth1_up):
     ipv6_addr_lead_zeroes = '2001:0db8:85a3:0000:0000:8a2e:0370:7331'
     desired_state = {

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -147,6 +147,31 @@ class TestAssertIfaceState(object):
 
         desired_state.verify_interfaces(current_state)
 
+    def test_accept_expanded_ipv6_notation(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        expanded_ipv6_addr = '2001:0db8:85a3:0000:0000:8a2e:0370:7331'
+
+        desired_state.interfaces['foo-name']['ipv6'] = {
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: expanded_ipv6_addr,
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                }
+            ],
+            InterfaceIPv6.ENABLED: True,
+        }
+        current_state.interfaces['foo-name']['ipv6'] = {
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: '2001:db8:85a3::8a2e:370:7331',
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                }
+            ],
+            InterfaceIPv6.ENABLED: True,
+        }
+        desired_state.verify_interfaces(current_state)
+
     @property
     def _base_state(self):
         return state.State(


### PR DESCRIPTION
Setting a static IP address on an interface fails, since it is reported by nmstate in the canonical format, as per [0].

The failure happens in nmstate's *verify* stage - since the desired state is expressed in the expanded notation, and the current state in the canonical notation, nmstate considers the IPs to be different, and an automatic rollback is used.

This patch addresses the aforementioned issue by canonicalizing (compressing) the static ipv6 address in the desired state.

The issue can be triggered w/ the following yaml:
```yaml
interfaces:
- name: eth1
  type: ethernet
  state: up
  ipv4:
    enabled: false
  ipv6:
    address:
    - ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7331
      prefix-length: 64
    enabled: true
```

Ref: https://bugzilla.redhat.com/1760800

[0] - https://tools.ietf.org/html/rfc5952#section-4
