### PR TITLE
nm.device: support reapply on IPv6 changes

### DIFF
--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -197,13 +197,6 @@ def _requires_activation(dev, connection_profile):
             dev.get_iface(),
         )
         return True
-    if _ipv6_changed(dev, connection_profile):
-        logging.debug(
-            'Device reapply does not support ipv6 changes, '
-            'fallback to device activation: dev=%s',
-            dev.get_iface(),
-        )
-        return True
     return False
 
 

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -28,6 +28,7 @@ from libnmstate.schema import InterfaceType
 
 from .testlib import assertlib
 from .testlib import statelib
+from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 
 # TEST-NET addresses: https://tools.ietf.org/html/rfc5737#section-3
 IPV4_ADDRESS1 = '192.0.2.251'
@@ -563,3 +564,13 @@ def test_add_iface_with_static_ipv6_expanded_format(eth1_up):
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
+
+
+@ip_monitor_assert_stable_link_up('eth1')
+def test_modify_ipv6_with_reapply(setup_eth1_ipv6):
+    ipv6_addr = IPV6_ADDRESS2
+    ipv6_state = setup_eth1_ipv6[Interface.KEY][0][Interface.IPV6]
+    ipv6_state[InterfaceIPv6.ADDRESS][0][InterfaceIPv6.ADDRESS_IP] = ipv6_addr
+    libnmstate.apply(setup_eth1_ipv6)
+
+    assertlib.assert_state(setup_eth1_ipv6)


### PR DESCRIPTION
Support reapply on IPv6 changes as it is supported by NetworkManager
again. In addition, we are supporting the workaround if the
NetworkManager version is lower than 1.20.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>