### PR TITLE
netapplier: retry verification after failing

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -36,9 +36,12 @@ from libnmstate.error import NmstateError
 from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstatePermissionError
 from libnmstate.error import NmstateValueError
+from libnmstate.error import NmstateVerificationError
 from libnmstate.nm import nmclient
 
 MAINLOOP_TIMEOUT = 35
+VERIFY_RETRY_INTERNAL = 1
+VERIFY_RETRY_TIMEOUT = 5
 
 
 @_warn_keyword_as_positional
@@ -155,8 +158,18 @@ def _apply_ifaces_state(
                     ifaces2add + ifaces2edit,
                     con_profiles=ifaces_add_configs + ifaces_edit_configs,
                 )
+            verified = False
             if verify_change:
-                _verify_change(desired_state)
+                for _ in range(VERIFY_RETRY_TIMEOUT):
+                    try:
+                        _verify_change(desired_state)
+                        verified = True
+                        break
+                    except NmstateVerificationError:
+                        time.sleep(VERIFY_RETRY_INTERNAL)
+                if not verified:
+                    _verify_change(desired_state)
+
         if not commit:
             return checkpoint
     except nm.checkpoint.NMCheckPointPermissionError:

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -200,10 +200,11 @@ def _list_new_interfaces(desired_state, current_state):
 
 def _verify_change(desired_state):
     current_state = state.State(netinfo.show())
-    desired_state.verify_interfaces(current_state)
-    desired_state.verify_routes(current_state)
-    desired_state.verify_dns(current_state)
-    desired_state.verify_route_rule(current_state)
+    verifiable_desired_state = copy.deepcopy(desired_state)
+    verifiable_desired_state.verify_interfaces(current_state)
+    verifiable_desired_state.verify_routes(current_state)
+    verifiable_desired_state.verify_dns(current_state)
+    verifiable_desired_state.verify_route_rule(current_state)
 
 
 @contextmanager

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -34,7 +34,6 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route as RT
 
 from libnmstate.error import NmstateNotImplementedError
-from libnmstate.error import NmstateVerificationError
 
 from .testlib import assertlib
 from .testlib import cmdlib
@@ -1112,11 +1111,6 @@ def eth1_with_dhcp6_no_dhcp_server():
         )
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/nmstate/nmstate/issues/736",
-    raises=NmstateVerificationError,
-    strict=True,
-)
 def test_switch_from_dynamic_ip_without_dhcp_srv_to_static_ipv6(
     eth1_with_dhcp6_no_dhcp_server,
 ):


### PR DESCRIPTION
During the verification sometimes ethtool is reporting 'unknown' in
duplex state. This is due a lack of time for some NICs to update the
information. We have noticed it only with Broadcom BCM57840 NetXtreme II
NIC but it could affect to other NICs.

In order to fix this, we are retrying the operation up to 5 times
sleeping 2 seconds for each retry.

Ref: https://bugzilla.redhat.com/1807034

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>