### PR TITLE
test team: Don't remove dependency rpm

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -40,7 +40,11 @@ BRIDGE1 = "br1"
 PORT1 = "ovs1"
 VLAN_IFNAME = "eth101"
 
-DNF_REMOVE_NM_OVS_CMD = ("dnf", "remove", "-y", "-q", "NetworkManager-ovs")
+DNF_REMOVE_NM_OVS_CMD = (
+    "rpm",
+    "-e",
+    "NetworkManager-ovs",
+)
 DNF_INSTALL_NM_OVS_CMD = (
     "dnf",
     "install",

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -42,10 +42,8 @@ DNF_INSTALL_NM_TEAM_PLUGIN_CMD = (
 )
 
 DNF_REMOVE_NM_TEAM_PLUGIN_CMD = (
-    "dnf",
-    "remove",
-    "-y",
-    "-q",
+    "rpm",
+    "-e",
     "NetworkManager-team",
 )
 


### PR DESCRIPTION
    When using `dnf remove NetworkManager-team`, dnf may also remove all
    dependent packages that have no other usages. Those packages are not
    cached and may fail integration test that follow.

    Using `rpm -e` will not remove dependency packages.