### PR TITLE
Remove xfail from all nm ovs tests

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -27,7 +27,6 @@ from libnmstate.schema import Interface
 from libnmstate.schema import OVSBridge as OB
 
 from .testlib import mainloop
-from .testlib import MainloopTestError
 
 
 BRIDGE0 = "brtest0"
@@ -54,10 +53,6 @@ def bridge_default_config():
     }
 
 
-@pytest.mark.xfail(
-    raises=(MainloopTestError, AssertionError),
-    reason="https://bugzilla.redhat.com/1724901",
-)
 def test_create_and_remove_minimum_config_bridge(
     bridge_minimum_config, bridge_default_config
 ):
@@ -71,10 +66,6 @@ def test_create_and_remove_minimum_config_bridge(
     assert not _get_bridge_current_state()
 
 
-@pytest.mark.xfail(
-    raises=(MainloopTestError, AssertionError),
-    reason="https://bugzilla.redhat.com/1724901",
-)
 def test_bridge_with_system_port(eth1_up, bridge_default_config):
     bridge_desired_state = bridge_default_config
 
@@ -94,10 +85,6 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
     assert not _get_bridge_current_state()
 
 
-@pytest.mark.xfail(
-    raises=(MainloopTestError, AssertionError),
-    reason="https://bugzilla.redhat.com/1724901",
-)
 def test_bridge_with_internal_interface(bridge_default_config):
     bridge_desired_state = bridge_default_config
 


### PR DESCRIPTION
tests, integ, nm: Remove xfail from all ovs tests

The OVS tests have been marked with xfail because there were instability
issues when running them.

In order to proceed with the development of OVS and detect new issues,
the xfail marking is removed.

Depends on #760