### PR TITLE
integration tests: Remove preserve_old_config fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,8 +22,6 @@ import subprocess
 
 import pytest
 
-import libnmstate
-
 from .testlib import ifacelib
 
 
@@ -41,7 +39,7 @@ def logging_setup():
 
 
 @pytest.fixture(scope='session', autouse=True)
-def ethx_init(preserve_old_config):
+def ethx_init():
     """ Remove any existing definitions on the ethX interfaces. """
     ifacelib.ifaces_init('eth1', 'eth2')
 
@@ -60,13 +58,6 @@ def eth2_up():
 
 port0_up = eth1_up
 port1_up = eth2_up
-
-
-@pytest.fixture(scope='session', autouse=True)
-def preserve_old_config():
-    old_state = libnmstate.show()
-    yield
-    libnmstate.apply(old_state, verify_change=False)
 
 
 def pytest_report_header(config):


### PR DESCRIPTION
The `preserve_old_config` fixture fails when Nmstate reports a
configuration that it cannot set, for example a gateway together with
DHCPv6 and autoconf. If someone needs to restore a certain network state
after running the tests, they need to use a custom wrapper/script to do
so.

References:
https://lists.fedorahosted.org/archives/list/nmstate-devel@lists.fedorahosted.org/thread/XFMPA5IMYCQCDWUSSNGVDBQA7BKB2N3N/
https://nmstate.atlassian.net/browse/NMSTATE-275

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/588)
<!-- Reviewable:end -->
