### PR TITLE
Python: Do not inherit from object explicitly

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -33,7 +33,7 @@ class ActivationError(Exception):
     pass
 
 
-class ActiveConnection(object):
+class ActiveConnection:
     def __init__(self, active_connection=None):
         self.handlers = set()
         self.device_handlers = set()

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -61,7 +61,7 @@ def nmdbus_manager():
     return _nmdbus_manager
 
 
-class _NMDbus(object):
+class _NMDbus:
     BUS_NAME = 'org.freedesktop.NetworkManager'
 
     bus = None
@@ -71,7 +71,7 @@ class _NMDbus(object):
         _NMDbus.bus = dbus.SystemBus()
 
 
-class _NMDbusManager(object):
+class _NMDbusManager:
     IF_NAME = 'org.freedesktop.NetworkManager'
     OBJ_PATH = '/org/freedesktop/NetworkManager'
 
@@ -89,7 +89,7 @@ def get_checkpoints():
     return [c.get_path() for c in nmclient.get_checkpoints()]
 
 
-class CheckPoint(object):
+class CheckPoint:
     def __init__(self, timeout=60, autodestroy=True, dbuspath=None):
         self._manager = nmdbus_manager()
         self._timeout = timeout

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -25,7 +25,7 @@ from . import nmclient
 from .active_connection import ActiveConnection
 
 
-class ConnectionProfile(object):
+class ConnectionProfile:
     def __init__(self, profile=None):
         self._con_profile = profile
         self._nmclient = nmclient.client()
@@ -389,7 +389,7 @@ class ConnectionProfile(object):
         self._con_profile = None
 
 
-class ConnectionSetting(object):
+class ConnectionSetting:
     def __init__(self, con_setting=None):
         self._setting = con_setting
 

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -93,7 +93,7 @@ def mainloop(refresh=False):
     return _mainloop
 
 
-class _MainLoop(object):
+class _MainLoop:
     SUCCESS = True
     FAIL = False
     RUN_TIMEOUT_ERROR = 'run timeout'

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -25,12 +25,12 @@ from . import nmclient
 IFACE_TYPE_UNKNOWN = 'unknown'
 
 
-class ApiIfaceAdminState(object):
+class ApiIfaceAdminState:
     DOWN = 'down'
     UP = 'up'
 
 
-class Api2Nm(object):
+class Api2Nm:
     _iface_types_map = None
 
     @staticmethod
@@ -76,7 +76,7 @@ class Api2Nm(object):
         return bond_opts
 
 
-class Nm2Api(object):
+class Nm2Api:
     _iface_types_map = None
 
     @staticmethod

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -27,7 +27,7 @@ from libnmstate.schema import Interface
 ZEROED_MAC = '00:00:00:00:00:00'
 
 
-class WiredSetting(object):
+class WiredSetting:
     def __init__(self, state):
         self.mtu = state.get(Interface.MTU)
         self.mac = state.get(Interface.MAC)

--- a/libnmstate/prettystate.py
+++ b/libnmstate/prettystate.py
@@ -55,7 +55,7 @@ def format_desired_current_state_diff(desired_state, current_state):
     )
 
 
-class PrettyState(object):
+class PrettyState:
     def __init__(self, state):
         yaml.add_representer(OrderedDict, represent_ordereddict)
         self.state = order_state(deepcopy(state))

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -193,7 +193,7 @@ def create_state(state, interfaces_to_filter=None):
     return State(new_state)
 
 
-class State(object):
+class State:
     def __init__(self, state):
         self._state = copy.deepcopy(state)
 

--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -27,7 +27,7 @@ import time
 TIMEOUT = 10
 
 
