### PR TITLE
ethtool: Remove Python2 specific code

### DIFF
--- a/libnmstate/ethtool.py
+++ b/libnmstate/ethtool.py
@@ -59,9 +59,7 @@ def minimal_ethtool(interface):
         ifreq = struct.pack("16sP", interface, ecmd.buffer_info()[0])
 
         fcntl.ioctl(sockfd, SIOCETHTOOL, ifreq)
-        # pylint: disable=no-member
-        res = ecmd.tobytes() if hasattr(ecmd, "tobytes") else ecmd.tostring()
-        # pylint: enable=no-member
+        res = ecmd.tobytes()
         speed, duplex, auto = struct.unpack("12xHB3xB24x", res)
     except IOError:
         speed, duplex, auto = 65535, 255, 255


### PR DESCRIPTION
Python 3 deprecated `array.array.tostring()`, `.tobytes()` should be
used.
Signed-off-by: Till Maas <opensource@till.name>