### PR TITLE
nm ipv6: Fix race problem when IPv6 is disabled

### DIFF
--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -52,6 +52,13 @@ def get_info(active_connection):
             info[InterfaceIPv6.AUTOCONF] = False
         elif method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL:
             is_link_local_method = True
+        # pylint: disable=no-member
+        elif (
+            nmclient.can_disable_ipv6()
+            and method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_DISABLED
+        ):
+            return info
+        # pylint: enable=no-member
 
         if info[InterfaceIPv6.DHCP] or info[InterfaceIPv6.AUTOCONF]:
             props = ip_profile.props


### PR DESCRIPTION
At the verification stage when disabling IPv6, the interface might still
have running IPv6 `NM.IPConfig` attached which turn out to be shown as

```yaml
ipv6:
 address: []
 autoconf: false
 dhcp: false
 enabled: true
```

The fix is check in-config method of IPv6, if disabled, return with
disabled IPv6 information.