### PR TITLE
test: Explicitly set test NICs as managed by NM

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -44,6 +44,10 @@ function add_extra_networks {
       ip link add eth2 type veth peer eth2peer && \
       ip link set eth1peer up && \
       ip link set eth2peer up
+      # Due to https://nmstate.atlassian.net/browse/NMSTATE-279
+      # Mandually set test NICs as managed by NetworkManager.
+      nmcli device set eth1 managed yes
+      nmcli device set eth2 managed yes
     '
 }
 


### PR DESCRIPTION
The race between `NM.Device.set_managed()` and
device activation could cause activation failure
with error:

    The device 'eth1' has no connections available
    for activation.

And there is no good solution tile NM 1.22 released
with `NM.Device.set_managed_async()` function.

Issue can be tracked by:
    https://nmstate.atlassian.net/browse/NMSTATE-279