### PR TITLE
schema: modify MAC address minimum limitation

### DIFF
--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -63,7 +63,7 @@ definitions:
         - down
     mac-address:
       type: string
-      pattern: "^([a-fA-F0-9]{2}:){5,31}[a-fA-F0-9]{2}$"
+      pattern: "^([a-fA-F0-9]{2}:){3,31}[a-fA-F0-9]{2}$"
     bridge-vlan-tag:
       type: integer
       minimum: 0

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -178,6 +178,34 @@ class TestIfaceCommon:
             libnmstate.validator.validate(default_data)
 
 
+class TestIfaceMacAddress:
+    @pytest.mark.parametrize(
+        "mac_address",
+        [
+            "00:11:22:33",
+            "00:11:22:33:44:55",
+            "80:00:02:08:fe:80:00:00:00:00:00:00:f4:52:14:03:00:8d:52:11",
+        ],
+    )
+    def test_valid_mac_address(self, default_data, mac_address):
+        default_data[INTERFACES][0][Interface.MAC] = mac_address
+        libnmstate.validator.validate(default_data)
+
+    @pytest.mark.parametrize(
+        "mac_address",
+        [
+            "00:11:22",
+            "00:xx:xx:yy:100",
+            "90:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+            "00:00:00:00:00:00:00:00:00:00:00",
+        ],
+    )
+    def test_invalid_mac_address(self, default_data, mac_address):
+        default_data[INTERFACES][0][Interface.MAC] = mac_address
+        with pytest.raises(js.ValidationError, match=str(mac_address)):
+            libnmstate.validator.validate(default_data)
+
+
 class TestIfaceTypeEthernet:
     def test_valid_ethernet_with_auto_neg(self, default_data):
         default_data[INTERFACES][0].update(


### PR DESCRIPTION
In some virtual interfaces like 'tun' or 'ip-tunnel' the MAC address
could be less than six octets. In order to fix that, we have modify the
minimum limitation to one octet.

If an user sets an invalid MAC address then NetworkManager is
reporting it clearly.

```
2020-02-06 14:50:20,585 root         ERROR    NM main-loop aborted:
		Connection update failed: error=nm-connection-error-quark:
		802-3-ethernet.cloned-mac-address: '12:BC:B9:2B' is not a valid MAC
		address (7), dev=eth1/<enum NM_DEVICE_STATE_ACTIVATED of type NM.DeviceState>
```

Ref: https://bugzilla.redhat.com/1796838

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>