### PR TITLE
Travis: Enable codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,12 @@ script:
     - ./automation/run-tests.sh $testflags
 
 after_success:
-    - sudo pip install coveralls
+    - sudo pip install coveralls codecov
     - sudo mv .coverage .coverage.orig || true
     - sudo mv tests/.coverage .coverage.tox || true
     - sudo coverage combine --append .
     - coveralls
+    - codecov
 
 after_failure:
     - ./automation/upload_test_artifacts.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@
 dist: bionic
 language: generic
 env:
+    global:
+        - use_codecov=true
     matrix:
         - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
+          use_codecov=false
+          use_coveralls=true
         - DOCKER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
@@ -57,8 +61,8 @@ after_success:
     - sudo mv .coverage .coverage.orig || true
     - sudo mv tests/.coverage .coverage.tox || true
     - sudo coverage combine --append .
-    - coveralls
-    - codecov
+    - test "${use_coveralls}" == "true" && coveralls || true
+    - test "${use_codecov}" == "true" && codecov || true
 
 after_failure:
     - ./automation/upload_test_artifacts.sh


### PR DESCRIPTION
This allows to use coveralls for integration test coverage and codecov
for everything else in the future.

Signed-off-by: Till Maas <opensource@till.name>