### PR TITLE
Dynamic: Use dhcp-iaid introduced in NM 1.22

### DIFF
--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -119,6 +119,7 @@ def create_setting(config, base_con_profile):
         nmclient.NM.SettingIP6ConfigAddrGenMode.EUI64
     )
     setting_ip.props.dhcp_duid = "ll"
+    setting_ip.props.dhcp_iaid = "mac"
 
     if not config or not config.get(InterfaceIPv6.ENABLED):
         setting_ip.props.method = (

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -13,7 +13,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager-ovs \
                    NetworkManager-team \
                    NetworkManager-config-server \
-                   dhcp-client \
                    openvswitch \
                    systemd-udev \
                    \

--- a/packaging/docker_sys_config.sh
+++ b/packaging/docker_sys_config.sh
@@ -11,10 +11,4 @@ sed -i \
     -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
     /etc/systemd/journald.conf
 
-cat > /etc/NetworkManager/conf.d/97-use-dhclient.conf <<EOF
-# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1749358
-[main]
-dhcp=dhclient
-EOF
-
 systemctl enable openvswitch.service


### PR DESCRIPTION
Use dhcp-iaid=mac for IPv4 and IPv6 dynamic address.