### PR TITLE
 tox, tavis: remove python 3.7 unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type unit_py36"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
-          testflags="--test-type unit_py37"
-        - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type unit_py38"
 
 matrix:

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -11,7 +11,6 @@ TEST_TYPE_ALL="all"
 TEST_TYPE_FORMAT="format"
 TEST_TYPE_LINT="lint"
 TEST_TYPE_UNIT_PY36="unit_py36"
-TEST_TYPE_UNIT_PY37="unit_py37"
 TEST_TYPE_UNIT_PY38="unit_py38"
 TEST_TYPE_INTEG="integ"
 
@@ -88,16 +87,6 @@ function run_tests {
             container_exec 'tox --sitepackages -e py36'
         else
             container_exec 'tox -e py36'
-        fi
-    fi
-
-    if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
-       [ $TEST_TYPE == $TEST_TYPE_UNIT_PY37 ];then
-        if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            echo "Running unit test in $CONTAINER_IMAGE container is not " \
-                 "support yet"
-        else
-            container_exec 'tox -e py37'
         fi
     fi
 
@@ -246,7 +235,6 @@ while true; do
         echo "     * $TEST_TYPE_LINT"
         echo "     * $TEST_TYPE_INTEG"
         echo "     * $TEST_TYPE_UNIT_PY36"
-        echo "     * $TEST_TYPE_UNIT_PY37"
         echo "     * $TEST_TYPE_UNIT_PY38"
         echo -n "--customize allows to specify a command to customize the "
         echo "container before running the tests"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black, flake8, pylint, py36, py37, py38
+envlist = black, flake8, pylint, py36, py38
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
As run-tests.sh is now using Fedora 32, it requires to install python 3.7
to run python 3.7 unit tests.

```
GLOB sdist-make: /root/nmstate-workspace/setup.py
py37 create: /root/nmstate-workspace/.tox/py37
SKIPPED: InterpreterNotFound: python3.7
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>