### PR TITLE
tox: Remove check-py27 from envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black, flake8, pylint, check-{py27,py36,py37}
+envlist = black, flake8, pylint, check-{py36,py37}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
The environment was removed earlier.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/585)
<!-- Reviewable:end -->
