### PR TITLE
nmclient: Use exceptions in mainloop.run and introduce NmstateTimeoutError

### DIFF
--- a/libnmstate/error.py
+++ b/libnmstate/error.py
@@ -109,3 +109,11 @@ class NmstateNotSupportedError(NmstateError):
     """
 
     pass
+
+
+class NmstateTimeoutError(NmstateLibnmError):
+    """
+    The transaction execution timed out.
+    """
+
+    pass

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -203,14 +203,11 @@ def _verify_change(desired_state):
 def _setup_providers():
     mainloop = nmclient.mainloop()
     yield
-    success = mainloop.run(timeout=MAINLOOP_TIMEOUT)
-    if not success:
+    try:
+        mainloop.run(timeout=MAINLOOP_TIMEOUT)
+    except NmstateLibnmError:
         nmclient.mainloop(refresh=True)
-        raise NmstateLibnmError(
-            "Unexpected failure of libnm when running the mainloop: {}".format(
-                mainloop.error
-            )
-        )
+        raise
 
 
 def _add_interfaces(new_interfaces, desired_state):

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -162,20 +162,22 @@ class _MainLoop:
             )
 
         if not self.actions_exists():
-            return _MainLoop.SUCCESS
+            return
 
         with self._idle_timeout(timeout):
             self._register_first_action()
             self._mainloop.run()
 
         if self._error == _MainLoop.RUN_TIMEOUT_ERROR:
-            return _MainLoop.FAIL
+            raise error.NmstateLibnmError(
+                f"libnm mainloop timed out after {timeout} seconds."
+            )
 
         if len(self._action_queue):
-            self._error = _MainLoop.RUN_EXECUTION_ERROR
-            return _MainLoop.FAIL
-
-        return _MainLoop.SUCCESS
+            err = _MainLoop.RUN_EXECUTION_ERROR
+            raise error.NmstateLibnmError(
+                f"Unexpected failure of libnm when running the mainloop: {err}"
+            )
 
     @property
     def cancellable(self):

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -169,7 +169,7 @@ class _MainLoop:
             self._mainloop.run()
 
         if self._error == _MainLoop.RUN_TIMEOUT_ERROR:
-            raise error.NmstateLibnmError(
+            raise error.NmstateTimeoutError(
                 f"libnm mainloop timed out after {timeout} seconds."
             )
 

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -19,6 +19,7 @@
 from contextlib import contextmanager
 import functools
 
+from libnmstate import error
 from libnmstate import nm
 from libnmstate.nm.nmclient import nmclient_context
 
@@ -31,10 +32,11 @@ class MainloopTestError(Exception):
 def mainloop():
     mloop = nm.nmclient.mainloop()
     yield
-    success = mloop.run(timeout=15)
-    if not success:
+    try:
+        mloop.run(timeout=15)
+    except error.NmstateLibnmError as ex:
         nm.nmclient.mainloop(refresh=True)
-        raise MainloopTestError(mloop.error)
+        raise MainloopTestError(str(ex.args))
 
 
 def mainloop_run(func):


### PR DESCRIPTION
Instead of using return values, use exceptions to reflect the reason of
the mainloop error.

In addition, raise NmstateTimeoutError on mainloop timeout

From the existing errors reported by the mainloop it is hard to
distinguish between a timeout error and an action failure.

This change introduces a dedicated timeout exception that may be used to
identify it by callers.

The integration tests may now be more specific when xfail-ing a test.