### PR TITLE
nm/nmclient: Fix the leak of NM.Client

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -26,6 +26,7 @@ import time
 from libnmstate import metadata
 from libnmstate import netinfo
 from libnmstate import nm
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate import schema
 from libnmstate import state
 from libnmstate import sysctl
@@ -40,6 +41,7 @@ from libnmstate.nm import nmclient
 MAINLOOP_TIMEOUT = 35
 
 
+@nmclient_context
 def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     """
     Apply the desired state

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -21,6 +21,7 @@ from operator import itemgetter
 from libnmstate import nm
 from libnmstate import validator
 from libnmstate.nm import dns as nm_dns
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
@@ -28,6 +29,7 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
 
+@nmclient_context
 def show(include_status_data=False):
     """
     Reports configuration and status data on the system.
@@ -38,9 +40,8 @@ def show(include_status_data=False):
     When include_status_data is set, both are reported, otherwise only the
     configuration data is reported.
     """
-    client = nm.nmclient.client(refresh=True)
-
-    report = {Constants.INTERFACES: interfaces()}
+    client = nm.nmclient.client()
+    report = {Constants.INTERFACES: _interfaces()}
     if include_status_data:
         report["capabilities"] = capabilities()
 
@@ -81,10 +82,8 @@ def capabilities():
     return list(caps)
 
 
-def interfaces():
+def _interfaces():
     info = []
-
-    nm.nmclient.client(refresh=True)
 
     devices_info = [
         (dev, nm.device.get_device_common_info(dev))

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -21,7 +21,8 @@ import logging
 
 import dbus
 
-import libnmstate.nm.nmclient
+from libnmstate.nm.nmclient import nmclient_context
+from libnmstate.nm.nmclient import client
 
 
 DBUS_STD_PROPERTIES_IFNAME = "org.freedesktop.DBus.Properties"
@@ -76,10 +77,11 @@ class _NMDbusManager:
         self.interface = dbus.Interface(mng_proxy, _NMDbusManager.IF_NAME)
 
 
+@nmclient_context
 def get_checkpoints():
-    nmclient = libnmstate.nm.nmclient.client(refresh=True)
-
-    return [c.get_path() for c in nmclient.get_checkpoints()]
+    nm_client = client()
+    checkpoints = [c.get_path() for c in nm_client.get_checkpoints()]
+    return checkpoints
 
 
 class CheckPoint:

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -28,7 +28,6 @@ from .active_connection import ActiveConnection
 class ConnectionProfile:
     def __init__(self, profile=None):
         self._con_profile = profile
-        self._nmclient = nmclient.client()
         self._mainloop = nmclient.mainloop()
         self._nmdevice = None
         self._con_id = None
@@ -49,15 +48,17 @@ class ConnectionProfile:
         if con_id:
             self.con_id = con_id
         if self.con_id:
-            self.profile = self._nmclient.get_connection_by_id(self.con_id)
+            client = nmclient.client()
+            self.profile = client.get_connection_by_id(self.con_id)
 
     def update(self, con_profile):
         self.profile.replace_settings_from_connection(con_profile.profile)
 
     def add(self, save_to_disk=True):
         user_data = self._mainloop
+        client = nmclient.client()
         self._mainloop.push_action(
-            self._nmclient.add_connection_async,
+            client.add_connection_async,
             self.profile,
             save_to_disk,
             self._mainloop.cancellable,
@@ -147,7 +148,8 @@ class ConnectionProfile:
 
         specific_object = None
         user_data = cancellable
-        self._nmclient.activate_connection_async(
+        client = nmclient.client()
+        client.activate_connection_async(
             self.profile,
             self.nmdevice,
             specific_object,

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -18,7 +18,9 @@
 #
 from collections import deque
 from contextlib import contextmanager
+import functools
 import logging
+import sys
 
 import gi
 
@@ -42,6 +44,7 @@ _nmclient = None
 _can_disable_ipv6 = hasattr(NM, "SETTING_IP6_CONFIG_METHOD_DISABLED")
 
 NM_MANAGER_ERROR_DOMAIN = "nm-manager-error-quark"
+_NMCLIENT_CLEANUP_TIMEOUT = 5
 
 
 def can_disable_ipv6():
@@ -52,14 +55,19 @@ def nm_version():
     return NM.Client.get_version(client())
 
 
-def client(refresh=False):
+def _delete_client():
     global _nmclient
-    # refresh is a workaround to get the current state when GMainLoop is not
-    # running
-    if _nmclient is None or refresh:
+    if _nmclient:
+        _nmclient.delete_client()
+        _nmclient = None
+
+
+def client():
+    global _nmclient
+    if _nmclient is None:
         if NM:
-            _nmclient = NM.Client.new(None)
-            if not _nmclient.get_nm_running():
+            _nmclient = _NmClient()
+            if not _nmclient.client.get_nm_running():
                 logging.error(
                     "NetworkManager is not running, please make sure"
                     "it is installed and running prior to running nmstate.\n"
@@ -77,7 +85,26 @@ def client(refresh=False):
             raise error.NmstateDependencyError(
                 "Missing introspection data for libnm"
             )
-    return _nmclient
+    return _nmclient.client
+
+
+def nmclient_context(func):
+    """
+    Decorator for handling NM.Client creation and clean up
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        try:
+            _delete_client()
+            # Delete NM.Client is required, if not, previous changed interfaces
+            # might not updated in current NM.Client caches.
+            ret = func(*args, **kwargs)
+        finally:
+            _delete_client()
+        return ret
+
+    return wrapped
 
 
 def mainloop(refresh=False):
