### PR TITLE
nm.device: support reapply on MTU changes

### DIFF
--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -23,6 +23,8 @@ from . import active_connection as ac
 from . import connection
 from . import nmclient
 
+from distutils.version import StrictVersion
+
 
 def activate(dev=None, connection_id=None):
     """Activate the given device or remote connection profile."""
@@ -186,7 +188,9 @@ def _modify_callback(src_object, result, user_data):
 
 
 def _requires_activation(dev, connection_profile):
-    if _mtu_changed(dev, connection_profile):
+    if StrictVersion(nmclient.nm_version()) < StrictVersion(
+        '1.18'
+    ) and _mtu_changed(dev, connection_profile):
         logging.debug(
             'Device reapply does not support mtu changes, '
             'fallback to device activation: dev=%s',

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -50,6 +50,10 @@ def can_disable_ipv6():
     return _can_disable_ipv6
 
 
+def nm_version():
+    return NM.Client.get_version(client())
+
+
 def client(refresh=False):
     global _nmclient
     # refresh is a workaround to get the current state when GMainLoop is not

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -31,6 +31,7 @@ from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import statelib
+from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.vlan import vlan_interface
 
 
@@ -155,3 +156,14 @@ def test_set_mtu_on_two_vlans_with_a_shared_base(eth1_up):
         libnmstate.apply(desired_state)
 
         assertlib.assert_state(desired_state)
+
+
+@ip_monitor_assert_stable_link_up('eth1')
+def test_change_mtu_with_stable_link_up(eth1_up):
+    desired_state = statelib.show_only(('eth1',))
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1900
+
+    libnmstate.apply(desired_state)
+
+    assertlib.assert_state(desired_state)

--- a/tests/integration/nm/wired_test.py
+++ b/tests/integration/nm/wired_test.py
@@ -19,6 +19,8 @@
 
 import pytest
 
+from distutils.version import StrictVersion
+
 from libnmstate import nm
 from libnmstate import schema
 
@@ -32,7 +34,11 @@ MAC0 = '02:FF:FF:FF:FF:00'
 MTU0 = 1200
 
 
-@pytest.mark.xfail(reason='https://bugzilla.redhat.com/1702657', strict=True)
+@pytest.mark.xfail(
+    condition=StrictVersion(nm.nmclient.nm_version()) < StrictVersion('1.18'),
+    reason='https://bugzilla.redhat.com/1702657',
+    strict=True,
+)
 def test_interface_mtu_change_with_reapply(eth1_up):
     _test_interface_mtu_change(nm.device.reapply)
 


### PR DESCRIPTION
Support reapply on MTU changes as it is supported by NetworkManager
again.

Ref: https://bugzilla.redhat.com/1702657

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>