### PR TITLE
Linux bridge port vlan filtering

### DIFF
--- a/examples/linuxbrige_eth1_up_port_vlan.yml
+++ b/examples/linuxbrige_eth1_up_port_vlan.yml
@@ -1,0 +1,23 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: linux-br0
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+        - name: eth1
+          stp-hairpin-mode: false
+          stp-path-cost: 100
+          stp-priority: 32
+          vlan:
+            mode: trunk
+            trunk-tags:
+            - id: 101
+            - id-range:
+                min: 500
+                max: 599
+            tag: 100
+            enable-native: true

--- a/libnmstate/appliers/linux_bridge.py
+++ b/libnmstate/appliers/linux_bridge.py
@@ -18,6 +18,15 @@
 #
 
 
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import LinuxBridge as LB
+
+
+BRIDGE_ENABLE_VLAN_FILTERING = "_enable_vlan_filtering"
+
+
 def get_slaves_from_state(state, default=()):
     ports = state.get("bridge", {}).get("port")
     if ports is None:
@@ -29,3 +38,51 @@ def set_bridge_ports_metadata(master_state, slave_state):
     ports = master_state.get("bridge", {}).get("port", [])
     port = next(filter(lambda n: n["name"] == slave_state["name"], ports), {})
     slave_state["_brport_options"] = port
+
+
+def generate_port_vlan_metadata(desired_state, current_state):
+    desired_bridges = _filter_interface_type(
+        desired_state.interfaces, InterfaceType.LINUX_BRIDGE
+    )
+    current_bridges = _filter_interface_type(
+        current_state.interfaces, InterfaceType.LINUX_BRIDGE
+    )
+    desired_port_vlan_status_per_bridge = _get_port_vlan_status(
+        desired_bridges
+    )
+    current_port_vlan_status_per_bridge = _get_port_vlan_status(
+        current_bridges
+    )
+
+    for brname, brstate in desired_bridges.items():
+        desired_port_vlan_status = desired_port_vlan_status_per_bridge.get(
+            brname, {}
+        )
+        current_port_vlan_status = current_port_vlan_status_per_bridge.get(
+            brname, {}
+        )
+        current_port_vlan_status.update(desired_port_vlan_status)
+        enable_vlan_filtering = any(current_port_vlan_status.values())
+        brstate[BRIDGE_ENABLE_VLAN_FILTERING] = enable_vlan_filtering
+
+
+def _get_port_vlan_status(bridges):
+    port_vlan_status = {}
+    for bridge_name, bridge_state in bridges.items():
+        port_vlan_status[bridge_name] = {}
+        bridge_config = bridge_state.get(LB.CONFIG_SUBTREE, {})
+        for port in bridge_config.get(LB.PORT_SUBTREE, []):
+            port_name = port[LB.Port.NAME]
+            bridge_port_vlan_status = port_vlan_status[bridge_name]
+            port_vlan_enabled = LB.Port.VLAN_SUBTREE in port
+            bridge_port_vlan_status[port_name] = port_vlan_enabled
+    return port_vlan_status
+
+
+def _filter_interface_type(interfaces, interface_type):
+    return {
+        if_name: if_state
+        for if_name, if_state in interfaces.items()
+        if if_state.get(Interface.TYPE) == interface_type
+        and if_state.get(Interface.STATE) == InterfaceState.UP
+    }

--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -29,7 +29,6 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
-from libnmstate.schema import LinuxBridge as LB
 
 
 BRPORT_OPTIONS = "_brport_options"
@@ -39,7 +38,6 @@ ROUTES = "_routes"
 DNS_METADATA = "_dns"
 DNS_METADATA_PRIORITY = "_priority"
 ROUTE_RULES_METADATA = "_route_rules"
-BRIDGE_ENABLE_VLAN_FILTERING = "_enable_vlan_filtering"
 
 
 def generate_ifaces_metadata(desired_state, current_state):
@@ -84,9 +82,9 @@ def generate_ifaces_metadata(desired_state, current_state):
         set_metadata_func=lambda *args: None,
     )
     _generate_dns_metadata(desired_state, current_state)
-    _generate_port_vlan_metadata(desired_state, current_state)
     _generate_route_metadata(desired_state, current_state)
     _generate_route_rule_metadata(desired_state)
+    linux_bridge.generate_port_vlan_metadata(desired_state, current_state)
 
 
 def remove_ifaces_metadata(ifaces_state):
@@ -94,7 +92,7 @@ def remove_ifaces_metadata(ifaces_state):
         iface_state.pop(MASTER, None)
         iface_state.pop(MASTER_TYPE, None)
         iface_state.pop(BRPORT_OPTIONS, None)
-        iface_state.pop(BRIDGE_ENABLE_VLAN_FILTERING, None)
+        iface_state.pop(linux_bridge.BRIDGE_ENABLE_VLAN_FILTERING, None)
         iface_state.get(Interface.IPV4, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV6, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV4, {}).pop(DNS_METADATA, None)
@@ -429,51 +427,3 @@ def _init_iface_route_rule_metadata(iface_state, ip_key):
     if not ip_state:
         ip_state = iface_state[ip_key] = {}
     ip_state[ROUTE_RULES_METADATA] = []
