### PR TITLE
validator: Validate duplicate interface names

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -59,6 +59,7 @@ def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     desired_state = copy.deepcopy(desired_state)
     validator.validate(desired_state)
     validator.validate_capabilities(desired_state, netinfo.capabilities())
+    validator.validate_unique_interface_name(desired_state)
     validator.validate_dhcp(desired_state)
     validator.validate_dns(desired_state)
     validator.validate_vxlan(desired_state)

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -45,6 +45,10 @@ class NmstateRouteWithNoUpInterfaceError(NmstateValueError):
 
 
 class NmstateRouteWithNoIPInterfaceError(NmstateValueError):
+    pass
+
+
+class NmstateDuplicateInterfaceNameError(NmstateValueError):
     pass
 
 
@@ -107,6 +111,17 @@ def validate_link_aggregation_state(desired_state, current_state):
                         )
                     )
                 specified_slaves |= slaves
+
+
+def validate_unique_interface_name(state):
+    ifaces_names = [
+        ifstate[schema.Interface.NAME]
+        for ifstate in state.get(schema.Interface.KEY, [])
+    ]
+    if len(ifaces_names) != len(set(ifaces_names)):
+        raise NmstateDuplicateInterfaceNameError(
+            f"Duplicate interfaces names detected: {sorted(ifaces_names)}"
+        )
 
 
 def validate_dhcp(state):

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -152,6 +152,18 @@ def test_dns_three_nameservers():
             }
         }
     )
+
+
+def test_unique_interface_name():
+    with pytest.raises(validator.NmstateDuplicateInterfaceNameError):
+        libnmstate.validator.validate_unique_interface_name(
+            {
+                schema.Interface.KEY: [
+                    {schema.Interface.NAME: "foo0"},
+                    {schema.Interface.NAME: "foo0"},
+                ]
+            }
+        )
 
 
 def empty_state():


### PR DESCRIPTION
The current interface state is using the name property as an unique
key. Passing in duplicate interfaces names causes a failure only at the
verification step (if it is executed), making it hard to understand the
problem.

This change adds a validation for duplicate interface names, raising an
error early on.