### PR TITLE
Travis: Switch codecov with coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ dist: bionic
 language: generic
 env:
     global:
-        - use_codecov=true
+        - use_coveralls=true
     matrix:
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
-          use_codecov=false
-          use_coveralls=true
+          use_codecov=true
+          use_coveralls=false
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"


### PR DESCRIPTION
Codecov does not seem to properly support multiple jobs but coveralls
does. Therefore use codecov for the CentOS 8 integration tests and
coveralls for everything else.

Signed-off-by: Till Maas <opensource@till.name>