### PR TITLE
bond: Add support of fail_over_mac=active with active backup mode

### DIFF
--- a/libnmstate/appliers/bond.py
+++ b/libnmstate/appliers/bond.py
@@ -18,7 +18,20 @@
 #
 
 from libnmstate.schema import Bond
+from libnmstate.schema import BondMode
 
 
 def get_bond_slaves_from_state(iface_state, default=()):
     return iface_state.get(Bond.CONFIG_SUBTREE, {}).get(Bond.SLAVES, default)
+
+
+def is_in_mac_restricted_mode(bond_options):
+    """
+    Return True when Bond option does not allow MAC address defined.
+    In MAC restricted mode means:
+        Bond mode is BondMode.ACTIVE_BACKUP
+        Bond option "fail_over_mac" is active.
+    """
+    return BondMode.ACTIVE_BACKUP == bond_options.get(
+        Bond.MODE
+    ) and bond_options.get("fail_over_mac") in ("1", 1, "active",)

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -122,6 +122,7 @@ def _choose_checkpoint(dbuspath):
 def _apply_ifaces_state(
     desired_state, verify_change, commit, rollback_timeout
 ):
+    original_desired_state = copy.deepcopy(desired_state)
     current_state = state.State(netinfo.show())
 
     desired_state.sanitize_ethernet(current_state)
@@ -133,7 +134,9 @@ def _apply_ifaces_state(
     desired_state.complement_master_interfaces_removal(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
-    validator.validate_interfaces_state(desired_state, current_state)
+    validator.validate_interfaces_state(
+        original_desired_state, desired_state, current_state
+    )
     validator.validate_routes(desired_state, current_state)
 
     new_interfaces = _list_new_interfaces(desired_state, current_state)

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -411,7 +411,7 @@ def _build_connection_profile(iface_desired_state, base_con_profile=None):
 
     bond_opts = translator.Api2Nm.get_bond_options(iface_desired_state)
     if bond_opts:
-        settings.append(bond.create_setting(bond_opts))
+        settings.append(bond.create_setting(bond_opts, wired_setting))
     elif iface_type == bridge.BRIDGE_TYPE:
         bridge_options = iface_desired_state.get(bridge.BRIDGE_TYPE, {}).get(
             LB.OPTIONS_SUBTREE

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -23,6 +23,7 @@ import re
 
 from . import nmclient
 from libnmstate.error import NmstateValueError
+from libnmstate.appliers.bond import is_in_mac_restricted_mode
 
 
 BOND_TYPE = "bond"
@@ -34,9 +35,12 @@ NM_SUPPORTED_BOND_OPTIONS = nmclient.NM.SettingBond.get_valid_options(
 )
 
 
-def create_setting(options):
+def create_setting(options, wired_setting):
     bond_setting = nmclient.NM.SettingBond.new()
     for option_name, option_value in options.items():
+        if wired_setting and is_in_mac_restricted_mode(options):
+            # When in MAC restricted mode, MAC address should be unset.
+            wired_setting.props.cloned_mac_address = None
         if option_value != SYSFS_EMPTY_VALUE:
             success = bond_setting.add_option(option_name, str(option_value))
             if not success:

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -108,7 +108,7 @@ def _create_bond(name, options):
         iface_name=name,
         iface_type=nm.nmclient.NM.SETTING_BOND_SETTING_NAME,
     )
-    bond_setting = nm.bond.create_setting(options)
+    bond_setting = nm.bond.create_setting(options, wired_setting=None)
     ipv4_setting = nm.ipv4.create_setting({}, None)
     ipv6_setting = nm.ipv6.create_setting({}, None)
 


### PR DESCRIPTION
When bond in active backup mode with fail_over_mac set to active,
the MAC address of bond interface cannot be set.

To support it:
    * When MAC address defined in desired state along with active
      backup mode and fail_over_mac=active, raise `NmstateValueError`.
    * When MAC address defined in desired state while the current
      state of bond is active backup mode with fail_over_mac=active,
      raise NmstateValueError.
    * When MAC address not defined in desired state while the current
      state of bond is active backup mode with fail_over_mac=active.
      Ignore the MAC address of current bond.

Test cases included.