### PR TITLE
automation: Fix failure of building srpm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include pyproject.toml
 include requirements.txt
 include doc/nmstatectl.8.in
 recursive-include examples *.yml
+exclude packaging/nmstate.spec


### PR DESCRIPTION
In RHEL/CentOS 8.1, the 'packaging/make_srpm.sh' will fail
with error `error: Found more than one spec file`.
The fix is exclude packaging/nmstate.spec when creating tarbal using
`python setup.py sdist --format tar`.