### PR TITLE
tests, integ: deprecate INTERFACES constant from statelib

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -41,7 +41,6 @@ from .testlib import statelib
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
-from .testlib.statelib import INTERFACES
 
 
 IPV4_ADDRESS1 = '192.0.2.251'
@@ -165,7 +164,7 @@ def iface_with_dynamic_ip_up(ifname, delay_state_time=0):
 
 def test_ipv4_dhcp(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(
         enabled=True, dhcp=True
@@ -182,7 +181,7 @@ def test_ipv4_dhcp(dhcpcli_up):
 
 def test_ipv6_dhcp_only(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=False
@@ -193,7 +192,7 @@ def test_ipv6_dhcp_only(dhcpcli_up):
     assertlib.assert_state(desired_state)
     time.sleep(5)  # libnm does not wait on ipv6-ra or DHCPv6.
     current_state = statelib.show_only((DHCP_CLI_NIC,))
-    dhcp_cli_current_state = current_state[INTERFACES][0]
+    dhcp_cli_current_state = current_state[Interface.KEY][0]
     has_dhcp_ip_addr = False
     for addr in dhcp_cli_current_state[Interface.IPV6][InterfaceIPv6.ADDRESS]:
         if (
@@ -210,7 +209,7 @@ def test_ipv6_dhcp_only(dhcpcli_up):
 
 def test_ipv6_dhcp_and_autoconf(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=True
@@ -238,7 +237,7 @@ def test_dhcp_with_addresses(dhcpcli_up):
     ]
 
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
                 Interface.NAME: DHCP_CLI_NIC,
                 Interface.STATE: InterfaceState.UP,
@@ -263,7 +262,7 @@ def test_ipv4_dhcp_on_bond(dhcpcli_up):
 
 def test_ipv4_dhcp_ignore_gateway(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(
         enabled=True, dhcp=True, auto_gateway=False
@@ -280,7 +279,7 @@ def test_ipv4_dhcp_ignore_gateway(dhcpcli_up):
 
 def test_ipv4_dhcp_ignore_dns(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(
         enabled=True, dhcp=True, auto_dns=False
@@ -296,7 +295,7 @@ def test_ipv4_dhcp_ignore_dns(dhcpcli_up):
 
 def test_ipv4_dhcp_ignore_routes(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(
         enabled=True, dhcp=True, auto_routes=False
@@ -313,7 +312,7 @@ def test_ipv4_dhcp_ignore_routes(dhcpcli_up):
 
 def test_ipv6_dhcp_and_autoconf_ignore_gateway(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=True, auto_gateway=False
@@ -330,7 +329,7 @@ def test_ipv6_dhcp_and_autoconf_ignore_gateway(dhcpcli_up):
 
 def test_ipv6_dhcp_and_autoconf_ignore_dns(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=True, auto_dns=False
@@ -347,7 +346,7 @@ def test_ipv6_dhcp_and_autoconf_ignore_dns(dhcpcli_up):
 
 def test_ipv6_dhcp_and_autoconf_ignore_routes(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=True, auto_routes=False
@@ -368,7 +367,7 @@ def test_ipv4_dhcp_off_and_option_on(dhcpcli_up):
     DHCP is disabled.
     """
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     ipv4_state = create_ipv4_state(
         enabled=True,
@@ -382,7 +381,8 @@ def test_ipv4_dhcp_off_and_option_on(dhcpcli_up):
 
     libnmstate.apply(desired_state)
 
-    dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
+    current_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_current_state = current_state[Interface.KEY][0]
     ipv4_current_state = dhcp_cli_current_state[Interface.IPV4]
     assert not ipv4_current_state[InterfaceIPv4.DHCP]
     assert InterfaceIPv4.AUTO_ROUTES not in ipv4_current_state
@@ -399,7 +399,7 @@ def test_ipv6_dhcp_off_and_option_on(dhcpcli_up):
     DHCP is disabled.
     """
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     ipv6_state = create_ipv6_state(
         enabled=True,
@@ -414,7 +414,8 @@ def test_ipv6_dhcp_off_and_option_on(dhcpcli_up):
 
     libnmstate.apply(desired_state)
 
-    dhcp_cli_current_state = statelib.show_only((DHCP_CLI_NIC,))[INTERFACES][0]
+    current_state = statelib.show_only((DHCP_CLI_NIC,))
+    dhcp_cli_current_state = current_state[Interface.KEY][0]
     ipv6_current_state = dhcp_cli_current_state[Interface.IPV6]
     assert not ipv6_current_state[InterfaceIPv6.DHCP]
     assert InterfaceIPv6.AUTO_ROUTES not in ipv6_current_state
@@ -427,7 +428,7 @@ def test_ipv6_dhcp_off_and_option_on(dhcpcli_up):
 
 def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(
         enabled=True, dhcp=True
@@ -442,7 +443,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
 
     # disable dhcp and make sure dns, route, gone.
     desired_state = statelib.show_only((DHCP_CLI_NIC,))
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = create_ipv4_state(enabled=True)
 
@@ -455,7 +456,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
 
 def test_ipv6_dhcp_switch_on_to_off(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, dhcp=True, autoconf=True
@@ -471,7 +472,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcpcli_up):
 
     # disable dhcp and make sure dns, route, gone.
     desired_state = statelib.show_only((DHCP_CLI_NIC,))
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(enabled=True)
 
@@ -538,7 +539,7 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
 
     slave_ifname = dhcpcli_up[Interface.KEY][0][Interface.NAME]
     slave_state = statelib.show_only((slave_ifname,))
-    slave_iface_state = slave_state[INTERFACES][0]
+    slave_iface_state = slave_state[Interface.KEY][0]
     dhcpcli_ip = slave_iface_state[Interface.IPV4][InterfaceIPv4.ADDRESS]
 
     bridge_state = add_port_to_bridge(
@@ -568,7 +569,7 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
 @pytest.mark.xfail(raises=NmstateNotImplementedError)
 def test_ipv6_autoconf_only(dhcpcli_up):
     desired_state = dhcpcli_up
-    dhcp_cli_desired_state = desired_state[INTERFACES][0]
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.IPV6] = create_ipv6_state(
         enabled=True, autoconf=True
     )

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -25,12 +25,12 @@ import pytest
 import jsonschema as js
 
 import libnmstate
-from libnmstate import schema
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
-from .testlib.statelib import INTERFACES
 from .testlib.vlan import vlan_interface
 
 
@@ -41,15 +41,15 @@ def eth1(eth1_up):
 
 @pytest.fixture
 def eth1_with_ipv6(eth1_up):
-    ifstate = eth1_up[schema.Interface.KEY][0]
-    ifstate[schema.Interface.IPV6][schema.InterfaceIPv6.ENABLED] = True
+    ifstate = eth1_up[Interface.KEY][0]
+    ifstate[Interface.IPV6][InterfaceIPv6.ENABLED] = True
     libnmstate.apply(eth1_up)
 
 
 def test_increase_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 1900
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1900
 
     libnmstate.apply(desired_state)
 
@@ -58,8 +58,8 @@ def test_increase_iface_mtu():
 
 def test_decrease_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 1400
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1400
 
     libnmstate.apply(desired_state)
 
@@ -68,8 +68,8 @@ def test_decrease_iface_mtu():
 
 def test_upper_limit_jambo_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 9000
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 9000
 
     libnmstate.apply(desired_state)
 
@@ -78,8 +78,8 @@ def test_upper_limit_jambo_iface_mtu():
 
 def test_increase_more_than_jambo_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 10000
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 10000
 
     libnmstate.apply(desired_state)
 
@@ -89,8 +89,8 @@ def test_increase_more_than_jambo_iface_mtu():
 def test_decrease_to_zero_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
     origin_desired_state = copy.deepcopy(desired_state)
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 0
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 0
 
     with pytest.raises(NmstateVerificationError) as err:
         libnmstate.apply(desired_state)
@@ -103,8 +103,8 @@ def test_decrease_to_zero_iface_mtu():
 def test_decrease_to_negative_iface_mtu():
     desired_state = statelib.show_only(('eth1',))
     origin_desired_state = copy.deepcopy(desired_state)
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = -1
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = -1
 
     with pytest.raises(js.ValidationError) as err:
         libnmstate.apply(desired_state)
@@ -114,8 +114,8 @@ def test_decrease_to_negative_iface_mtu():
 
 def test_decrease_to_ipv6_min_ethernet_frame_size_iface_mtu(eth1_with_ipv6):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 1280
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1280
 
     libnmstate.apply(desired_state)
 
@@ -125,8 +125,8 @@ def test_decrease_to_ipv6_min_ethernet_frame_size_iface_mtu(eth1_with_ipv6):
 def test_decrease_to_lower_than_min_ipv6_iface_mtu(eth1_with_ipv6):
     original_state = statelib.show_only(('eth1',))
     desired_state = copy.deepcopy(original_state)
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['mtu'] = 1279
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1279
 
     with pytest.raises(NmstateVerificationError) as err:
         libnmstate.apply(desired_state)
@@ -138,19 +138,19 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu(eth1_with_ipv6):
 
 @pytest.mark.xfail(reason='https://bugzilla.redhat.com/1751079', strict=True)
 def test_set_mtu_on_two_vlans_with_a_shared_base(eth1_up):
-    base_ifname = eth1_up[schema.Interface.KEY][0][schema.Interface.NAME]
+    base_ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     v101 = vlan_interface('eth1.101', 101, base_ifname)
     v102 = vlan_interface('eth1.102', 102, base_ifname)
     with v101 as v101_state, v102 as v102_state:
         desired_state = {
-            schema.Interface.KEY: [
-                base_ifname[schema.Interface.KEY][0],
-                v101_state[schema.Interface.KEY][0],
-                v102_state[schema.Interface.KEY][0],
+            Interface.KEY: [
+                base_ifname[Interface.KEY][0],
+                v101_state[Interface.KEY][0],
+                v102_state[Interface.KEY][0],
             ]
         }
-        for iface_state in desired_state[schema.Interface.KEY]:
-            iface_state[schema.Interface.MTU] = 2000
+        for iface_state in desired_state[Interface.KEY]:
+            iface_state[Interface.MTU] = 2000
 
         libnmstate.apply(desired_state)
 

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -21,13 +21,21 @@ import pytest
 
 import libnmstate
 
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
 from .testlib import assertlib
-from .testlib.statelib import INTERFACES
 
 
 def test_set_a_down_iface_down(eth1_up):
     desired_state = {
-        INTERFACES: [{'name': 'eth1', 'type': 'ethernet', 'state': 'down'}]
+        Interface.KEY: [
+            {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.DOWN,
+            }
+        ]
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
@@ -40,7 +48,13 @@ def test_set_a_down_iface_down(eth1_up):
 @pytest.mark.xfail(reason='Some ifaces cannot be removed', strict=True)
 def test_removing_a_non_removable_iface(eth1_up):
     desired_state = {
-        INTERFACES: [{'name': 'eth1', 'type': 'ethernet', 'state': 'absent'}]
+        Interface.KEY: [
+            {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.ABSENT,
+            }
+        ]
     }
 
     libnmstate.apply(desired_state)
@@ -49,14 +63,20 @@ def test_removing_a_non_removable_iface(eth1_up):
 
 
 def test_set_iface_down_without_type(eth1_up):
-    desired_state = {INTERFACES: [{'name': 'eth1', 'state': 'down'}]}
+    desired_state = {
+        Interface.KEY: [
+            {Interface.NAME: 'eth1', Interface.STATE: InterfaceState.DOWN}
+        ]
+    }
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
 
 
 def test_change_iface_without_type(eth1_up):
-    desired_state = {INTERFACES: [{'name': 'eth1', 'mtu': 1400}]}
+    desired_state = {
+        Interface.KEY: [{Interface.NAME: 'eth1', Interface.MTU: 1400}]
+    }
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)

--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -21,12 +21,14 @@ from contextlib import contextmanager
 
 import libnmstate
 from libnmstate.nm import nmclient
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
 
 from .testlib import statelib
 from .testlib import cmd as libcmd
-from .testlib.statelib import INTERFACES
 
 _IPV4_EXTRA_CONFIG = 'ipv4.dad-timeout'
 _IPV4_EXTRA_VALUE = '0'
@@ -40,12 +42,12 @@ IPV6_ADDRESS1 = '2001:db8:1::1'
 def test_reapply_preserve_ip_config(eth1_up):
     libnmstate.apply(
         {
-            'interfaces': [
+            Interface.KEY: [
                 {
-                    'name': 'eth1',
-                    'type': 'ethernet',
-                    'state': 'up',
-                    'ipv4': {
+                    Interface.NAME: 'eth1',
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.IPV4: {
                         InterfaceIPv4.ADDRESS: [
                             {
                                 InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
@@ -54,7 +56,7 @@ def test_reapply_preserve_ip_config(eth1_up):
                         ],
                         InterfaceIPv4.ENABLED: True,
                     },
-                    'ipv6': {
+                    Interface.IPV6: {
                         InterfaceIPv6.ADDRESS: [
                             {
                                 InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
@@ -63,13 +65,13 @@ def test_reapply_preserve_ip_config(eth1_up):
                         ],
                         InterfaceIPv6.ENABLED: True,
                     },
-                    'mtu': 1500,
+                    Interface.MTU: 1500,
                 }
             ]
         }
     )
     cur_state = statelib.show_only(('eth1',))
-    iface_name = cur_state[INTERFACES][0]['name']
+    iface_name = cur_state[Interface.KEY][0][Interface.NAME]
 
     uuid = _get_nm_profile_uuid(iface_name)
 

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -28,7 +28,6 @@ from libnmstate.schema import InterfaceType
 
 from .testlib import assertlib
 from .testlib import statelib
-from .testlib.statelib import INTERFACES
 
 # TEST-NET addresses: https://tools.ietf.org/html/rfc5737#section-3
 IPV4_ADDRESS1 = '192.0.2.251'
@@ -46,12 +45,12 @@ IPV6_LINK_LOCAL_ADDRESS2 = 'fe80::2'
 @pytest.fixture
 def setup_eth1_ipv4(eth1_up):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -69,12 +68,12 @@ def setup_eth1_ipv4(eth1_up):
 @pytest.fixture
 def setup_eth1_ipv6(eth1_up):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -94,12 +93,12 @@ def setup_eth1_ipv6(eth1_up):
 @pytest.fixture
 def setup_eth1_ipv6_disable(eth1_up):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {InterfaceIPv6.ENABLED: False},
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {InterfaceIPv6.ENABLED: False},
             }
         ]
     }
@@ -110,11 +109,11 @@ def setup_eth1_ipv6_disable(eth1_up):
 
 def test_add_static_ipv4_with_full_state(eth1_up):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state = desired_state[Interface.KEY][0]
 
-    eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv4'][InterfaceIPv4.ENABLED] = True
-    eth1_desired_state['ipv4'][InterfaceIPv4.ADDRESS] = [
+    eth1_desired_state[Interface.STATE] = InterfaceState.UP
+    eth1_desired_state[Interface.IPV4][InterfaceIPv4.ENABLED] = True
+    eth1_desired_state[Interface.IPV4][InterfaceIPv4.ADDRESS] = [
         {
             InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS3,
             InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
@@ -127,12 +126,12 @@ def test_add_static_ipv4_with_full_state(eth1_up):
 
 def test_add_static_ipv4_with_min_state(eth2_up):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -151,11 +150,11 @@ def test_add_static_ipv4_with_min_state(eth2_up):
 
 def test_remove_static_ipv4(setup_eth1_ipv4):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'ipv4': {InterfaceIPv4.ENABLED: False},
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.IPV4: {InterfaceIPv4.ENABLED: False},
             }
         ]
     }
@@ -167,12 +166,12 @@ def test_remove_static_ipv4(setup_eth1_ipv4):
 
 def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -194,12 +193,12 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
     eth1_up, eth2_up
 ):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -210,10 +209,10 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
                 },
             },
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -235,12 +234,12 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(
     setup_eth1_ipv4, eth2_up
 ):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv4': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
                     InterfaceIPv4.ENABLED: True,
                     InterfaceIPv4.ADDRESS: [
                         {
@@ -259,10 +258,10 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(
 
 def test_add_static_ipv6_with_full_state(eth1_up):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
-    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.STATE] = InterfaceState.UP
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS] = [
         {
             InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
             InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
@@ -279,10 +278,10 @@ def test_add_static_ipv6_with_full_state(eth1_up):
 
 def test_add_static_ipv6_with_link_local(eth1_up):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
-    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.STATE] = InterfaceState.UP
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS] = [
         {
             InterfaceIPv6.ADDRESS_IP: IPV6_LINK_LOCAL_ADDRESS1,
             InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
@@ -297,23 +296,23 @@ def test_add_static_ipv6_with_link_local(eth1_up):
 
     # Make sure only the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
-    eth1_cur_state = cur_state[INTERFACES][0]
+    eth1_cur_state = cur_state[Interface.KEY][0]
     assert (
-        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
-        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS][0]
+        not in eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
     assert (
-        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][1]
-        in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS][1]
+        in eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
 
 
 def test_add_static_ipv6_with_link_local_only(eth1_up):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
-    eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS] = [
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.STATE] = InterfaceState.UP
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS] = [
         {
             InterfaceIPv6.ADDRESS_IP: IPV6_LINK_LOCAL_ADDRESS1,
             InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
@@ -328,39 +327,39 @@ def test_add_static_ipv6_with_link_local_only(eth1_up):
 
     # Make sure the link local address got ignored.
     cur_state = statelib.show_only(('eth1',))
-    eth1_cur_state = cur_state[INTERFACES][0]
+    eth1_cur_state = cur_state[Interface.KEY][0]
     assert (
-        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
-        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS][0]
+        not in eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
     assert (
-        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][1]
-        not in eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS][1]
+        not in eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
 
 
 def test_add_static_ipv6_with_no_address(eth1_up):
     desired_state = statelib.show_only(('eth1',))
-    eth1_desired_state = desired_state[INTERFACES][0]
-    eth1_desired_state['state'] = 'up'
-    eth1_desired_state['ipv6'][InterfaceIPv6.ENABLED] = True
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.STATE] = InterfaceState.UP
+    eth1_desired_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
 
     libnmstate.apply(desired_state)
 
     cur_state = statelib.show_only(('eth1',))
-    eth1_cur_state = cur_state[INTERFACES][0]
+    eth1_cur_state = cur_state[Interface.KEY][0]
     # Should have at least 1 link-local address.
-    assert len(eth1_cur_state['ipv6'][InterfaceIPv6.ADDRESS]) >= 1
+    assert len(eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]) >= 1
 
 
 def test_add_static_ipv6_with_min_state(eth2_up):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -379,11 +378,11 @@ def test_add_static_ipv6_with_min_state(eth2_up):
 
 def test_disable_static_ipv6(setup_eth1_ipv6):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'ipv6': {InterfaceIPv6.ENABLED: False},
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.IPV6: {InterfaceIPv6.ENABLED: False},
             }
         ]
     }
@@ -395,11 +394,11 @@ def test_disable_static_ipv6(setup_eth1_ipv6):
 
 def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'ipv6': {InterfaceIPv6.ENABLED: False},
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                 'foo': 'bad_value',
             }
         ]
@@ -413,11 +412,11 @@ def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
 
 def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'ipv6': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -438,14 +437,14 @@ def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
 
 
 def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
-    eth1_setup = setup_eth1_ipv6[INTERFACES][0]
+    eth1_setup = setup_eth1_ipv6[Interface.KEY][0]
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -459,19 +458,19 @@ def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
     }
 
     libnmstate.apply(desired_state)
-    eth1_desired_state = desired_state[INTERFACES][0]
+    eth1_desired_state = desired_state[Interface.KEY][0]
     current_state = statelib.show_only(('eth1',))
 
-    eth1_current_state = current_state[INTERFACES][0]
+    eth1_current_state = current_state[Interface.KEY][0]
 
     assert (
-        eth1_desired_state['ipv6'][InterfaceIPv6.ADDRESS][0]
-        in eth1_current_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_desired_state[Interface.IPV6][InterfaceIPv6.ADDRESS][0]
+        in eth1_current_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
 
     assert (
-        eth1_setup['ipv6'][InterfaceIPv6.ADDRESS][0]
-        not in eth1_current_state['ipv6'][InterfaceIPv6.ADDRESS]
+        eth1_setup[Interface.IPV6][InterfaceIPv6.ADDRESS][0]
+        not in eth1_current_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
     )
 
 
@@ -479,12 +478,12 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(
     eth1_up, eth2_up
 ):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth1',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth1',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -495,10 +494,10 @@ def test_add_ifaces_with_same_static_ipv6_address_in_one_transaction(
                 },
             },
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {
@@ -520,12 +519,12 @@ def test_add_iface_with_same_static_ipv6_address_to_existing(
     setup_eth1_ipv6, eth2_up
 ):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': 'eth2',
-                'type': 'ethernet',
-                'state': 'up',
-                'ipv6': {
+                Interface.NAME: 'eth2',
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
                     InterfaceIPv6.ENABLED: True,
                     InterfaceIPv6.ADDRESS: [
                         {

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -24,7 +24,6 @@ from libnmstate.schema import Route
 from libnmstate.schema import Interface
 
 from . import statelib
-from .statelib import INTERFACES
 
 
 def assert_state(desired_state_data):
@@ -40,7 +39,7 @@ def assert_absent(*ifnames):
     """ Assert that a interface is not present in the current state """
 
     current_state = statelib.show_only(ifnames)
-    assert not current_state[INTERFACES]
+    assert not current_state[Interface.KEY]
 
 
 def assert_state_match(desired_state_data):

--- a/tests/integration/testlib/vlan.py
+++ b/tests/integration/testlib/vlan.py
@@ -20,18 +20,21 @@
 from contextlib import contextmanager
 
 import libnmstate
-from .statelib import INTERFACES
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import VLAN
 
 
 @contextmanager
 def vlan_interface(ifname, vlan_id, base_iface):
     desired_state = {
-        INTERFACES: [
+        Interface.KEY: [
             {
-                'name': ifname,
-                'type': 'vlan',
-                'state': 'up',
-                'vlan': {'id': vlan_id, 'base-iface': base_iface},
+                Interface.NAME: ifname,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.TYPE: {VLAN.ID: vlan_id, VLAN.BASE_IFACE: base_iface},
             }
         ]
     }
@@ -40,5 +43,13 @@ def vlan_interface(ifname, vlan_id, base_iface):
         yield desired_state
     finally:
         libnmstate.apply(
-            {INTERFACES: [{'name': ifname, 'type': 'vlan', 'state': 'absent'}]}
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: ifname,
+                        Interface.TYPE: InterfaceType.VLAN,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
         )


### PR DESCRIPTION
INTERFACES constant from statelib is deprecated and should not be used
anymore. Instead, use Interface.KEY from the schema module.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>