### PR TITLE
nm ovs: Handle race problem when OVS bridge is deleting

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -139,16 +139,22 @@ def is_ovs_interface_type_id(type_id):
 
 
 def get_bridge_info(bridge_device, devices_info):
-    return {OB.CONFIG_SUBTREE: get_ovs_info(bridge_device, devices_info)}
+    info = get_ovs_info(bridge_device, devices_info)
+    if info:
+        return {OB.CONFIG_SUBTREE: info}
+    else:
+        return {}
 
 
 def get_ovs_info(bridge_device, devices_info):
     port_profiles = _get_slave_profiles(bridge_device, devices_info)
+    ports = _get_bridge_ports_info(port_profiles, devices_info)
+    options = _get_bridge_options(bridge_device)
 
-    return {
-        'port': _get_bridge_ports_info(port_profiles, devices_info),
-        'options': _get_bridge_options(bridge_device),
-    }
+    if ports or options:
+        return {'port': ports, 'options': options}
+    else:
+        return {}
 
 
 def _get_bridge_ports_info(port_profiles, devices_info):


### PR DESCRIPTION
The 'test_bridge_with_internal_interface' test case of 'nm/ovs_test.py'
might fail randomly on line:

    assert not _get_bridge_current_state()

Where _get_bridge_current_state() should return {}.

But when OVS bridge is deleting, libnm might still have the NMDevice
object for the bridge while it has empty data in it, in that case,
we got:

    {
        'bridge': {
            'port': [],
            'options': {}
        }
    }

The fix is treat above data as not exists interface and return {}
instead in `get_bridge_info()` of `nm/ovs.py`