### PR TITLE
stdci: Use CentOS 8

### DIFF
--- a/.environment.yaml
+++ b/.environment.yaml
@@ -1,3 +1,0 @@
----
-- name: 'CI'
-  value: 'true'

--- a/.stdci.yml
+++ b/.stdci.yml
@@ -6,4 +6,4 @@ Architectures:
       runtime-requirements:
         host-distro: same
 script:
-    from-file: automation/run-tests.sh
+  from-file: automation/run-tests.sh

--- a/automation/run-tests.environment.yaml
+++ b/automation/run-tests.environment.yaml
@@ -3,3 +3,5 @@
   value: 'integ'
 - name: 'DOCKER_IMAGE'
   value: 'nmstate/fedora-nmstate-dev'
+- name: 'CI'
+  value: 'true'

--- a/automation/run-tests.environment.yaml
+++ b/automation/run-tests.environment.yaml
@@ -2,6 +2,6 @@
 - name: 'TEST_TYPE'
   value: 'integ'
 - name: 'DOCKER_IMAGE'
-  value: 'nmstate/fedora-nmstate-dev'
+  value: 'nmstate/centos8-nmstate-dev'
 - name: 'CI'
   value: 'true'


### PR DESCRIPTION
Use CentOS 8 for stdci because the Fedora tests are currently
meaningless. Since CentOS 8 only supports the integration tests for now,
run only the integration tests.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/582)
<!-- Reviewable:end -->
