### PR TITLE
nm, ovs: Learn the ovs bridge ports and ifaces from NM

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -154,6 +154,10 @@ def get_ovs_info(bridge_device, devices_info):
         return {}
 
 
+def get_slaves(nm_device):
+    return nm_device.get_slaves()
+
+
 def _get_bridge_ports_info(port_profiles, devices_info):
     ports_info = []
     for p in port_profiles:


### PR DESCRIPTION
OVS ports and interfaces have been interpreted by parsing the current
state instead of fetching it from the NM device.
Now that the `get_slaves` function is available (from NM 1.14), the
parsing and the hard-coded port name prefix assumptions are no longer
needed.

Note: The hard-coded prefix of the ovs ports names limited changes to
their name format in the future. The current change allows future
changes to the port names, keeping backward compatibility.