-
-
-def _generate_port_vlan_metadata(desired_state, current_state):
-    desired_bridges = _filter_interface_type(
-        desired_state.interfaces, InterfaceType.LINUX_BRIDGE
-    )
-    current_bridges = _filter_interface_type(
-        current_state.interfaces, InterfaceType.LINUX_BRIDGE
-    )
-    desired_port_vlan_status_per_bridge = _get_port_vlan_status(
-        desired_bridges
-    )
-    current_port_vlan_status_per_bridge = _get_port_vlan_status(
-        current_bridges
-    )
-
-    for brname, brstate in desired_bridges.items():
-        desired_port_vlan_status = desired_port_vlan_status_per_bridge.get(
-            brname, {}
-        )
-        current_port_vlan_status = current_port_vlan_status_per_bridge.get(
-            brname, {}
-        )
-        current_port_vlan_status.update(desired_port_vlan_status)
-        enable_vlan_filtering = any(current_port_vlan_status.values())
-        brstate[BRIDGE_ENABLE_VLAN_FILTERING] = enable_vlan_filtering
-
-
-def _get_port_vlan_status(bridges):
-    port_vlan_status = {}
-    for bridge_name, bridge_state in bridges.items():
-        port_vlan_status[bridge_name] = {}
-        bridge_config = bridge_state.get(LB.CONFIG_SUBTREE, {})
-        for port in bridge_config.get(LB.PORT_SUBTREE, []):
-            port_name = port[LB.Port.NAME]
-            bridge_port_vlan_status = port_vlan_status[bridge_name]
-            port_vlan_enabled = LB.Port.VLAN_SUBTREE in port
-            bridge_port_vlan_status[port_name] = port_vlan_enabled
-    return port_vlan_status
-
-
-def _filter_interface_type(interfaces, interface_type):
-    return {
-        if_name: if_state
-        for if_name, if_state in interfaces.items()
-        if if_state.get(Interface.TYPE) == interface_type
-        and if_state.get(Interface.STATE) == InterfaceState.UP
-    }

--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -29,6 +29,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import LinuxBridge as LB
 
 
 BRPORT_OPTIONS = "_brport_options"
@@ -38,6 +39,7 @@ ROUTES = "_routes"
 DNS_METADATA = "_dns"
 DNS_METADATA_PRIORITY = "_priority"
 ROUTE_RULES_METADATA = "_route_rules"
+BRIDGE_ENABLE_VLAN_FILTERING = "_enable_vlan_filtering"
 
 
 def generate_ifaces_metadata(desired_state, current_state):
@@ -82,6 +84,7 @@ def generate_ifaces_metadata(desired_state, current_state):
         set_metadata_func=lambda *args: None,
     )
     _generate_dns_metadata(desired_state, current_state)
+    _generate_port_vlan_metadata(desired_state, current_state)
     _generate_route_metadata(desired_state, current_state)
     _generate_route_rule_metadata(desired_state)
 
@@ -91,6 +94,7 @@ def remove_ifaces_metadata(ifaces_state):
         iface_state.pop(MASTER, None)
         iface_state.pop(MASTER_TYPE, None)
         iface_state.pop(BRPORT_OPTIONS, None)
+        iface_state.pop(BRIDGE_ENABLE_VLAN_FILTERING, None)
         iface_state.get(Interface.IPV4, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV6, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV4, {}).pop(DNS_METADATA, None)
@@ -425,3 +429,51 @@ def _init_iface_route_rule_metadata(iface_state, ip_key):
     if not ip_state:
         ip_state = iface_state[ip_key] = {}
     ip_state[ROUTE_RULES_METADATA] = []
+
+
+def _generate_port_vlan_metadata(desired_state, current_state):
+    desired_bridges = _filter_interface_type(
+        desired_state.interfaces, InterfaceType.LINUX_BRIDGE
+    )
+    current_bridges = _filter_interface_type(
+        current_state.interfaces, InterfaceType.LINUX_BRIDGE
+    )
+    desired_port_vlan_status_per_bridge = _get_port_vlan_status(
+        desired_bridges
+    )
+    current_port_vlan_status_per_bridge = _get_port_vlan_status(
+        current_bridges
+    )
+
+    for brname, brstate in desired_bridges.items():
+        desired_port_vlan_status = desired_port_vlan_status_per_bridge.get(
+            brname, {}
+        )
+        current_port_vlan_status = current_port_vlan_status_per_bridge.get(
+            brname, {}
+        )
+        current_port_vlan_status.update(desired_port_vlan_status)
+        enable_vlan_filtering = any(current_port_vlan_status.values())
+        brstate[BRIDGE_ENABLE_VLAN_FILTERING] = enable_vlan_filtering
+
+
+def _get_port_vlan_status(bridges):
+    port_vlan_status = {}
+    for bridge_name, bridge_state in bridges.items():
+        port_vlan_status[bridge_name] = {}
+        bridge_config = bridge_state.get(LB.CONFIG_SUBTREE, {})
+        for port in bridge_config.get(LB.PORT_SUBTREE, []):
+            port_name = port[LB.Port.NAME]
+            bridge_port_vlan_status = port_vlan_status[bridge_name]
+            port_vlan_enabled = LB.Port.VLAN_SUBTREE in port
+            bridge_port_vlan_status[port_name] = port_vlan_enabled
+    return port_vlan_status
+
+
+def _filter_interface_type(interfaces, interface_type):
+    return {
+        if_name: if_state
+        for if_name, if_state in interfaces.items()
+        if if_state.get(Interface.TYPE) == interface_type
+        and if_state.get(Interface.STATE) == InterfaceState.UP
+    }

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -413,14 +413,10 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
     if bond_opts:
         settings.append(bond.create_setting(bond_opts, wired_setting))
     elif iface_type == bridge.BRIDGE_TYPE:
