### PR TITLE
nm.checkpoint: Initialize the dbus connection per instance

### DIFF
--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -33,9 +33,6 @@ CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES = 0x04
 NM_PERMISSION_DENIED = "org.freedesktop.NetworkManager.PermissionDenied"
 
 
-_nmdbus_manager = None
-
-
 class NMCheckPointError(Exception):
     pass
 
@@ -51,14 +48,10 @@ class NMCheckPointPermissionError(NMCheckPointError):
 def nmdbus_manager():
     """
     Returns the NM manager.
-    If it does not exists, it will initialize the dbus connection and
-    create the manager.
+    Initializes the dbus connection and creates the manager.
     """
-    global _nmdbus_manager
-    if _nmdbus_manager is None:
-        _NMDbus.init()
-        _nmdbus_manager = _NMDbusManager()
-    return _nmdbus_manager
+    _NMDbus.init()
+    return _NMDbusManager()
 
 
 class _NMDbus:


### PR DESCRIPTION
The checkpoint module is using dbus directly.
The current implementation uses a global dbus connection, however, if
NM service is restarted, this connection needs to be refreshed.

As the checkpoint is the only client of the dbus connection, the dbus
connection is now initialized on each instantiation of the checkpoint
object.