### PR TITLE
test: Collect coredump when exists

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -141,8 +141,7 @@ function run_tests {
 function collect_artifacts {
     container_exec "
       journalctl > "$CONT_EXPORT_DIR/journal.log" && \
-      dmesg > "$CONT_EXPORT_DIR/dmesg.log" && \
-      cp core* "$CONT_EXPORT_DIR/" || true
+      dmesg > "$CONT_EXPORT_DIR/dmesg.log" || true
     "
 }
 
@@ -298,6 +297,10 @@ fi
 if [[ -v customize_cmd ]];then
     container_exec "${customize_cmd}"
 fi
+
+container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
+    /proc/sys/kernel/core_pattern"
+container_exec "ulimit -c unlimited"
 
 container_exec 'while ! systemctl is-active dbus; do sleep 1; done'
 container_exec 'systemctl start systemd-udevd

--- a/automation/upload_test_artifacts.sh
+++ b/automation/upload_test_artifacts.sh
@@ -5,6 +5,7 @@ SCP_BASEDIR="upload"
 SCP_USERNAME="nmstate"
 SCP_KEY="./automation/upload_test_artifacts.key"
 BASE_URL="https://grisge.info/nmstate"
+ARTIFACTS_DIR="exported-artifacts"
 
 if [ -z "$TRAVIS_JOB_ID" ];then
     echo "Need to be run in travis-CI, quiting"
@@ -14,14 +15,11 @@ fi
 TMP_DIR=$(mktemp -d)
 LOG_DIR=$TMP_DIR/$TRAVIS_JOB_ID
 mkdir $LOG_DIR
-LOG_FILE_LIST="$LOG_DIR/LOG_FILE_LIST.txt"
 LOG_TAR_FILE="$LOG_DIR/nmstate_test_$TRAVIS_JOB_ID.tar.xz"
 
 trap 'rm -rf "$TMP_DIR"' INT TERM HUP EXIT
 
-git ls-files --full-name -o  --exclude=*.pyc --exclude=htmlcov* \
-    --exclude=*.py --exclude=*.py > $LOG_FILE_LIST
-tar cfJ $LOG_TAR_FILE -T $LOG_FILE_LIST
+tar cfJv $LOG_TAR_FILE $ARTIFACTS_DIR
 chmod 600 $SCP_KEY
 scp -o StrictHostKeyChecking=no -r -i $SCP_KEY \
     $LOG_DIR "$SCP_USERNAME@$SCP_SRV:$SCP_BASEDIR/"


### PR DESCRIPTION
When segfault happens in container, only the host can save the coredump.
Enable the systemd coredump in Travis host and collect the coredump
files to exported-artifacts/ folder waiting for upload.