### PR TITLE
Travis: Make CentOS 8 test the canonical tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@
 language: generic
 env:
     matrix:
-        - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
-          testflags="--test-type integ --pytest-args='-x'"
         - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
-        - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
+        - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
-        - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
-          testflags="--test-type integ --pytest-args='-x'
-              --copr networkmanager/NetworkManager-1.20"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type format"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
@@ -24,13 +19,8 @@ env:
 matrix:
     allow_failures:
         - env: DOCKER_IMAGE=nmstate/centos8-nmstate-dev
-               testflags="--test-type integ --pytest-args='-x'"
-        - env: DOCKER_IMAGE=nmstate/fedora-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
-        - env: DOCKER_IMAGE=nmstate/fedora-nmstate-dev
-               testflags="--test-type integ --pytest-args='-x'
-                   --copr networkmanager/NetworkManager-1.20"
 
 addons:
     apt:


### PR DESCRIPTION
Since the CI keeps failing on Fedora, only use CentOS 8 images for now.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/580)
<!-- Reviewable:end -->
