### PR TITLE
schema: Add basic support of routing rule

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -25,6 +25,7 @@ from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
+from libnmstate.schema import RouteRule
 
 
 def show(include_status_data=False):
@@ -50,6 +51,13 @@ def show(include_status_data=False):
         Route.CONFIG: (
             nm.ipv4.get_route_config() + nm.ipv6.get_route_config()
         ),
+    }
+
+    report[RouteRule.KEY] = {
+        RouteRule.CONFIG: (
+            nm.ipv4.get_routing_rule_config()
+            + nm.ipv6.get_routing_rule_config()
+        )
     }
 
     report[Constants.DNS] = {

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -174,3 +174,7 @@ def is_dynamic(active_connection):
             nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO
         )
     return False
+
+
+def get_routing_rule_config():
+    return []

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -254,3 +254,7 @@ def is_dynamic(active_connection):
             nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP,
         )
     return False
+
+
+def get_routing_rule_config():
+    return []

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -61,6 +61,17 @@ class Route(object):
     USE_DEFAULT_ROUTE_TABLE = 0
 
 
+class RouteRule(object):
+    KEY = 'route-rules'
+    CONFIG = 'config'
+    IP_FROM = 'ip-from'
+    IP_TO = 'ip-to'
+    PRIORITY = 'priority'
+    ROUTE_TABLE = 'route-table'
+    USE_DEFAULT_PRIORITY = -1
+    USE_DEFAULT_ROUTE_TABLE = 0
+
+
 class DNS(object):
     KEY = 'dns-resolver'
     RUNNING = 'running'

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -36,6 +36,13 @@ properties:
         type: array
         items:
           $ref: "#/definitions/route"
+  route-rules:
+    type: object
+    properties:
+      config:
+        type: array
+        items:
+          $ref: "#/definitions/route-rule"
   dns-resolver:
     type: object
     properties:
@@ -514,3 +521,14 @@ definitions:
             $ref: "#/definitions/types/bridge-vlan-tag"
           max:
             $ref: "#/definitions/types/bridge-vlan-tag"
+  route-rule:
+    type: object
+    properties:
+      from:
+        type: string
+      to:
+        type: string
+      priority:
+        type: integer
+      route-table:
+        type: integer

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -49,6 +49,8 @@ def netapplier_nm_mock():
 @pytest.fixture
 def netinfo_nm_mock():
     with mock.patch.object(netapplier.netinfo, 'nm') as m:
+        m.ipv4.get_routing_rule_config.return_value = []
+        m.ipv6.get_routing_rule_config.return_value = []
         yield m
 
 

--- a/tests/lib/netinfo_test.py
+++ b/tests/lib/netinfo_test.py
@@ -23,6 +23,7 @@ from unittest import mock
 from libnmstate import netinfo
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
+from libnmstate.schema import RouteRule
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 
@@ -34,6 +35,8 @@ ROUTES = Constants.ROUTES
 @pytest.fixture
 def nm_mock():
     with mock.patch.object(netinfo, 'nm') as m:
+        m.ipv4.get_routing_rule_config.return_value = []
+        m.ipv6.get_routing_rule_config.return_value = []
         yield m
 
 
@@ -47,6 +50,7 @@ def test_netinfo_show_generic_iface(nm_mock, nm_dns_mock):
     current_config = {
         DNS.KEY: {DNS.RUNNING: {}, DNS.CONFIG: {}},
         ROUTES: {'config': [], 'running': []},
+        RouteRule.KEY: {RouteRule.CONFIG: []},
         INTERFACES: [
             {
                 'name': 'foo',
@@ -82,6 +86,7 @@ def test_netinfo_show_bond_iface(nm_mock, nm_dns_mock):
     current_config = {
         DNS.KEY: {DNS.RUNNING: {}, DNS.CONFIG: {}},
         ROUTES: {'config': [], 'running': []},
+        RouteRule.KEY: {RouteRule.CONFIG: []},
         INTERFACES: [
             {
                 'name': 'bond99',

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -30,6 +30,7 @@ from libnmstate.schema import LinuxBridge as LB
 from libnmstate.schema import VXLAN
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import RouteRule
 
 INTERFACES = Constants.INTERFACES
 ROUTES = Constants.ROUTES
@@ -89,6 +90,16 @@ COMMON_DATA = {
                 'next-hop-address': 'fe80::1',
             }
         ],
+    },
+    RouteRule.KEY: {
+        RouteRule.CONFIG: [
+            {
+                RouteRule.IP_FROM: '192.0.2.0/24',
+                RouteRule.IP_TO: '198.51.100.0/24',
+                RouteRule.PRIORITY: 500,
+                RouteRule.ROUTE_TABLE: 254,
+            }
+        ]
     },
     DNS.KEY: {
         DNS.RUNNING: {
@@ -387,3 +398,13 @@ class TestLinuxBridgeVlanFiltering(object):
                 LB.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
             }
         }
+
+
+class TestRouteRules(object):
+    def test_non_interger_route_table(self, default_data):
+        route_rules = default_data[RouteRule.KEY][RouteRule.CONFIG]
+        route_rules[0][RouteRule.ROUTE_TABLE] = 'main'
+
+        with pytest.raises(js.ValidationError) as err:
+            libnmstate.validator.validate(default_data)
+        assert 'main' in err.value.args[0]


### PR DESCRIPTION
Providing basic support of routing rule support:

```yml
route-rules:
  config:
  - ip-from: 192.168.3.2/32
    ip-to: 203.0.113.1
    priority: 30000
    route-table: 200
  - ip-from: 2001:db8:b::/64
    ip-to: 2001:db8:a::/64
    priority: 30000
    route-table: 200
```

Test case included also.