### PR TITLE
libnmstate: Do not remove slaves implicitly with master

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -126,6 +126,7 @@ def _apply_ifaces_state(
     desired_state.merge_dns(current_state)
     desired_state.merge_route_rules(current_state)
     desired_state.remove_unknown_interfaces()
+    desired_state.complement_master_interfaces_removal(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
     validator.validate_interfaces_state(desired_state, current_state)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -111,6 +111,16 @@ def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
 
     state = statelib.show_only((state[Interface.KEY][0][Interface.NAME],))
     assert not state[Interface.KEY]
+
+    state = statelib.show_only(
+        (
+            eth1_up[Interface.KEY][0][Interface.NAME],
+            eth2_up[Interface.KEY][0][Interface.NAME],
+        )
+    )
+    assert state
+    assert state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
+    assert state[Interface.KEY][1][Interface.STATE] == InterfaceState.UP
 
 
 def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
@@ -367,9 +377,6 @@ def test_create_linux_bridge_over_bond(bond99_with_slave):
         assertlib.assert_state(desired_state)
 
 
-@pytest.mark.xfail(
-    strict=True, reason="https://nmstate.atlassian.net/browse/NMSTATE-272"
-)
 def test_preserve_bond_after_bridge_removal(bond99_with_slave):
     bridge_name = "linux-br0"
     bridge_state = add_port_to_bridge(create_bridge_subtree_state(), BOND99)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -137,6 +137,10 @@ def test_create_and_remove_linux_bridge_with_one_port(port0_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent(bridge_name)
+
+    state = show_only((port_name,))
+    assert state
+    assert state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
 
 
 def test_create_and_remove_linux_bridge_with_two_ports(port0_up, port1_up):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -31,6 +31,7 @@ from libnmstate.error import NmstateValueError
 
 from .testlib import assertlib
 from .testlib import nmlib
+from .testlib import statelib
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.ovslib import Bridge
 from .testlib.vlan import vlan_interface
@@ -97,6 +98,10 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(port0_up):
         assertlib.assert_state_match(state)
 
     assertlib.assert_absent(BRIDGE1)
+
+    state = statelib.show_only((port0_name,))
+    assert state
+    assert state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
When a master interface is removed, nmstate should not implicitly remove
its slaves. If such an action is desired, the user needs to explicitly
specify it.

This change scope includes the following interface types:
- Bond
- Linux Bridge
- OVS Bridge
- Team

Note: OVS internal interfaces (ovs-interface type) are an exception
here, as such interfaces may not exist without an OVS bridge. Therefore,
these are expected to get removed together with their bridge.

This is also fixing the issue reported in https://nmstate.atlassian.net/browse/NMSTATE-272.