### PR TITLE
nm.nmclient: add timeout per action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
           use_coveralls=false
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+          testflags="--test-type integ_slow --pytest-args='-x'"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
           testflags="--test-type integ --pytest-args='-x'"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
@@ -23,11 +25,14 @@ env:
           testflags="--test-type unit_py38"
 
 matrix:
+    fast_finish: true
     allow_failures:
         - env: CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'"
         - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
                testflags="--test-type integ --pytest-args='-x'"
+        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+               testflags="--test-type integ_slow --pytest-args='-x'"
 
 addons:
     apt:

--- a/automation/README.md
+++ b/automation/README.md
@@ -28,10 +28,15 @@ using 'nmstate/fedora-nmstate-dev' docker image.
 You may change the test type by specifying the `--test-type` flag, for example:
 
  * `./automation/run-tests.sh --test-type integ --el8`:
-   Integration tests using 'nmstate/centos8-nmstate-dev' docker image.
+   Integration tests (without slow test cases) using
+   'nmstate/centos8-nmstate-dev' docker image.
 
  * `./automation/run-tests.sh --test-type integ`:
-   Integration tests using 'nmstate/fedora-nmstate-dev' docker image.
+   Integration tests (without slow test cases) using
+   'nmstate/fedora-nmstate-dev' docker image.
+
+ * `./automation/run-tests.sh --test-type integ_slow`:
+   Integration slow test cases using `nmstate/fedora-nmstate-dev` docker image.
 
 For a full list of command-line flags, run `./automation/run-tests.sh --help`.
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -13,9 +13,19 @@ TEST_TYPE_LINT="lint"
 TEST_TYPE_UNIT_PY36="unit_py36"
 TEST_TYPE_UNIT_PY38="unit_py38"
 TEST_TYPE_INTEG="integ"
+TEST_TYPE_INTEG_SLOW="integ_slow"
 
 FEDORA_IMAGE_DEV="nmstate/fedora-nmstate-dev"
 CENTOS_IMAGE_DEV="nmstate/centos8-nmstate-dev"
+
+PYTEST_OPTIONS="--verbose --verbose \
+        --log-level=DEBUG \
+        --log-date-format='%Y-%m-%d %H:%M:%S' \
+        --log-format='%(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s' \
+        --durations=5 \
+        --cov /usr/lib/python*/site-packages/libnmstate \
+        --cov /usr/lib/python*/site-packages/nmstatectl \
+        --cov-report=term"
 
 : ${CONTAINER_CMD:=docker}
 
@@ -109,15 +119,20 @@ function run_tests {
         container_exec "
           cd $CONTAINER_WORKSPACE &&
           pytest \
-            --verbose --verbose \
-            --log-level=DEBUG \
-            --log-date-format='%Y-%m-%d %H:%M:%S' \
-            --log-format='%(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s' \
-            --durations=5 \
-            --cov /usr/lib/python*/site-packages/libnmstate \
-            --cov /usr/lib/python*/site-packages/nmstatectl \
+            $PYTEST_OPTIONS \
             --cov-report=html:htmlcov-integ \
-            --cov-report=term \
+            tests/integration \
+            ${nmstate_pytest_extra_args}"
+    fi
+
+    if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
+       [ $TEST_TYPE == $TEST_TYPE_INTEG_SLOW ];then
+        container_exec "
+          cd $CONTAINER_WORKSPACE &&
+          pytest \
+            $PYTEST_OPTIONS \
+            --cov-report=html:htmlcov-integ_slow \
+            -m slow --runslow \
             tests/integration \
             ${nmstate_pytest_extra_args}"
     fi
@@ -238,6 +253,7 @@ while true; do
         echo "     * $TEST_TYPE_FORMAT"
         echo "     * $TEST_TYPE_LINT"
         echo "     * $TEST_TYPE_INTEG"
+        echo "     * $TEST_TYPE_INTEG_SLOW"
         echo "     * $TEST_TYPE_UNIT_PY36"
         echo "     * $TEST_TYPE_UNIT_PY38"
         echo -n "--customize allows to specify a command to customize the "

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -164,9 +164,8 @@ class _MainLoop:
         if not self.actions_exists():
             return
 
-        with self._idle_timeout(timeout):
-            self._register_first_action()
-            self._mainloop.run()
+        self._register_first_action(timeout)
+        self._mainloop.run()
 
         if self._error == _MainLoop.RUN_TIMEOUT_ERROR:
             raise error.NmstateTimeoutError(
@@ -238,11 +237,12 @@ class _MainLoop:
         mainloop.quit()
         return _MainLoop.FAIL
 
-    def _register_first_action(self):
-        GLib.timeout_add(1, self._execute_action_once, None)
+    def _register_first_action(self, timeout):
+        GLib.timeout_add(1, self._execute_action_once, timeout)
 
-    def _execute_action_once(self, _):
-        self.execute_next_action()
+    def _execute_action_once(self, timeout):
+        with self._idle_timeout(timeout):
+            self.execute_next_action()
         return False
 
     def _execute_teardown_action(self):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,6 +33,22 @@ OS: {osname}
 """
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow is given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def logging_setup():
     logging.basicConfig(

--- a/tests/integration/timeout_test.py
+++ b/tests/integration/timeout_test.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import time
+
+import pytest
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import LinuxBridge
+from libnmstate.schema import VLAN
+
+
+@pytest.mark.slow
+def test_lot_of_vlans_with_bridges(eth1_up):
+    interfaces = []
+    for i in range(100, 400):
+        interfaces.extend(
+            [
+                {
+                    Interface.NAME: "vlan." + str(i),
+                    Interface.TYPE: InterfaceType.VLAN,
+                    Interface.STATE: InterfaceState.UP,
+                    VLAN.CONFIG_SUBTREE: {VLAN.BASE_IFACE: "eth1", VLAN.ID: i},
+                },
+                {
+                    Interface.NAME: "linux-br" + str(i),
+                    Interface.TYPE: InterfaceType.LINUX_BRIDGE,
+                    Interface.STATE: InterfaceState.UP,
+                    LinuxBridge.CONFIG_SUBTREE: {
+                        LinuxBridge.PORT_SUBTREE: [
+                            {LinuxBridge.Port.NAME: "vlan." + str(i)}
+                        ]
+                    },
+                },
+            ]
+        )
+    checkpoint = libnmstate.apply({Interface.KEY: interfaces}, commit=False)
+    libnmstate.rollback(checkpoint)
+    time.sleep(5)


### PR DESCRIPTION
When doing a lot of operations in a single transaction the timeout
expires and the transaction fails. Adding a timeout per action instead
of per transaction solves this issue.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>