### PR TITLE
validator: Drop unnused parameter at validate_interfaces_state()

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -134,9 +134,7 @@ def _apply_ifaces_state(
     desired_state.complement_master_interfaces_removal(current_state)
     metadata.generate_ifaces_metadata(desired_state, current_state)
 
-    validator.validate_interfaces_state(
-        original_desired_state, desired_state, current_state
-    )
+    validator.validate_interfaces_state(original_desired_state, current_state)
     validator.validate_routes(desired_state, current_state)
 
     new_interfaces = _list_new_interfaces(desired_state, current_state)

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -94,9 +94,7 @@ def validate_interface_capabilities(ifaces_state, capabilities):
             )
 
 
-def validate_interfaces_state(
-    original_desired_state, desired_state, current_state
-):
+def validate_interfaces_state(original_desired_state, current_state):
     validate_link_aggregation_state(original_desired_state, current_state)
     _validate_linux_bond(original_desired_state, current_state)
 

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -577,11 +577,10 @@ class TestLinuxBondValidator:
         iface_state = self._gen_iface_state("bond0")
         iface_state[Bond.CONFIG_SUBTREE].pop(Bond.MODE)
         original_desired_state = state.State({Interface.KEY: [iface_state]})
-        desired_state = state.State({Interface.KEY: [iface_state]})
         current_state = empty_state()
         with pytest.raises(NmstateValueError):
             libnmstate.validator.validate_interfaces_state(
-                original_desired_state, desired_state, current_state
+                original_desired_state, current_state
             )
 
     def test_mac_restriction_without_mac_in_desire(self):
@@ -591,11 +590,10 @@ class TestLinuxBondValidator:
         bond_config[Bond.OPTIONS_SUBTREE]["fail_over_mac"] = "active"
 
         original_desired_state = state.State({Interface.KEY: [iface_state]})
-        desired_state = state.State({Interface.KEY: [iface_state]})
         current_state = empty_state()
 
         libnmstate.validator.validate_interfaces_state(
-            original_desired_state, desired_state, current_state
+            original_desired_state, current_state
         )
 
     def test_mac_restriction_with_mac_in_desire(self):
@@ -606,12 +604,11 @@ class TestLinuxBondValidator:
         bond_config[Bond.OPTIONS_SUBTREE]["fail_over_mac"] = "active"
 
         original_desired_state = state.State({Interface.KEY: [iface_state]})
-        desired_state = state.State({Interface.KEY: [iface_state]})
         current_state = state.State({Interface.KEY: [iface_state]})
 
         with pytest.raises(NmstateValueError):
             libnmstate.validator.validate_interfaces_state(
-                original_desired_state, desired_state, current_state
+                original_desired_state, current_state
             )
 
     def test_mac_restriction_in_desire_mac_in_current(self):
@@ -621,12 +618,11 @@ class TestLinuxBondValidator:
         bond_config[Bond.OPTIONS_SUBTREE]["fail_over_mac"] = "active"
 
         original_desired_state = state.State({Interface.KEY: [iface_state]})
-        desired_state = state.State({Interface.KEY: [iface_state]})
         iface_state[Interface.MAC] = MAC0
         current_state = state.State({Interface.KEY: [iface_state]})
 
         libnmstate.validator.validate_interfaces_state(
-            original_desired_state, desired_state, current_state
+            original_desired_state, current_state
         )
 
     def test_mac_restriction_in_current_mac_in_desire(self):
@@ -641,11 +637,10 @@ class TestLinuxBondValidator:
         bond_config = iface_state[Bond.CONFIG_SUBTREE]
         bond_config.pop(Bond.MODE)
         original_desired_state = state.State({Interface.KEY: [iface_state]})
-        desired_state = state.State({Interface.KEY: [iface_state]})
 
         with pytest.raises(NmstateValueError):
             libnmstate.validator.validate_interfaces_state(
-                original_desired_state, desired_state, current_state
+                original_desired_state, current_state
             )
 
     def _gen_iface_state(self, bond_name):


### PR DESCRIPTION
The function validate_interfaces_state does not use the parameter
desired_state, therefore this patch removes it.

Signed-off-by: Elvira García Ruiz <elviragr@riseup.net>