### PR TITLE
nm applier: Skip editing on unknown type interface

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -123,6 +123,7 @@ def _apply_ifaces_state(
     desired_state.merge_routes(current_state)
     desired_state.merge_dns(current_state)
     desired_state.merge_route_rules(current_state)
+    desired_state.remove_unknown_interfaces()
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
     validator.validate_interfaces_state(desired_state, current_state)

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -399,6 +399,18 @@ class State:
             dict_update(other_state.interfaces[name], self.interfaces[name])
             self._ifaces_state[name] = other_state.interfaces[name]
 
+    def remove_unknown_interfaces(self):
+        """
+        Remove unknown type interfaces
+        """
+        unknown_ifaces = [
+            ifname
+            for ifname, ifstate in self.interfaces.items()
+            if ifstate.get(Interface.TYPE) == InterfaceType.UNKNOWN
+        ]
+        for unknown_iface in unknown_ifaces:
+            del self.interfaces[unknown_iface]
+
     def merge_routes(self, other_state):
         """
         Given the self and other states, complete the self state by merging

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -27,6 +27,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
@@ -956,3 +957,16 @@ def _create_route_rule_dict(ip_from, ip_to, priority, table):
         RouteRule.PRIORITY: priority,
         RouteRule.ROUTE_TABLE: table,
     }
+
+
+def test_remove_unknown_interfaces():
+    desired_state = state.State(
+        {
+            Interface.KEY: [
+                {Interface.NAME: 'foo', Interface.TYPE: InterfaceType.UNKNOWN}
+            ]
+        }
+    )
+
+    desired_state.remove_unknown_interfaces()
+    assert not desired_state.interfaces


### PR DESCRIPTION
Skip editing on unknown type interface by introduce
`State.remove_unknown_interfaces()` function to remove interface with
unknown type.