-class IpMonitorResult(object):
+class IpMonitorResult:
     def __init__(self):
         self.out = None
         self.err = None

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -27,7 +27,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge
 
 
-class Bridge(object):
+class Bridge:
     def __init__(self, name):
         self._name = name
         self._ifaces = [

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -50,7 +50,7 @@ def show_only(ifnames):
     return current_state.state
 
 
-class State(object):
+class State:
     def __init__(self, state):
         self._state = copy.deepcopy(state)
 

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -60,7 +60,7 @@ def nm_dns_mock(nm_mock):
     return
 
 
-class TestDesiredStateMetadata(object):
+class TestDesiredStateMetadata:
     def test_empty_states(self):
         desired_state = state.State({})
         current_state = state.State({})
@@ -71,7 +71,7 @@ class TestDesiredStateMetadata(object):
         assert current_state.state == {Interface.KEY: []}
 
 
-class TestDesiredStateBondMetadata(object):
+class TestDesiredStateBondMetadata:
     def test_bond_creation_with_new_slaves(self):
         desired_state = state.State(
             {
@@ -330,7 +330,7 @@ def create_bond_state_dict(name, slaves=None):
     }
 
 
-class TestDesiredStateOvsMetadata(object):
+class TestDesiredStateOvsMetadata:
     def test_ovs_creation_with_new_ports(self):
         desired_state = state.State(
             {
@@ -610,7 +610,7 @@ class TestDesiredStateOvsMetadata(object):
         assert current_state == expected_cstate
 
 
-class TestRouteMetadata(object):
+class TestRouteMetadata:
     def test_with_empty_states(self):
         desired_state = state.State({})
         current_state = state.State({})
@@ -947,7 +947,7 @@ def _gen_default_gateway_route(iface_name):
     ]
 
 
-class TestRouteRuleMetadata(object):
+class TestRouteRuleMetadata:
     TEST_ROUTE_TABLE = 50
 
     def test_with_empty_states(self):

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -173,7 +173,7 @@ def test_prepare_edited_ifaces_configuration(
     con_profile.update.assert_has_calls([mock.call(con_profile)])
 
 
-class TestIfaceAdminStateControl(object):
+class TestIfaceAdminStateControl:
     def test_set_ifaces_admin_state_up(self, nm_device_mock):
         ifaces_desired_state = [
             {'name': 'eth0', 'type': 'ethernet', 'state': 'up'}

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -160,7 +160,7 @@ def test_get_info_with_invalid_duplex(ethtool_mock, NM_mock):
     }
 
 
-class TestWiredSetting(object):
+class TestWiredSetting:
     def test_identity(self):
         state = {}
         obj1 = obj2 = nm.wired.WiredSetting(state)

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -160,7 +160,7 @@ def ovs_bridge_state(portless_ovs_bridge_state):
     return portless_ovs_bridge_state
 
 
-class TestIfaceCommon(object):
+class TestIfaceCommon:
     def test_valid_instance(self, default_data):
         libnmstate.validator.validate(default_data)
 
@@ -179,7 +179,7 @@ class TestIfaceCommon(object):
         assert 'bad-type' in err.value.args[0]
 
 
-class TestIfaceTypeEthernet(object):
+class TestIfaceTypeEthernet:
     def test_valid_ethernet_with_auto_neg(self, default_data):
         default_data[INTERFACES][0].update(
             {'type': 'ethernet', 'auto-negotiation': True}
@@ -234,7 +234,7 @@ class TestIfaceTypeEthernet(object):
             libnmstate.validator.validate(default_data)
 
 
-class TestIfaceTypeVxlan(object):
+class TestIfaceTypeVxlan:
     def test_bad_id_type_is_invalid(self, default_data):
         default_data[Interface.KEY].append(
             {
@@ -282,7 +282,7 @@ class TestIfaceTypeVxlan(object):
         libnmstate.validator.validate(default_data)
 
 
-class TestIfaceTypeTeam(object):
+class TestIfaceTypeTeam:
     def test_valid_team_without_options(self, default_data):
         default_data[Interface.KEY].append(
             {
@@ -340,7 +340,7 @@ class TestIfaceTypeTeam(object):
         libnmstate.validator.validate(default_data)
 
 
-class TestRoutes(object):
+class TestRoutes:
     def test_valid_state_absent(self, default_data):
         default_data[ROUTES]['config'][0]['state'] = 'absent'
         libnmstate.validator.validate(default_data)
@@ -353,7 +353,7 @@ class TestRoutes(object):
         assert 'bad-state' in err.value.args[0]
 
 
-class TestLinuxBridgeVlanFiltering(object):
+class TestLinuxBridgeVlanFiltering:
     @pytest.mark.parametrize('port_type', argvalues=['trunk', 'access'])
     def test_vlan_port_types(self, default_data, bridge_state, port_type):
         valid_port_type = self._generate_vlan_filtering_config(port_type)
@@ -482,7 +482,7 @@ class TestLinuxBridgeVlanFiltering(object):
         }
 
 
-class TestOvsBridgeVlan(object):
+class TestOvsBridgeVlan:
     @pytest.mark.parametrize('vlan_mode', argvalues=['trunk', 'access'])
     def test_vlan_port_modes(self, default_data, ovs_bridge_state, vlan_mode):
         valid_vlan_mode = self._generate_vlan_config(vlan_mode)
@@ -624,7 +624,7 @@ class TestOvsBridgeVlan(object):
         }
 
 
-class TestRouteRules(object):
+class TestRouteRules:
     def test_non_interger_route_table(self, default_data):
         route_rules = default_data[RouteRule.KEY][RouteRule.CONFIG]
         route_rules[0][RouteRule.ROUTE_TABLE] = 'main'

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -43,7 +43,7 @@ parametrize_route_property = pytest.mark.parametrize(
 )
 
 
-class TestAssertIfaceState(object):
+class TestAssertIfaceState:
     def test_desired_is_identical_to_current(self):
         desired_state = self._base_state
         current_state = self._base_state
@@ -223,7 +223,7 @@ class TestAssertIfaceState(object):
         )
 
 
-class TestRouteEntry(object):
+class TestRouteEntry:
     def test_hash_unique(self):
         route = _create_route('198.51.100.0/24', '192.0.2.1', 'eth1', 50, 103)
         assert hash(route) == hash(route)
@@ -389,7 +389,7 @@ class TestRouteEntry(object):
         assert expected_routes == sorted(routes)
 
 
-class TestRouteStateMerge(object):
+class TestRouteStateMerge:
     def test_merge_empty_states(self):
         s0 = state.State({})
         s1 = state.State({})
@@ -771,7 +771,7 @@ def _route_sort_key(route):
     )
 
 
-class TestAssertDnsState(object):
+class TestAssertDnsState:
     def test_merge_dns_empty_state_with_non_empty_state(self):
         dns_config = self._get_test_dns_config()
         current_state = state.State({DNS.KEY: dns_config})
@@ -820,7 +820,7 @@ class TestAssertDnsState(object):
         }
 
 
-class TestStateMatch(object):
+class TestStateMatch:
     def test_match_empty_dict(self):
         assert state.state_match({}, {})
 

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -32,7 +32,7 @@ from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
 
 
-class TestLinkAggregationState(object):
+class TestLinkAggregationState:
     def test_bonds_with_no_slaves(self):
         desired_state = state.State(
             {
@@ -158,7 +158,7 @@ def empty_state():
     return state.State({})
 
 
-class TestRouteValidation(object):
+class TestRouteValidation:
     def test_empty_states(self):
         validator.validate_routes(state.State({}), state.State({}))
 
@@ -292,7 +292,7 @@ class TestRouteValidation(object):
         )
 
 
-class TestVxlanValidation(object):
+class TestVxlanValidation:
 
     parametrize_vxlan_req_fields = pytest.mark.parametrize(
         'required_field', [VXLAN.ID, VXLAN.REMOTE, VXLAN.BASE_IFACE]
@@ -340,7 +340,7 @@ class TestVxlanValidation(object):
         libnmstate.validator.validate_vxlan(desired_state)
 
 
-class TestVlanFilteringValidation(object):
+class TestVlanFilteringValidation:
     def test_access_port_cant_have_trunks(self):
         invalid_vlan_config = {
             LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.ACCESS,


### PR DESCRIPTION
In Python 3, all classes inherit from object implicitly. There is no
need to do this explicitly anymore.

Signed-off-by: Till Maas <opensource@till.name>

This is a follow-up on #616

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/621)
<!-- Reviewable:end -->
