### PR TITLE
py3: Drop usage of collections.Mapping/Sequence

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -17,16 +17,11 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-try:
-    from collections.abc import Mapping
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Mapping
-    from collections import Sequence
-
 from abc import ABCMeta
 from abc import abstractmethod
 from collections import defaultdict
+from collections.abc import Mapping
+from collections.abc import Sequence
 import copy
 from functools import total_ordering
 from ipaddress import ip_address


### PR DESCRIPTION
There is not need to support Python 2 code anymore, therefore removing
leftovers like collections.Mapping/Sequence usage.

Python 3 uses collections.abc.Mapping/Sequence.