### PR TITLE
test: xfail test_take_over_virtual_interface_then_remove

### DIFF
--- a/tests/integration/interface_common_test.py
+++ b/tests/integration/interface_common_test.py
@@ -78,6 +78,10 @@ def test_iface_description_removal(eth1_up):
     assert Interface.DESCRIPTION not in current_state[Interface.KEY][0]
 
 
+@pytest.mark.xfail(
+    raises=(AssertionError),
+    reason='https://nmstate.atlassian.net/browse/NMSTATE-277',
+)
 def test_take_over_virtual_interface_then_remove(ip_link_dummy):
     with dummy_interface(DUMMY_INTERFACE) as dummy_desired_state:
         assertlib.assert_state_match(dummy_desired_state)


### PR DESCRIPTION
Mark `test_take_over_virtual_interface_then_remove` as OK
to fail as current code skip the device deletion when
`NM.Device` in `DEACTIVATING` state.

Jira issue created for tracking this issue:
https://nmstate.atlassian.net/browse/NMSTATE-277