### PR TITLE
nm, ovs: Properly delete ovs-port profiles

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -274,6 +274,10 @@ def _get_affected_devices(iface_state):
             devs += bridge.get_slaves(nmdev)
         elif iface_type == bond.BOND_TYPE:
             devs += bond.get_slaves(nmdev)
+
+        ovs_port_dev = ovs.get_port_by_slave(nmdev)
+        if ovs_port_dev:
+            devs.append(ovs_port_dev)
     return devs
 
 

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -266,9 +266,7 @@ def _get_affected_devices(iface_state):
         iface_type = iface_state[Interface.TYPE]
         if iface_type == ovs.BRIDGE_TYPE:
             port_slaves = ovs.get_slaves(nmdev)
-            iface_slaves = [
-                iface for port in port_slaves for iface in ovs.get_slaves(port)
-            ]
+            iface_slaves = _get_ovs_interfaces(iface_state)
             devs += port_slaves + iface_slaves
         elif iface_type == LB.TYPE:
             devs += bridge.get_slaves(nmdev)
@@ -279,6 +277,25 @@ def _get_affected_devices(iface_state):
         if ovs_port_dev:
             devs.append(ovs_port_dev)
     return devs
+
+
+def _get_ovs_interfaces(iface_state):
+    """
+    Report a list of all interfaces that are connected to the OVS bridge.
+    This is a workaround solution for https://bugzilla.redhat.com/1797478.
+    """
+    ifaces = [
+        port[Interface.NAME]
+        for port in iface_state.get(OvsB.CONFIG_SUBTREE, {}).get(
+            OvsB.PORT_SUBTREE, []
+        )
+    ]
+    nmdevs = []
+    for ifname in ifaces:
+        dev = device.get_device_by_name(ifname)
+        if dev:
+            nmdevs.append(dev)
+    return nmdevs
 
 
 def prepare_proxy_ifaces_desired_state(ifaces_desired_state):

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -135,6 +135,15 @@ def is_ovs_interface_type_id(type_id):
     return type_id == nmclient.NM.DeviceType.OVS_INTERFACE
 
 
+def get_port_by_slave(nmdev):
+    active_con = connection.get_device_active_connection(nmdev)
+    if active_con:
+        master = active_con.get_master()
+        if master and is_ovs_port_type_id(master.get_device_type()):
+            return master
+    return None
+
+
 def get_bridge_info(bridge_device, devices_info):
     info = get_ovs_info(bridge_device, devices_info)
     if info:

--- a/tests/integration/testlib/nmlib.py
+++ b/tests/integration/testlib/nmlib.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.nm import connection
+from libnmstate.nm import device
+from libnmstate.nm import ovs
+
+
+def list_profiles_by_iface_name(iface_name):
+    return connection.list_connections_by_ifname(iface_name)
+
+
+def get_ovs_port_by_slave(iface_name):
+    """
+    Given an interface name, return the interface name of the OVS port
+    it is connected to. In any other case, return None.
+    """
+    iface_nmdev = device.get_device_by_name(iface_name)
+    if iface_nmdev:
+        port_nmdev = ovs.get_port_by_slave(iface_nmdev)
+        if port_nmdev:
+            return port_nmdev.get_iface()
+    return None


### PR DESCRIPTION
When an interface that is connected to an OVS bridge is removed, there
is a need to remove also the ovs-port profile which implicitly exists.

This change removes the ovs-port profile toghether with the enslaved
interface.

This PR replaces #511 .