### PR TITLE
travis, automation: move format, lint and unit tests to el8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
               --copr networkmanager/NetworkManager-master"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type format"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type lint"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type unit_py36"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type unit_py37"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -74,38 +74,23 @@ function install_nmstate {
 function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_FORMAT ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running formatter in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e black'
-        fi
+        container_exec 'tox -e black'
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_LINT ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e flake8,pylint'
-        fi
+        container_exec 'tox -e flake8,pylint'
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_UNIT_PY36 ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e py36'
-        fi
+        container_exec 'tox -e py36'
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_UNIT_PY37 ];then
         if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
+            echo "Running python 3.7 unit test in $CONTAINER_IMAGE container is not " \
                  "support yet"
         else
             container_exec 'tox -e py37'
@@ -115,7 +100,7 @@ function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_UNIT_PY38 ];then
         if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
+            echo "Running python 3.8 unit test in $CONTAINER_IMAGE container is not " \
                  "support yet"
         else
             container_exec 'tox -e py38'

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -14,6 +14,8 @@ RUN dnf -y install dnf-plugins-core && \
 RUN dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable networkmanager/NetworkManager-1.20 -y
 
+RUN dnf -y install https://extras.getpagespeed.com/release-el8-latest.rpm
+
 RUN dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
@@ -32,6 +34,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    git \
                    iproute \
                    rpm-build \
+                   pygobject2-devel \
+                   dbus-python-devel \
                    && \
     dnf -y group install "Development Tools" && \
     pip3 install pytest==4.6.6 pytest-cov==2.8.1 \


### PR DESCRIPTION
Format test, lint and python3.6 unit tests are going to run on el8.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>