### PR TITLE
tests, integ: Do not run test_nm_ovs_plugin_missing

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -163,6 +163,9 @@ def test_ovs_interface_with_max_length_name():
     assertlib.assert_absent(ovs_interface_name)
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/nmstate/nmstate/issues/759", run=False
+)
 def test_nm_ovs_plugin_missing():
     with disable_nm_ovs_plugin():
         with pytest.raises(NmstateLibnmError):


### PR DESCRIPTION
When running test_nm_ovs_plugin_missing test, the NM ovs plugin is
removed. Unfortunatly it fails to be re-installed when the test ends.

Until this issue is fixed, the test is marked not to run in the suite.

Ref: https://github.com/nmstate/nmstate/issues/759