### PR TITLE
test stdci: Set CI environment variable

### DIFF
--- a/.environment.yaml
+++ b/.environment.yaml
@@ -1,0 +1,3 @@
+---
+- name: 'CI'
+  value: 'true'


### PR DESCRIPTION
Set CI environment variable as travis did for STDCI. The run-test.sh
script uses it.

Signed-off-by: Gris Ge <fge@redhat.com>

Pulled out from #543

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/564)
<!-- Reviewable:end -->
