### PR TITLE
test: Move back to Fedora 31 for CI test

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -191,8 +191,11 @@ function is_file_changed {
 
 function rebuild_container_images {
     if is_file_changed "$PROJECT_PATH/packaging"; then
-
-        ${PROJECT_PATH}/packaging/build-container.sh all
+        if [ $CONTAINER_IMAGE == $CENTOS_IMAGE_DEV ];then
+            ${PROJECT_PATH}/packaging/build-container.sh centos8-nmstate-dev
+        elif [ $CONTAINER_IMAGE == $FEDORA_IMAGE_DEV ];then
+            ${PROJECT_PATH}/packaging/build-container.sh fedora-nmstate-dev
+        fi
     fi
 }
 

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,13 +2,15 @@
 # Fedora official repository
 # (https://hub.docker.com/r/fedora/systemd-systemd/).
 # It enables systemd to be operational.
-FROM docker.io/library/fedora:32
+FROM docker.io/library/fedora
 ENV container docker
 COPY docker_enable_systemd.sh docker_sys_config.sh ./
 
 RUN bash ./docker_enable_systemd.sh && rm ./docker_enable_systemd.sh
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install dnf-plugins-core && \
+    dnf copr enable networkmanager/NetworkManager-1.22 -y && \
+    dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
                    NetworkManager-team \


### PR DESCRIPTION
The Fedora 32(currently rawhide) is failing a [lot][1] when build from
Dockerfile.

Moving back to Fedora 31 and use 'networkmanager/NetworkManager-1.22'
copr repo.

[1]: https://hub.docker.com/repository/docker/nmstate/fedora-nmstate-dev

