### PR TITLE
Add support of routing rule

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -122,6 +122,7 @@ def _apply_ifaces_state(
     desired_state.sanitize_dynamic_ip()
     desired_state.merge_routes(current_state)
     desired_state.merge_dns(current_state)
+    desired_state.merge_route_rules(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
     validator.validate_interfaces_state(desired_state, current_state)
@@ -198,6 +199,7 @@ def _verify_change(desired_state):
     desired_state.verify_interfaces(current_state)
     desired_state.verify_routes(current_state)
     desired_state.verify_dns(current_state)
+    desired_state.verify_route_rule(current_state)
 
 
 @contextmanager


### PR DESCRIPTION
Allowing changing routing rule using:

```yml
route-rules:
  config:
  - ip-from: 192.168.3.2/32
    ip-to: 203.0.113.1
    priority: 30000
    route-table: 200
  - ip-from: 2001:db8:b::/64
    ip-to: 2001:db8:a::/64
    priority: 30000
    route-table: 200
```

The routing rule will be stored in the interface which contains
static routes with the same route table ID of the rule.

Limitations:
    * Does not support querying running routing rule yet.
    * Does not support partial editing on routing rule.