### PR TITLE
ci EL8: Fix unit test on CentOS 8

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -84,7 +84,11 @@ function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_UNIT_PY36 ];then
         if [[ $CONTAINER_IMAGE == *"centos"* ]]; then
-            container_exec 'tox --sitepackages -e py36'
+            # Due to https://github.com/pypa/virtualenv/issues/1009
+            # Instruct virtualenv not to upgrade to the latest versions of pip,
+            # setuptools, wheel and etc
+            container_exec 'env VIRTUALENV_NO_DOWNLOAD=1 \
+                            tox --sitepackages -e py36'
         else
             container_exec 'tox -e py36'
         fi

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -8,7 +8,7 @@ COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
 
-RUN dnf -y install dnf-plugins-core && \
+RUN dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools
 
 RUN dnf copr enable nmstate/ovs-el8 -y && \
@@ -32,16 +32,14 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    git \
                    iproute \
                    rpm-build \
+                   python3-pytest \
+                   python3-pytest-cov \
+                   python3-virtualenv \
                    && \
-    dnf -y group install "Development Tools" && \
-    pip3 install pytest==4.6.6 pytest-cov==2.8.1 \
-        python-coveralls tox --user && \
-    # Upgrade OS python3-setuptool as workaround of bug:
-    #   https://github.com/pypa/pip/issues/6264
-    pip3 install setuptools --upgrade && \
+    pip3 install python-coveralls tox==3.5.3 --user && \
     alternatives --set python /usr/bin/python3 && \
-    ln -s /root/.local/bin/pytest /usr/bin/pytest && \
     ln -s /root/.local/bin/tox /usr/bin/tox && \
+    ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \
     bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
 


### PR DESCRIPTION
The CentOS 8 tox is using latest virtualenv which is not compatible
with pip installed python3-six(when intalling pytest) due to
https://github.com/pypa/virtualenv/issues/1009 issue.

The `VIRTUALENV_NO_DOWNLOAD=1` environment variable will stop virtualenv
doing so.

Use dnf to install pytest from AppStream and pytest-cov from EPEL8 and
fixed the tox version to 3.5.3 using pip3.

Since we are using site packages in tox unit test, there is no need
for rpms from "Development Tools" group.