### PR TITLE
ActiveConnection: Handle uninitialized device

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -86,7 +86,7 @@ class ActiveConnection:
             if self._mainloop.is_action_canceled(e):
                 logging.debug(
                     "Connection deactivation aborted on %s: error=%s",
-                    self._nmdev.get_iface(),
+                    self.devname,
                     e,
                 )
             else:
@@ -105,20 +105,19 @@ class ActiveConnection:
                 else:
                     self._mainloop.quit(
                         "Connection deactivation failed on {}: "
-                        "error={}".format(self._nmdev.get_iface(), e)
+                        "error={}".format(self.devname, e)
                     )
                     return
 
         if success:
             logging.debug(
-                "Connection deactivation succeeded on %s",
-                self._nmdev.get_iface(),
+                "Connection deactivation succeeded on %s", self.devname,
             )
             self._mainloop.execute_next_action()
         else:
             self._mainloop.quit(
                 "Connection deactivation failed on %s: error=unknown"
-                % self._nmdev.get_iface()
+                % self.devname
             )
 
     @property

--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -168,7 +168,10 @@ class ActiveConnection:
 
     @property
     def devname(self):
-        return self._nmdev.get_iface()
+        if self._nmdev:
+            return self._nmdev.get_iface()
+        else:
+            return None
 
     @property
     def nmdevice(self):


### PR DESCRIPTION
    Handle ActiveConnection._nmdev being None. This should fix a Traceback
    when the openvswitch service is not running:
    
    Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/libnmstate/nm/connection.py", line 226, in _active_connection_callback
        ac.devname, ac.reason
      File "/usr/lib/python3.6/site-packages/libnmstate/nm/active_connection.py", line 171, in devname
        return self._nmdev.get_iface()
    AttributeError: 'NoneType' object has no attribute 'get_iface'

This also makes everything use ActiveConnection.devname