### PR TITLE
stdci: Remove oVirt STDCI

### DIFF
--- a/.stdci.yml
+++ b/.stdci.yml
@@ -1,9 +1,0 @@
----
-Architectures:
-  - x86_64:
-      Distributions:
-        - fc30
-      runtime-requirements:
-        host-distro: same
-script:
-  from-file: automation/run-tests.sh

--- a/automation/README.md
+++ b/automation/README.md
@@ -19,14 +19,6 @@ It may be used both locally and through CI.
 
   It also handles the cleanup of the container and nets (stop,rm).
 
-- run-tests.mounts: Includes mounts to be used by the oVirt CI (STDCI) worker.
-
-- run-tests.packages: Includes the packages needed by the oVirt CI (STDCI)
-  worker.
-
-- run-tests.environment.yaml: Instruct the oVirt CI (STDCI) to run
-  integration test.
-
 ## Running the Tests
 Assuming *docker* is installed on the host, just run:
 `./automation/run-tests.sh`

--- a/automation/run-tests.environment.yaml
+++ b/automation/run-tests.environment.yaml
@@ -1,7 +1,0 @@
----
-- name: 'TEST_TYPE'
-  value: 'integ'
-- name: 'CONTAINER_IMAGE'
-  value: 'nmstate/centos8-nmstate-dev'
-- name: 'CI'
-  value: 'true'

--- a/automation/run-tests.mounts
+++ b/automation/run-tests.mounts
@@ -1,1 +1,0 @@
-/var/run/docker.sock:/var/run/docker.sock

--- a/automation/run-tests.packages
+++ b/automation/run-tests.packages
@@ -1,2 +1,0 @@
-docker
-iputils


### PR DESCRIPTION
oVirt STDCI has been optional for some time now and we rarely look at
its results.
Therefore, there is no point in keeping them running.