-        bridge_options = iface_desired_state.get(bridge.BRIDGE_TYPE, {}).get(
-            LB.OPTIONS_SUBTREE
+        linux_bridge_setting = bridge.create_setting(
+            iface_desired_state, base_profile,
         )
-        if bridge_options:
-            linux_bridge_setting = bridge.create_setting(
-                bridge_options, base_profile
-            )
-            settings.append(linux_bridge_setting)
+        settings.append(linux_bridge_setting)
     elif iface_type == ovs.BRIDGE_TYPE:
         ovs_bridge_state = iface_desired_state.get(OvsB.CONFIG_SUBTREE, {})
         ovs_bridge_options = ovs_bridge_state.get(OvsB.OPTIONS_SUBTREE)

--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -24,15 +24,19 @@ from libnmstate.schema import LinuxBridge as LB
 
 
 BRIDGE_TYPE = "bridge"
+BRIDGE_ENABLE_VLAN_FILTERING_METADATA = "_enable_vlan_filtering"
 
 
-def create_setting(options, base_con_profile):
+def create_setting(options, base_con_profile, bridge_desired_state=None):
     bridge_setting = _get_current_bridge_setting(base_con_profile)
     if not bridge_setting:
         bridge_setting = nmclient.NM.SettingBridge.new()
-
     if options:
         _set_bridge_properties(bridge_setting, options)
+    if bridge_desired_state:
+        _set_bridge_properties_from_metadata(
+            bridge_setting, bridge_desired_state
+        )
 
     return bridge_setting
 
@@ -70,6 +74,12 @@ def _set_bridge_stp_properties(bridge_setting, bridge_stp):
                 bridge_setting.props.hello_time = stp_val
             elif stp_key == LB.STP.MAX_AGE:
                 bridge_setting.props.max_age = stp_val
+
+
+def _set_bridge_properties_from_metadata(bridge_setting, metadata):
+    for metadata_name, metadata_value in metadata.items():
+        if metadata_name == BRIDGE_ENABLE_VLAN_FILTERING_METADATA:
+            bridge_setting.props.vlan_filtering = metadata_value
 
 
 def create_port_setting(options, base_con_profile):

--- a/libnmstate/nm/bridge_port_vlan.py
+++ b/libnmstate/nm/bridge_port_vlan.py
@@ -1,0 +1,256 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+from libnmstate.nm import nmclient
+from libnmstate.schema import LinuxBridge as LB
+
+
+class PortVlanFilter(object):
+    Pvid = "pvid"
+    Untagged = "untagged"
+
+    def __init__(self):
+        self._trunk_ports = []
+        self._tag = None
+        self._is_native_vlan = None
+        self._port_type = None
+
+    def create_configuration(self, trunk_tags, tag, is_native_vlan=False):
+        """
+        Fill the PortVlanFilter object with data whose format is tied to the
+        API.
+
+        :param trunk_tags: list of schema.LinuxBridge.Port.Vlan.TrunkTags
+               objects.
+        :param tag: the access tag for access ports, the native vlan ID for
+               trunk ports
+        :param is_native_vlan: boolean attribute indicating if the trunk port
+               has a native vlan.
+        """
+        self._trunk_ports = trunk_tags
+        self._tag = tag
+        self._is_native_vlan = is_native_vlan
+        self._port_type = (
+            LB.Port.Vlan.Mode.TRUNK if trunk_tags else LB.Port.Vlan.Mode.ACCESS
+        )
+
+    @property
+    def trunk_ports(self):
+        return self._trunk_ports
+
+    @property
+    def tag(self):
+        return self._tag
+
+    @property
+    def enable_native_vlan(self):
+        return self._is_native_vlan
+
+    @property
+    def port_type(self):
+        return self._port_type
+
+    def to_nm(self):
+        """
+        Generate a list of NM.BridgeVlan objects from the encapsulated
+        PortVlanFilter data
+        """
+
+        port_vlan_config = []
+        if self.port_type == LB.Port.Vlan.Mode.TRUNK:
+            for trunk_port in self.trunk_ports:
+                port_vlan_config.append(
+                    self._generate_vlan_trunk_port_config(trunk_port)
+                )
+            if self.enable_native_vlan and self.tag:
+                port_vlan_config.append(
+                    self._generate_vlan_access_port_config(self.tag)
+                )
+        elif self.port_type == LB.Port.Vlan.Mode.ACCESS and self.tag:
+            port_vlan_config.append(
+                self._generate_vlan_access_port_config(self.tag)
+            )
+
+        return port_vlan_config
+
+    def to_dict(self):
+        """
+        Get the port vlan filtering configuration in dict format - e.g. in yaml
+        format:
+
+        - name: eth1
+          vlan:
+            type: trunk
+            trunk-tags:
+              - id: 101
+              - id-range:
+                  min: 200
+                  max: 4095
+            tag: 100
+            enable-native: true
+        """
+
+        port_vlan_state = {
+            LB.Port.Vlan.MODE: self.port_type,
+            LB.Port.Vlan.TRUNK_TAGS: self.trunk_ports,
+        }
+        if self.tag:
+            port_vlan_state[LB.Port.Vlan.TAG] = self.tag
+        if self.port_type == LB.Port.Vlan.Mode.TRUNK:
+            port_vlan_state[
+                LB.Port.Vlan.ENABLE_NATIVE
+            ] = self.enable_native_vlan
+        return port_vlan_state
+
+    def import_from_bridge_settings(self, port_vlans):
+        """
+        Instantiates a PortVlanFilter object from a list of NM.BridgeVlan
+        objects.
+        """
+
+        bridge_vlan_config = [
+            self._get_vlan_info(port_vlan_filter_entry)
+            for port_vlan_filter_entry in port_vlans
+        ]
+
+        trunk_tags, tag, enable_native = self._get_vlan_config(
+            bridge_vlan_config
+        )
+
+        self._trunk_ports = trunk_tags
+        self._tag = tag
+        self._is_native_vlan = enable_native
+        self._port_type = (
+            LB.Port.Vlan.Mode.TRUNK if trunk_tags else LB.Port.Vlan.Mode.ACCESS
+        )
+
+    @staticmethod
+    def get_vlan_tag_range(port_vlan):
+        """
+        Extract the vlan tags from the NM.BridgeVlan object.
+        A single NM.BridgeVlan object can have a range of vlan tags, or a
+        single one.
+
+        When a NM.BridgeVlan holds a single tag, the min_range, and max_range
+        returned will have the same vlan tag.
+
+        :return: min_range, max_range
+        """
+
+        port_vlan_tags = port_vlan.to_str().split()
+
+        if "-" in port_vlan_tags[0]:
+            vlan_min, vlan_max = port_vlan_tags[0].split("-")
+            return int(vlan_min), int(vlan_max)
+        else:
+            tag = port_vlan_tags[0]
+            return int(tag), int(tag)
+
+    @staticmethod
+    def _is_access_port(trunk_tags):
+        if (
+            len(trunk_tags) == 1
+            and trunk_tags[0][PortVlanFilter.Pvid]
+            and trunk_tags[0][PortVlanFilter.Untagged]
+        ):
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def _get_vlan_info(port_vlan_info):
+        vlan_min, vlan_max = PortVlanFilter.get_vlan_tag_range(port_vlan_info)
+        pvid = port_vlan_info.is_pvid()
+        untagged = port_vlan_info.is_untagged()
+        if vlan_max != vlan_min:
+            port_data = {
+                LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE: vlan_min,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE: vlan_max,
+                }
+            }
+        else:
+            port_data = {LB.Port.Vlan.TrunkTags.ID: vlan_min}
+        port_data.update(pvid=pvid, untagged=untagged)
+        return port_data
+
+    @staticmethod
+    def _generate_vlan_trunk_port_config(trunk_port):
+        single_vlan_tag = trunk_port.get(LB.Port.Vlan.TrunkTags.ID)
+        ranged_vlan_tags = trunk_port.get(LB.Port.Vlan.TrunkTags.ID_RANGE)
+        port_vlan = None
+
+        if single_vlan_tag:
+            port_vlan = nmclient.NM.BridgeVlan.new(
+                single_vlan_tag, single_vlan_tag
+            )
+        elif ranged_vlan_tags:
+            min_range, max_range = (
+                ranged_vlan_tags[range_type]
+                for range_type in (
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE,
+                )
+            )
+            port_vlan = nmclient.NM.BridgeVlan.new(min_range, max_range)
+        port_vlan.set_untagged(False)
+        port_vlan.set_pvid(False)
+        return port_vlan
+
+    @staticmethod
+    def _generate_vlan_access_port_config(vlan_tag):
+        port_vlan = nmclient.NM.BridgeVlan.new(vlan_tag, vlan_tag)
+        port_vlan.set_untagged(True)
+        port_vlan.set_pvid(True)
+        return port_vlan
+
+    @staticmethod
+    def _get_vlan_config(bridge_vlan_config):
+        enable_native = False
+        trunk_tags = []
+        tag = None
+
+        for port_vlan_filter_entry in bridge_vlan_config:
+            single_vlan_tag = port_vlan_filter_entry.get(
+                LB.Port.Vlan.TrunkTags.ID
+            )
+            ranged_vlan_tags = port_vlan_filter_entry.get(
+                LB.Port.Vlan.TrunkTags.ID_RANGE
+            )
+            if PortVlanFilter._is_access_port(bridge_vlan_config):
+                tag = single_vlan_tag
+            else:
+                if port_vlan_filter_entry[PortVlanFilter.Pvid]:
+                    tag = (
+                        single_vlan_tag
+                        or ranged_vlan_tags[LB.Port.Vlan.TrunkTags.MAX_RANGE]
+                    )
+                    enable_native = True
+                else:
+                    PortVlanFilter._sanitize_trunk_port(port_vlan_filter_entry)
+                    trunk_tags.append(port_vlan_filter_entry)
+
+        return trunk_tags, tag, enable_native
+
+    @staticmethod
+    def _sanitize_trunk_port(port):
+        if PortVlanFilter.Pvid and PortVlanFilter.Untagged in port:
+            del port[PortVlanFilter.Pvid]
+            del port[PortVlanFilter.Untagged]

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -148,3 +148,13 @@ def test_add_remove_team_with_slaves(eth1_up, eth2_up):
 def test_set_ethernet_sriov(eth1_up):
     with example_state("eth1_with_sriov.yml") as desired_state:
         assertlib.assert_state_match(desired_state)
