### PR TITLE
pyproject.toml: Add PEP 508 specifications

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.md
+include pyproject.toml
 include requirements.txt
 include VERSION
 include doc/nmstatectl.8.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Fedora is going to use this information in the future.

References:
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/LB3GTGGWEKBT2QWOB77XQ3WXEWN4XRUK/
https://www.python.org/dev/peps/pep-0518/#build-system-table

Signed-off-by: Till Maas <opensource@till.name>