### PR TITLE
python3, statelib: drop usage of collections.Mapping/Sequence

### DIFF
--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -17,13 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-try:
-    from collections.abc import Mapping
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Mapping
-    from collections import Sequence
-
+from collections.abc import Mapping
+from collections.abc import Sequence
 import copy
 from operator import itemgetter
 


### PR DESCRIPTION
There is not need to support Python 2 code anymore, therefore removing
leftovers like collections.Mapping/Sequence usage.

Python3 uses collections.abc.Mapping/Sequence.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>