### PR TITLE
validator: allow validation for states without interfaces

### DIFF
--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -24,7 +24,6 @@ import jsonschema as js
 
 from . import nm
 from . import schema
-from .schema import Constants
 from libnmstate.appliers.bond import is_in_mac_restricted_mode
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
@@ -71,7 +70,7 @@ def validate(data, validation_schema=schema.ifaces_schema):
 
 
 def validate_capabilities(state, capabilities):
-    validate_interface_capabilities(state[Constants.INTERFACES], capabilities)
+    validate_interface_capabilities(state.get(Interface.KEY, []), capabilities)
 
 
 def validate_interface_capabilities(ifaces_state, capabilities):
@@ -143,7 +142,7 @@ def validate_unique_interface_name(state):
 
 
 def validate_dhcp(state):
-    for iface_state in state[Constants.INTERFACES]:
+    for iface_state in state.get(Interface.KEY, []):
         for family in ("ipv4", "ipv6"):
             ip = iface_state.get(family, {})
             if (

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -164,21 +164,37 @@ class TestLinkAggregationState:
             )
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotImplementedError,
-    reason="https://nmstate.atlassian.net/browse/NMSTATE-220",
-    strict=True,
-)
-def test_dns_three_nameservers():
-    libnmstate.validator.validate_dns(
-        {
-            DNS.KEY: {
-                DNS.CONFIG: {
-                    DNS.SERVER: ["8.8.8.8", "2001:4860:4860::8888", "8.8.4.4"]
+class TestDnsValidation:
+    @pytest.mark.xfail(
+        raises=NmstateNotImplementedError,
+        reason="https://nmstate.atlassian.net/browse/NMSTATE-220",
+        strict=True,
+    )
+    def test_dns_three_nameservers(self):
+        libnmstate.validator.validate_dns(
+            {
+                DNS.KEY: {
+                    DNS.CONFIG: {
+                        DNS.SERVER: [
+                            "8.8.8.8",
+                            "2001:4860:4860::8888",
+                            "8.8.4.4",
+                        ]
+                    }
                 }
             }
-        }
-    )
+        )
+
+    def test_dns_state_without_interfaces(self):
+        libnmstate.validator.validate_dns(
+            {
+                DNS.KEY: {
+                    DNS.CONFIG: {
+                        DNS.SERVER: ["8.8.8.8", "2001:4860:4860:8888"]
+                    }
+                }
+            }
+        )
 
 
 def test_unique_interface_name():


### PR DESCRIPTION
Now it is possible to apply the a DNS configuration without specifying
the interfaces or routes. e.g.

```
---
dns-resolver:
  config:
    search:
    - example.com
    - example.org
    server:
    - 2001:4860:4860::8888
    - 8.8.8.8
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>