### PR TITLE
nm/bond: Get in-kernel runtime bond options

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -17,24 +17,34 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from . import connection
+import os
+import glob
+import re
+
 from . import nmclient
 from libnmstate.error import NmstateValueError
 
 
 BOND_TYPE = "bond"
 
+SYSFS_EMPTY_VALUE = ""
+
+NM_SUPPORTED_BOND_OPTIONS = nmclient.NM.SettingBond.get_valid_options(
+    nmclient.NM.SettingBond.new()
+)
+
 
 def create_setting(options):
     bond_setting = nmclient.NM.SettingBond.new()
     for option_name, option_value in options.items():
-        success = bond_setting.add_option(option_name, option_value)
-        if not success:
-            raise NmstateValueError(
-                "Invalid bond option: '{}'='{}'".format(
-                    option_name, option_value
+        if option_value != SYSFS_EMPTY_VALUE:
+            success = bond_setting.add_option(option_name, str(option_value))
+            if not success:
+                raise NmstateValueError(
+                    "Invalid bond option: '{}'='{}'".format(
+                        option_name, option_value
+                    )
                 )
-            )
 
     return bond_setting
 
@@ -45,20 +55,35 @@ def is_bond_type_id(type_id):
 
 def get_bond_info(nm_device):
     slaves = get_slaves(nm_device)
-    options = get_options(nm_device)
+    options = _get_options(nm_device)
     if slaves or options:
         return {"slaves": slaves, "options": options}
     else:
         return {}
 
 
-def get_options(nm_device):
-    con = connection.ConnectionProfile()
-    con.import_by_device(nm_device)
-    if con.profile:
-        bond_settings = con.profile.get_setting_bond()
-        return bond_settings.props.options
-    return {}
+def _get_options(nm_device):
+    ifname = nm_device.get_iface()
+    options = {}
+    for sysfs_file in glob.iglob(f"/sys/class/net/{ifname}/bonding/*"):
+        option = os.path.basename(sysfs_file)
+        if option in NM_SUPPORTED_BOND_OPTIONS:
+            options[option] = _read_sysfs_file(sysfs_file)
+    return options
+
+
+def _read_sysfs_file(file_path):
+    with open(file_path) as fd:
+        return _strip_sysfs_name_number_value(fd.read().rstrip("\n"))
+
+
+def _strip_sysfs_name_number_value(value):
+    """
+    In sysfs/kernel, the value of some are shown with both human friendly
+    string and integer. For example, bond mode in sysfs is shown as
+    'balance-rr 0'. This function only return the human friendly string.
+    """
+    return re.sub(" [0-9]$", "", value)
 
 
 def get_slaves(nm_device):

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -394,3 +394,12 @@ def test_create_vlan_over_a_bond(bond99_with_slave):
     ) as desired_state:
         assertlib.assert_state(desired_state)
     assertlib.assert_state(bond99_with_slave)
+
+
+def test_change_bond_option_miimon(bond99_with_2_slaves):
+    desired_state = statelib.show_only((BOND99,))
+    iface_state = desired_state[Interface.KEY][0]
+    bond_options = iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
+    bond_options["miimon"] = "200"
+    libnmstate.apply(desired_state)
+    assertlib.assert_state(desired_state)

--- a/tests/lib/nm/bond_test.py
+++ b/tests/lib/nm/bond_test.py
@@ -64,21 +64,3 @@ def test_is_bond_type_id(NM_mock):
     type_id = NM_mock.DeviceType.BOND
 
     assert nm.bond.is_bond_type_id(type_id)
-
-
-@mock.patch.object(nm.bond.connection, "ConnectionProfile")
-def test_get_bond_info(con_profile_mock, dev_mock):
-    info = nm.bond.get_bond_info(dev_mock)
-
-    con_profile_mock.return_value.import_by_device.assert_called_once_with(
-        dev_mock
-    )
-
-    connection_mock = con_profile_mock.return_value.profile
-    opts_mock = connection_mock.get_setting_bond.return_value.props.options
-
-    expected_info = {
-        Bond.SLAVES: dev_mock.get_slaves.return_value,
-        Bond.OPTIONS_SUBTREE: opts_mock,
-    }
-    assert expected_info == info


### PR DESCRIPTION
NetworkManager has a list of supported bond options in their source
code, use that list and check `/sys/class/net/<bond_name>/bonding` folder
for in-kernel runtime bond options.

When applying bond options, ignore empty string option.

New integration test case added to set all the supported non-default
bond options. Currently with NM 1.22 and 1.20, it might fail due to
https://bugzilla.redhat.com/show_bug.cgi?id=1789437 .