### PR TITLE
Travis: Run py36 unit test on CentOS 8 CI image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
           testflags="--test-type format"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type lint"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type unit_py36"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type unit_py37"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -85,8 +85,7 @@ function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_UNIT_PY36 ];then
         if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
-                 "support yet"
+            container_exec 'tox --sitepackages -e py36'
         else
             container_exec 'tox -e py36'
         fi

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -36,6 +36,9 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     dnf -y group install "Development Tools" && \
     pip3 install pytest==4.6.6 pytest-cov==2.8.1 \
         python-coveralls tox --user && \
+    # Upgrade OS python3-setuptool as workaround of bug:
+    #   https://github.com/pypa/pip/issues/6264
+    pip3 install setuptools --upgrade && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /root/.local/bin/pytest /usr/bin/pytest && \
     ln -s /root/.local/bin/tox /usr/bin/tox && \


### PR DESCRIPTION
Change Travis to use CentOS 8 for unit test on python 3.6 instead of
Fedora.

Due to pip/setuptools bug: https://github.com/pypa/pip/issues/6264 ,
upgrade system installed python3-setuptools is required.