### PR TITLE
nm: Don't block activation on DHCP/Autoconf for all interface types

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -165,3 +165,12 @@ def acs_and_ip_profiles(client):
         if not ip_profile:
             continue
         yield ac, ip_profile
+
+
+def is_dynamic(active_connection):
+    ip_profile = get_ip_profile(active_connection)
+    if ip_profile:
+        return ip_profile.get_method() == (
+            nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO
+        )
+    return False

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -243,3 +243,14 @@ def acs_and_ip_profiles(client):
         if not ip_profile:
             continue
         yield ac, ip_profile
+
+
+def is_dynamic(active_connection):
+    ip_profile = get_ip_profile(active_connection)
+    if ip_profile:
+        method = ip_profile.get_method()
+        return method in (
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP,
+        )
+    return False

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -29,6 +29,7 @@ from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route as RT
 
@@ -821,3 +822,22 @@ def create_ipv6_address_state(address, prefix_length):
         InterfaceIPv6.ADDRESS_IP: address,
         InterfaceIPv6.ADDRESS_PREFIX_LENGTH: prefix_length,
     }
+
+
+def test_activate_dummy_without_dhcp_service():
+    ifstate = {
+        Interface.NAME: 'dummy00',
+        Interface.TYPE: InterfaceType.DUMMY,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: create_ipv4_state(enabled=True, dhcp=True),
+        Interface.IPV6: create_ipv6_state(
+            enabled=True, dhcp=True, autoconf=True
+        ),
+    }
+    try:
+        libnmstate.apply({Interface.KEY: [ifstate]})
+    finally:
+        ifstate[Interface.STATE] = InterfaceState.ABSENT
+        libnmstate.apply(
+            {Interface.KEY: [ifstate]}, verify_change=False,
+        )


### PR DESCRIPTION
Previously we don't block activation on DHCP/Autoconf for
master interfaces, now we expand that to all interface types.

Test case added for activating DHCP/Autoconf on dummy interface.