### PR TITLE
test: Explicitly delete device even in DEACTIVATING state

### DIFF
--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -249,11 +249,6 @@ def delete_device(nmdev):
 
 def _safe_delete_device_async(nmdev):
     mainloop = nmclient.mainloop()
-    if nmdev.get_state() == nmclient.NM.DeviceState.DEACTIVATING:
-        # Nothing to do since the device is already being removed.
-        mainloop.execute_next_action()
-        return
-
     user_data = mainloop, nmdev
     nmdev.delete_async(
         mainloop.cancellable, _delete_device_callback, user_data

--- a/tests/integration/interface_common_test.py
+++ b/tests/integration/interface_common_test.py
@@ -78,10 +78,6 @@ def test_iface_description_removal(eth1_up):
     assert Interface.DESCRIPTION not in current_state[Interface.KEY][0]
 
 
-@pytest.mark.xfail(
-    raises=(AssertionError),
-    reason='https://nmstate.atlassian.net/browse/NMSTATE-277',
-)
 def test_take_over_virtual_interface_then_remove(ip_link_dummy):
     with dummy_interface(DUMMY_INTERFACE) as dummy_desired_state:
         assertlib.assert_state_match(dummy_desired_state)


### PR DESCRIPTION
Even when device is in DEACTIVATING state, still invoke
`NM.Device.delete_async()`.