### PR TITLE
automation: upgrade fedora container image to F32

### DIFF
--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,7 +2,7 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM docker.io/library/fedora:31
+FROM docker.io/library/fedora:32
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 


### PR DESCRIPTION
As we are going to support NetworkManager 1.22 we are testing now on
Fedora rawhide instead of Fedora 31.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>