### PR TITLE
schema: Unify schema hierarchy

### DIFF
--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -83,11 +83,11 @@ def create_port_setting(options, base_con_profile):
         port_setting = nmclient.NM.SettingBridgePort.new()
 
     for key, val in options.items():
-        if key == LB.PORT_STP_PRIORITY:
+        if key == LB.Port.STP_PRIORITY:
             port_setting.props.priority = val
-        elif key == LB.PORT_STP_HAIRPIN_MODE:
+        elif key == LB.Port.STP_HAIRPIN_MODE:
             port_setting.props.hairpin_mode = val
-        elif key == LB.PORT_STP_PATH_COST:
+        elif key == LB.Port.STP_PATH_COST:
             port_setting.props.path_cost = val
         elif key == LB.Port.VLAN_SUBTREE:
             raise NmstateNotImplementedError
@@ -152,10 +152,10 @@ def _get_bridge_port_info(port_profile):
 
     port_setting = port_profile.get_setting_bridge_port()
     return {
-        LB.PORT_NAME: port_profile.get_interface_name(),
-        LB.PORT_STP_PRIORITY: port_setting.props.priority,
-        LB.PORT_STP_HAIRPIN_MODE: port_setting.props.hairpin_mode,
-        LB.PORT_STP_PATH_COST: port_setting.props.path_cost,
+        LB.Port.NAME: port_profile.get_interface_name(),
+        LB.Port.STP_PRIORITY: port_setting.props.priority,
+        LB.Port.STP_HAIRPIN_MODE: port_setting.props.hairpin_mode,
+        LB.Port.STP_PATH_COST: port_setting.props.path_cost,
     }
 
 

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -181,6 +181,10 @@ class LinuxBridge(object):
     PORT_STP_PATH_COST = 'stp-path-cost'
 
     class Port(object):
+        NAME = 'name'
+        STP_HAIRPIN_MODE = 'stp-hairpin-mode'
+        STP_PATH_COST = 'stp-path-cost'
+        STP_PRIORITY = 'stp-priority'
         VLAN_SUBTREE = 'vlan'
 
         class Vlan(object):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -293,7 +293,7 @@ def test_linux_bridge_add_port_with_name_only(bridge0_with_port0, port1_up):
     bridge_state = bridge_iface_state[LinuxBridge.CONFIG_SUBTREE]
     port1_name = port1_up[Interface.KEY][0][Interface.NAME]
     bridge_state[LinuxBridge.PORT_SUBTREE].append(
-        {LinuxBridge.PORT_NAME: port1_name}
+        {LinuxBridge.Port.NAME: port1_name}
     )
 
     libnmstate.apply(desired_state)
@@ -309,7 +309,7 @@ def test_replace_port_on_linux_bridge(port0_vlan101, port1_up):
     with linux_bridge(bridge_name, bridge_state) as state:
         brconf_state = state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE]
         brconf_state[LinuxBridge.PORT_SUBTREE] = [
-            {LinuxBridge.PORT_NAME: port1_name}
+            {LinuxBridge.Port.NAME: port1_name}
         ]
         libnmstate.apply(state)
 
@@ -317,7 +317,7 @@ def test_replace_port_on_linux_bridge(port0_vlan101, port1_up):
         brconf_state = br_state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE]
         br_ports_state = brconf_state[LinuxBridge.PORT_SUBTREE]
         assert 1 == len(br_ports_state)
-        assert port1_name == br_ports_state[0][LinuxBridge.PORT_NAME]
+        assert port1_name == br_ports_state[0][LinuxBridge.Port.NAME]
 
         port_state = show_only((vlan_port0_name,))
         assert (

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -104,10 +104,10 @@ def _create_bridge_config(ports):
 def _create_bridge_ports_config(ports):
     return [
         {
-            LB.PORT_NAME: port,
-            LB.PORT_STP_PRIORITY: 32,
-            LB.PORT_STP_HAIRPIN_MODE: False,
-            LB.PORT_STP_PATH_COST: 100,
+            LB.Port.NAME: port,
+            LB.Port.STP_PRIORITY: 32,
+            LB.Port.STP_HAIRPIN_MODE: False,
+            LB.Port.STP_PATH_COST: 100,
         }
         for port in ports
     ]
@@ -121,7 +121,7 @@ def _bridge_interface(state):
     finally:
         _delete_iface(BRIDGE0)
         for p in state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE]:
-            _delete_iface(p[LB.PORT_NAME])
+            _delete_iface(p[LB.Port.NAME])
 
 
 @mainloop_run

