### PR TITLE
tests: add unit tests definitions for python 3.8

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -12,6 +12,7 @@ TEST_TYPE_FORMAT="format"
 TEST_TYPE_LINT="lint"
 TEST_TYPE_UNIT_PY36="unit_py36"
 TEST_TYPE_UNIT_PY37="unit_py37"
+TEST_TYPE_UNIT_PY38="unit_py38"
 TEST_TYPE_INTEG="integ"
 
 FEDORA_IMAGE_DEV="nmstate/fedora-nmstate-dev"
@@ -108,6 +109,16 @@ function run_tests {
                  "support yet"
         else
             container_exec 'tox -e py37'
+        fi
+    fi
+
+    if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
+       [ $TEST_TYPE == $TEST_TYPE_UNIT_PY38 ];then
+        if [[ $DOCKER_IMAGE == *"centos"* ]]; then
+            echo "Running unit test in $DOCKER_IMAGE container is not " \
+                 "support yet"
+        else
+            container_exec 'tox -e py38'
         fi
     fi
 
@@ -247,6 +258,7 @@ while true; do
         echo "     * $TEST_TYPE_INTEG"
         echo "     * $TEST_TYPE_UNIT_PY36"
         echo "     * $TEST_TYPE_UNIT_PY37"
+        echo "     * $TEST_TYPE_UNIT_PY38"
         echo -n "--customize allows to specify a command to customize the "
         echo "container before running the tests"
         exit

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -25,6 +25,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    \
                    python36 \
                    \
+                   python38 \
+                   \
                    dnsmasq \
                    git \
                    iproute \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black, flake8, pylint, py36, py37
+envlist = black, flake8, pylint, py36, py37, py38
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This patch introduces python 3.8 support for unit tests.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>