### PR TITLE
nmclient: Remove client creation/deletion logging

### DIFF
--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -246,7 +246,6 @@ class _MainLoop:
 class _NmClient:
     def __init__(self):
         self._client = NM.Client.new(None)
-        logging.debug("NM.Client created")
 
     @property
     def client(self):
@@ -308,4 +307,3 @@ class _NmClient:
                         context.iteration(True)
                 finally:
                     timeout_source.destroy()
-            logging.debug("NM.Client cleaned")


### PR DESCRIPTION
nmclient: Remove client creation/deletion logging

The existing client logging is overloading the log.
Therefore, this change removes them.
```
2020-01-27 22:54:54 nmclient.py:249 DEBUG NM.Client created
2020-01-27 22:54:54 nmclient.py:311 DEBUG NM.Client cleaned
2020-01-27 22:54:54 nmclient.py:249 DEBUG NM.Client created
2020-01-27 22:54:54 nmclient.py:311 DEBUG NM.Client cleaned
2020-01-27 22:54:54 nmclient.py:249 DEBUG NM.Client created
```