+
+
+def test_port_vlan(eth1_up):
+    with example_state(
+        "linuxbrige_eth1_up_port_vlan.yml",
+        cleanup="linuxbrige_eth1_absent.yml",
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    assertlib.assert_absent("linux-br0")

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -24,7 +24,6 @@ import pytest
 import yaml
 
 import libnmstate
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -395,30 +394,6 @@ def test_activate_empty_bridge_does_not_blocked_by_dhcp():
         assertlib.assert_state(desired_state)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotImplementedError,
-    reason="https://nmstate.atlassian.net/browse/NMSTATE-230",
-    strict=True,
-)
-def test_port_vlan_not_implemented(port0_up):
-    bridge_name = TEST_BRIDGE0
-    port_name = port0_up[Interface.KEY][0][Interface.NAME]
-    port_vlan_config = {
-        LinuxBridge.Port.VLAN_SUBTREE: {
-            LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.ACCESS,
-            LinuxBridge.Port.Vlan.TAG: 101,
-        }
-    }
-
-    bridge_state = _create_bridge_subtree_config((port_name,))
-    bridge_state[LinuxBridge.PORT_SUBTREE][0].update(port_vlan_config)
-    with linux_bridge(bridge_name, bridge_state):
-        pass
-
-
-@pytest.mark.xfail(
-    reason="https://nmstate.atlassian.net/browse/NMSTATE-230", strict=True
-)
 class TestVlanFiltering:
     access_tag = 300
 

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -128,12 +128,12 @@ def _bridge_interface(state):
 @mainloop_run
 def _modify_bridge(bridge_desired_state):
     bridge_config = bridge_desired_state[LB.CONFIG_SUBTREE]
-    _modify_bridge_options(bridge_config)
+    _modify_bridge_options(bridge_desired_state)
     _modify_ports(bridge_config[LB.PORT_SUBTREE])
 
 
-def _modify_bridge_options(bridge_config):
-    br_options = bridge_config.get(LB.OPTIONS_SUBTREE)
+def _modify_bridge_options(bridge_state):
+    br_options = bridge_state.get(LB.CONFIG_SUBTREE).get(LB.OPTIONS_SUBTREE)
     nmdev = nm.device.get_device_by_name(BRIDGE0)
     conn = nm.connection.ConnectionProfile()
     conn.import_by_id(BRIDGE0)
