### PR TITLE
ConnectionProfile: Use interface name from NM.RemoteConnection

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -223,7 +223,7 @@ class ConnectionProfile:
             else:
                 self._mainloop.quit(
                     "Connection activation failed on {}: reason={}".format(
-                        ac.devname, ac.reason
+                        devname, ac.reason
                     )
                 )
 


### PR DESCRIPTION
ActiveConnection.devname might be None if the activation failed for
virtual interfaces. Therefore use the interface name from the
NM.RemoteConnection for logging.

Signed-off-by: Till Maas <opensource@till.name>