### PR TITLE
test coverage: Fix code coverage report

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -286,8 +286,10 @@ add_extra_networks
 dump_network_info
 
 pyclean
-docker_exec "cp -rf $CONTAINER_WORKSPACE /tmp/"
-# Change workspace to keep the original one clean
-CONTAINER_WORKSPACE="/tmp/nmstate"
+if [[ "$CI" != "true" ]];then
+    docker_exec "cp -rf $CONTAINER_WORKSPACE /tmp/"
+    # Change workspace to keep the original one clean
+    CONTAINER_WORKSPACE="/tmp/nmstate"
+fi
 install_nmstate
 run_tests


### PR DESCRIPTION
As we run the test in the `/tmp/nmstate` after copy `/workspace/nmstate` to
`/tmp`, the coverage files are stored in `/tmp` folder which does not
get collected to the website for report.
The fix is copy coverage files to `/workspace/nmstate` folder if in CI
environment.