### PR TITLE
Don't block on DHCP when activating virtual device

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -34,6 +34,7 @@ class ActivationError(Exception):
 class ActiveConnection(object):
     def __init__(self, active_connection=None):
         self.handlers = set()
+        self.device_handlers = set()
         self._act_con = active_connection
         self._mainloop = nmclient.mainloop()
 
@@ -180,6 +181,9 @@ class ActiveConnection(object):
         for handler_id in self.handlers:
             self.nm_active_connection.handler_disconnect(handler_id)
         self.handlers = set()
+        for handler_id in self.device_handlers:
+            self.nmdevice.handler_disconnect(handler_id)
+        self.device_handlers = set()
 
 
 def _is_device_master_type(nmdev):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -311,6 +311,26 @@ def test_rollback_for_linux_bridge():
     assert original_state == current_state
 
 
+def test_activate_empty_bridge_does_not_blocked_by_dhcp():
+    bridge_name = TEST_BRIDGE0
+    bridge_state = None
+    extra_iface_state = {
+        Interface.IPV4: {
+            InterfaceIPv4.ENABLED: True,
+            InterfaceIPv4.DHCP: True,
+        },
+        Interface.IPV6: {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.AUTOCONF: True,
+            InterfaceIPv6.DHCP: True,
+        },
+    }
+    with linux_bridge(
+        bridge_name, bridge_state, extra_iface_state
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+
 def _add_port_to_bridge(bridge_state, ifname):
     port_state = yaml.load(BRIDGE_PORT_YAML, Loader=yaml.SafeLoader)
     add_port_to_bridge(bridge_state, ifname, port_state)


### PR DESCRIPTION
Treat virtual device `IP_CONFIG` state as activation finished.

Previously, the code only hook on 'state-change' signal of
active connection which is not sufficient to track the device
state of `IP_CONFIG`. This patch add code to hook on 'state-change'
signal of device.