### PR TITLE
travis: do not mark integ_slow tests as allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
                testflags="--test-type integ --pytest-args='-x'"
         - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev-nm-1.22-git
                testflags="--test-type integ --pytest-args='-x'"
-        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
-               testflags="--test-type integ_slow --pytest-args='-x'"
 
 addons:
     apt:


### PR DESCRIPTION
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>