@@ -158,9 +158,7 @@ def _get_bridge_current_state():
 
 @mainloop_run
 def _create_bridge(bridge_desired_state):
-    bridge_config = bridge_desired_state.get(LB.CONFIG_SUBTREE, {})
-    br_options = bridge_config.get(LB.OPTIONS_SUBTREE)
-    iface_bridge_settings = _create_iface_bridge_settings(br_options)
+    iface_bridge_settings = _create_iface_bridge_settings(bridge_desired_state)
 
     _create_bridge_iface(iface_bridge_settings)
     ports_state = bridge_desired_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE]
@@ -208,7 +206,7 @@ def _delete_iface(devname):
     nm.device.delete(nmdev)
 
 
-def _create_iface_bridge_settings(bridge_options, base_con_profile=None):
+def _create_iface_bridge_settings(bridge_state, base_con_profile=None):
     con_profile = None
     con_setting = nm.connection.ConnectionSetting()
     if base_con_profile:
@@ -220,7 +218,7 @@ def _create_iface_bridge_settings(bridge_options, base_con_profile=None):
             iface_name=BRIDGE0,
             iface_type=nm.nmclient.NM.SETTING_BRIDGE_SETTING_NAME,
         )
-    bridge_setting = nm.bridge.create_setting(bridge_options, con_profile)
+    bridge_setting = nm.bridge.create_setting(bridge_state, con_profile)
     ipv4_setting = nm.ipv4.create_setting({}, None)
     ipv6_setting = nm.ipv6.create_setting({}, None)
     return con_setting.setting, bridge_setting, ipv4_setting, ipv6_setting

--- a/tests/lib/metadata_linux_bridge_test.py
+++ b/tests/lib/metadata_linux_bridge_test.py
@@ -21,6 +21,7 @@ import copy
 
 from libnmstate import metadata
 from libnmstate import state
+from libnmstate.appliers import linux_bridge
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
@@ -500,4 +501,4 @@ def _create_metadata_state(bridge_name, port_name):
 
 
 def _create_bridge_metadata_state(vlan_filtering):
-    return {metadata.BRIDGE_ENABLE_VLAN_FILTERING: vlan_filtering}
+    return {linux_bridge.BRIDGE_ENABLE_VLAN_FILTERING: vlan_filtering}

