### PR TITLE
Container: Specify registry for container images

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -2,7 +2,7 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM centos:8
+FROM docker.io/library/centos:8
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,7 +2,7 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM fedora:31
+FROM docker.io/library/fedora:31
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 


### PR DESCRIPTION
To avoid name squatting attacks/problems it is necessary to specify the
container registry when specifying a container image. Otherwise an image
with the same name from a different registry could be obtained. This
needs to be fixed in `run-tests.sh` and `.travis.yml` as well but needs
special care to ensure that rebuilding containers locally still works.

References: https://raesene.github.io/blog/2019/09/25/typosquatting-in-a-multi-registry-world/

Signed-off-by: Till Maas <opensource@till.name>

Signed-off-by: Till Maas <opensource@till.name>