### PR TITLE
OVS Link Aggregation

### DIFF
--- a/examples/ovsbridge_bond_create.yml
+++ b/examples/ovsbridge_bond_create.yml
@@ -1,0 +1,15 @@
+---
+interfaces:
+  - name: ovs-br0
+    type: ovs-bridge
+    state: up
+    bridge:
+      options:
+        stp: false
+      port:
+        - name: ovs-bond1
+          link-aggregation:
+            mode: balance-slb
+            slaves:
+              - name: eth1
+              - name: eth2

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -187,8 +187,11 @@ def _get_lag_info(port_name, port_setting, port_slave_names):
 
     lacp = port_setting.props.lacp
     mode = port_setting.props.bond_mode
-    if not mode and lacp == LacpValue.ACTIVE:
-        mode = OB.Port.LinkAggregation.Mode.LACP
+    if not mode:
+        if lacp == LacpValue.ACTIVE:
+            mode = OB.Port.LinkAggregation.Mode.LACP
+        else:
+            mode = OB.Port.LinkAggregation.Mode.ACTIVE_BACKUP
     port_info[OB.Port.NAME] = port_name
     port_info[OB.Port.LINK_AGGREGATION_SUBTREE] = {
         OB.Port.LinkAggregation.MODE: mode,

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -53,6 +53,16 @@ def test_add_remove_ovs_bridge(eth1_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent("ovs-br0")
+
+
+def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
+    with example_state(
+        "ovsbridge_bond_create.yml", cleanup="ovsbridge_delete.yml"
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    assertlib.assert_absent("ovs-br0")
+    assertlib.assert_absent("ovs-bond1")
 
 
 def test_add_remove_linux_bridge(eth1_up):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -37,6 +37,7 @@ from .testlib.ovslib import Bridge
 from .testlib.vlan import vlan_interface
 
 
+BOND1 = "bond1"
 BRIDGE1 = "br1"
 PORT1 = "ovs1"
 VLAN_IFNAME = "eth101"
@@ -230,3 +231,18 @@ def test_change_ovs_interface_mac():
 
     assertlib.assert_absent(BRIDGE1)
     assertlib.assert_absent(PORT1)
+
+
+class TestOvsLinkAggregation:
+    def test_create_and_remove_lag(self, port0_up, port1_up):
+        port0_name = port0_up[Interface.KEY][0][Interface.NAME]
+        port1_name = port1_up[Interface.KEY][0][Interface.NAME]
+
+        bridge = Bridge(BRIDGE1)
+        bridge.add_link_aggregation_port(BOND1, (port0_name, port1_name))
+
+        with bridge.create() as state:
+            assertlib.assert_state_match(state)
+
+        assertlib.assert_absent(BRIDGE1)
+        assertlib.assert_absent(BOND1)

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -51,7 +51,10 @@ class Bridge:
         self._add_port(name)
         port = self._get_port(name)
         port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE] = {
-            OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: slaves
+            OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: [
+                {OVSBridge.Port.LinkAggregation.Slave.NAME: slave}
+                for slave in slaves
+            ]
         }
         if mode:
             port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -164,6 +164,34 @@ class TestAssertIfaceState:
 
         desired_state.verify_interfaces(current_state)
 
+    def test_sort_ovs_lag_slaves(self):
+        desired_state = self._base_state
+        current_state = self._base_state
+        slaves = [
+            {OVSBridge.Port.LinkAggregation.Slave.NAME: "slave1"},
+            {OVSBridge.Port.LinkAggregation.Slave.NAME: "slave2"},
+        ]
+        desired_ovs = {
+            OVSBridge.PORT_SUBTREE: [
+                {
+                    OVSBridge.Port.NAME: "boo",
+                    OVSBridge.Port.LINK_AGGREGATION_SUBTREE: {
+                        OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: slaves
+                    },
+                }
+            ]
+        }
+        current_ovs = copy.deepcopy(desired_ovs)
+        current_port0 = current_ovs[OVSBridge.PORT_SUBTREE][0]
+        current_lag0 = current_port0[OVSBridge.Port.LINK_AGGREGATION_SUBTREE]
+        current_lag0[OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE].reverse()
+        desired_iface_state = desired_state.interfaces["foo-name"]
+        desired_iface_state[OVSBridge.CONFIG_SUBTREE] = desired_ovs
+        current_iface_state = current_state.interfaces["foo-name"]
+        current_iface_state[OVSBridge.CONFIG_SUBTREE] = current_ovs
+
+        desired_state.verify_interfaces(current_state)
+
     def test_description_is_empty(self):
         desired_state = self._base_state
         current_state = self._base_state


### PR DESCRIPTION
Enable support for OVS port Link Aggregation (LAG).

A user can use the following desired state to define an OVS LAG:
```
interfaces:
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      options:
        stp: false
      port:
        - name: ovs-bond1
          link-aggregation:
            mode: balance-slb
            slaves:
              - name: eth1
              - name: eth2
```