### PR TITLE
STDCI: Use Fedora 30 since 29 is EOL

### DIFF
--- a/.stdci.yml
+++ b/.stdci.yml
@@ -2,7 +2,7 @@
 Architectures:
   - x86_64:
       Distributions:
-        - fc29
+        - fc30
       runtime-requirements:
         host-distro: same
 script:


### PR DESCRIPTION
Signed-off-by: Till Maas <opensource@till.name>