### PR TITLE
schema: Fix MAC address pattern

### DIFF
--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -63,7 +63,7 @@ definitions:
         - down
     mac-address:
       type: string
-      pattern: "^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$"
+      pattern: "^([a-fA-F0-9]{2}:){5,31}[a-fA-F0-9]{2}$"
     bridge-vlan-tag:
       type: integer
       minimum: 0


### PR DESCRIPTION
Infiniband MAC addresses have the following format:

80:00:02:08:FE:80:00:00:00:00:00:00:F4:52:14:03:00:61:AA:91

This patch change the schema "mac-address" pattern in order to match
this format too.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>