@@ -220,3 +247,71 @@ class _MainLoop:
     def _execute_action_once(self, _):
         self.execute_next_action()
         return False
+
+
+class _NmClient:
+    def __init__(self):
+        self._client = NM.Client.new(None)
+        logging.debug("NM.Client created")
+
+    @property
+    def client(self):
+        return self._client
+
+    def delete_client(self):
+        if not self._client:
+            return
+        try:
+            ref_count = sys.getrefcount(self._client)
+            if ref_count != 2:
+                # The getrefcount() hold 1 reference and self.client itself
+                # hold 1 reference.
+                raise error.NmstateInternalError(
+                    "_NmClient.delete_client() cannot release resources "
+                    "of NM.Client duo to other unreleased use."
+                )
+            self._nmclient_cleanup()
+        except Exception:
+            pass
+
+    def __del__(self):
+        if self._client:
+            raise error.NmstateInternalError(
+                "_NmClient.delete_client() should be explicitly called "
+                "before python GC clean up the object."
+            )
+
+    def _nmclient_cleanup(self):
+        if self._client:
+            is_done = []
+            try:
+                context = self.client.get_main_context()
+                self.client.get_context_busy_watcher().weak_ref(
+                    lambda: is_done.append(1)
+                )
+            except AttributeError:
+                # For NM 1.20 which don't have get_context_busy_watcher()
+                # or get_main_context().
+                context = GLib.MainContext.default()
+                is_done.append(1)
+
+            self._client = None
+
+            while context.iteration(False):
+                pass
+
+            if not is_done:
+                logging.debug(
+                    "context.iteration() does not delete "
+                    "the context_busy_watcher, "
+                    "waiting 50 milliseconds"
+                )
+                timeout_source = GLib.timeout_source_new(50)
+                try:
+                    timeout_source.set_callback(lambda x: is_done.append(1))
+                    timeout_source.attach(context)
+                    while not is_done:
+                        context.iteration(True)
+                finally:
+                    timeout_source.destroy()
+            logging.debug("NM.Client cleaned")

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 
 from libnmstate import nm
 from libnmstate import schema
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Interface
 
 from .testlib import mainloop_run
@@ -74,8 +75,8 @@ def _bond_interface(name, options):
         _delete_bond(name)
 
 
+@nmclient_context
 def _get_bond_current_state(name):
-    nm.nmclient.client(refresh=True)
     nmdev = nm.device.get_device_by_name(name)
     nm_bond_info = nm.bond.get_bond_info(nmdev) if nmdev else {}
     return _convert_slaves_devices_to_iface_names(nm_bond_info)

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -23,6 +23,7 @@ import pytest
 
 from libnmstate import nm
 from libnmstate import schema
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import LinuxBridge as LB
 
 from ..testlib import iproutelib
@@ -149,8 +150,8 @@ def _modify_ports(ports_state):
         _attach_port_to_bridge(port_state)
 
 
+@nmclient_context
 def _get_bridge_current_state():
-    nm.nmclient.client(refresh=True)
     nmdev = nm.device.get_device_by_name(BRIDGE0)
     return nm.bridge.get_info(nmdev) if nmdev else {}
 

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 import pytest
 
 from libnmstate import nm
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Interface
 from libnmstate.schema import OVSBridge as OB
 
@@ -125,8 +126,8 @@ def _bridge_interface(state):
             _delete_iface(p[OB.Port.NAME])
 
 
+@nmclient_context
 def _get_bridge_current_state():
-    nm.nmclient.client(refresh=True)
     state = {}
     nmdev = nm.device.get_device_by_name(BRIDGE0)
     if nmdev:
@@ -138,6 +139,7 @@ def _get_bridge_current_state():
     return state
 
 
+@nmclient_context
 def _create_bridge(bridge_desired_state):
     br_options = nm.ovs.translate_bridge_options(bridge_desired_state)
     iface_bridge_settings = _get_iface_bridge_settings(br_options)
@@ -243,6 +245,7 @@ def _create_internal_iface_setting(iface_name, master_name):
     )
 
 
+@nmclient_context
 def _delete_iface(devname):
     nmdev = nm.device.get_device_by_name(devname)
     with mainloop():

