### PR TITLE
Enable Packit for automatic Copr builds

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,15 @@
+---
+specfile_path: nmstate.spec
+upstream_package_name: nmstate
+upstream_project_url: http://nmstate.io
+create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
+current_version_command: ["python3", "setup.py", "--version"]
+actions:
+  post-upstream-clone: "bash -c './packaging/make_spec.sh > nmstate.spec'"
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - centos-stream-x86_64
+        - epel-8-x86_64

--- a/packaging/make_srpm.sh
+++ b/packaging/make_srpm.sh
@@ -39,9 +39,10 @@ TAR_FILE="${TMP_DIR}/nmstate-${VERSION}.tar"
 
     ./packaging/make_spec.sh > "${SPEC_FILE}"
     tar --append --file=$TAR_FILE $SPEC_FILE
+    gzip "${TAR_FILE}"
 
     rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
-    -ts $TAR_FILE
+    -ts $TAR_FILE.gz
 ) &> /dev/stderr
 
 SRPM=$(find $TMP_DIR -type f -name \*.src.rpm -exec basename {} \;)

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -8,7 +8,7 @@ Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
 License:        LGPLv2+
 URL:            https://github.com/%{srcname}/%{srcname}
-Source0:        https://github.com/%{srcname}/%{srcname}/archive/v%{version}/%{srcname}-%{version}.tar
+Source0:        https://github.com/%{srcname}/%{srcname}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools


### PR DESCRIPTION
Add configuration for packit-as-a-service to enable automatic Copr builds for pull requests.

We can also use this in the future to simplify updating the Fedora Rawhide package.
