### PR TITLE
netapplier: Wait before the verification step

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -149,6 +149,9 @@ def _apply_ifaces_state(
                     con_profiles=ifaces_add_configs + ifaces_edit_configs,
                 )
             if verify_change:
+                # Some actions are not getting updated fast enough in the
+                # kernel/cache. Wait a bit before the verification step.
+                time.sleep(2)
                 _verify_change(desired_state)
         if not commit:
             return checkpoint


### PR DESCRIPTION
CI tests have frequently failed on the `test_dhcp4_with_static_ipv6`
test, missing the IPv6 address.

This change assumes that such problems occur due to the kernel or NM
client cache not updating fast enough, therefore, a small sleep period
is added before the verification step.