--- a/tests/integration/nm/route_rule_test.py
+++ b/tests/integration/nm/route_rule_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -24,6 +24,7 @@ import pytest
 import libnmstate
 from libnmstate import nm
 from libnmstate import iplib
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import RouteRule
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -186,8 +187,8 @@ def _check_ip_rules_exist_in_os(rules):
         )
 
 
+@nmclient_context
 def _assert_route_rules(expected_rules):
-    nm.nmclient.client(refresh=True)
     cur_rules = (
         nm.ipv4.get_routing_rule_config() + nm.ipv6.get_routing_rule_config()
     )

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -20,6 +20,7 @@
 from contextlib import contextmanager
 
 from libnmstate import nm
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import VLAN
 
 from .testlib import mainloop
@@ -50,13 +51,14 @@ def _vlan_interface(state):
         _delete_vlan(_get_vlan_ifname(state))
 
 
+@nmclient_context
 def _get_vlan_current_state(vlan_desired_state):
-    nm.nmclient.client(refresh=True)
     ifname = _get_vlan_ifname(vlan_desired_state)
     nmdev = nm.device.get_device_by_name(ifname)
     return nm.vlan.get_info(nmdev) if nmdev else {}
 
 
+@nmclient_context
 def _create_vlan(vlan_desired_state):
     ifname = _get_vlan_ifname(vlan_desired_state)
     con_setting = nm.connection.ConnectionSetting()
@@ -79,6 +81,7 @@ def _create_vlan(vlan_desired_state):
         nm.device.activate(connection_id=ifname)
 
 
+@nmclient_context
 def _delete_vlan(devname):
     nmdev = nm.device.get_device_by_name(devname)
     with mainloop():

--- a/tests/integration/nm/vxlan_test.py
+++ b/tests/integration/nm/vxlan_test.py
@@ -24,6 +24,7 @@ import pytest
 from distutils.version import StrictVersion
 
 from libnmstate import nm
+from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Interface
 from libnmstate.schema import VXLAN
 
@@ -110,14 +111,15 @@ def _delete_vxlan(devname):
     nm.device.delete_device(nmdev)
 
 
+@nmclient_context
 def _get_vxlan_current_state(ifname):
     nmdev = _get_vxlan_device(ifname)
     return nm.vxlan.get_info(nmdev) if nmdev else {}
 
 
 def _get_vxlan_device(ifname):
-    nm.nmclient.client(refresh=True)
-    return nm.device.get_device_by_name(ifname)
+    dev = nm.device.get_device_by_name(ifname)
+    return dev
 
 
 def _vxlan_ifname(state):

--- a/tests/integration/nm/wired_test.py
+++ b/tests/integration/nm/wired_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -23,6 +23,7 @@ from distutils.version import StrictVersion
 
 from libnmstate import nm
 from libnmstate import schema
+from libnmstate.nm.nmclient import nmclient_context
 
 from .testlib import mainloop
 from .testlib import MainloopTestError
@@ -55,7 +56,6 @@ def _test_interface_mtu_change(apply_operation):
             apply_operation=apply_operation,
         )
 
-    nm.nmclient.client(refresh=True)
     wired_current_state = _get_wired_current_state(ETH1)
 
     assert wired_current_state == {
@@ -81,7 +81,6 @@ def _test_interface_mac_change(apply_operation):
             apply_operation=apply_operation,
         )
 
-    nm.nmclient.client(refresh=True)
     wired_current_state = _get_wired_current_state(ETH1)
 
     assert wired_current_state == {
@@ -90,6 +89,7 @@ def _test_interface_mac_change(apply_operation):
     }
 
 
+@nmclient_context
 def _modify_interface(wired_state, apply_operation):
     conn = nm.connection.ConnectionProfile()
     conn.import_by_id(ETH1)
@@ -103,6 +103,7 @@ def _modify_interface(wired_state, apply_operation):
     apply_operation(nmdev, conn.profile)
 
 
+@nmclient_context
 def _get_wired_current_state(ifname):
     nmdev = nm.device.get_device_by_name(ifname)
     return nm.wired.get_info(nmdev) if nmdev else {}

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -123,6 +123,8 @@ def test_two_vlans_on_eth1_change_mtu_rollback(eth1_up):
     libnmstate.apply(desired_state, commit=False)
     libnmstate.rollback()
 
+    time.sleep(5)  # Give some time for NetworkManager to rollback
+
     eth1_vlan_iface_cstate = statelib.show_only((VLAN_IFNAME,))
     assert eth1_vlan_iface_cstate[Interface.KEY][0][Interface.MTU] == 2000
 


### PR DESCRIPTION
In NM 1.22, NM.Client require explicitly clean via
`NM.Client.get_context_busy_watcher()`.

Created `class libnmstate.nm.nmclient._NmClient()` with
`__del__()` to do the proper clean up.