### PR TITLE
test: Polling on linux bridge DHCP address.

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -530,6 +530,8 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
 
     libnmstate.apply(dhcpcli_up)
 
+    assert _poll(_has_dhcpv4_addr)
+
     slave_ifname = dhcpcli_up[Interface.KEY][0][Interface.NAME]
     slave_state = statelib.show_only((slave_ifname,))
     slave_iface_state = slave_state[Interface.KEY][0]


### PR DESCRIPTION
The `test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge`
test case will fail with no static IPv4 address assigned to bridge.

Since the `libnmstate.apply()` will return on IP_CONFIG state for DHCP,
at the time of checking slave interface DHCP IPv4 addresses, there is no
IPv4 addresses assigned to the slave interface yet, hence no static
address for assigning to bridge.

Fix by polling on DHCPv4 IPv4 address.