### PR TITLE
test: Mark Fedora 31 integration test as optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
         - env: DOCKER_IMAGE=nmstate/centos8-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
+        - env: DOCKER_IMAGE=nmstate/fedora-nmstate-dev
+               testflags="--test-type integ --pytest-args='-x'"
 
 addons:
     apt:


### PR DESCRIPTION
The NM 1.20.6 shipped in Fedora 31 is not stable enough to block CI
results.