### PR TITLE
state, timeout: Increase main timeout to 60s

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -38,7 +38,7 @@ from libnmstate.error import NmstatePermissionError
 from libnmstate.error import NmstateValueError
 from libnmstate.nm import nmclient
 
-MAINLOOP_TIMEOUT = 35
+MAINLOOP_TIMEOUT = 60
 
 
 def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):


### PR DESCRIPTION
At kstate we have found that recovering from a reboot 35s is not enough
and 60s is fine.

Signed-off-by: Quique Llorente <ellorent@redhat.com>