### PR TITLE
tox: Statically specify black version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands =
 skip_install = true
 basepython = python3.6
 deps =
-    black
+    black==19.3b0
 # style configured via pyproject.toml
 commands =
     black \


### PR DESCRIPTION
Black formatter updates may empose new rules which require changes in
the project code.

In order to control this, the black version is fixed.
From time to time the version needs to be updated and with it adjusting
the code.