### PR TITLE
automation, travis: Specify registry for container images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,28 @@ env:
     global:
         - use_coveralls=true
     matrix:
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
           use_codecov=true
           use_coveralls=false
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ_slow --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type format"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type lint"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type unit_py36"
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - env: CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -79,8 +79,8 @@ sudo ../packaging/build-container.sh local/fedora-nmstate-dev
 To test the image, either specify it manually as described above or tag it locally:
 
 ```
-sudo podman tag local/centos8-nmstate-dev nmstate/centos8-nmstate-dev:latest
-sudo podman tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:latest
+sudo podman tag local/centos8-nmstate-dev docker.io/nmstate/centos8-nmstate-dev:latest
+sudo podman tag local/fedora-nmstate-dev docker.io/nmstate/fedora-nmstate-dev:latest
 ```
 
 ### Push local image to the docker hub

--- a/automation/README.md
+++ b/automation/README.md
@@ -72,15 +72,15 @@ or:
 ### Build a new container image
 
 ```
-sudo ../packaging/build-container.sh local/centos8-nmstate-dev
-sudo ../packaging/build-container.sh local/fedora-nmstate-dev
+../packaging/build-container.sh local/centos8-nmstate-dev
+../packaging/build-container.sh local/fedora-nmstate-dev
 ```
 
 To test the image, either specify it manually as described above or tag it locally:
 
 ```
-sudo podman tag local/centos8-nmstate-dev docker.io/nmstate/centos8-nmstate-dev:latest
-sudo podman tag local/fedora-nmstate-dev docker.io/nmstate/fedora-nmstate-dev:latest
+podman tag local/centos8-nmstate-dev docker.io/nmstate/centos8-nmstate-dev:latest
+podman tag local/fedora-nmstate-dev docker.io/nmstate/fedora-nmstate-dev:latest
 ```
 
 ### Push local image to the docker hub
@@ -91,13 +91,13 @@ persistent. If this is not feasible, a new build could be pushed as follow to
 the Docker Hub:
 
 ```shell
-sudo podman login docker.io
-sudo podman tag local/centos8-nmstate-dev nmstate/centos8-nmstate-dev:latest
-sudo podman push nmstate/centos8-nmstate-dev:latest \
+podman login docker.io
+podman tag local/centos8-nmstate-dev nmstate/centos8-nmstate-dev:latest
+podman push nmstate/centos8-nmstate-dev:latest \
     docker://docker.io/nmstate/centos8-nmstate-dev:latest
 
-sudo podman tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:latest
-sudo podman push nmstate/fedora-nmstate-dev:latest \
+podman tag local/fedora-nmstate-dev nmstate/fedora-nmstate-dev:latest
+podman push nmstate/fedora-nmstate-dev:latest \
     docker://docker.io/nmstate/fedora-nmstate-dev:latest
 ```
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -15,8 +15,8 @@ TEST_TYPE_UNIT_PY38="unit_py38"
 TEST_TYPE_INTEG="integ"
 TEST_TYPE_INTEG_SLOW="integ_slow"
 
-FEDORA_IMAGE_DEV="nmstate/fedora-nmstate-dev"
-CENTOS_IMAGE_DEV="nmstate/centos8-nmstate-dev"
+FEDORA_IMAGE_DEV="docker.io/nmstate/fedora-nmstate-dev"
+CENTOS_IMAGE_DEV="docker.io/nmstate/centos8-nmstate-dev"
 
 PYTEST_OPTIONS="--verbose --verbose \
         --log-level=DEBUG \

--- a/packaging/build-container.sh
+++ b/packaging/build-container.sh
@@ -22,7 +22,7 @@ EXEC_PATH="$(dirname "$(realpath "$0")")"
 PROJECT_PATH="$(dirname $EXEC_PATH)"
 
 DEFAULT_BUILD_FLAGS="--no-cache --rm"
-DEFAULT_TAG_PREFIX="nmstate"
+DEFAULT_TAG_PREFIX="docker.io/nmstate"
 
 : ${CONTAINER_CMD:=podman}
 


### PR DESCRIPTION
Container registry is now specified at container images in order to
avoid name squatting attacks or any other related problems.

Ref: https://raesene.github.io/blog/2019/09/25/typosquatting-in-a-multi-registry-world/

This PR fixes #785.

Signed-off-by: Elvira García Ruiz <elviragr@riseup.net>