### PR TITLE
nm ovs: Fix bug of editing existing OVS interface

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -94,6 +94,8 @@ def prepare_edited_ifaces_configuration(ifaces_desired_state):
 
     for iface_desired_state in ifaces_desired_state:
         ifname = iface_desired_state[Interface.NAME]
+        if iface_desired_state[Interface.TYPE] == InterfaceType.OVS_PORT:
+            ifname = iface_desired_state[IFACE_NAME_METADATA]
         nmdev = device.get_device_by_name(ifname)
         cur_con_profile = None
         if nmdev:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -207,3 +207,20 @@ def vlan_on_eth1(eth1_up):
         VLAN_IFNAME, 101, eth1_up[Interface.KEY][0][Interface.NAME]
     ):
         yield VLAN_IFNAME
+
+
+def test_change_ovs_interface_mac():
+    bridge = Bridge(BRIDGE1)
+    bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
+
+    with bridge.create() as state:
+        desired_state = {
+            Interface.KEY: [
+                {Interface.NAME: PORT1, Interface.MAC: "32:e4:ff:ff:ff:ff"}
+            ]
+        }
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent(PORT1)


### PR DESCRIPTION
When editing existing OVS interface, nmstate failed with
    AttributeError: 'SimpleConnection' object has no attribute
    'commit_changes_async'

The root cause is nm/applier failed to load existing profile using
the OVS port interface name when OVS port name changed to hash string.
The fix is correct the interface name before look up when facing OVS
port.

Integration test case added.

Resolves #777