### PR TITLE
nm ip: Extend the DHCP/Autoconf timeout to infinity

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -25,6 +25,8 @@ from libnmstate.nm import route as nm_route
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import Route
 
+INT32_MAX = 2 ** 31 - 1
+
 
 def create_setting(config, base_con_profile):
     setting_ipv4 = None
@@ -64,6 +66,10 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.ignore_auto_dns = not config.get(
                 InterfaceIPv4.AUTO_DNS, True
             )
+            # NetworkManager will remove the virtual interfaces like bridges
+            # when the DHCP timeout expired, set it to the maximum value to
+            # make this unlikely.
+            setting_ipv4.props.dhcp_timeout = INT32_MAX
         elif config.get(InterfaceIPv4.ADDRESS):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -30,6 +30,7 @@ from libnmstate.schema import Route
 
 
 IPV6_DEFAULT_ROUTE_METRIC = 1024
+INT32_MAX = 2 ** 31 - 1
 
 
 def get_info(active_connection):
@@ -133,6 +134,10 @@ def create_setting(config, base_con_profile):
 
     if is_dhcp or is_autoconf:
         _set_dynamic(setting_ip, is_dhcp, is_autoconf)
+        # NetworkManager will remove the virtual interface when DHCPv6 or
+        # IPv6-RA timeout, set them to infinity.
+        setting_ip.props.dhcp_timeout = INT32_MAX
+        setting_ip.props.ra_timeout = INT32_MAX
         setting_ip.props.ignore_auto_routes = not config.get(
             InterfaceIPv6.AUTO_ROUTES, True
         )

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -23,7 +23,7 @@ provider support on the southbound.
 
 %package -n python3-%{libname}
 Summary:        nmstate Python 3 API library
-Requires:       NetworkManager-libnm >= 1:1.22
+Requires:       NetworkManager-libnm >= 1:1.22.8
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
 Recommends:     NetworkManager


### PR DESCRIPTION
For virtual interface(like bond, dummy, etc), once the DHCP or IPv6-RA
timeout, the virtual interface will be removed.

To prevent that, set the DHCP and Autoconf timeout to infinity(INT32_MAX).

Two test cases added:
 * Dummy interface with DHCPv4 and/or DHCPv6 enabled. Check whether
      after default DHCP timeout(45 seconds) cause interface been deleted.
 * Dummy interface with IPv6 autoconf and DHCPv6 enabled. Check
      whether after default IPv6 RA timeout(30 seconds) cause interface
      been deleted.
