### PR TITLE
packaging: Remove python3-dbus workaround

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -20,6 +20,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager-config-server \
                    openvswitch2.11 \
                    systemd-udev \
+                   python3-devel \
                    python3-dbus \
                    python3-gobject-base \
                    python3-jsonschema \
@@ -30,15 +31,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    git \
                    iproute \
                    rpm-build \
-                   # Below package for pip (used by tox) to build dbus-python
-                   # Bug https://bugzilla.redhat.com/show_bug.cgi?id=1654774
-                   make \
-                   python3-devel \
-                   cairo-devel \
-                   cairo-gobject-devel \
-                   glib2-devel \
-                   gobject-introspection-devel \
-                   dbus-devel && \
+                   && \
     dnf -y group install "Development Tools" && \
     pip3 install pytest==4.6.6 pytest-cov==2.8.1 \
         python-coveralls tox --user && \

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -23,7 +23,6 @@ provider support on the southbound.
 
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
-Requires:       python3-dbus
 Requires:       NetworkManager-libnm >= 1:1.20
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
@@ -39,7 +38,6 @@ This package contains the Python 3 library for Nmstate.
 
 %prep
 %setup -q
-sed -i -e '/^dbus-python$/d' requirements.txt
 
 %build
 %py3_build


### PR DESCRIPTION
Since CentOS 8.1 is out, we do not need the python3-dbus workaround
anymore. It now contains a fixed package.

Signed-off-by: Till Maas <opensource@till.name>