### PR TITLE
linux bridge, port vlan: raise not implemented error

### DIFF
--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import connection
 from libnmstate.nm import nmclient
 from libnmstate.schema import LinuxBridge as LB
@@ -88,6 +89,8 @@ def create_port_setting(options, base_con_profile):
             port_setting.props.hairpin_mode = val
         elif key == LB.PORT_STP_PATH_COST:
             port_setting.props.path_cost = val
+        elif key == LB.Port.VLAN_SUBTREE:
+            raise NmstateNotImplementedError
 
     return port_setting
 

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -24,6 +24,7 @@ import pytest
 import yaml
 
 import libnmstate
+from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -373,6 +374,27 @@ def test_activate_empty_bridge_does_not_blocked_by_dhcp():
         bridge_name, bridge_state, extra_iface_state
     ) as desired_state:
         assertlib.assert_state(desired_state)
+
+
+@pytest.mark.xfail(
+    raises=NmstateNotImplementedError,
+    reason='https://nmstate.atlassian.net/browse/NMSTATE-230',
+    strict=True,
+)
+def test_port_vlan_not_implemented(port0_up):
+    bridge_name = TEST_BRIDGE0
+    port_name = port0_up[Interface.KEY][0][Interface.NAME]
+    port_vlan_config = {
+        LinuxBridge.Port.VLAN_SUBTREE: {
+            LinuxBridge.Port.Vlan.TYPE: LinuxBridge.Port.Vlan.ACCESS_TYPE,
+            LinuxBridge.Port.Vlan.TAG: 101,
+        }
+    }
+
+    bridge_state = _create_bridge_subtree_config((port_name,))
+    bridge_state[LinuxBridge.PORT_SUBTREE][0].update(port_vlan_config)
+    with linux_bridge(bridge_name, bridge_state):
+        pass
 
 
 def _add_port_to_bridge(bridge_state, ifname):


### PR DESCRIPTION
When the port vlan feature is used, raise NmstateNotImplementedError.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>