### PR TITLE
Travis: Test CentOS against NM 1.22, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ env:
           testflags="--test-type integ --pytest-args='-x'"
         - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
+              --copr networkmanager/NetworkManager-1.22-git"
+        - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
+          testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
         - DOCKER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
@@ -24,6 +27,9 @@ matrix:
         - env: DOCKER_IMAGE=nmstate/centos8-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
+        - env: DOCKER_IMAGE=nmstate/centos8-nmstate-dev
+               testflags="--test-type integ --pytest-args='-x'
+                   --copr networkmanager/NetworkManager-1.22-git"
         - env: DOCKER_IMAGE=nmstate/fedora-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'"
 


### PR DESCRIPTION
NetworkManager 1.22 was branched. Add it to Travis. Since the tests on
Fedora are not as stable, use CentOS 8 to test it.

Signed-off-by: Till Maas <opensource@till.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nmstate/nmstate/630)
<!-- Reviewable:end -->
