### PR TITLE
travis: run integration tests using NM-1.22-git Copr in el8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
           use_coveralls=false
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
+          testflags="--test-type integ --pytest-args='-x'"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
           testflags="--test-type format"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
@@ -23,6 +25,8 @@ env:
 matrix:
     allow_failures:
         - env: CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
+               testflags="--test-type integ --pytest-args='-x'"
+        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
                testflags="--test-type integ --pytest-args='-x'"
 
 addons:

--- a/packaging/Dockerfile.centos8-nmstate-dev-nm-1.22-git
+++ b/packaging/Dockerfile.centos8-nmstate-dev-nm-1.22-git
@@ -1,0 +1,48 @@
+# This Dockerfile is based on the recommendations provided in the
+# Fedora official repository
+# (https://hub.docker.com/r/fedora/systemd-systemd/).
+# It enables systemd to be operational.
+FROM docker.io/library/centos:8
+ENV container docker
+COPY docker_enable_systemd.sh docker_sys_config.sh ./
+
+RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
+
+RUN dnf -y install dnf-plugins-core epel-release && \
+    dnf config-manager --set-enabled PowerTools
+
+RUN dnf copr enable nmstate/ovs-el8 -y && \
+    dnf copr enable networkmanager/NetworkManager-1.22-git -y
+
+RUN dnf -y install --setopt=install_weak_deps=False \
+                   NetworkManager \
+                   NetworkManager-ovs \
+                   NetworkManager-team \
+                   NetworkManager-config-server \
+                   openvswitch2.11 \
+                   systemd-udev \
+                   python3-devel \
+                   python3-dbus \
+                   python3-gobject-base \
+                   python3-jsonschema \
+                   python3-pyyaml \
+                   python3-setuptools \
+                   python36 \
+                   dnsmasq \
+                   git \
+                   iproute \
+                   rpm-build \
+                   python3-pytest \
+                   python3-pytest-cov \
+                   python3-virtualenv \
+                   && \
+    pip3 install python-coveralls tox==3.5.3 --user && \
+    alternatives --set python /usr/bin/python3 && \
+    ln -s /root/.local/bin/tox /usr/bin/tox && \
+    ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
+    dnf clean all && \
+    bash ./docker_sys_config.sh && rm ./docker_sys_config.sh
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]


### PR DESCRIPTION
DockerHub currently breaks the RPM DB in our CentOS 8 container image
making the NM Copr CI jobs fail when updating NM from Copr (see #740).

In order to fix this, we have created a new image repository and have
built the image locally.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>