### PR TITLE
nm, ovs: Remove translate {port, bridge} options step

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -311,9 +311,8 @@ def prepare_proxy_ifaces_desired_state(ifaces_desired_state):
         port_opts_metadata = iface_desired_state.get(BRPORT_OPTIONS_METADATA)
         if port_opts_metadata is None:
             continue
-        port_options = ovs.translate_port_options(port_opts_metadata)
         port_iface_desired_state = _create_ovs_port_iface_desired_state(
-            iface_desired_state, port_options
+            iface_desired_state, port_opts_metadata
         )
         new_ifaces_desired_state.append(port_iface_desired_state)
         # The "visible" slave/interface needs to point to the port profile

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -407,7 +407,8 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
             )
             settings.append(linux_bridge_setting)
     elif iface_type == ovs.BRIDGE_TYPE:
-        ovs_bridge_options = ovs.translate_bridge_options(iface_desired_state)
+        ovs_bridge_state = iface_desired_state.get(OvsB.CONFIG_SUBTREE, {})
+        ovs_bridge_options = ovs_bridge_state.get(OvsB.OPTIONS_SUBTREE)
         if ovs_bridge_options:
             settings.append(ovs.create_bridge_setting(ovs_bridge_options))
     elif iface_type == ovs.PORT_TYPE:

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -35,16 +35,6 @@ CAPABILITY = "openvswitch"
 _BRIDGE_OPTION_NAMES = ["fail-mode", "mcast-snooping-enable", "rstp", "stp"]
 
 
-_PORT_OPTION_NAMES = [
-    "tag",
-    "vlan-mode",
-    "bond-mode",
-    "lacp",
-    "bond-updelay",
-    "bond-downdelay",
-]
-
-
 def has_ovs_capability():
     try:
         nmclient.NM.DeviceType.OVS_BRIDGE
@@ -75,9 +65,9 @@ def create_bridge_setting(options):
     return bridge_setting
 
 
-def create_port_setting(options):
+def create_port_setting(port_state):
     port_setting = nmclient.NM.SettingOvsPort.new()
-    for option_name, option_value in options.items():
+    for option_name, option_value in port_state.items():
         if option_name == "tag":
             port_setting.props.tag = option_value
         elif option_name == "vlan-mode":
@@ -90,12 +80,6 @@ def create_port_setting(options):
             port_setting.props.bond_updelay = option_value
         elif option_name == "bond-downdelay":
             port_setting.props.bond_downdelay = option_value
-        else:
-            raise NmstateValueError(
-                "Invalid OVS port option: '{}'='{}'".format(
-                    option_name, option_value
-                )
-            )
 
     return port_setting
 
@@ -113,14 +97,6 @@ def translate_bridge_options(iface_state):
         br_opts[key] = bridge_state[key]
 
     return br_opts
-
-
-def translate_port_options(port_state):
-    port_opts = {}
-    for key in port_state.keys() & set(_PORT_OPTION_NAMES):
-        port_opts[key] = port_state[key]
-
-    return port_opts
 
 
 def is_ovs_bridge_type_id(type_id):

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -128,7 +128,8 @@ def _get_bridge_current_state():
 
 @nmclient_context
 def _create_bridge(bridge_desired_state):
-    br_options = nm.ovs.translate_bridge_options(bridge_desired_state)
+    bridge_state = bridge_desired_state.get(OB.CONFIG_SUBTREE, {})
+    br_options = bridge_state.get(OB.OPTIONS_SUBTREE, {})
     iface_bridge_settings = _get_iface_bridge_settings(br_options)
 
     with mainloop():

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -208,8 +208,7 @@ def _create_port_setting(port_state, port_profile_name):
         iface_type=nm.ovs.PORT_TYPE,
     )
     iface_con_setting.set_master(BRIDGE0, nm.ovs.BRIDGE_TYPE)
-    port_options = nm.ovs.translate_port_options(port_state)
-    bridge_port_setting = nm.ovs.create_port_setting(port_options)
+    bridge_port_setting = nm.ovs.create_port_setting(port_state)
     return iface_con_setting.setting, bridge_port_setting
 
 

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -77,8 +77,6 @@ def test_create_new_ifaces(con_profile_mock):
 def test_prepare_new_ifaces_configuration(
     nm_bond_mock, nm_connection_mock, nm_ipv4_mock, nm_ipv6_mock, nm_ovs_mock
 ):
-    nm_ovs_mock.translate_bridge_options.return_value = {}
-
     ifaces_desired_state = [
         {
             "name": "eth0",
@@ -158,8 +156,6 @@ def test_edit_existing_ifaces_without_profile(
 def test_prepare_edited_ifaces_configuration(
     nm_device_mock, nm_connection_mock, nm_ipv4_mock, nm_ipv6_mock, nm_ovs_mock
 ):
-    nm_ovs_mock.translate_bridge_options.return_value = {}
-
     ifaces_desired_state = [
         {"name": "eth0", "type": "ethernet", "state": "up"}
     ]

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -78,7 +78,6 @@ def test_prepare_new_ifaces_configuration(
     nm_bond_mock, nm_connection_mock, nm_ipv4_mock, nm_ipv6_mock, nm_ovs_mock
 ):
     nm_ovs_mock.translate_bridge_options.return_value = {}
-    nm_ovs_mock.translate_port_options.return_value = {}
 
     ifaces_desired_state = [
         {
@@ -160,7 +159,6 @@ def test_prepare_edited_ifaces_configuration(
     nm_device_mock, nm_connection_mock, nm_ipv4_mock, nm_ipv6_mock, nm_ovs_mock
 ):
     nm_ovs_mock.translate_bridge_options.return_value = {}
-    nm_ovs_mock.translate_port_options.return_value = {}
 
     ifaces_desired_state = [
         {"name": "eth0", "type": "ethernet", "state": "up"}


### PR DESCRIPTION
The OVS {port, bridge} options translation step has no added value at the moment and
can be dropped.

Depends on #761, #760