### PR TITLE
tests: ovs interface set mac test

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -93,11 +93,12 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(port0_up):
     raises=(NmstateLibnmError, AssertionError),
     reason="https://bugzilla.redhat.com/1724901",
 )
-def test_create_and_remove_ovs_bridge_with_internal_port_and_static_ip():
+def test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac():
     bridge = Bridge(BRIDGE1)
     bridge.add_internal_port(
         PORT1,
-        {
+        mac="02:ff:ff:ff:ff:01",
+        ipv4_state={
             InterfaceIPv4.ENABLED: True,
             InterfaceIPv4.ADDRESS: [
                 {

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -58,15 +58,18 @@ class Bridge:
                 OVSBridge.Port.LinkAggregation.MODE
             ] = mode
 
-    def add_internal_port(self, name, ipv4_state):
+    def add_internal_port(self, name, *, mac=None, ipv4_state=None):
+        ifstate = {
+            Interface.NAME: name,
+            Interface.TYPE: InterfaceType.OVS_INTERFACE,
+        }
+        if mac:
+            ifstate[Interface.MAC] = mac
+        if ipv4_state:
+            ifstate[Interface.IPV4] = ipv4_state
+
         self._add_port(name)
-        self._ifaces.append(
-            {
-                Interface.NAME: name,
-                Interface.TYPE: InterfaceType.OVS_INTERFACE,
-                Interface.IPV4: ipv4_state,
-            }
-        )
+        self._ifaces.append(ifstate)
 
     def _add_port(self, name):
         self._bridge_iface[OVSBridge.CONFIG_SUBTREE].setdefault(


### PR DESCRIPTION
Now it is possible to set the mac address of an ovs-interface.

Depends on #664 