### PR TITLE
nm.sriov: SRIOVSetting implementation

### DIFF
--- a/libnmstate/error.py
+++ b/libnmstate/error.py
@@ -101,3 +101,11 @@ class NmstateInternalError(NmstateError):
     """
 
     pass
+
+
+class NmstateNotSupportedError(NmstateError):
+    """
+    A resource like a device does not support the requested feature.
+    """
+
+    pass

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -413,7 +413,7 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
     if vxlan_setting:
         settings.append(vxlan_setting)
 
-    sriov_setting = sriov.create_setting(iface_desired_state)
+    sriov_setting = sriov.create_setting(iface_desired_state, base_con_profile)
     if sriov_setting:
         settings.append(sriov_setting)
 

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -169,6 +169,14 @@ class ConnectionProfile(object):
             user_data,
         )
 
+    def get_setting_duplicate(self, setting_name):
+        setting = None
+        if self.profile:
+            setting = self.profile.get_setting_by_name(setting_name)
+            if setting:
+                setting = setting.duplicate()
+        return setting
+
     def _active_connection_callback(self, src_object, result, user_data):
         cancellable = user_data
         self._mainloop.drop_cancellable(cancellable)

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -19,6 +19,7 @@
 
 from libnmstate.ethtool import minimal_ethtool
 from libnmstate.nm import nmclient
+from libnmstate.nm import sriov
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
 
@@ -165,4 +166,9 @@ def _get_ethernet_info(device, iface):
         ethernet[Ethernet.DUPLEX] = duplex_setting
     else:
         return None
+
+    sriov_info = sriov.get_info(device)
+    if sriov_info:
+        ethernet.update(sriov_info)
+
     return ethernet


### PR DESCRIPTION
This patch adds basic SR-IOV support in nmstate. It is possible to
retrieve and set the total number of VFs per PF.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>