### PR TITLE
libnmstate: Deprecate positional arguments to be used for keyword arguments

### DIFF
--- a/libnmstate/deprecation.py
+++ b/libnmstate/deprecation.py
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import inspect
+import warnings
+
+
+def _warn_keyword_as_positional(func):
+    signature = inspect.signature(func)
+    parameters = signature.parameters.values()
+    intended_posargs_count = len(
+        [p for p in parameters if p.default == inspect.Parameter.empty]
+    )
+
+    def wrapper(*args, **kwargs):
+        for arg_number in range(intended_posargs_count, len(args)):
+            bad_argname = list(parameters)[arg_number].name
+            warnings.warn(
+                f"Specifying '{bad_argname}' as positional argument is "
+                "deprecated. Please specify it as a keyword argument.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -30,6 +30,7 @@ from libnmstate.nm.nmclient import nmclient_context
 from libnmstate import schema
 from libnmstate import state
 from libnmstate import validator
+from libnmstate.deprecation import _warn_keyword_as_positional
 from libnmstate.error import NmstateConflictError
 from libnmstate.error import NmstateError
 from libnmstate.error import NmstateLibnmError
@@ -40,6 +41,7 @@ from libnmstate.nm import nmclient
 MAINLOOP_TIMEOUT = 35
 
 
+@_warn_keyword_as_positional
 @nmclient_context
 def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     """
@@ -71,6 +73,7 @@ def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
         return str(checkpoint.dbuspath)
 
 
+@_warn_keyword_as_positional
 def commit(checkpoint=None):
     """
     Commit a checkpoint that was received from `apply()`.
@@ -87,6 +90,7 @@ def commit(checkpoint=None):
         raise NmstateValueError(str(e))
 
 
+@_warn_keyword_as_positional
 def rollback(checkpoint=None):
     """
     Roll back a checkpoint that was received from `apply()`.

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 
 from libnmstate import nm
 from libnmstate import validator
+from libnmstate.deprecation import _warn_keyword_as_positional
 from libnmstate.nm import dns as nm_dns
 from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Constants
@@ -29,6 +30,7 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
 
+@_warn_keyword_as_positional
 @nmclient_context
 def show(include_status_data=False):
     """

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -190,3 +190,38 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
     m_prepare.assert_called_once_with([])
+
+
+@mock.patch.object(netapplier, "_apply_ifaces_state", lambda *_: None)
+def test_warning_apply():
+    with pytest.warns(FutureWarning) as record:
+        netapplier.apply({"interfaces": []}, True)
+
+    assert len(record) == 1
+    assert "'verify_change'" in record[0].message.args[0]
+
+    with pytest.warns(FutureWarning) as record:
+        netapplier.apply({"interfaces": []}, True, True, 0)
+
+    assert len(record) == 3
+    assert "'verify_change'" in record[0].message.args[0]
+    assert "'commit'" in record[1].message.args[0]
+    assert "'rollback_timeout'" in record[2].message.args[0]
+
+
+@mock.patch.object(netapplier, "_choose_checkpoint", lambda *_: mock.Mock())
+def test_warning_commit():
+    with pytest.warns(FutureWarning) as record:
+        netapplier.commit(None)
+
+    assert len(record) == 1
+    assert "'checkpoint'" in record[0].message.args[0]
+
+
+@mock.patch.object(netapplier, "_choose_checkpoint", lambda *_: mock.Mock())
+def test_warning_rollback():
+    with pytest.warns(FutureWarning) as record:
+        netapplier.rollback(None)
+
+    assert len(record) == 1
+    assert "'checkpoint'" in record[0].message.args[0]


### PR DESCRIPTION
Warn when keyword arguments in `libnmstate.apply()`,
`libnmstate.commit()`, `libnmstate.rollback()` and `libnmstate.show()`
are specified as positional arguments. They will become keyword-only
arguments in nmstate-0.3.

Signed-off-by: Till Maas <opensource@till.name>