### PR TITLE
nm, applier, ovs: Hash the OVS port device name

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import base64
+import hashlib
 import itertools
 
 from libnmstate.error import NmstateValueError
@@ -43,11 +45,15 @@ from . import vxlan
 from . import wired
 
 
+MAXIMUM_INTERFACE_LENGTH = 15
+
 MASTER_METADATA = "_master"
 MASTER_TYPE_METADATA = "_master_type"
 MASTER_IFACE_TYPES = ovs.BRIDGE_TYPE, bond.BOND_TYPE, LB.TYPE
 
 BRPORT_OPTIONS_METADATA = "_brport_options"
+
+IFACE_NAME_METADATA = "_iface_name"
 
 
 def create_new_ifaces(con_profiles):
@@ -246,6 +252,10 @@ def _get_new_ifaces(con_profiles):
         ifname = con_profile.devname
         nmdev = device.get_device_by_name(ifname)
         if not nmdev:
+            # When the profile id is different from the iface name, use the
+            # profile id.
+            if ifname != con_profile.con_id:
+                ifname = con_profile.con_id
             ifaces_without_device.add(ifname)
     return ifaces_without_device
 
@@ -325,21 +335,38 @@ def prepare_proxy_ifaces_desired_state(ifaces_desired_state):
         new_ifaces_desired_state.append(port_iface_desired_state)
         # The "visible" slave/interface needs to point to the port profile
         iface_desired_state[MASTER_METADATA] = port_iface_desired_state[
-            Interface.NAME
+            IFACE_NAME_METADATA
         ]
         iface_desired_state[MASTER_TYPE_METADATA] = ovs.PORT_TYPE
     return new_ifaces_desired_state
 
 
 def _create_ovs_port_iface_desired_state(iface_desired_state, port_options):
+    port_name = ovs.PORT_PROFILE_PREFIX + iface_desired_state[Interface.NAME]
     return {
-        "name": ovs.PORT_PROFILE_PREFIX + iface_desired_state[Interface.NAME],
-        "type": ovs.PORT_TYPE,
-        "state": iface_desired_state[Interface.STATE],
+        Interface.NAME: port_name,
+        Interface.TYPE: ovs.PORT_TYPE,
+        Interface.STATE: iface_desired_state[Interface.STATE],
+        OvsB.OPTIONS_SUBTREE: port_options,
         MASTER_METADATA: iface_desired_state[MASTER_METADATA],
         MASTER_TYPE_METADATA: iface_desired_state[MASTER_TYPE_METADATA],
-        "options": port_options,
+        IFACE_NAME_METADATA: _generate_hash_iface_name(port_name),
     }
+
+
+def _generate_hash_iface_name(name):
+    """
+    Given a name, generate a hash string that may be used as an interface name.
+
+    The OVS port does not have an actual interface in the kernel, but
+    its length is still limited by NM connection.interface-name.
+    https://bugzilla.redhat.com/1788432
+    As a workaround, hash the full name and use it as an alternative device
+    name (assigned as a metadata). The profile/connection name format has
+    an OVS PORT prefix
+    """
+    name_ = base64.urlsafe_b64encode(hashlib.sha256(name.encode()).digest())
+    return name_[:MAXIMUM_INTERFACE_LENGTH].decode()
 
 
 def _build_connection_profile(iface_desired_state, base_con_profile=None):
@@ -362,9 +389,13 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
     if base_profile:
         con_setting.import_by_profile(base_con_profile)
     else:
+        iface_name = (
+            iface_desired_state.get(IFACE_NAME_METADATA)
+            or iface_desired_state[Interface.NAME]
+        )
         con_setting.create(
             con_name=iface_desired_state[Interface.NAME],
-            iface_name=iface_desired_state[Interface.NAME],
+            iface_name=iface_name,
             iface_type=iface_type,
         )
     master = iface_desired_state.get(MASTER_METADATA)

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -125,7 +125,8 @@ class ConnectionProfile:
 
     @property
     def con_id(self):
-        return self._con_id
+        con_id = self._con_profile.get_id() if self._con_profile else None
+        return self._con_id or con_id
 
     @con_id.setter
     def con_id(self, connection_id):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -143,6 +143,22 @@ def test_vlan_as_ovs_bridge_slave(vlan_on_eth1):
         assertlib.assert_state_match(state)
 
 
+@pytest.mark.xfail(
+    raises=(NmstateLibnmError, AssertionError),
+    reason="https://bugzilla.redhat.com/1724901",
+)
+def test_ovs_interface_with_max_length_name():
+    bridge = Bridge(BRIDGE1)
+    ovs_interface_name = "ovs123456789012"
+    bridge.add_internal_port(ovs_interface_name)
+
+    with bridge.create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent(ovs_interface_name)
+
+
 def test_nm_ovs_plugin_missing():
     with disable_nm_ovs_plugin():
         with pytest.raises(NmstateLibnmError):


### PR DESCRIPTION
nm, applier, ovs: Hash the OVS port device name

The OVS port device name is limited by NM to the kernel interface name
length (15 chars) even though there is no real underline interface. [1]

As a workaround, this change hashes the profile name into a max of 15 hex
characters and uses it as the profile interface/device name.
The interface name is creaded as part of the OVS port (proxy) interface
state and passed on through the setup flow by adding it as metadata to
the state.

[1] https://bugzilla.redhat.com/1788432


Depends on #717 
An alternative to #678 