### PR TITLE
nm ipv6: Extend the IPv6 autoconf timeout to infinity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
           testflags="--test-type integ --pytest-args='-x'"
           use_codecov=true
           use_coveralls=false
+        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+          testflags="--test-type integ_slow --pytest-args='-x'"
         - CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'"
         - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
@@ -23,6 +25,7 @@ env:
           testflags="--test-type unit_py38"
 
 matrix:
+    fast_finish: true
     allow_failures:
         - env: CONTAINER_IMAGE=nmstate/fedora-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'"

--- a/automation/README.md
+++ b/automation/README.md
@@ -28,10 +28,15 @@ using 'nmstate/fedora-nmstate-dev' docker image.
 You may change the test type by specifying the `--test-type` flag, for example:
 
  * `./automation/run-tests.sh --test-type integ --el8`:
-   Integration tests using 'nmstate/centos8-nmstate-dev' docker image.
+   Integration tests (without slow test case) using
+   'nmstate/centos8-nmstate-dev' docker image.
 
  * `./automation/run-tests.sh --test-type integ`:
-   Integration tests using 'nmstate/fedora-nmstate-dev' docker image.
+   Integration tests (without slow test case) using
+   'nmstate/fedora-nmstate-dev' docker image.
+
+ * `./automation/run-tests.sh --test-type integ_slow`:
+   Integration slow test cases using 'nmstate/fedora-nmstate-dev' docker image.
 
 For a full list of command-line flags, run `./automation/run-tests.sh --help`.
 

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -25,6 +25,8 @@ from libnmstate.nm import route as nm_route
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import Route
 
+INT32_MAX = 2 ** 31 - 1
+
 
 def create_setting(config, base_con_profile):
     setting_ipv4 = None
@@ -64,6 +66,10 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.ignore_auto_dns = not config.get(
                 InterfaceIPv4.AUTO_DNS, True
             )
+            setting_ipv4.props.dhcp_timeout = INT32_MAX
+            # NetworkManager will remove the virtual interfaces like bridges
+            # when the DHCP timeout expired, set it to the maximum value to
+            # make this unlikely.
         elif config.get(InterfaceIPv4.ADDRESS):
             setting_ipv4.props.method = (
                 nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -134,9 +134,10 @@ def create_setting(config, base_con_profile):
 
     if is_dhcp or is_autoconf:
         _set_dynamic(setting_ip, is_dhcp, is_autoconf)
+        # NetworkManager will remove the virtual interface when DHCPv6 or
+        # IPv6-RA timeout, set them to infinity.
         setting_ip.props.dhcp_timeout = INT32_MAX
-        # NetworkManager will remove the virtual interface when DHCP
-        # timeout, set it to infinity.
+        setting_ip.props.ra_timeout = INT32_MAX
         setting_ip.props.ignore_auto_routes = not config.get(
             InterfaceIPv6.AUTO_ROUTES, True
         )

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -30,6 +30,7 @@ from libnmstate.schema import Route
 
 
 IPV6_DEFAULT_ROUTE_METRIC = 1024
+INT32_MAX = 2 ** 31 - 1
 
 
 def get_info(active_connection):
@@ -133,6 +134,9 @@ def create_setting(config, base_con_profile):
 
     if is_dhcp or is_autoconf:
         _set_dynamic(setting_ip, is_dhcp, is_autoconf)
+        setting_ip.props.dhcp_timeout = INT32_MAX
+        # NetworkManager will remove the virtual interface when DHCP
+        # timeout, set it to infinity.
         setting_ip.props.ignore_auto_routes = not config.get(
             InterfaceIPv6.AUTO_ROUTES, True
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,6 +33,22 @@ OS: {osname}
 """
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow is given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def logging_setup():
     logging.basicConfig(

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1001,11 +1001,6 @@ def test_dummy_existance_after_dhcp_timeout(ip_ver, dummy00):
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    raises=AssertionError,
-    strict=True,
-    reason="https://bugzilla.redhat.com/1801158",
-)
 def test_dummy_existance_after_ipv6_autoconf_timeout(dummy00):
     ifstate = dummy00
     ifstate[Interface.IPV4] = create_ipv4_state(enabled=False)

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -46,6 +46,9 @@ from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
 
 DEFAULT_TIMEOUT = 20
+NM_DHCP_TIMEOUT_DEFAULT = 45
+# The default IPv6 RA/Autoconf timeout is 30 seconds, less than above.
+NM_IPV6_AUTOCONF_TIMEOUT_DEFAULT = 30
 
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV4_ADDRESS2 = "192.0.2.252"
@@ -979,3 +982,40 @@ def test_change_static_to_dhcp6_autoconf_with_disabled_ipv4(
     assert _poll(_has_ipv6_auto_gateway)
     assert _poll(_has_ipv6_auto_nameserver)
     assert _poll(_has_ipv6_auto_extra_route)
+
+
+@pytest.mark.slow
+@parametrize_ip_ver
+def test_dummy_existance_after_dhcp_timeout(ip_ver, dummy00):
+    ifstate = dummy00
+    if Interface.IPV4 in ip_ver:
+        ifstate[Interface.IPV4] = create_ipv4_state(enabled=True, dhcp=True)
+    if Interface.IPV6 in ip_ver:
+        ifstate[Interface.IPV6] = create_ipv6_state(
+            enabled=True, dhcp=True, autoconf=False
+        )
+    libnmstate.apply({Interface.KEY: [ifstate]})
+    time.sleep(NM_DHCP_TIMEOUT_DEFAULT + 1)
+    # NetworkManager by default remove virtual interface after DHCP timeout
+    assertlib.assert_state({Interface.KEY: [ifstate]})
+
+
+@pytest.mark.slow
+@pytest.mark.xfail(
+    raises=AssertionError,
+    strict=True,
+    reason="https://bugzilla.redhat.com/1801158",
+)
+def test_dummy_existance_after_ipv6_autoconf_timeout(dummy00):
+    ifstate = dummy00
+    ifstate[Interface.IPV4] = create_ipv4_state(enabled=False)
+    ifstate[Interface.IPV6] = create_ipv6_state(
+        enabled=True, dhcp=True, autoconf=True
+    )
+    libnmstate.apply({Interface.KEY: [ifstate]})
+    time.sleep(NM_IPV6_AUTOCONF_TIMEOUT_DEFAULT + 1)
+
+    # NetworkManager by default remove virtual interface after autoconf timeout
+    # According to RFC 4861, autoconf(IPv6-RA) will instruct client to do
+    # DHCPv6 or not. With autoconf timeout, DHCPv6 will not start.
+    assertlib.assert_state({Interface.KEY: [ifstate]})


### PR DESCRIPTION
For virtual interface(like bond, dummy, etc), once the IPv6 autoconf(IPv6-RA)
timeout, the virtual interface will be removed.

To prevent that, set the IPv6 RA timeout to infinity(INT32_MAX).