### PR TITLE
test ci: Fix the hang of nmcli command

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -55,7 +55,9 @@ function add_extra_networks {
 function dump_network_info {
     docker_exec '
       nmcli dev; \
-      nmcli con; \
+      # Use empty PAGER variable to stop nmcli send output to less which hang \
+      # the CI. \
+      PAGER= nmcli con; \
       ip addr; \
       ip route; \
       cat /etc/resolv.conf; \


### PR DESCRIPTION
~~The 'nmcli con' might(30% chances) hang for 10+ minutes when we dumping
network information before exit.~~

~~This fail our CI tests and the information it provides is not helpful
in most case.~~

In CI system, the `nmcli con` will use pager(less) when the text length exceeded
80 which cause the command hang for 10 minutes.

Set $PAGER environment variable as empty string will fix this.
