### PR TITLE
gitignore: ignore htmlcov-py37 directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ __pycache__/
 dist/
 
 .coverage
-htmlcov-py27/
-htmlcov-py36/
+htmlcov-*/
 
 AUTHORS
 ChangeLog


### PR DESCRIPTION
When the unit_py37 test fails it generates the coverage under the
htmlcov-py37 directory. We do not want to track this on git.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>