### PR TITLE
nm ovs: Enforce compliance of OVS port VLAN schema

### DIFF
--- a/examples/ovsbridge_vlan_port.yml
+++ b/examples/ovsbridge_vlan_port.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+  - name: ovs0
+    type: ovs-interface
+    state: up
+  - name: ovs-br0
+    type: ovs-bridge
+    state: up
+    bridge:
+      port:
+        - name: ovs0
+          vlan:
+            mode: access
+            tag: 2

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -335,6 +335,7 @@ class OVSBridge(metaclass=_DeprecatorType):
             class Mode:
                 ACCESS = "access"
                 TRUNK = "trunk"
+                UNKNOWN = "unknown"
 
             class TrunkTags:
                 ID = "id"

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -67,6 +67,15 @@ def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
     assertlib.assert_absent("ovs-bond1")
 
 
+def test_add_remove_ovs_bridge_vlan(eth1_up, eth2_up):
+    with example_state(
+        "ovsbridge_vlan_port.yml", cleanup="ovsbridge_delete.yml"
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    assertlib.assert_absent("ovs-br0")
+
+
 def test_add_remove_linux_bridge(eth1_up):
     with example_state(
         "linuxbrige_eth1_up.yml", cleanup="linuxbrige_eth1_absent.yml"

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -71,9 +71,10 @@ def test_bridge_with_system_port(eth1_up, bridge_default_config):
 
     eth1_port = {
         OB.Port.NAME: "eth1",
-        # OVS vlan/s are not yet supported.
-        # OB.VLAN.MODE: None,
-        # OB.VLAN.TAG: 0,
+        OB.Port.VLAN_SUBTREE: {
+            OB.Port.Vlan.MODE: OB.Port.Vlan.Mode.ACCESS,
+            OB.Port.Vlan.TAG: 2,
+        },
     }
 
     bridge_desired_state[OB.CONFIG_SUBTREE][OB.PORT_SUBTREE].append(eth1_port)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -246,3 +246,23 @@ class TestOvsLinkAggregation:
 
         assertlib.assert_absent(BRIDGE1)
         assertlib.assert_absent(BOND1)
+
+
+def test_ovs_vlan_access_tag():
+    bridge = Bridge(BRIDGE1)
+    bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
+    bridge.set_port_option(
+        PORT1,
+        {
+            OVSBridge.Port.NAME: PORT1,
+            OVSBridge.Port.VLAN_SUBTREE: {
+                OVSBridge.Port.Vlan.MODE: OVSBridge.Port.Vlan.Mode.ACCESS,
+                OVSBridge.Port.Vlan.TAG: 2,
+            },
+        },
+    )
+    with bridge.create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent(PORT1)

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -94,6 +94,13 @@ class Bridge:
             OVSBridge.PORT_SUBTREE, []
         )
 
+    def set_port_option(self, port_name, new_option):
+        for port_option in self._bridge_iface[OVSBridge.CONFIG_SUBTREE].get(
+            OVSBridge.PORT_SUBTREE, []
+        ):
+            if port_option[OVSBridge.Port.NAME] == port_name:
+                port_option.update(new_option)
+
     @contextmanager
     def create(self):
         desired_state = self.state


### PR DESCRIPTION
The OVS port vlan schema is:

```yml
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      port:
        - name: ovs0
          vlan:
            mode: access
            tag: 2
```

Add two test cases:
    * Example test against `examples/ovsbridge_vlan_port.yml`.
    * Integration test: `test_ovs_vlan_access_tag`