--- a/tests/lib/nm/linux_bridge_vlan_filtering_test.py
+++ b/tests/lib/nm/linux_bridge_vlan_filtering_test.py
@@ -1,0 +1,255 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from unittest import mock
+
+from libnmstate import nm
+from libnmstate.nm.bridge_port_vlan import PortVlanFilter
+from libnmstate.schema import LinuxBridge as LB
+
+
+ACCESS_TAG = 4000
+
+
+@pytest.fixture
+def NM_mock():
+    with mock.patch.object(nm.user.nmclient, "NM") as m:
+        yield m
+
+
+@pytest.mark.parametrize(
+    "trunk_tags",
+    [
+        [],
+        [{LB.Port.Vlan.TrunkTags.ID: 100}],
+        [{LB.Port.Vlan.TrunkTags.ID: 100}, {LB.Port.Vlan.TrunkTags.ID: 101}],
+        [
+            {
+                LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE: 100,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE: 199,
+                }
+            }
+        ],
+        [
+            {
+                LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE: 100,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE: 199,
+                }
+            },
+            {
+                LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE: 500,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE: 1000,
+                }
+            },
+        ],
+        [
+            {LB.Port.Vlan.TrunkTags.ID: 100},
+            {
+                LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                    LB.Port.Vlan.TrunkTags.MIN_RANGE: 500,
+                    LB.Port.Vlan.TrunkTags.MAX_RANGE: 1000,
+                }
+            },
+        ],
+    ],
+    ids=[
+        "no-trunk-tags",
+        "single-trunk-tag",
+        "two-single-trunk-tags",
+        "tag-ranges",
+        "multiple-tag-ranges",
+        "mixed-single-tag-and-tag-ranges",
+    ],
+)
+@pytest.mark.parametrize(
+    "is_native_vlan", [False, True], ids=["not-native-vlan", "native-vlan"]
+)
+def test_generate_nm_vlan_filtering_config(trunk_tags, is_native_vlan):
+    port_vlan_filter = PortVlanFilter()
+    port_vlan_filter.create_configuration(
+        trunk_tags, ACCESS_TAG if is_native_vlan else None, is_native_vlan
+    )
+    port_bridge_vlan_list = port_vlan_filter.to_nm()
+    expected_trunk_tag_length = len(trunk_tags) + (1 if is_native_vlan else 0)
+    assert expected_trunk_tag_length == len(port_bridge_vlan_list)
+    assert is_native_vlan == any(
+        [
+            port_bridge_vlan.is_pvid() and port_bridge_vlan.is_untagged()
+            for port_bridge_vlan in port_bridge_vlan_list
+        ]
+    )
+    desired_trunk_tags = _port_vlan_trunk_tags_to_tag_list(
+        trunk_tags, ACCESS_TAG, is_native_vlan
+    )
+    _assert_port_settings_vlan_conf(port_bridge_vlan_list, desired_trunk_tags)
+
+
+@pytest.mark.parametrize(
+    "trunk_tags",
+    [
+        [],
+        [100],
+        [100, 200],
+        [(100, 200)],
+        [100, (200, 300)],
+        [(100, 200), (300, 400)],
+    ],
+    ids=[
+        "access-port",
+        "single-trunk-tag",
+        "two-trunk-tags",
+        "one-tag-range",
+        "mixed-tag-and-range",
+        "multiple-ranges",
+    ],
+)
+@pytest.mark.parametrize(
+    "is_native_vlan", [False, True], ids=["not-native-vlan", "native-vlan"]
+)
+def test_bridge_port_vlan_to_dict(NM_mock, trunk_tags, is_native_vlan):
+    port_vlans = _generate_port_vlan_mocks(
+        trunk_tags, is_native_vlan, ACCESS_TAG
+    )
+
+    vlan_config = PortVlanFilter()
+    vlan_config.import_from_bridge_settings(port_vlans)
+    assert vlan_config.tag == (
+        ACCESS_TAG if (not trunk_tags or is_native_vlan) else None
+    )
+    assert len(vlan_config.trunk_ports) == len(trunk_tags)
+    assert vlan_config.enable_native_vlan == (
+        is_native_vlan and len(trunk_tags) > 0
+    )
+    assert vlan_config.to_dict() == _get_vlan_config_dict(
+        trunk_tags, ACCESS_TAG, is_native_vlan
+    )
+
+
+def _port_vlan_trunk_tags_to_tag_list(trunk_tags, access_tag, enable_vlan):
+    tag_list = []
+    for trunk_tag in trunk_tags:
+        single_tag = trunk_tag.get(LB.Port.Vlan.TrunkTags.ID)
+        range_tags = trunk_tag.get(LB.Port.Vlan.TrunkTags.ID_RANGE, {})
+        if single_tag:
+            tag_list.append(single_tag)
+        else:
+            for tag in range(
+                range_tags.get(LB.Port.Vlan.TrunkTags.MIN_RANGE),
+                range_tags.get(LB.Port.Vlan.TrunkTags.MAX_RANGE) + 1,
+            ):
+                tag_list.append(tag)
+    if enable_vlan:
+        tag_list.append(access_tag)
+    return tag_list
+
+
+def _assert_port_settings_vlan_conf(port_vlans, desired_vlans):
+    expected_vlans = set(desired_vlans)
+    for port_vlan in port_vlans:
+        min_vlan, max_vlan = PortVlanFilter.get_vlan_tag_range(port_vlan)
+        for i in range(min_vlan, max_vlan + 1):
+            expected_vlans.remove(i)
+    assert not expected_vlans, "vlans: {} were not configured".format(
+        expected_vlans
+    )
+
+
+def _generate_port_vlan_mocks(trunk_tags, is_native_vlan, access_tag):
+    port_vlans = []
+    for trunk_tag in trunk_tags:
+        if _is_trunk_tag_ranged(trunk_tag):
+            min_tag_range, max_tag_range = (trunk_tag[i] for i in range(2))
+            trunk_tag_vlan_config = _generate_bridge_vlan_mock(
+                min_tag_range, max_tag_range, pvid=False, untagged=False
+            )
+        else:
+            trunk_tag_vlan_config = _generate_bridge_vlan_mock(
+                trunk_tag, trunk_tag, pvid=False, untagged=False
+            )
+        port_vlans.append(trunk_tag_vlan_config)
+    if is_native_vlan or not trunk_tags:
+        port_vlans.append(
+            _generate_bridge_vlan_mock(
+                access_tag, access_tag, pvid=True, untagged=True
+            )
+        )
+    return port_vlans
+
+
+def _is_trunk_tag_ranged(trunk_tag):
+    return (
+        isinstance(trunk_tag, tuple) or isinstance(trunk_tag, list)
+    ) and len(trunk_tag) == 2
+
+
+def _generate_bridge_vlan_mock(
+    min_tag_range, max_tag_range, pvid=False, untagged=False
+):
+    bridge_vlan = mock.MagicMock()
+    bridge_vlan.is_untagged.return_value = untagged
+    bridge_vlan.is_pvid.return_value = pvid
+    bridge_vlan.to_str.return_value = "{}{}".format(
+        min_tag_range,
+        "-{}".format(max_tag_range) if max_tag_range != min_tag_range else "",
+    )
+    return bridge_vlan
+
+
+def _get_vlan_config_dict(trunk_tags, access_tag, enable_native_vlan):
+    vlan_config_dict = {
+        LB.Port.Vlan.MODE: _get_port_vlan_type(trunk_tags),
+        LB.Port.Vlan.TRUNK_TAGS: _tag_list_to_trunk_tags(trunk_tags),
+    }
+    if trunk_tags:
+        if enable_native_vlan:
+            vlan_config_dict[LB.Port.Vlan.TAG] = access_tag
+        vlan_config_dict[LB.Port.Vlan.ENABLE_NATIVE] = enable_native_vlan
+    else:
+        vlan_config_dict[LB.Port.Vlan.TAG] = access_tag
+    return vlan_config_dict
+
+
+def _tag_list_to_trunk_tags(tag_config_list):
+    trunk_tags = []
+    for tag_config in tag_config_list:
+        if isinstance(tag_config, list) or isinstance(tag_config, tuple):
+            min_range, max_range = tag_config
+            trunk_tags.append(
+                {
+                    LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                        LB.Port.Vlan.TrunkTags.MIN_RANGE: min_range,
+                        LB.Port.Vlan.TrunkTags.MAX_RANGE: max_range,
+                    }
+                }
+            )
+        else:
+            trunk_tags.append({LB.Port.Vlan.TrunkTags.ID: tag_config})
+    return trunk_tags
+
+
+def _get_port_vlan_type(trunk_tags):
+    if not trunk_tags:
+        return LB.Port.Vlan.Mode.ACCESS
+    else:
+        return LB.Port.Vlan.Mode.TRUNK

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -36,6 +36,10 @@ from libnmstate.schema import RouteRule
 from libnmstate.schema import Team
 from libnmstate.schema import VXLAN
 
+from .testlib.portvlanlib import generate_vlan_id_config
+from .testlib.portvlanlib import generate_vlan_id_range_config
+from .testlib.portvlanlib import generate_vlan_filtering_config
+
 
 INTERFACES = Constants.INTERFACES
 ROUTES = Constants.ROUTES
@@ -455,7 +459,7 @@ class TestLinuxBridgeVlanFiltering:
         argvalues=[LB.Port.Vlan.Mode.TRUNK, LB.Port.Vlan.Mode.ACCESS],
     )
     def test_vlan_port_types(self, default_data, bridge_state, port_type):
-        valid_port_type = self._generate_vlan_filtering_config(port_type)
+        valid_port_type = generate_vlan_filtering_config(port_type)
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(valid_port_type)
         default_data[Interface.KEY].append(bridge_state)
