### PR TITLE
nm.device: delete inactive profiles when editting an interface

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -54,6 +54,12 @@ def create_new_ifaces(con_profiles):
 
 
 def prepare_new_ifaces_configuration(ifaces_desired_state):
+    # Delete the existing profiles before create the new ones
+    for iface_desired_state in ifaces_desired_state:
+        connection.delete_iface_inactive_connections(
+            iface_desired_state[Interface.NAME]
+        )
+
     return [
         _build_connection_profile(iface_desired_state)
         for iface_desired_state in ifaces_desired_state
@@ -79,7 +85,8 @@ def prepare_edited_ifaces_configuration(ifaces_desired_state):
     con_profiles = []
 
     for iface_desired_state in ifaces_desired_state:
-        nmdev = device.get_device_by_name(iface_desired_state[Interface.NAME])
+        ifname = iface_desired_state[Interface.NAME]
+        nmdev = device.get_device_by_name(ifname)
         cur_con_profile = None
         if nmdev:
             cur_con_profile = connection.ConnectionProfile()
@@ -95,6 +102,7 @@ def prepare_edited_ifaces_configuration(ifaces_desired_state):
             con_profiles.append(cur_con_profile)
         else:
             # Missing connection, attempting to create a new one.
+            connection.delete_iface_inactive_connections(ifname)
             con_profiles.append(new_con_profile)
 
     return con_profiles

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -450,3 +450,16 @@ def get_device_active_connection(nm_device):
     if nm_device:
         active_conn = nm_device.get_active_connection()
     return active_conn
+
+
+def delete_iface_inactive_connections(ifname):
+    for con in list_connections_by_ifname(ifname):
+        con.delete()
+
+
+def list_connections_by_ifname(ifname):
+    return [
+        ConnectionProfile(con)
+        for con in nmclient.NM.Client.get_connections(nmclient.client())
+        if con.get_interface_name() == ifname
+    ]

--- a/tests/integration/profile_test.py
+++ b/tests/integration/profile_test.py
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+import os
+
+
+import pytest
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+
+from .testlib import cmd as libcmd
+
+
+DUMMY0_IFNAME = 'dummy0'
+
+NMCLI_CON_ADD_DUMMY_CMD = [
+    'nmcli',
+    'con',
+    'add',
+    'type',
+    'dummy',
+    'con-name',
+    'testProfile',
+    'connection.autoconnect',
+    'no',
+    'ifname',
+    DUMMY0_IFNAME,
+]
+
+NMCLI_CON_ADD_ETH_CMD = [
+    'nmcli',
+    'con',
+    'add',
+    'type',
+    'ethernet',
+    'con-name',
+    'testProfile',
+    'connection.autoconnect',
+    'no',
+    'ifname',
+    'eth1',
+]
+
+DUMMY_PROFILE_DIRECTORY = '/etc/NetworkManager/system-connections/'
+
+ETH_PROFILE_DIRECTORY = '/etc/sysconfig/network-scripts/'
+
+
+def test_delete_new_interface_inactive_profiles(dummy_inactive_profile):
+    with dummy_interface(dummy_inactive_profile):
+        profile_exists = _profile_exists(
+            DUMMY_PROFILE_DIRECTORY + 'testProfile.nmconnection'
+        )
+        assert not profile_exists
+
+
+def test_delete_existing_interface_inactive_profiles(eth1_up):
+    with create_inactive_profile(eth1_up[Interface.KEY][0][Interface.NAME]):
+        eth1_up[Interface.KEY][0][Interface.MTU] = 2000
+        libnmstate.apply(eth1_up)
+        profile_exists = _profile_exists(
+            ETH_PROFILE_DIRECTORY + 'ifcfg-testProfile'
+        )
+        assert not profile_exists
+
+
+@contextmanager
+def dummy_interface(ifname):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: ifname,
+                Interface.TYPE: InterfaceType.DUMMY,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    try:
+        yield
+    finally:
+        dummy0_dstate = desired_state[Interface.KEY][0]
+        dummy0_dstate[Interface.STATE] = InterfaceState.ABSENT
+        libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def dummy_inactive_profile():
+    libcmd.exec_cmd(NMCLI_CON_ADD_DUMMY_CMD)
+    profile_exists = _profile_exists(
+        DUMMY_PROFILE_DIRECTORY + 'testProfile.nmconnection'
+    )
+    assert profile_exists
+    try:
+        yield DUMMY0_IFNAME
+    finally:
+        libcmd.exec_cmd(_nmcli_delete_connection('testProfile'))
+
+
+@contextmanager
+def create_inactive_profile(con_name):
+    libcmd.exec_cmd(_nmcli_deactivate_connection(con_name))
+    libcmd.exec_cmd(NMCLI_CON_ADD_ETH_CMD)
+    profile_exists = _profile_exists(
+        ETH_PROFILE_DIRECTORY + 'ifcfg-testProfile'
+    )
+    assert profile_exists
+    try:
+        yield
+    finally:
+        libcmd.exec_cmd(_nmcli_delete_connection('testProfile'))
+
+
+def _nmcli_deactivate_connection(con_name):
+    return ['nmcli', 'con', 'down', con_name]
+
+
+def _nmcli_delete_connection(con_name):
+    return ['nmcli', 'con', 'delete', con_name]
+
+
+def _profile_exists(profile_name):
+    return os.path.isfile(profile_name)


### PR DESCRIPTION
When editting an interface that doesn't have an active profile we are
creating a new profile. Now, we are deleting all the inactive profiles
of an interface before creating the new one.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>