### PR TITLE
schema, ovs: Change bridge VLAN schema

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -295,5 +295,22 @@ class OVSBridge(object):
 
     PORT_SUBTREE = 'port'
     PORT_NAME = 'name'
-    PORT_VLAN_MODE = 'vlan-mode'
-    PORT_ACCESS_TAG = 'access-tag'
+
+    class Port:
+        VLAN_SUBTREE = 'vlan'
+
+        class Vlan:
+            TRUNK_TAGS = 'trunk-tags'
+            TAG = 'tag'
+            ENABLE_NATIVE = 'enable-native'
+            MODE = 'mode'
+
+            class Mode:
+                ACCESS = 'access'
+                TRUNK = 'trunk'
+
+            class TrunkTags:
+                ID = 'id'
+                ID_RANGE = 'id-range'
+                MIN_RANGE = 'min'
+                MAX_RANGE = 'max'

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -316,10 +316,22 @@ definitions:
                 properties:
                   name:
                     type: string
-                  vlan-mode:
-                    type: string
-                  access-tag:
-                    type: string
+                  vlan:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum:
+                          - trunk
+                          - access
+                      trunk-tags:
+                        type: array
+                        items:
+                          $ref: "#/definitions/bridge-port-vlan"
+                      tag:
+                        $ref: "#/definitions/types/bridge-vlan-tag"
+                      enable-native:
+                        type: boolean
             options:
               type: object
               properties:

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -79,8 +79,8 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
     eth1_port = {
         OB.PORT_NAME: 'eth1',
         # OVS vlan/s are not yet supported.
-        # OB.PORT_VLAN_MODE: None,
-        # OB.PORT_ACCESS_TAG: 0,
+        # OB.VLAN.MODE: None,
+        # OB.VLAN.TAG: 0,
     }
 
     bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(eth1_port)


### PR DESCRIPTION
Sync the OVS bridge port vlan schema with the one of the Linux bridge.
As the port vlan has never been implemented, this change is backward
safe and requires no production code changes.