### PR TITLE
nm.team: Check if "device" exists before delete it

### DIFF
--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -102,7 +102,7 @@ def get_info(device):
 
 
 def _convert_teamd_config_to_nmstate_config(team_config):
-    team_config.pop("device")
+    team_config.pop(TEAMD_JSON_DEVICE, None)
     port_config = team_config.get(Team.PORT_SUBTREE)
 
     if port_config:


### PR DESCRIPTION
If a team interface with options is set using nmcli then "device" is not
found in the team JSON configuration because is optional.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>