### PR TITLE
state: Fix bridge type interface state parsing

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -502,7 +502,8 @@ class State:
         bridge_ifaces = (
             ifstate
             for ifstate in self.interfaces.values()
-            if ifstate[Interface.TYPE]
+            if ifstate[Interface.STATE] == InterfaceState.UP
+            and ifstate[Interface.TYPE]
             in (InterfaceType.LINUX_BRIDGE, InterfaceType.OVS_BRIDGE)
         )
         for br_ifstate in bridge_ifaces:


### PR DESCRIPTION
A bridge type interface state includes the `bridge` subconfig only if it
is in an UP state.
When a bridge exists on the system but has no NM profile, it will appear
with state DOWN and will miss the bridge subconfig tree.

When parsing the current bridge interfaces, ignore the ones that their
state is not UP.