--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -73,7 +73,7 @@ def add_port_to_bridge(bridge_subtree_state, port_name, port_state=None):
     if port_state is None:
         port_state = {}
 
-    port_state[LinuxBridge.PORT_NAME] = port_name
+    port_state[LinuxBridge.Port.NAME] = port_name
     bridge_subtree_state[LinuxBridge.PORT_SUBTREE].append(port_state)
 
     return bridge_subtree_state

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -156,7 +156,7 @@ class State(object):
         for ifstate in self._state[Interface.KEY]:
             ifstate.get(LinuxBridge.CONFIG_SUBTREE, {}).get(
                 LinuxBridge.PORT_SUBTREE, []
-            ).sort(key=itemgetter(LinuxBridge.PORT_NAME))
+            ).sort(key=itemgetter(LinuxBridge.Port.NAME))
 
     def _ipv6_skeleton_canonicalization(self):
         for iface_state in self._state.get(Interface.KEY, []):

--- a/tests/lib/schema_deprecation_test.py
+++ b/tests/lib/schema_deprecation_test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+import pytest
+
+from libnmstate.schema import LinuxBridge
+
+
+@pytest.mark.parametrize(
+    'changes',
+    argvalues=[
+        ['PORT_NAME', LinuxBridge.Port.NAME],
+        ['PORT_STP_HAIRPIN_MODE', LinuxBridge.Port.STP_HAIRPIN_MODE],
+        ['PORT_STP_PATH_COST', LinuxBridge.Port.STP_PATH_COST],
+        ['PORT_STP_PRIORITY', LinuxBridge.Port.STP_PRIORITY],
+    ],
+)
+def test_linuxbridge_deprecated_constants(changes):
+    with pytest.warns(FutureWarning) as record:
+        deprecated_value = getattr(LinuxBridge, changes[0])
+
+    assert len(record) == 1
+    assert changes[0] in record[0].message.args[0]
+    assert deprecated_value == changes[1]

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -131,7 +131,7 @@ def portless_bridge_state():
 
 @pytest.fixture
 def bridge_state(portless_bridge_state):
-    port = {LB.PORT_NAME: 'eth1', LB.Port.VLAN_SUBTREE: {}}
+    port = {LB.Port.NAME: 'eth1', LB.Port.VLAN_SUBTREE: {}}
     portless_bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE].append(port)
     return portless_bridge_state
 

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -361,7 +361,7 @@ class TestVlanFilteringValidation(object):
                     schema.Interface.STATE: schema.InterfaceState.UP,
                     LB.PORT_SUBTREE: [
                         {
-                            LB.PORT_NAME: 'eth1',
+                            LB.Port.NAME: 'eth1',
                             LB.Port.VLAN_SUBTREE: invalid_vlan_config,
                         }
                     ],
@@ -386,7 +386,7 @@ class TestVlanFilteringValidation(object):
                     schema.Interface.STATE: schema.InterfaceState.UP,
                     LB.PORT_SUBTREE: [
                         {
-                            LB.PORT_NAME: 'eth1',
+                            LB.Port.NAME: 'eth1',
                             LB.Port.VLAN_SUBTREE: invalid_vlan_config,
                         }
                     ],
@@ -420,7 +420,7 @@ class TestVlanFilteringValidation(object):
                     schema.Interface.STATE: schema.InterfaceState.UP,
                     LB.PORT_SUBTREE: [
                         {
-                            LB.PORT_NAME: 'eth1',
+                            LB.Port.NAME: 'eth1',
                             LB.Port.VLAN_SUBTREE: invalid_vlan_config,
                         }
                     ],
@@ -449,7 +449,7 @@ class TestVlanFilteringValidation(object):
                     schema.Interface.STATE: schema.InterfaceState.UP,
                     LB.PORT_SUBTREE: [
                         {
-                            LB.PORT_NAME: 'eth1',
+                            LB.Port.NAME: 'eth1',
                             LB.Port.VLAN_SUBTREE: {
                                 LB.Port.Vlan.TYPE: LB.Port.Vlan.TRUNK_TYPE,
                                 LB.Port.Vlan.TRUNK_TAGS: [


### PR DESCRIPTION
Move constant to LinuxBridge.Port, LinuxBridge.STP and OVSBridge.Port
classes. Create DeprecationWarnings when the old constants are used.

Signed-off-by: Till Maas <opensource@till.name>

@EdDev this is an example about how we could change/deprecate the constants. I did this only for the LinuxBridge.Port constants for now but if you agree with this approach, it can easily be done for the other candidates as well. Also change the constants in our CI is missing and the API guide needs to be updated afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/608)
<!-- Reviewable:end -->