@@ -463,7 +467,7 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_invalid_vlan_port_type(self, default_data, bridge_state):
-        invalid_port_type = self._generate_vlan_filtering_config("fake-type")
+        invalid_port_type = generate_vlan_filtering_config("fake-type")
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_port_type)
         default_data[Interface.KEY].append(bridge_state)
@@ -472,8 +476,8 @@ class TestLinuxBridgeVlanFiltering:
             libnmstate.validator.validate(default_data)
 
     def test_access_port_accepted(self, default_data, bridge_state):
-        vlan_access_port_state = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag=101
+        vlan_access_port_state = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag=101
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(vlan_access_port_state)
@@ -482,8 +486,8 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_wrong_access_port_tag_type(self, default_data, bridge_state):
-        invalid_access_port_tag_type = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag="holy-guacamole!"
+        invalid_access_port_tag_type = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag="holy-guacamole!"
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_access_port_tag_type)
@@ -493,8 +497,8 @@ class TestLinuxBridgeVlanFiltering:
             libnmstate.validator.validate(default_data)
 
     def test_wrong_access_tag_range(self, default_data, bridge_state):
-        invalid_vlan_id_range = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag=48000
+        invalid_vlan_id_range = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag=48000
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_vlan_id_range)
@@ -509,9 +513,9 @@ class TestLinuxBridgeVlanFiltering:
     def test_trunk_port_native_vlan(
         self, default_data, bridge_state, is_native_vlan
     ):
-        vlan_access_port_state = self._generate_vlan_filtering_config(
+        vlan_access_port_state = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK,
-            access_tag=101 if is_native_vlan else None,
+            tag=101 if is_native_vlan else None,
             native_vlan=is_native_vlan,
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
@@ -521,9 +525,9 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_trunk_ports(self, default_data, bridge_state):
-        trunk_tags = self._generate_vlan_id_config(101, 102, 103)
-        trunk_tags.append(self._generate_vlan_id_range_config(500, 1000))
-        vlan_trunk_tags_port_state = self._generate_vlan_filtering_config(
+        trunk_tags = generate_vlan_id_config(101, 102, 103)
+        trunk_tags.append(generate_vlan_id_range_config(500, 1000))
+        vlan_trunk_tags_port_state = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK, trunk_tags=trunk_tags
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
@@ -533,9 +537,9 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_invalid_trunk_port_vlan_range(self, default_data, bridge_state):
-        invalid_port_vlan_configuration = self._generate_vlan_filtering_config(
+        invalid_port_vlan_configuration = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK,
-            trunk_tags=[self._generate_vlan_id_range_config(100, 5000)],
+            trunk_tags=[generate_vlan_id_range_config(100, 5000)],
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_port_vlan_configuration)
@@ -543,35 +547,6 @@ class TestLinuxBridgeVlanFiltering:
 
         with pytest.raises(js.ValidationError):
             libnmstate.validator.validate(default_data)
-
-    @staticmethod
-    def _generate_vlan_filtering_config(
-        port_type, trunk_tags=None, access_tag=None, native_vlan=None
-    ):
-        vlan_filtering_state = {
-            LB.Port.Vlan.MODE: port_type,
-            LB.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
-        }
-
-        if access_tag:
-            vlan_filtering_state[LB.Port.Vlan.TAG] = access_tag
-        if native_vlan:
-            vlan_filtering_state[LB.Port.Vlan.ENABLE_NATIVE] = native_vlan
-
-        return {LB.Port.VLAN_SUBTREE: vlan_filtering_state}
-
-    @staticmethod
-    def _generate_vlan_id_config(*vlan_ids):
-        return [{LB.Port.Vlan.TrunkTags.ID: vlan_id} for vlan_id in vlan_ids]
-
-    @staticmethod
-    def _generate_vlan_id_range_config(min_vlan_id, max_vlan_id):
-        return {
-            LB.Port.Vlan.TrunkTags.ID_RANGE: {
-                LB.Port.Vlan.TrunkTags.MIN_RANGE: min_vlan_id,
-                LB.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
-            }
-        }
 
 
 class TestOvsBridgeVlan:
@@ -583,7 +558,7 @@ class TestOvsBridgeVlan:
         ],
     )
     def test_vlan_port_modes(self, default_data, ovs_bridge_state, vlan_mode):
-        valid_vlan_mode = self._generate_vlan_config(vlan_mode)
+        valid_vlan_mode = generate_vlan_filtering_config(vlan_mode)
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
         the_port.update(valid_vlan_mode)
@@ -592,7 +567,7 @@ class TestOvsBridgeVlan:
         libnmstate.validator.validate(default_data)
 
     def test_invalid_vlan_port_mode(self, default_data, ovs_bridge_state):
-        invalid_vlan_mode = self._generate_vlan_config("fake-mode")
+        invalid_vlan_mode = generate_vlan_filtering_config("fake-mode")
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
         the_port.update(invalid_vlan_mode)
@@ -602,8 +577,8 @@ class TestOvsBridgeVlan:
             libnmstate.validator.validate(default_data)
 
     def test_access_port_accepted(self, default_data, ovs_bridge_state):
