### PR TITLE
tox/black: Output diff for black check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ deps =
 commands =
     black \
         --check \
+        --diff \
         {posargs} \
         ./
 


### PR DESCRIPTION
Show the necessary diff to make black pass to make it easier to
understand why black failed and to allow contributors to fix the code
without having to run black themselves.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/565)
<!-- Reviewable:end -->
