### PR TITLE
nm bond: Handle bond get_info() while deleting

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -46,7 +46,12 @@ def is_bond_type_id(type_id):
 
 
 def get_bond_info(nm_device):
-    return {'slaves': get_slaves(nm_device), 'options': get_options(nm_device)}
+    slaves = get_slaves(nm_device)
+    options = get_options(nm_device)
+    if slaves or options:
+        return {'slaves': slaves, 'options': options}
+    else:
+        return {}
 
 
 def get_options(nm_device):


### PR DESCRIPTION
The test `test_bond_with_a_slave` of `nm/bond_test.py` will fail on

    AssertionError: assert not {'options': {}, 'slaves': []}

Due to the race of doing nm/bond.py get_info() against newly deleted
bond interface.

In order to fix the above scenario, treat the data as if the interface
does not exist and return `{}`.