### PR TITLE
nm/state: Discard IP stack when disabled for verification

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -286,6 +286,7 @@ class State(object):
         self._sort_ip_addresses()
         self._capitalize_mac()
         self._remove_empty_description()
+        self._remove_ip_stack_if_disabled()
 
     def merge_interfaces(self, other_state):
         """
@@ -473,6 +474,13 @@ class State(object):
                     addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
                 )
             )
+
+    def _remove_ip_stack_if_disabled(self):
+        for ifstate in self.interfaces.values():
+            for family in (Interface.IPV4, Interface.IPV6):
+                ip_state = ifstate.get(family)
+                if ip_state and not ip_state.get(InterfaceIP.ENABLED):
+                    ifstate[family] = {InterfaceIP.ENABLED: False}
 
     def _sort_ip_addresses(self):
         for ifstate in six.viewvalues(self.interfaces):

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -74,6 +74,27 @@ class TestAssertIfaceState(object):
         with pytest.raises(NmstateVerificationError):
             desired_state.verify_interfaces(current_state)
 
+    def test_desired_has_extra_info_when_ip_disabled(self):
+        desired_state = self._base_state
+        desired_state.interfaces['foo-name'][Interface.IPV4] = {
+            InterfaceIPv4.ENABLED: False,
+            InterfaceIPv4.DHCP: False,
+        }
+        desired_state.interfaces['foo-name'][Interface.IPV6] = {
+            InterfaceIPv6.ENABLED: False,
+            InterfaceIPv6.DHCP: False,
+            InterfaceIPv6.AUTOCONF: False,
+        }
+        current_state = self._base_state
+        current_state.interfaces['foo-name'][Interface.IPV4] = {
+            InterfaceIPv4.ENABLED: False
+        }
+        current_state.interfaces['foo-name'][Interface.IPV6] = {
+            InterfaceIPv6.ENABLED: False
+        }
+
+        desired_state.verify_interfaces(current_state)
+
     def test_sort_multiple_ip(self):
         desired_state = self._base_state
         current_state = self._base_state


### PR DESCRIPTION
When desire contain extra IP information when IP disabled,
the verification will fail.

For example:

    desire:     {'enabled': False, 'dhcp': False}
    current:    {'enabled': False}

The verification should pass on the above use case.
The fix is remove the whole IP stack before verification when disabled.

A unit test case has been added for this use case.