### PR TITLE
nm.checkpoint: fix incorrect interval when adding a timer

### DIFF
--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -127,7 +127,7 @@ class CheckPoint:
             raise NMCheckPointCreationError(str(e))
 
         GLib.timeout_add(
-            self._timeout * 0.5, self._refresh_checkpoint_timeout, None,
+            self._timeout * 500, self._refresh_checkpoint_timeout, None,
         )
 
     def _refresh_checkpoint_timeout(self, data):


### PR DESCRIPTION
According to GLib documentation the interval specified when using
timeout_add() is on miliseconds.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>