### PR TITLE
schema, bridge: Change vlan.type to vlan.mode

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -227,12 +227,14 @@ class LinuxBridge(metaclass=_DeprecatorType):
         VLAN_SUBTREE = 'vlan'
 
         class Vlan(object):
-            TRUNK_TAGS = 'trunk-tags'
-            TAG = 'tag'
             ENABLE_NATIVE = 'enable-native'
-            TYPE = 'type'
-            ACCESS_TYPE = 'access'
-            TRUNK_TYPE = 'trunk'
+            MODE = 'mode'
+            TAG = 'tag'
+            TRUNK_TAGS = 'trunk-tags'
+
+            class Mode:
+                ACCESS = 'access'
+                TRUNK = 'trunk'
 
             class TrunkTags(object):
                 ID = 'id'

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -260,7 +260,7 @@ definitions:
                   vlan:
                     type: object
                     properties:
-                      type:
+                      mode:
                         type: string
                         enum:
                           - trunk

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -251,10 +251,10 @@ def _assert_vxlan_has_missing_attribute(state, *attributes):
 def _assert_vlan_filtering_trunk_tags(ports_state):
     for port_state in ports_state:
         port_vlan_state = port_state.get(LB.Port.VLAN_SUBTREE, {})
-        vlan_type = port_vlan_state.get(LB.Port.Vlan.TYPE)
+        vlan_mode = port_vlan_state.get(LB.Port.Vlan.MODE)
         trunk_tags = port_vlan_state.get(LB.Port.Vlan.TRUNK_TAGS, [])
 
-        if vlan_type == LB.Port.Vlan.ACCESS_TYPE:
+        if vlan_mode == LB.Port.Vlan.Mode.ACCESS:
             if trunk_tags:
                 raise NmstateValueError('Access port cannot have trunk tags')
         elif port_vlan_state:

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -386,7 +386,7 @@ def test_port_vlan_not_implemented(port0_up):
     port_name = port0_up[Interface.KEY][0][Interface.NAME]
     port_vlan_config = {
         LinuxBridge.Port.VLAN_SUBTREE: {
-            LinuxBridge.Port.Vlan.TYPE: LinuxBridge.Port.Vlan.ACCESS_TYPE,
+            LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.ACCESS,
             LinuxBridge.Port.Vlan.TAG: 101,
         }
     }

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -396,7 +396,7 @@ class TestLinuxBridgeVlanFiltering(object):
         port_type, trunk_tags=None, access_tag=None, native_vlan=None
     ):
         vlan_filtering_state = {
-            LB.Port.Vlan.TYPE: port_type,
+            LB.Port.Vlan.MODE: port_type,
             LB.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
         }
 

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -343,7 +343,7 @@ class TestVxlanValidation(object):
 class TestVlanFilteringValidation(object):
     def test_access_port_cant_have_trunks(self):
         invalid_vlan_config = {
-            LB.Port.Vlan.TYPE: LB.Port.Vlan.ACCESS_TYPE,
+            LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.ACCESS,
             LB.Port.Vlan.TRUNK_TAGS: [
                 {
                     LB.Port.Vlan.TrunkTags.ID_RANGE: {
@@ -375,7 +375,7 @@ class TestVlanFilteringValidation(object):
 
     def test_trunk_port_must_have_at_least_1_tag(self):
         invalid_vlan_config = {
-            LB.Port.Vlan.TYPE: LB.Port.Vlan.TRUNK_TYPE,
+            LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.TRUNK,
             LB.Port.Vlan.TRUNK_TAGS: [],
         }
         desired_state = {
@@ -401,7 +401,7 @@ class TestVlanFilteringValidation(object):
 
     def test_specify_both_vlan_id_and_id_range_is_invalid(self):
         invalid_vlan_config = {
-            LB.Port.Vlan.TYPE: LB.Port.Vlan.TRUNK_TYPE,
+            LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.TRUNK,
             LB.Port.Vlan.TRUNK_TAGS: [
                 {
                     LB.Port.Vlan.TrunkTags.ID: 101,
@@ -451,7 +451,7 @@ class TestVlanFilteringValidation(object):
                         {
                             LB.Port.NAME: 'eth1',
                             LB.Port.VLAN_SUBTREE: {
-                                LB.Port.Vlan.TYPE: LB.Port.Vlan.TRUNK_TYPE,
+                                LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.TRUNK,
                                 LB.Port.Vlan.TRUNK_TAGS: [
                                     {
                                         LB.Port.Vlan.TrunkTags.ID_RANGE: {


### PR DESCRIPTION
Most references to the vlan access/trunk term are using the
name `vlan.mode`.
Therefore, `type` is changed in this context to `mode`.

As the implementation is not yet in, this change is backward safe.