### PR TITLE
nm activation: Manual check on activation state

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -34,6 +34,7 @@ class ActiveConnection:
     def __init__(self, active_connection=None):
         self.handlers = set()
         self.device_handlers = set()
+        self.state_check_running = False
         self._act_con = active_connection
         self._mainloop = nmclient.mainloop()
 

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -105,18 +105,8 @@ SYSFS_DISABLE_RA_SRV = "/proc/sys/net/ipv6/conf/{}/accept_ra".format(
 parametrize_ip_ver = pytest.mark.parametrize(
     "ip_ver",
     [
-        pytest.param(
-            (Interface.IPV4,),
-            marks=pytest.mark.xfail(
-                reason="https://bugzilla.redhat.com/1798374", strict=True
-            ),
-        ),
-        pytest.param(
-            (Interface.IPV6,),
-            marks=pytest.mark.xfail(
-                reason="https://bugzilla.redhat.com/1798374", strict=True
-            ),
-        ),
+        (InterfaceIPv4,),
+        (InterfaceIPv6,),
         (Interface.IPV4, Interface.IPV6),
     ],
     ids=["ipv4", "ipv6", "ipv4&6"],


### PR DESCRIPTION
The commit 071102afce4e12161f9b6f0d14e4249a85932403 introduced
code checking on state-flags(IP4_READY and IP6_READY) of NM.ActivateConnection,
but NetworkManager does trigger event on 'stage-change' signal when
state-flags changes.
This stop user from activating DHCPv4 with IPv6 disabled.

To fix this issue, do manual repeat(1 second interval) check on
activation state.