### PR TITLE
DHCP tests: Do not use the lease database

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -71,6 +71,7 @@ IPV6_DEFAULT_GATEWAY = "::/0"
 IPV4_DEFAULT_GATEWAY = "0.0.0.0/0"
 
 DNSMASQ_CONF_STR = """
+leasefile-ro
 interface={iface}
 dhcp-range={ipv4_prefix}.200,{ipv4_prefix}.250,255.255.255.0,48h
 enable-ra


### PR DESCRIPTION
When running DHCP integration test repeatedly, the DHCPv4
pool will be exhausted. Do not update the lease file to fix this.

A simpler approach to address the issue from #724