### PR TITLE
validator: fix linux bridge validation 

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -66,6 +66,7 @@ def apply(desired_state, verify_change=True, commit=True, rollback_timeout=60):
     validator.validate_dhcp(desired_state)
     validator.validate_dns(desired_state)
     validator.validate_vxlan(desired_state)
+    validator.validate_bridge(desired_state)
 
     checkpoint = _apply_ifaces_state(
         state.State(desired_state), verify_change, commit, rollback_timeout

--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -17,7 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.nm import connection
 from libnmstate.nm import nmclient
 from libnmstate.schema import LinuxBridge as LB
@@ -89,8 +88,6 @@ def create_port_setting(options, base_con_profile):
             port_setting.props.hairpin_mode = val
         elif key == LB.Port.STP_PATH_COST:
             port_setting.props.path_cost = val
-        elif key == LB.Port.VLAN_SUBTREE:
-            raise NmstateNotImplementedError
 
     return port_setting
 

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -209,9 +209,10 @@ def validate_vxlan(state):
 def validate_bridge(state):
     for iface_state in state.get(schema.Interface.KEY, []):
         if iface_state.get(schema.Interface.TYPE) == LB.TYPE:
-            _assert_vlan_filtering_trunk_tags(
-                iface_state.get(LB.PORT_SUBTREE, [])
+            port_states = iface_state.get(LB.CONFIG_SUBTREE, {}).get(
+                LB.PORT_SUBTREE, []
             )
+            _assert_vlan_filtering_trunk_tags(port_states)
 
 
 def validate_ovs_link_aggregation(state):

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -213,6 +213,15 @@ def validate_bridge(state):
                 LB.PORT_SUBTREE, []
             )
             _assert_vlan_filtering_trunk_tags(port_states)
+            _assert_bridge_port_vlan_not_implemented(port_states)
+
+
+def _assert_bridge_port_vlan_not_implemented(port_states):
+    for port in port_states:
+        if port.get(LB.Port.VLAN_SUBTREE):
+            raise NmstateNotImplementedError(
+                "Linux bridge port vlan filtering is not implemented yet."
+            )
 
 
 def validate_ovs_link_aggregation(state):

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -414,12 +414,14 @@ class TestVlanFilteringValidation:
                     schema.Interface.NAME: "br0",
                     schema.Interface.TYPE: LB.TYPE,
                     schema.Interface.STATE: schema.InterfaceState.UP,
-                    LB.PORT_SUBTREE: [
-                        {
-                            LB.Port.NAME: "eth1",
-                            LB.Port.VLAN_SUBTREE: invalid_vlan_config,
-                        }
-                    ],
+                    LB.CONFIG_SUBTREE: {
+                        LB.PORT_SUBTREE: [
+                            {
+                                LB.Port.NAME: "eth1",
+                                LB.Port.VLAN_SUBTREE: invalid_vlan_config,
+                            }
+                        ],
+                    },
                 }
             ]
         }
@@ -439,12 +441,14 @@ class TestVlanFilteringValidation:
                     schema.Interface.NAME: "br0",
                     schema.Interface.TYPE: LB.TYPE,
                     schema.Interface.STATE: schema.InterfaceState.UP,
-                    LB.PORT_SUBTREE: [
-                        {
-                            LB.Port.NAME: "eth1",
-                            LB.Port.VLAN_SUBTREE: invalid_vlan_config,
-                        }
-                    ],
+                    LB.CONFIG_SUBTREE: {
+                        LB.PORT_SUBTREE: [
+                            {
+                                LB.Port.NAME: "eth1",
+                                LB.Port.VLAN_SUBTREE: invalid_vlan_config,
+                            }
+                        ],
+                    },
                 }
             ]
         }
@@ -473,12 +477,14 @@ class TestVlanFilteringValidation:
                     schema.Interface.NAME: "br0",
                     schema.Interface.TYPE: LB.TYPE,
                     schema.Interface.STATE: schema.InterfaceState.UP,
-                    LB.PORT_SUBTREE: [
-                        {
-                            LB.Port.NAME: "eth1",
-                            LB.Port.VLAN_SUBTREE: invalid_vlan_config,
-                        }
-                    ],
+                    LB.CONFIG_SUBTREE: {
+                        LB.PORT_SUBTREE: [
+                            {
+                                LB.Port.NAME: "eth1",
+                                LB.Port.VLAN_SUBTREE: invalid_vlan_config,
+                            }
+                        ],
+                    },
                 }
             ]
         }
@@ -502,21 +508,23 @@ class TestVlanFilteringValidation:
                     schema.Interface.NAME: "br0",
                     schema.Interface.TYPE: LB.TYPE,
                     schema.Interface.STATE: schema.InterfaceState.UP,
-                    LB.PORT_SUBTREE: [
-                        {
-                            LB.Port.NAME: "eth1",
-                            LB.Port.VLAN_SUBTREE: {
-                                LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.TRUNK,
-                                LB.Port.Vlan.TRUNK_TAGS: [
-                                    {
-                                        LB.Port.Vlan.TrunkTags.ID_RANGE: {
-                                            range_key: vlan_tag
+                    LB.CONFIG_SUBTREE: {
+                        LB.PORT_SUBTREE: [
+                            {
+                                LB.Port.NAME: "eth1",
+                                LB.Port.VLAN_SUBTREE: {
+                                    LB.Port.Vlan.MODE: LB.Port.Vlan.Mode.TRUNK,
+                                    LB.Port.Vlan.TRUNK_TAGS: [
+                                        {
+                                            LB.Port.Vlan.TrunkTags.ID_RANGE: {
+                                                range_key: vlan_tag
+                                            }
                                         }
-                                    }
-                                ],
-                            },
-                        }
-                    ],
+                                    ],
+                                },
+                            }
+                        ],
+                    },
                 }
             ]
         }


### PR DESCRIPTION
When creating a linux bridge with an invalid bridge state the cleanup is
not being done.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>