### PR TITLE
Integration tests: Rename cmd to cmdlib

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -36,7 +36,7 @@ from libnmstate.schema import Route as RT
 from libnmstate.error import NmstateNotImplementedError
 
 from .testlib import assertlib
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 from .testlib import bondlib
 from .testlib import ifacelib
 from .testlib import statelib
@@ -117,7 +117,7 @@ def dhcp_env():
 
         with open(DNSMASQ_CONF_PATH, "w") as fd:
             fd.write(DNSMASQ_CONF_STR)
-        assert libcmd.exec_cmd(["systemctl", "restart", "dnsmasq"])[0] == 0
+        assert cmdlib.exec_cmd(["systemctl", "restart", "dnsmasq"])[0] == 0
 
         yield
     finally:
@@ -574,7 +574,7 @@ def test_ipv6_autoconf_only(dhcpcli_up):
 
 def _create_veth_pair():
     assert (
-        libcmd.exec_cmd(
+        cmdlib.exec_cmd(
             [
                 "ip",
                 "link",
@@ -592,14 +592,14 @@ def _create_veth_pair():
 
 
 def _remove_veth_pair():
-    libcmd.exec_cmd(["ip", "link", "del", "dev", DHCP_SRV_NIC])
+    cmdlib.exec_cmd(["ip", "link", "del", "dev", DHCP_SRV_NIC])
 
 
 def _setup_dhcp_nics():
-    assert libcmd.exec_cmd(["ip", "link", "set", DHCP_SRV_NIC, "up"])[0] == 0
-    assert libcmd.exec_cmd(["ip", "link", "set", DHCP_CLI_NIC, "up"])[0] == 0
+    assert cmdlib.exec_cmd(["ip", "link", "set", DHCP_SRV_NIC, "up"])[0] == 0
+    assert cmdlib.exec_cmd(["ip", "link", "set", DHCP_CLI_NIC, "up"])[0] == 0
     assert (
-        libcmd.exec_cmd(
+        cmdlib.exec_cmd(
             [
                 "ip",
                 "addr",
@@ -612,7 +612,7 @@ def _setup_dhcp_nics():
         == 0
     )
     assert (
-        libcmd.exec_cmd(
+        cmdlib.exec_cmd(
             ["nmcli", "device", "set", DHCP_CLI_NIC, "managed", "yes"]
         )[0]
         == 0
@@ -625,7 +625,7 @@ def _setup_dhcp_nics():
         fd.write("0")
 
     assert (
-        libcmd.exec_cmd(
+        cmdlib.exec_cmd(
             [
                 "ip",
                 "addr",
@@ -639,7 +639,7 @@ def _setup_dhcp_nics():
     )
 
     assert (
-        libcmd.exec_cmd(
+        cmdlib.exec_cmd(
             [
                 "ip",
                 "addr",
@@ -654,7 +654,7 @@ def _setup_dhcp_nics():
 
 
 def _clean_up():
-    libcmd.exec_cmd(["systemctl", "stop", "dnsmasq"])
+    cmdlib.exec_cmd(["systemctl", "stop", "dnsmasq"])
     _remove_veth_pair()
     try:
         os.unlink(DNSMASQ_CONF_PATH)

--- a/tests/integration/interface_common_test.py
+++ b/tests/integration/interface_common_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -25,7 +25,7 @@ import libnmstate
 from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 from .testlib import statelib
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -37,11 +37,11 @@ DUMMY_INTERFACE = "dummy_test"
 
 @pytest.fixture(scope="function")
 def ip_link_dummy():
-    libcmd.exec_cmd(["ip", "link", "add", DUMMY_INTERFACE, "type", "dummy"])
+    cmdlib.exec_cmd(["ip", "link", "add", DUMMY_INTERFACE, "type", "dummy"])
     try:
         yield
     finally:
-        libcmd.exec_cmd(["ip", "link", "del", DUMMY_INTERFACE])
+        cmdlib.exec_cmd(["ip", "link", "del", DUMMY_INTERFACE])
 
 
 @contextmanager

--- a/tests/integration/nmstatectl_edit_test.py
+++ b/tests/integration/nmstatectl_edit_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -20,7 +20,7 @@
 import os
 
 
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 
 
 RC_SUCCESS = 0
@@ -33,7 +33,7 @@ def test_edit_abort():
     runenv.update(env)
 
     cmds = ["nmstatectl", "edit", "lo"]
-    ret = libcmd.exec_cmd(cmds, env=runenv)
+    ret = cmdlib.exec_cmd(cmds, env=runenv)
     rc, out, err = ret
 
     assert_rc(rc, os.EX_DATAERR, ret)
@@ -46,7 +46,7 @@ def test_edit_no_change_eth1():
     runenv.update(env)
 
     cmds = ["nmstatectl", "edit", "eth1"]
-    ret = libcmd.exec_cmd(cmds, env=runenv)
+    ret = cmdlib.exec_cmd(cmds, env=runenv)
     rc, out, err = ret
 
     assert_rc(rc, RC_SUCCESS, ret)

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -25,7 +25,7 @@ import time
 from libnmstate.schema import Constants
 
 from .testlib import assertlib
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 from .testlib.examplelib import example_state
 from .testlib.examplelib import find_examples_dir
 from .testlib.examplelib import load_example
@@ -92,18 +92,18 @@ CONFIRMATION_TIMOUT_COMMAND = SET_CMD + [
 
 def test_missing_operation():
     cmds = ["nmstatectl", "no-such-oper"]
-    ret = libcmd.exec_cmd(cmds)
+    ret = cmdlib.exec_cmd(cmds)
     rc, out, err = ret
 
-    assert rc == libcmd.RC_FAIL2, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_FAIL2, cmdlib.format_exec_cmd_result(ret)
     assert "nmstatectl: error: invalid choice: 'no-such-oper'" in err
 
 
 def test_show_command_with_json():
-    ret = libcmd.exec_cmd(SHOW_CMD + ["--json"])
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["--json"])
     rc, out, err = ret
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
     assert LOOPBACK_JSON_CONFIG in out
 
     state = json.loads(out)
@@ -111,18 +111,18 @@ def test_show_command_with_json():
 
 
 def test_show_command_with_yaml_format():
-    ret = libcmd.exec_cmd(SHOW_CMD)
+    ret = cmdlib.exec_cmd(SHOW_CMD)
     rc, out, err = ret
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
     assert LOOPBACK_YAML_CONFIG in out
 
 
 def test_show_command_json_only_lo():
-    ret = libcmd.exec_cmd(SHOW_CMD + ["--json", "lo"])
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["--json", "lo"])
     rc, out, err = ret
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
     state = json.loads(out)
     assert len(state[Constants.INTERFACES]) == 1
@@ -130,20 +130,20 @@ def test_show_command_json_only_lo():
 
 
 def test_show_command_only_non_existing():
-    ret = libcmd.exec_cmd(SHOW_CMD + ["--json", "non_existing_interface"])
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["--json", "non_existing_interface"])
     rc, out, err = ret
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
     state = json.loads(out)
     assert len(state[Constants.INTERFACES]) == 0
 
 
 def test_set_command_with_yaml_format():
-    ret = libcmd.exec_cmd(SET_CMD, stdin=ETH1_YAML_CONFIG)
+    ret = cmdlib.exec_cmd(SET_CMD, stdin=ETH1_YAML_CONFIG)
     rc, out, err = ret
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
 
 def test_set_command_with_two_states():
@@ -152,10 +152,10 @@ def test_set_command_with_two_states():
         os.path.join(examples, "linuxbrige_eth1_up.yml"),
         os.path.join(examples, "linuxbrige_eth1_absent.yml"),
     ]
-    ret = libcmd.exec_cmd(cmd)
+    ret = cmdlib.exec_cmd(cmd)
     rc = ret[0]
 
-    assert rc == libcmd.RC_SUCCESS, libcmd.format_exec_cmd_result(ret)
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
 
 def test_manual_confirmation(eth1_up):
@@ -206,9 +206,9 @@ def test_automatic_rollback(eth1_up):
         assertlib.assert_state(clean_state)
 
 
-def assert_command(cmd, expected_rc=libcmd.RC_SUCCESS):
-    ret = libcmd.exec_cmd(cmd)
+def assert_command(cmd, expected_rc=cmdlib.RC_SUCCESS):
+    ret = cmdlib.exec_cmd(cmd)
     returncode = ret[0]
 
-    assert returncode == expected_rc, libcmd.format_exec_cmd_result(ret)
+    assert returncode == expected_rc, cmdlib.format_exec_cmd_result(ret)
     return ret

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -30,7 +30,7 @@ from libnmstate.schema import OVSBridge
 from libnmstate.error import NmstateLibnmError
 
 from .testlib import assertlib
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 from .testlib.ovslib import Bridge
 from .testlib.vlan import vlan_interface
 
@@ -143,13 +143,13 @@ def test_nm_ovs_plugin_missing():
 
 @contextmanager
 def disable_nm_ovs_plugin():
-    libcmd.exec_cmd(DNF_REMOVE_NM_OVS_CMD)
-    libcmd.exec_cmd(SYSTEMCTL_RESTART_NM_CMD)
+    cmdlib.exec_cmd(DNF_REMOVE_NM_OVS_CMD)
+    cmdlib.exec_cmd(SYSTEMCTL_RESTART_NM_CMD)
     try:
         yield
     finally:
-        libcmd.exec_cmd(DNF_INSTALL_NM_OVS_CMD)
-        libcmd.exec_cmd(SYSTEMCTL_RESTART_NM_CMD)
+        cmdlib.exec_cmd(DNF_INSTALL_NM_OVS_CMD)
+        cmdlib.exec_cmd(SYSTEMCTL_RESTART_NM_CMD)
 
 
 @pytest.fixture

--- a/tests/integration/preserve_ip_config_test.py
+++ b/tests/integration/preserve_ip_config_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -28,7 +28,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 
 from .testlib import statelib
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 
 _IPV4_EXTRA_CONFIG = "ipv4.dad-timeout"
 _IPV4_EXTRA_VALUE = "0"
@@ -97,7 +97,7 @@ def _get_nm_profile_uuid(iface_name):
 
 
 def _get_cur_extra_ip_config(uuid, key):
-    rc, output, _ = libcmd.exec_cmd(
+    rc, output, _ = cmdlib.exec_cmd(
         ["nmcli", "--get-values", key, "connection", "show", uuid]
     )
     assert rc == 0
@@ -116,7 +116,7 @@ def _extra_ip_config(uuid, key, value):
 
 def _apply_extra_ip_config(uuid, key, value):
     assert (
-        libcmd.exec_cmd(["nmcli", "connection", "modify", uuid, key, value])[0]
+        cmdlib.exec_cmd(["nmcli", "connection", "modify", uuid, key, value])[0]
         == 0
     )
 

--- a/tests/integration/profile_test.py
+++ b/tests/integration/profile_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -28,7 +28,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 
-from .testlib import cmd as libcmd
+from .testlib import cmdlib
 
 
 DUMMY0_IFNAME = "dummy0"
@@ -106,7 +106,7 @@ def dummy_interface(ifname):
 
 @pytest.fixture
 def dummy_inactive_profile():
-    libcmd.exec_cmd(NMCLI_CON_ADD_DUMMY_CMD)
+    cmdlib.exec_cmd(NMCLI_CON_ADD_DUMMY_CMD)
     profile_exists = _profile_exists(
         DUMMY_PROFILE_DIRECTORY + "testProfile.nmconnection"
     )
@@ -114,13 +114,13 @@ def dummy_inactive_profile():
     try:
         yield DUMMY0_IFNAME
     finally:
-        libcmd.exec_cmd(_nmcli_delete_connection("testProfile"))
+        cmdlib.exec_cmd(_nmcli_delete_connection("testProfile"))
 
 
 @contextmanager
 def create_inactive_profile(con_name):
-    libcmd.exec_cmd(_nmcli_deactivate_connection(con_name))
-    libcmd.exec_cmd(NMCLI_CON_ADD_ETH_CMD)
+    cmdlib.exec_cmd(_nmcli_deactivate_connection(con_name))
+    cmdlib.exec_cmd(NMCLI_CON_ADD_ETH_CMD)
     profile_exists = _profile_exists(
         ETH_PROFILE_DIRECTORY + "ifcfg-testProfile"
     )
@@ -128,7 +128,7 @@ def create_inactive_profile(con_name):
     try:
         yield
     finally:
-        libcmd.exec_cmd(_nmcli_delete_connection("testProfile"))
+        cmdlib.exec_cmd(_nmcli_delete_connection("testProfile"))
 
 
 def _nmcli_deactivate_connection(con_name):

--- a/tests/integration/testlib/cmdlib.py
+++ b/tests/integration/testlib/cmdlib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -21,7 +21,7 @@ import json
 import logging
 
 from libnmstate import iplib
-from . import cmd as libcmd
+from . import cmdlib
 
 
 def ip_rule_exist_in_os(ip_from, ip_to, priority, table):
@@ -32,7 +32,7 @@ def ip_rule_exist_in_os(ip_from, ip_to, priority, table):
         ip_to and iplib.is_ipv6_address(ip_to)
     ):
         cmds.append("-6")
-    result = libcmd.exec_cmd(cmds + ["--json", "rule"])
+    result = cmdlib.exec_cmd(cmds + ["--json", "rule"])
     logging.debug(f"Current ip rules in OS: {result[1]}")
     assert result[0] == 0
     current_rules = json.loads(result[1])

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -28,9 +28,9 @@ from libnmstate.schema import Interface
 
 from .testlib import assertlib
 from .testlib.bondlib import bond_interface
-from .testlib.cmd import RC_SUCCESS
-from .testlib.cmd import exec_cmd
-from .testlib.cmd import format_exec_cmd_result
+from .testlib.cmdlib import RC_SUCCESS
+from .testlib.cmdlib import exec_cmd
+from .testlib.cmdlib import format_exec_cmd_result
 from .testlib.vxlan import VxlanState
 from .testlib.vxlan import vxlan_interfaces
 from .testlib.vxlan import vxlans_absent


### PR DESCRIPTION
The `testlib.cmd` module is imported under a custom name because `cmd`
is too generic. Rename it to `cmdlib` to follow other sub libs in
`testlib`.

Signed-off-by: Till Maas <opensource@till.name>