### PR TITLE
team: Fix failure of creating team interface with slaves

### DIFF
--- a/libnmstate/appliers/team.py
+++ b/libnmstate/appliers/team.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import Team
+
+
+def get_slaves_from_state(state, default=()):
+    ports = state.get(Team.CONFIG_SUBTREE, {}).get(Team.PORT_SUBTREE)
+    if ports is None:
+        return default
+    return [p[Team.Port.NAME] for p in ports]

--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -21,6 +21,7 @@ from libnmstate import iplib
 from libnmstate.appliers import linux_bridge
 from libnmstate.appliers import ovs_bridge
 from libnmstate.appliers import bond
+from libnmstate.appliers import team
 from libnmstate.error import NmstateValueError
 from libnmstate import nm
 from libnmstate.schema import DNS
@@ -72,6 +73,13 @@ def generate_ifaces_metadata(desired_state, current_state):
         master_type=InterfaceType.LINUX_BRIDGE,
         get_slaves_func=linux_bridge.get_slaves_from_state,
         set_metadata_func=linux_bridge.set_bridge_ports_metadata,
+    )
+    _generate_link_master_metadata(
+        desired_state.interfaces,
+        current_state.interfaces,
+        master_type=InterfaceType.TEAM,
+        get_slaves_func=team.get_slaves_from_state,
+        set_metadata_func=lambda *args: None,
     )
     _generate_dns_metadata(desired_state, current_state)
     _generate_route_metadata(desired_state, current_state)

--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import copy
 import json
 
 from libnmstate.nm import connection as nm_connection
@@ -59,6 +60,7 @@ def create_setting(iface_state, base_con_profile):
 
 
 def _convert_team_config_to_teamd_format(team_config, ifname):
+    team_config = copy.deepcopy(team_config)
     team_config[TEAMD_JSON_DEVICE] = ifname
 
     team_ports = team_config.get(Team.PORT_SUBTREE, ())


### PR DESCRIPTION
Got failure when creating team interface with slaves caused by:

 * When create setting, the `create_setting()` of `nm/team.py` altered the data layout which trigger failure in `merge_interfaces` at the verification stage.
 * The slave interface does not set `connection.master` and `connection.slave-type`.

Fixed and also added integration test to assert on the run time status
of team interface.