-        vlan_access_port_state = self._generate_vlan_config(
-            OVSBridge.Port.Vlan.Mode.ACCESS, access_tag=101
+        vlan_access_port_state = generate_vlan_filtering_config(
+            OVSBridge.Port.Vlan.Mode.ACCESS, tag=101
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
@@ -613,8 +588,8 @@ class TestOvsBridgeVlan:
         libnmstate.validator.validate(default_data)
 
     def test_wrong_access_port_tag_mode(self, default_data, ovs_bridge_state):
-        invalid_access_port_tag_mode = self._generate_vlan_config(
-            OVSBridge.Port.Vlan.Mode.ACCESS, access_tag="holy-guacamole!"
+        invalid_access_port_tag_mode = generate_vlan_filtering_config(
+            OVSBridge.Port.Vlan.Mode.ACCESS, tag="holy-guacamole!"
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
@@ -625,8 +600,8 @@ class TestOvsBridgeVlan:
             libnmstate.validator.validate(default_data)
 
     def test_wrong_access_tag_range(self, default_data, ovs_bridge_state):
-        invalid_vlan_id_range = self._generate_vlan_config(
-            OVSBridge.Port.Vlan.Mode.ACCESS, access_tag=48000
+        invalid_vlan_id_range = generate_vlan_filtering_config(
+            OVSBridge.Port.Vlan.Mode.ACCESS, tag=48000
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
@@ -642,9 +617,9 @@ class TestOvsBridgeVlan:
     def test_trunk_port_native_vlan(
         self, default_data, ovs_bridge_state, is_native_vlan
     ):
-        vlan_access_port_state = self._generate_vlan_config(
+        vlan_access_port_state = generate_vlan_filtering_config(
             OVSBridge.Port.Vlan.Mode.TRUNK,
-            access_tag=101 if is_native_vlan else None,
+            tag=101 if is_native_vlan else None,
             native_vlan=is_native_vlan,
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
@@ -655,9 +630,9 @@ class TestOvsBridgeVlan:
         libnmstate.validator.validate(default_data)
 
     def test_trunk_ports(self, default_data, ovs_bridge_state):
-        trunk_tags = self._generate_vlan_id_config(101, 102, 103)
-        trunk_tags.append(self._generate_vlan_id_range_config(500, 1000))
-        vlan_trunk_tags_port_state = self._generate_vlan_config(
+        trunk_tags = generate_vlan_id_config(101, 102, 103)
+        trunk_tags.append(generate_vlan_id_range_config(500, 1000))
+        vlan_trunk_tags_port_state = generate_vlan_filtering_config(
             OVSBridge.Port.Vlan.Mode.TRUNK, trunk_tags=trunk_tags
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
@@ -670,9 +645,9 @@ class TestOvsBridgeVlan:
     def test_invalid_trunk_port_vlan_range(
         self, default_data, ovs_bridge_state
     ):
-        invalid_port_vlan_configuration = self._generate_vlan_config(
+        invalid_port_vlan_configuration = generate_vlan_filtering_config(
             OVSBridge.Port.Vlan.Mode.TRUNK,
-            trunk_tags=[self._generate_vlan_id_range_config(100, 5000)],
+            trunk_tags=[generate_vlan_id_range_config(100, 5000)],
         )
         bridge_state_config = ovs_bridge_state[OVSBridge.CONFIG_SUBTREE]
         the_port = bridge_state_config[OVSBridge.PORT_SUBTREE][0]
@@ -681,38 +656,6 @@ class TestOvsBridgeVlan:
 
         with pytest.raises(js.ValidationError):
             libnmstate.validator.validate(default_data)
-
-    @staticmethod
-    def _generate_vlan_config(
-        vlan_mode, trunk_tags=None, access_tag=None, native_vlan=None
-    ):
-        vlan_state = {
-            OVSBridge.Port.Vlan.MODE: vlan_mode,
-            OVSBridge.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
-        }
-
-        if access_tag:
-            vlan_state[OVSBridge.Port.Vlan.TAG] = access_tag
-        if native_vlan:
-            enable_native = OVSBridge.Port.Vlan.ENABLE_NATIVE
-            vlan_state[enable_native] = native_vlan
-
-        return {OVSBridge.Port.VLAN_SUBTREE: vlan_state}
-
-    @staticmethod
-    def _generate_vlan_id_config(*vlan_ids):
-        return [
-            {OVSBridge.Port.Vlan.TrunkTags.ID: vlan_id} for vlan_id in vlan_ids
-        ]
-
-    @staticmethod
-    def _generate_vlan_id_range_config(min_vlan_id, max_vlan_id):
-        return {
-            OVSBridge.Port.Vlan.TrunkTags.ID_RANGE: {
-                OVSBridge.Port.Vlan.TrunkTags.MIN_RANGE: min_vlan_id,
-                OVSBridge.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
-            }
-        }
 
 
 class TestRouteRules:

--- a/tests/lib/testlib/portvlanlib.py
+++ b/tests/lib/testlib/portvlanlib.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import LinuxBridge
+
+
+def update_bridge_port_vlan_config(bridge, port_name, vlan_config):
+    port_subtree = bridge[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE]
+    port = next((port for port in port_subtree if port["name"] == port_name))
+
+    port[LinuxBridge.Port.VLAN_SUBTREE] = vlan_config
+
+
+def generate_vlan_filtering_config(
+    port_type, trunk_tags=None, tag=None, native_vlan=None
+):
+    vlan_filtering_state = {
+        LinuxBridge.Port.Vlan.MODE: port_type,
+        LinuxBridge.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
+    }
+
+    if tag:
+        vlan_filtering_state[LinuxBridge.Port.Vlan.TAG] = tag
+    if native_vlan is not None:
+        vlan_filtering_state[LinuxBridge.Port.Vlan.ENABLE_NATIVE] = native_vlan
+
+    return {LinuxBridge.Port.VLAN_SUBTREE: vlan_filtering_state}
+
+
+def generate_vlan_id_config(*vlan_ids):
+    return [
+        {LinuxBridge.Port.Vlan.TrunkTags.ID: vlan_id} for vlan_id in vlan_ids
+    ]
+
+
+def generate_vlan_id_range_config(min_vlan_id, max_vlan_id):
+    return {
+        LinuxBridge.Port.Vlan.TrunkTags.ID_RANGE: {
+            LinuxBridge.Port.Vlan.TrunkTags.MIN_RANGE: min_vlan_id,
+            LinuxBridge.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
+        }
+    }


### PR DESCRIPTION
Implement vlan filtering for linux bridge ports
    
This patch implements trunk ports and access ports as per the port vlan schema, introduced in [0].

[0] - https://github.com/nmstate/nmstate/pull/440
    
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

Depends on #591 