### PR TITLE
verification, bond: prepare "arp_ip_target" option for verification

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -77,6 +77,8 @@ def _get_options(nm_device):
             if option == "mode" or value != bond_setting.get_option_default(
                 option
             ):
+                if option == "arp_ip_target":
+                    value = value.replace(" ", ",")
                 options[option] = value
     return options
 

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -501,3 +501,21 @@ def test_create_bond_with_mac(eth1_up, eth2_up):
         extra_iface_state={Interface.MAC: MAC0},
     ) as state:
         assertlib.assert_state_match(state)
+
+
+@pytest.mark.parametrize("ips", ("192.0.2.1,192.0.2.2", "192.0.2.2,192.0.1.1"))
+def test_bond_with_arp_ip_target(eth1_up, eth2_up, ips):
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+                Bond.OPTIONS_SUBTREE: {
+                    "arp_interval": 1000,
+                    "arp_ip_target": ips,
+                },
+            },
+        },
+    ) as desired_state:
+        assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
The "arp_ip_target" option format for NM is "10.1.1.2,10.1.1.3" but we
are reading the options from sysfs and the format is
"10.1.1.2 10.1.1.3".

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>