### PR TITLE
Travis: Run unit tests on CentOS 8 CI image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
               --copr networkmanager/NetworkManager-master"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type format"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type lint"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type unit_py36"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -74,22 +74,12 @@ function install_nmstate {
 function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_FORMAT ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running formatter in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e black'
-        fi
+        container_exec "tox -e black"
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_LINT ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e flake8,pylint'
-        fi
+        container_exec "tox -e flake8,pylint"
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ commands =
 
 [testenv:pylint]
 basepython = python3.6
+sitepackages = True
 skip_install = true
 changedir = {toxinidir}
 deps = {[testenv]deps}


### PR DESCRIPTION
The `--sitepackages` tox argument could instruct tox to use OS installed
python site packages for nmstate dependencies instead of pip installed
one.
