### PR TITLE
nm, ovs: Support link-aggregation port

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -350,6 +350,16 @@ class OVSBridge(metaclass=_DeprecatorType):
 
             class Slave:
                 NAME = "name"
+
+            class Options:
+                DOWN_DELAY = "bond-downdelay"
+                UP_DELAY = "bond-updelay"
+
+            class Mode:
+                ACTIVE_BACKUP = "active-backup"
+                BALANCE_SLB = "balance-slb"
+                BALANCE_TCP = "balance-tcp"
+                LACP = "lacp"
 
 
 class Team:

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -22,6 +22,7 @@ import pytest
 from unittest import mock
 
 from libnmstate import nm
+from libnmstate.schema import OVSBridge
 
 
 @pytest.fixture
@@ -144,22 +145,26 @@ def test_create_bridge_setting(NM_mock):
 
 
 def test_create_port_setting(NM_mock):
+    mode = OVSBridge.Port.LinkAggregation.Mode.BALANCE_TCP
+    updelay = 1
+    downdelay = 2
     options = {
         "tag": 101,
         "vlan-mode": "voomode",
-        "bond-mode": "boomode",
-        "lacp": "yes",
-        "bond-updelay": 0,
-        "bond-downdelay": 0,
+        OVSBridge.Port.LINK_AGGREGATION_SUBTREE: {
+            OVSBridge.Port.LinkAggregation.MODE: mode,
+            OVSBridge.Port.LinkAggregation.Options.UP_DELAY: updelay,
+            OVSBridge.Port.LinkAggregation.Options.DOWN_DELAY: downdelay,
+        },
     }
     port_setting = nm.ovs.create_port_setting(options)
 
     assert port_setting.props.tag == options["tag"]
     assert port_setting.props.vlan_mode == options["vlan-mode"]
-    assert port_setting.props.bond_mode == options["bond-mode"]
-    assert port_setting.props.lacp == options["lacp"]
-    assert port_setting.props.bond_updelay == options["bond-updelay"]
-    assert port_setting.props.bond_downdelay == options["bond-downdelay"]
+    assert port_setting.props.bond_mode == mode
+    assert port_setting.props.lacp == nm.ovs.LacpValue.ACTIVE
+    assert port_setting.props.bond_updelay == updelay
+    assert port_setting.props.bond_downdelay == downdelay
 
 
 def _mock_port_profile(nm_connection_mock):


### PR DESCRIPTION
Link aggregation is implemented in the nm.ovs module, supporting both
setting and reporting the state.

The state (report) is interpreted from the NM configuration.

As part of the change, existing bond related properties (updelay and
downdelay) have been relocated to the link-aggregation subtree.

The lacp property has been integrated into the `mode` property.
Specifically, lacp is set to `active` when the lag mode is "lacp" or
"balance-tcp" and to "off" when the lag mode is "active-backup" or
"balance-slb".

The following OVS port state may be used to configure a bond:
```
name: ovs-bond1
link-aggregation:
  mode: balance-slb
  slaves:
    - name: eth1
    - name: eth2
```

Depends on #760, #761, #762