### PR TITLE
nm, team: Fix reporting of team slaves

### DIFF
--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -27,6 +27,7 @@ from libnmstate.schema import Team
 
 CAPABILITY = "team"
 TEAMD_JSON_DEVICE = "device"
+TEAMD_JSON_PORTS = "ports"
 
 
 def has_team_capability():
@@ -94,14 +95,13 @@ def get_info(device):
     return info
 
 
-def _convert_teamd_config_to_nmstate_config(team_config):
-    team_config.pop(TEAMD_JSON_DEVICE, None)
-    port_config = team_config.get(Team.PORT_SUBTREE)
+def _convert_teamd_config_to_nmstate_config(teamd_config):
+    teamd_config.pop(TEAMD_JSON_DEVICE, None)
+    port_config = teamd_config.get(TEAMD_JSON_PORTS, {})
+    team_port = _teamd_port_to_nmstate_port(port_config)
 
-    if port_config:
-        team_port = _teamd_port_to_nmstate_port(port_config)
-        team_config[Team.PORT_SUBTREE] = team_port
-
+    team_config = teamd_config
+    team_config[Team.PORT_SUBTREE] = team_port
     return team_config
 
 

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -61,7 +61,7 @@ def test_create_team_iface_without_slaves():
 )
 def test_create_team_iface_with_slaves():
     with team_interface(TEAM0, [PORT1, PORT2]) as team_state:
-        assertlib.assert_state(team_state)
+        assertlib.assert_state_match(team_state)
         assert [PORT1, PORT2] == _get_runtime_team_slaves(TEAM0)
     assertlib.assert_absent(TEAM0)
 
@@ -78,7 +78,7 @@ def test_edit_team_iface():
             Team.PORT_SUBTREE: [{Team.Port.NAME: "eth1"}],
         }
         libnmstate.apply(team_state)
-        assertlib.assert_state(team_state)
+        assertlib.assert_state_match(team_state)
 
 
 def test_nm_team_plugin_missing():


### PR DESCRIPTION
When configuring team ports, the team may return a state like this:
`{'device': 'team0', 'ports': {}, 'runner': {'name': 'roundrobin'}}`

such a state includes the `ports` key with an empty dictionary.

The team ports reporting is adjusted to support such a report.