### PR TITLE
nm: Fix ActiveConnection.is_activating

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -142,7 +142,10 @@ class ActiveConnection(object):
 
     @property
     def is_activating(self):
-        return self.state == nmclient.NM.ActiveConnectionState.ACTIVATING
+        return (
+            self.state == nmclient.NM.ActiveConnectionState.ACTIVATING
+            and not self.is_active
+        )
 
     @property
     def reason(self):


### PR DESCRIPTION
The `ActiveConnection.is_activating` is overlapping
with `ActiveConnection.is_active` when master interface
in IP_CONFIG mode, overlap removed by this patch.