### PR TITLE
tests integ: VLAN as a slave of a bond

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -99,6 +99,16 @@ def bond99_with_slave(eth2_up):
         yield state
 
 
+@pytest.fixture
+def eth2_vlan102(eth2_up):
+    vlan_id = 102
+    vlan_base_iface = eth2_up[Interface.KEY][0][Interface.NAME]
+    port_name = '{}.{}'.format(vlan_base_iface, vlan_id)
+    with vlan_interface(port_name, vlan_id, vlan_base_iface):
+        state = statelib.show_only((port_name,))
+        yield state
+
+
 def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
     state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
     libnmstate.apply(state)
@@ -387,3 +397,11 @@ def test_create_vlan_over_a_bond(bond99_with_slave):
     ) as desired_state:
         assertlib.assert_state(desired_state)
     assertlib.assert_state(bond99_with_slave)
+
+
+def test_create_vlan_as_slave_of_bond(eth2_vlan102, bond99_with_slave):
+    bond_name = bond99_with_slave[Interface.KEY][0][Interface.NAME]
+    vlan_id = 102
+    slaves = ['{}.{}'.format(bond_name, vlan_id)]
+    with bond_interface(bond_name, slaves) as state:
+        assertlib.assert_state(state)


### PR DESCRIPTION
Test that a VLAN interface has been successfully added as a
slave to a bond.

**Changelog:**
The `eth2_vlan102` fixture returns a VLAN over an interface (eth2), and then adds `eth2_vlan102` as a slave to the bond (bond99)

Signed-off-by: Nandan Kulkarni <NandanSanjivKulkarni@gmail.com>