### PR TITLE
Prepare run-tests.sh for podman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+dist: bionic
 language: generic
 env:
     matrix:
@@ -29,7 +30,6 @@ addons:
         packages:
             - git
             - gnupg2
-            - realpath
             - openssh-client
             - python-tox
             - xz-utils

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -7,9 +7,6 @@ CONT_EXPORT_DIR="/exported-artifacts"
 
 CONTAINER_WORKSPACE="/workspace/nmstate"
 
-NET0="nmstate-net0"
-NET1="nmstate-net1"
-
 TEST_TYPE_ALL="all"
 TEST_TYPE_FORMAT="format"
 TEST_TYPE_LINT="lint"
@@ -27,8 +24,6 @@ function remove_container {
     [ "$res" -ne 0 ] && echo "*** ERROR: $res"
     docker_exec 'rm -rf $CONTAINER_WORKSPACE/*nmstate*.rpm'
     docker rm $CONTAINER_ID -f
-    docker network rm $NET0
-    docker network rm $NET1
 }
 
 function pyclean {
@@ -42,13 +37,11 @@ function docker_exec {
 }
 
 function add_extra_networks {
-    docker network create $NET0 || true
-    docker network create $NET1 || true
-    docker network connect $NET0 $CONTAINER_ID
-    docker network connect $NET1 $CONTAINER_ID
     docker_exec '
-      ip addr flush eth1 && \
-      ip addr flush eth2
+      ip link add eth1 type veth peer eth1peer && \
+      ip link add eth2 type veth peer eth2peer && \
+      ip link set eth1peer up && \
+      ip link set eth2peer up
     '
 }
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -293,9 +293,9 @@ dump_network_info
 
 pyclean
 if [[ "$CI" != "true" ]];then
-    container_exec "cp -rf $CONTAINER_WORKSPACE /tmp/"
+    container_exec "cp -rf $CONTAINER_WORKSPACE /root/nmstate-workspace"
     # Change workspace to keep the original one clean
-    CONTAINER_WORKSPACE="/tmp/nmstate"
+    CONTAINER_WORKSPACE="/root/nmstate-workspace"
 fi
 install_nmstate
 run_tests


### PR DESCRIPTION
The first commit allows to run multiple containers at once without error messages regarding the docker networks. The other commits also prepare run-tests.sh to be used with podman.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/577)
<!-- Reviewable:end -->
