### PR TITLE
validator: report missing NM plugin during validation

### DIFF
--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -79,6 +79,9 @@ def capabilities():
     if nm.ovs.has_ovs_capability():
         caps.add(nm.ovs.CAPABILITY)
 
+    if nm.team.has_team_capability():
+        caps.add(nm.team.CAPABILITY)
+
     return list(caps)
 
 

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -192,16 +192,6 @@ class ConnectionProfile:
                 self._reset_profile()
                 time.sleep(0.1)
                 self.safe_activate_async()
-            elif self._is_ovs_plugin_missing(e):
-                self._mainloop.quit(
-                    "Missing 'NetworkManager-ovs' plugin"
-                    f" to handle device={self.devname}"
-                )
-            elif self._is_team_plugin_missing(e):
-                self._mainloop.quit(
-                    "Missing 'NetworkManager-team' plugin"
-                    f" to handle device={self.devname}"
-                )
             else:
                 self._mainloop.quit(
                     "Connection activation failed on {} {}: error={}".format(
@@ -244,32 +234,6 @@ class ConnectionProfile:
             and err.domain == "nm-manager-error-quark"
             and err.code == 2
             and "is not available on the device" in err.message
-        )
-
-    def _is_ovs_plugin_missing(self, err):
-        return (
-            isinstance(err, nmclient.GLib.GError)
-            and err.domain == nmclient.NM_MANAGER_ERROR_DOMAIN
-            and (
-                self._con_profile.is_type(
-                    nmclient.NM.SETTING_OVS_INTERFACE_SETTING_NAME
-                )
-                or self._con_profile.is_type(
-                    nmclient.NM.SETTING_OVS_PORT_SETTING_NAME
-                )
-                or self._con_profile.is_type(
-                    nmclient.NM.SETTING_OVS_BRIDGE_SETTING_NAME
-                )
-            )
-        )
-
-    def _is_team_plugin_missing(self, err):
-        return (
-            isinstance(err, nmclient.GLib.GError)
-            and err.domain == nmclient.NM_MANAGER_ERROR_DOMAIN
-            and self._con_profile.is_type(
-                nmclient.NM.SETTING_TEAM_SETTING_NAME
-            )
         )
 
     def _get_activation_metadata(self):

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -37,11 +37,8 @@ class LacpValue:
 
 
 def has_ovs_capability():
-    try:
-        nmclient.NM.DeviceType.OVS_BRIDGE
-        return True
-    except AttributeError:
-        return False
+    nm_client = nmclient.client()
+    return nmclient.NM.Capability.OVS in nm_client.get_capabilities()
 
 
 def create_bridge_setting(options_state):

--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -25,7 +25,13 @@ from libnmstate.schema import Interface
 from libnmstate.schema import Team
 
 
+CAPABILITY = "team"
 TEAMD_JSON_DEVICE = "device"
+
+
+def has_team_capability():
+    nm_client = nmclient.client()
+    return nmclient.NM.Capability.TEAM in nm_client.get_capabilities()
 
 
 def create_setting(iface_state, base_con_profile):

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -28,6 +28,7 @@ from .schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge as LB
 from libnmstate.schema import VXLAN
 from libnmstate.error import NmstateDependencyError
@@ -67,6 +68,7 @@ def validate_capabilities(state, capabilities):
 def validate_interface_capabilities(ifaces_state, capabilities):
     ifaces_types = [iface_state.get("type") for iface_state in ifaces_state]
     has_ovs_capability = nm.ovs.CAPABILITY in capabilities
+    has_team_capability = nm.team.CAPABILITY in capabilities
     for iface_type in ifaces_types:
         is_ovs_type = iface_type in (
             nm.ovs.BRIDGE_TYPE,
@@ -77,6 +79,10 @@ def validate_interface_capabilities(ifaces_state, capabilities):
             raise NmstateDependencyError(
                 "Open vSwitch NetworkManager support not installed "
                 "and started"
+            )
+        if iface_type == InterfaceType.TEAM and not has_team_capability:
+            raise NmstateDependencyError(
+                "NetworkManager-team plugin not installed and started"
             )
 
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -25,6 +25,7 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge
+from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateValueError
 
@@ -167,7 +168,7 @@ def test_ovs_interface_with_max_length_name():
 
 def test_nm_ovs_plugin_missing():
     with disable_nm_plugin("ovs"):
-        with pytest.raises(NmstateLibnmError):
+        with pytest.raises(NmstateDependencyError):
             libnmstate.apply(
                 {
                     Interface.KEY: [

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -23,7 +23,7 @@ import os
 import pytest
 
 import libnmstate
-from libnmstate.error import NmstateLibnmError
+from libnmstate.error import NmstateDependencyError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
@@ -63,7 +63,7 @@ def test_edit_team_iface():
 
 def test_nm_team_plugin_missing():
     with disable_nm_plugin("team"):
-        with pytest.raises(NmstateLibnmError):
+        with pytest.raises(NmstateDependencyError):
             libnmstate.apply(
                 {
                     Interface.KEY: [


### PR DESCRIPTION
Now it is possible to get the plugin capabilities from the NM client.
Nmstate is reporting the missing NetworkManager plugin during the
validation instead of during profile activation.

Ref: https://bugzilla.redhat.com/1785160

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>