### PR TITLE
bond: Support bond options with numeric values as input

### DIFF
--- a/libnmstate/appliers/bond.py
+++ b/libnmstate/appliers/bond.py
@@ -17,8 +17,55 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import contextlib
+
 from libnmstate.schema import Bond
 from libnmstate.schema import BondMode
+
+
+class BondNamedOptions:
+    AD_SELECT = "ad_select"
+    ARP_ALL_TARGETS = "arp_all_targets"
+    ARP_VALIDATE = "arp_validate"
+    FAIL_OVER_MAC = "fail_over_mac"
+    LACP_RATE = "lacp_rate"
+    MODE = "mode"
+    PRIMARY_RESELECT = "primary_reselect"
+    XMIT_HASH_POLICY = "xmit_hash_policy"
+
+
+BOND_OPTIONS_NUMERIC_TO_NAMED_MAP = {
+    BondNamedOptions.AD_SELECT: ("stable", "bandwidth", "count"),
+    BondNamedOptions.ARP_ALL_TARGETS: ("any", "all"),
+    BondNamedOptions.ARP_VALIDATE: (
+        "none",
+        "active",
+        "backup",
+        "all",
+        "filter",
+        "filter_active",
+        "filter_backup",
+    ),
+    BondNamedOptions.FAIL_OVER_MAC: ("none", "active", "follow"),
+    BondNamedOptions.LACP_RATE: ("slow", "fast"),
+    BondNamedOptions.MODE: (
+        "balance-rr",
+        "active-backup",
+        "balance-xor",
+        "broadcast",
+        "802.3ad",
+        "balance-tlb",
+        "balance-alb",
+    ),
+    BondNamedOptions.PRIMARY_RESELECT: ("always", "better", "failure"),
+    BondNamedOptions.XMIT_HASH_POLICY: (
+        "layer2",
+        "layer3+4",
+        "layer2+3",
+        "encap2+3",
+        "encap3+4",
+    ),
+}
 
 
 def get_bond_slaves_from_state(iface_state, default=()):
@@ -35,3 +82,32 @@ def is_in_mac_restricted_mode(bond_options):
     return BondMode.ACTIVE_BACKUP == bond_options.get(
         Bond.MODE
     ) and bond_options.get("fail_over_mac") in ("1", 1, "active",)
+
+
+def normalize_options_values(iface_state):
+    bond_state = iface_state.get(Bond.CONFIG_SUBTREE, {})
+    options = bond_state.get(Bond.OPTIONS_SUBTREE)
+    if options:
+        normalized_options = {}
+        for option_name, option_value in options.items():
+            option_value = get_bond_named_option_value_by_id(
+                option_name, option_value
+            )
+            normalized_options[option_name] = option_value
+        options.update(normalized_options)
+
+
+def get_bond_named_option_value_by_id(option_name, option_id_value):
+    """
+    Given an option name and its value, return a named option value
+    if it exists.
+    Return the same option value as inputted if:
+    - The option name has no dual named and id values.
+    - The option value is not numeric.
+    - The option value has no corresponding named value (not in range).
+    """
+    option_value = BOND_OPTIONS_NUMERIC_TO_NAMED_MAP.get(option_name)
+    if option_value:
+        with contextlib.suppress(ValueError, IndexError):
+            return option_value[int(option_id_value)]
+    return option_id_value

--- a/libnmstate/appliers/bond.py
+++ b/libnmstate/appliers/bond.py
@@ -90,6 +90,8 @@ def normalize_options_values(iface_state):
     if options:
         normalized_options = {}
         for option_name, option_value in options.items():
+            with contextlib.suppress(ValueError):
+                option_value = int(option_value)
             option_value = get_bond_named_option_value_by_id(
                 option_name, option_value
             )

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -38,6 +38,7 @@ from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.iplib import is_ipv6_address
 from libnmstate.prettystate import format_desired_current_state_diff
+from libnmstate.schema import Bond
 from libnmstate.schema import DNS
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
@@ -360,6 +361,7 @@ class State:
 
     def normalize_for_verification(self):
         self._clean_sanitize_ethernet()
+        self._normalize_lag_options()
         self._sort_lag_slaves()
         self._sort_ovs_lag_slaves()
         self._sort_bridge_ports()
@@ -613,6 +615,11 @@ class State:
     def _sort_lag_slaves(self):
         for ifstate in self.interfaces.values():
             ifstate.get("link-aggregation", {}).get("slaves", []).sort()
+
+    def _normalize_lag_options(self):
+        for ifstate in self.interfaces.values():
+            if ifstate.get(Interface.TYPE) == Bond.KEY:
+                bond.normalize_options_values(ifstate)
 
     def _sort_ovs_lag_slaves(self):
         for ifstate in self.interfaces.values():

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -408,6 +408,18 @@ def test_change_bond_option_miimon(bond99_with_2_slaves):
     assertlib.assert_state(desired_state)
 
 
+def test_change_bond_option_with_an_id_value(bond99_with_slave):
+    option_name = "xmit_hash_policy"
+    desired_state = statelib.show_only((BOND99,))
+    iface_state = desired_state[Interface.KEY][0]
+    bond_options = iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
+    bond_options[option_name] = "2"
+    libnmstate.apply(desired_state)
+    new_iface_state = statelib.show_only((BOND99,))[Interface.KEY][0]
+    new_options = new_iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
+    assert new_options.get(option_name) == "layer2+3"
+
+
 def test_create_bond_without_mode():
     with bond_interface(name=BOND99, slaves=[], create=False) as state:
         state[Interface.KEY][0][Bond.CONFIG_SUBTREE].pop(Bond.MODE)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -403,7 +403,7 @@ def test_change_bond_option_miimon(bond99_with_2_slaves):
     desired_state = statelib.show_only((BOND99,))
     iface_state = desired_state[Interface.KEY][0]
     bond_options = iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
-    bond_options["miimon"] = "200"
+    bond_options["miimon"] = 200
     libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
 

--- a/tests/lib/appliers/__init__.py
+++ b/tests/lib/appliers/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#

--- a/tests/lib/appliers/bond_test.py
+++ b/tests/lib/appliers/bond_test.py
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate.appliers import bond
+
+
+@pytest.mark.parametrize(
+    ("option_name", "named_value", "id_value"),
+    (
+        ("ad_select", "stable", 0),
+        ("ad_select", "bandwidth", 1),
+        ("ad_select", "count", 2),
+        ("arp_validate", "active", 1),
+        ("arp_validate", "filter", 4),
+        ("arp_validate", "filter_backup", 6),
+        ("fail_over_mac", "none", 0),
+        ("fail_over_mac", "active", 1),
+        ("fail_over_mac", "follow", 2),
+    ),
+)
+def test_numeric_to_named_option_value(option_name, id_value, named_value):
+    assert named_value == bond.get_bond_named_option_value_by_id(
+        option_name, id_value
+    )
+
+
+@pytest.mark.parametrize("option_value", ("a", 99))
+def test_numeric_to_named_option_value_with_invalid_id(option_value):
+    assert option_value == bond.get_bond_named_option_value_by_id(
+        "ad_select", option_value
+    )
+
+
+def test_numeric_to_named_option_value_with_invalid_option_name():
+    value = 0
+    assert value == bond.get_bond_named_option_value_by_id("foo", value)


### PR DESCRIPTION
Support bond numeric options by normalizing bond options values in the verification step:
- Numeric only values are converted to integers.
- Dual named and numeric values are converted to named values.

This PR fixes:
https://bugzilla.redhat.com/1805223