### PR TITLE
run-tests: Print a separator when the script fails

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -147,7 +147,25 @@ function collect_artifacts {
     "
 }
 
+function write_separator {
+    set +x
+    local text="$(echo "${1}" | sed 's,., \0,g') "
+    local char="="
+
+    local textlength=$(echo -n "${text}" | wc --chars)
+    local cols="$(tput cols)"
+    local wraplength=$(((cols - textlength) / 2))
+
+    eval printf %.1s "${char}"'{1..'"${wraplength}"\}
+    echo -n "${text}"
+    wraplength=$((wraplength + ((cols - textlength) % 2)))
+    eval printf %.1s "${char}"'{1..'"${wraplength}"\}
+    echo
+    set -x
+}
+
 function run_exit {
+    write_separator "TEARDOWN"
     dump_network_info
     collect_artifacts
     remove_container


### PR DESCRIPTION
When the script fails without running any tests, it is hard to find the
actual failure. Print a marker before the teardown starts to make it
easier to locate the last line that triggered the error.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/567)
<!-- Reviewable:end -->
