### PR TITLE
integ: download plugin packages before running the tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -102,7 +102,14 @@ def _get_osname():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def download_nm_team_plugin():
+def download_packages():
     cmdlib.exec_cmd(
-        ("dnf", "install", "-y", "--downloadonly", "NetworkManager-team",)
+        (
+            "dnf",
+            "install",
+            "-y",
+            "--downloadonly",
+            "NetworkManager-ovs",
+            "NetworkManager-team",
+        )
     )

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -40,7 +40,13 @@ PORT1 = "ovs1"
 VLAN_IFNAME = "eth101"
 
 DNF_REMOVE_NM_OVS_CMD = ("dnf", "remove", "-y", "-q", "NetworkManager-ovs")
-DNF_INSTALL_NM_OVS_CMD = ("dnf", "install", "-y", "-q", "NetworkManager-ovs")
+DNF_INSTALL_NM_OVS_CMD = (
+    "dnf",
+    "install",
+    "-y",
+    "--cacheonly",
+    "NetworkManager-ovs",
+)
 SYSTEMCTL_RESTART_NM_CMD = ("systemctl", "restart", "NetworkManager")
 
 


### PR DESCRIPTION
This patch is going to avoid connectivity issues during the package
installation when running tests.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>