### PR TITLE
nm ovs: Fix the limitation of OVS interface name length

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -125,6 +125,22 @@ def test_vlan_as_ovs_bridge_slave(vlan_on_eth1):
         assertlib.assert_state_match(state)
 
 
+@pytest.mark.xfail(
+    raises=(NmstateLibnmError, AssertionError),
+    reason="https://bugzilla.redhat.com/1724901",
+)
+def test_ovs_interface_with_longest_name():
+    bridge = Bridge(BRIDGE1)
+    ovs_interface_name = "ovs123456789012"
+    bridge.add_internal_port(ovs_interface_name, ipv4_state={})
+
+    with bridge.create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent(ovs_interface_name)
+
+
 def test_nm_ovs_plugin_missing():
     with disable_nm_ovs_plugin():
         with pytest.raises(NmstateLibnmError):


### PR DESCRIPTION
When desire OVS interface name has 5 or more characters, nmstate
will fail due to limitation of 15 characters of OVS port interface name
as OVS port use prefix `ovs-port-`.

Due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1788432 ,
NetworkManager limited the interface name on 15 characters as kernel
did even port profile does not have kernel network interface.

And NetworkManager does not allow OVS ports sharing the same name.

To fix the issue, OVS port profile will use the interface name of
OVS interface and OVS interface will refer it as master using UUID
instead of interface name.
