### PR TITLE
test: Grouping important test cases as tier1

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -104,6 +104,7 @@ def bond99_with_slave(eth2_up):
         yield state
 
 
+@pytest.mark.tier1
 def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
     state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
     libnmstate.apply(state)
@@ -128,6 +129,7 @@ def test_add_and_remove_bond_with_two_slaves(eth1_up, eth2_up):
     assert state[Interface.KEY][1][Interface.STATE] == InterfaceState.UP
 
 
+@pytest.mark.tier1
 def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
     state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
     bond_name = state[Interface.KEY][0][Interface.NAME]
@@ -154,6 +156,7 @@ def test_add_bond_without_slaves():
         assert state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.SLAVES] == []
 
 
+@pytest.mark.tier1
 def test_add_bond_with_slaves_and_ipv4(eth1_up, eth2_up, setup_remove_bond99):
     desired_bond_state = {
         Interface.KEY: [
@@ -187,6 +190,7 @@ def test_add_bond_with_slaves_and_ipv4(eth1_up, eth2_up, setup_remove_bond99):
     assertlib.assert_state(desired_bond_state)
 
 
+@pytest.mark.tier1
 def test_rollback_for_bond(eth1_up, eth2_up):
     current_state = libnmstate.show()
     desired_state = {
@@ -230,6 +234,7 @@ def test_rollback_for_bond(eth1_up, eth2_up):
     )
 
 
+@pytest.mark.tier1
 def test_add_slave_to_bond_without_slaves(eth1_up):
     slave_name = eth1_up[Interface.KEY][0][Interface.NAME]
     with bond_interface(name=BOND99, slaves=[]) as state:
@@ -257,6 +262,7 @@ def test_remove_all_slaves_from_bond(eth1_up):
         assert bond_cur_state[Bond.CONFIG_SUBTREE][Bond.SLAVES] == []
 
 
+@pytest.mark.tier1
 def test_replace_bond_slave(eth1_up, eth2_up):
     slave1_name = eth1_up[Interface.KEY][0][Interface.NAME]
     slave2_name = eth2_up[Interface.KEY][0][Interface.NAME]
@@ -274,6 +280,7 @@ def test_replace_bond_slave(eth1_up, eth2_up):
         ]
 
 
+@pytest.mark.tier1
 def test_remove_one_of_the_bond_slaves(eth1_up, eth2_up):
     slave1_name = eth1_up[Interface.KEY][0][Interface.NAME]
     slave2_name = eth2_up[Interface.KEY][0][Interface.NAME]
@@ -291,6 +298,7 @@ def test_remove_one_of_the_bond_slaves(eth1_up, eth2_up):
     assert bond_cur_state[Bond.CONFIG_SUBTREE][Bond.SLAVES] == [slave2_name]
 
 
+@pytest.mark.tier1
 def test_swap_slaves_between_bonds(bond88_with_slave, bond99_with_slave):
     bonding88 = bond88_with_slave[Interface.KEY][0][Bond.CONFIG_SUBTREE]
     bonding99 = bond99_with_slave[Interface.KEY][0][Bond.CONFIG_SUBTREE]
@@ -307,6 +315,7 @@ def test_swap_slaves_between_bonds(bond88_with_slave, bond99_with_slave):
     assertlib.assert_state(state)
 
 
+@pytest.mark.tier1
 def test_set_bond_mac_address(eth1_up):
     slave_name = eth1_up[Interface.KEY][0][Interface.NAME]
     with bond_interface(name=BOND99, slaves=[slave_name]) as state:
@@ -323,6 +332,7 @@ def test_set_bond_mac_address(eth1_up):
         assert_mac_address(current_state, MAC1)
 
 
+@pytest.mark.tier1
 def test_reordering_the_slaves_does_not_change_the_mac(bond99_with_2_slaves):
     bond_state = bond99_with_2_slaves[Interface.KEY][0]
     bond_slaves = bond_state[Bond.CONFIG_SUBTREE][Bond.SLAVES]
@@ -340,6 +350,7 @@ def test_reordering_the_slaves_does_not_change_the_mac(bond99_with_2_slaves):
     )
 
 
+@pytest.mark.tier1
 def test_bond_with_empty_ipv6_static_address(eth1_up):
     extra_iface_state = {
         Interface.IPV6: {
@@ -356,6 +367,7 @@ def test_bond_with_empty_ipv6_static_address(eth1_up):
     assertlib.assert_absent(BOND99)
 
 
+@pytest.mark.tier1
 def test_create_vlan_over_a_bond_slave(bond99_with_slave):
     bond_ifstate = bond99_with_slave[Interface.KEY][0]
     bond_slave_ifname = bond_ifstate[Bond.CONFIG_SUBTREE][Bond.SLAVES][0]
@@ -368,6 +380,7 @@ def test_create_vlan_over_a_bond_slave(bond99_with_slave):
     assertlib.assert_state(bond99_with_slave)
 
 
+@pytest.mark.tier1
 def test_create_linux_bridge_over_bond(bond99_with_slave):
     port_state = {
         "stp-hairpin-mode": False,
@@ -382,6 +395,7 @@ def test_create_linux_bridge_over_bond(bond99_with_slave):
         assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_preserve_bond_after_bridge_removal(bond99_with_slave):
     bridge_name = "linux-br0"
     bridge_state = add_port_to_bridge(create_bridge_subtree_state(), BOND99)
@@ -390,6 +404,7 @@ def test_preserve_bond_after_bridge_removal(bond99_with_slave):
     assertlib.assert_state(bond99_with_slave)
 
 
+@pytest.mark.tier1
 def test_create_vlan_over_a_bond(bond99_with_slave):
     vlan_base_iface = bond99_with_slave[Interface.KEY][0][Interface.NAME]
     vlan_id = 102
@@ -401,6 +416,7 @@ def test_create_vlan_over_a_bond(bond99_with_slave):
     assertlib.assert_state(bond99_with_slave)
 
 
+@pytest.mark.tier1
 def test_change_bond_option_miimon(bond99_with_2_slaves):
     desired_state = statelib.show_only((BOND99,))
     iface_state = desired_state[Interface.KEY][0]
@@ -410,6 +426,7 @@ def test_change_bond_option_miimon(bond99_with_2_slaves):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_change_bond_option_with_an_id_value(bond99_with_slave):
     option_name = "xmit_hash_policy"
     desired_state = statelib.show_only((BOND99,))
@@ -429,6 +446,7 @@ def test_create_bond_without_mode():
             libnmstate.apply(state)
 
 
+@pytest.mark.tier1
 def test_bond_mac_restriction_without_mac_in_desire(eth1_up, eth2_up):
     with bond_interface(
         name=BOND99,
@@ -460,6 +478,7 @@ def test_bond_mac_restriction_with_mac_in_desire(eth1_up, eth2_up):
             libnmstate.apply(state)
 
 
+@pytest.mark.tier1
 def test_bond_mac_restriction_in_desire_mac_in_current(bond99_with_2_slaves):
     with bond_interface(
         name=BOND99,
@@ -496,6 +515,7 @@ def test_bond_mac_restriction_in_current_mac_in_desire(eth1_up, eth2_up):
             )
 
 
+@pytest.mark.tier1
 def test_create_bond_with_mac(eth1_up, eth2_up):
     with bond_interface(
         name=BOND99,
@@ -505,6 +525,7 @@ def test_create_bond_with_mac(eth1_up, eth2_up):
         assertlib.assert_state_match(state)
 
 
+@pytest.mark.tier1
 @pytest.mark.parametrize("ips", ("192.0.2.1,192.0.2.2", "192.0.2.2,192.0.1.1"))
 def test_bond_with_arp_ip_target(eth1_up, eth2_up, ips):
     with bond_interface(
@@ -523,6 +544,7 @@ def test_bond_with_arp_ip_target(eth1_up, eth2_up, ips):
         assertlib.assert_state_match(desired_state)
 
 
+@pytest.mark.tier1
 def test_create_bond_with_default_miimon_explicitly():
     with bond_interface(
         name=BOND99,

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -57,6 +57,7 @@ def dns_test_env(eth1_up, eth2_up):
     netapplier.apply(desired_state)
 
 
+@pytest.mark.tier1
 @parametrize_ip_ver
 def test_dns_edit_nameserver_with_static_gateway(dns_config):
     desired_state = {
@@ -84,6 +85,7 @@ def test_dns_edit_ipv4_nameserver_before_ipv6():
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
 
 
+@pytest.mark.tier1
 def test_dns_edit_ipv6_nameserver_before_ipv4():
     dns_config = {
         DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
@@ -119,6 +121,7 @@ def test_dns_edit_three_nameservers():
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
 
 
+@pytest.mark.tier1
 def test_remove_dns_config():
     dns_config = {
         DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -179,6 +179,7 @@ def iface_with_dynamic_ip_up(ifname):
         )
 
 
+@pytest.mark.tier1
 def test_ipv4_dhcp(dhcpcli_up):
     desired_state = dhcpcli_up
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
@@ -213,6 +214,7 @@ def test_ipv6_dhcp_only(dhcpcli_up):
     assert not _has_ipv6_auto_extra_route()
 
 
+@pytest.mark.tier1
 def test_ipv6_dhcp_and_autoconf(dhcpcli_up):
     desired_state = dhcpcli_up
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
@@ -257,6 +259,7 @@ def test_dhcp_with_addresses(dhcpcli_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_ipv4_dhcp_on_bond(dhcpcli_up):
     ipv4_state = {Interface.IPV4: create_ipv4_state(enabled=True, dhcp=True)}
     with bondlib.bond_interface(
@@ -482,6 +485,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcpcli_up):
     assert not _has_ipv6_auto_nameserver()
 
 
+@pytest.mark.tier1
 def test_dhcp_on_bridge0(dhcpcli_up_with_dynamic_ip):
     """
     Test dynamic IPv4 & IPv6 addresses over a Linux bridge interface.
@@ -530,6 +534,7 @@ def test_dhcp_on_bridge0(dhcpcli_up_with_dynamic_ip):
     assert origin_ipv6_state == new_ipv6_state
 
 
+@pytest.mark.tier1
 def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
     dhcpcli_up,
 ):
@@ -860,6 +865,7 @@ def test_activate_dummy_without_dhcp_service(ip_ver, dummy00):
     libnmstate.apply({Interface.KEY: [ifstate]})
 
 
+@pytest.mark.tier1
 def test_dummy_disable_ip_stack_with_on_going_dhcp(dummy00):
     ifstate = dummy00
     ifstate[Interface.IPV4] = create_ipv4_state(enabled=True, dhcp=True)
@@ -949,6 +955,7 @@ def dhcpcli_up_with_static_ip(dhcpcli_up):
     yield desired_state
 
 
+@pytest.mark.tier1
 def test_change_static_to_dhcp4_with_disabled_ipv6(dhcpcli_up_with_static_ip):
     desired_state = dhcpcli_up_with_static_ip
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
@@ -964,6 +971,7 @@ def test_change_static_to_dhcp4_with_disabled_ipv6(dhcpcli_up_with_static_ip):
     assert _poll(_has_ipv4_classless_route)
 
 
+@pytest.mark.tier1
 def test_change_static_to_dhcp6_autoconf_with_disabled_ipv4(
     dhcpcli_up_with_static_ip,
 ):
@@ -983,6 +991,7 @@ def test_change_static_to_dhcp6_autoconf_with_disabled_ipv4(
     assert _poll(_has_ipv6_auto_extra_route)
 
 
+@pytest.mark.tier1
 @pytest.mark.slow
 @parametrize_ip_ver
 def test_dummy_existance_after_dhcp_timeout(ip_ver, dummy00):
@@ -999,6 +1008,7 @@ def test_dummy_existance_after_dhcp_timeout(ip_ver, dummy00):
     assertlib.assert_state({Interface.KEY: [ifstate]})
 
 
+@pytest.mark.tier1
 @pytest.mark.slow
 def test_dummy_existance_after_ipv6_autoconf_timeout(dummy00):
     ifstate = dummy00
@@ -1047,6 +1057,7 @@ def dhcpcli_up_with_static_ip_and_route(dhcpcli_up_with_static_ip):
     yield desired_state
 
 
+@pytest.mark.tier1
 def test_static_ip_with_routes_switch_back_to_dynamic(
     dhcpcli_up_with_static_ip_and_route,
 ):

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -45,6 +45,7 @@ def eth1_with_ipv6(eth1_up):
     libnmstate.apply(eth1_up)
 
 
+@pytest.mark.tier1
 def test_increase_iface_mtu():
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]
@@ -55,6 +56,7 @@ def test_increase_iface_mtu():
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_decrease_iface_mtu():
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]
@@ -65,6 +67,7 @@ def test_decrease_iface_mtu():
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_upper_limit_jambo_iface_mtu():
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]
@@ -141,6 +144,7 @@ def test_mtu_without_ipv6(eth1_up):
     assertlib.assert_state(eth1_up)
 
 
+@pytest.mark.tier1
 def test_set_mtu_on_two_vlans_with_a_shared_base(eth1_up):
     base_ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     v101 = vlan_interface("eth1.101", 101, base_ifname)
@@ -161,6 +165,7 @@ def test_set_mtu_on_two_vlans_with_a_shared_base(eth1_up):
         assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 @ip_monitor_assert_stable_link_up("eth1")
 def test_change_mtu_with_stable_link_up(eth1_up):
     desired_state = statelib.show_only(("eth1",))

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -30,6 +30,7 @@ from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import DNS
 
 
+@pytest.mark.tier1
 def test_add_down_remove_vlan(eth1_up):
     """
     Test adding, downing and removing a vlan
@@ -46,6 +47,7 @@ def test_add_down_remove_vlan(eth1_up):
     assertlib.assert_absent(vlan_ifname)
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=NmstateLibnmError, reason="https://bugzilla.redhat.com/1724901"
 )
@@ -58,6 +60,7 @@ def test_add_remove_ovs_bridge(eth1_up):
     assertlib.assert_absent("ovs-br0")
 
 
+@pytest.mark.tier1
 def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
     with example_state(
         "ovsbridge_bond_create.yml", cleanup="ovsbridge_delete.yml"
@@ -68,6 +71,7 @@ def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
     assertlib.assert_absent("ovs-bond1")
 
 
+@pytest.mark.tier1
 def test_add_remove_ovs_bridge_vlan(eth1_up, eth2_up):
     with example_state(
         "ovsbridge_vlan_port.yml", cleanup="ovsbridge_delete.yml"
@@ -77,6 +81,7 @@ def test_add_remove_ovs_bridge_vlan(eth1_up, eth2_up):
     assertlib.assert_absent("ovs-br0")
 
 
+@pytest.mark.tier1
 def test_add_remove_linux_bridge(eth1_up):
     with example_state(
         "linuxbrige_eth1_up.yml", cleanup="linuxbrige_eth1_absent.yml"
@@ -86,6 +91,7 @@ def test_add_remove_linux_bridge(eth1_up):
     assertlib.assert_absent("linux-br0")
 
 
+@pytest.mark.tier1
 def test_bond_linuxbridge_vlan(eth1_up, eth2_up):
     with example_state(
         "bond_linuxbridge_vlan_up.yml",
@@ -99,6 +105,7 @@ def test_bond_linuxbridge_vlan(eth1_up, eth2_up):
     assertlib.assert_absent("vlan29")
 
 
+@pytest.mark.tier1
 def test_dns_edit(eth1_up):
     with example_state(
         "dns_edit_eth1.yml", cleanup="dns_remove.yml"
@@ -112,6 +119,7 @@ def test_dns_edit(eth1_up):
     }
 
 
+@pytest.mark.tier1
 def test_add_remove_routes(eth1_up):
     """
     Test adding a strict route and removing all routes next hop to eth1.
@@ -124,6 +132,7 @@ def test_add_remove_routes(eth1_up):
     assertlib.assert_no_config_route_to_iface("eth1")
 
 
+@pytest.mark.tier1
 @pytest.mark.skipif(
     os.environ.get("CI") == "true",
     reason="Team kmod not available in Travis CI",

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -143,6 +143,7 @@ def test_create_and_remove_linux_bridge_with_one_port(port0_up):
     assert state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
 
 
+@pytest.mark.tier1
 def test_create_and_remove_linux_bridge_with_two_ports(port0_up, port1_up):
     bridge_name = TEST_BRIDGE0
     port0_name = port0_up[Interface.KEY][0][Interface.NAME]
@@ -155,6 +156,7 @@ def test_create_and_remove_linux_bridge_with_two_ports(port0_up, port1_up):
     assertlib.assert_absent(bridge_name)
 
 
+@pytest.mark.tier1
 def test_remove_bridge_and_keep_slave_up(bridge0_with_port0, port0_up):
     bridge_name = bridge0_with_port0[Interface.KEY][0][Interface.NAME]
     port_name = port0_up[Interface.KEY][0][Interface.NAME]
@@ -187,6 +189,7 @@ def test_remove_bridge_and_keep_slave_up(bridge0_with_port0, port0_up):
     assert 1 == len(current_state[Interface.KEY])
 
 
+@pytest.mark.tier1
 def test_create_vlan_as_slave_of_linux_bridge(port0_vlan101):
     bridge_name = TEST_BRIDGE0
     port_name = port0_vlan101[Interface.KEY][0][Interface.NAME]
@@ -195,6 +198,7 @@ def test_create_vlan_as_slave_of_linux_bridge(port0_vlan101):
         assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_create_vlan_over_linux_bridge(bridge0_with_port0):
     vlan_base_iface = TEST_BRIDGE0
     vlan_id = 101
@@ -203,6 +207,7 @@ def test_create_vlan_over_linux_bridge(bridge0_with_port0):
         assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 @ip_monitor_assert_stable_link_up(TEST_BRIDGE0)
 def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
     desired_state = bridge0_with_port0
@@ -216,6 +221,7 @@ def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     is_fedora(),
     reason=(
@@ -236,6 +242,7 @@ def test_linux_bridge_uses_the_port_mac_implicitly(
     )
 
 
+@pytest.mark.tier1
 def test_linux_bridge_uses_specified_mac_address(
     port0_up, bridge0_with_port0_with_explicit_port_mac
 ):
@@ -305,6 +312,7 @@ def test_linux_bridge_add_port_with_name_only(bridge0_with_port0, port1_up):
     assertlib.assert_state_match(desired_state)
 
 
+@pytest.mark.tier1
 def test_replace_port_on_linux_bridge(port0_vlan101, port1_up):
     bridge_name = TEST_BRIDGE0
     vlan_port0_name = port0_vlan101[Interface.KEY][0][Interface.NAME]
@@ -360,6 +368,7 @@ def test_rollback_for_linux_bridge():
     assert original_state == current_state
 
 
+@pytest.mark.tier1
 def test_activate_empty_bridge_does_not_blocked_by_dhcp():
     bridge_name = TEST_BRIDGE0
     bridge_state = None

--- a/tests/integration/mem_leak_test.py
+++ b/tests/integration/mem_leak_test.py
@@ -17,15 +17,19 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-import libnmstate
 import os
 import time
+
+import pytest
+
+import libnmstate
 
 
 def get_current_open_fd():
     return len(os.listdir("/proc/self/fd"))
 
 
+@pytest.mark.tier1
 def test_libnmstate_show_fd_leak():
     original_fd = get_current_open_fd()
     for x in range(0, 100):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -54,6 +54,7 @@ def bridge_with_ports(port0_up):
         yield bridge
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=(NmstateLibnmError, AssertionError),
     reason="https://bugzilla.redhat.com/1724901",
@@ -86,6 +87,7 @@ def test_create_and_remove_ovs_bridge_options_specified():
     assertlib.assert_absent(BRIDGE1)
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=(NmstateLibnmError, AssertionError),
     reason="https://bugzilla.redhat.com/1724901",
@@ -105,6 +107,7 @@ def test_create_and_remove_ovs_bridge_with_a_system_port(port0_up):
     assert state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=(NmstateLibnmError, AssertionError),
     reason="https://bugzilla.redhat.com/1724901",
@@ -149,6 +152,7 @@ def test_create_and_remove_ovs_bridge_with_internal_port_same_name():
     assertlib.assert_absent(BRIDGE1)
 
 
+@pytest.mark.tier1
 def test_vlan_as_ovs_bridge_slave(vlan_on_eth1):
     bridge = Bridge(BRIDGE1)
     bridge.add_system_port(vlan_on_eth1)
@@ -156,6 +160,7 @@ def test_vlan_as_ovs_bridge_slave(vlan_on_eth1):
         assertlib.assert_state_match(state)
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=(NmstateLibnmError, AssertionError),
     reason="https://bugzilla.redhat.com/1724901",
@@ -188,6 +193,7 @@ def test_nm_ovs_plugin_missing():
             )
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=NmstateLibnmError, reason="https://bugzilla.redhat.com/1724901"
 )
@@ -216,6 +222,7 @@ def vlan_on_eth1(eth1_up):
         yield VLAN_IFNAME
 
 
+@pytest.mark.tier1
 def test_change_ovs_interface_mac():
     bridge = Bridge(BRIDGE1)
     bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
@@ -234,6 +241,7 @@ def test_change_ovs_interface_mac():
 
 
 class TestOvsLinkAggregation:
+    @pytest.mark.tier1
     def test_create_and_remove_lag(self, port0_up, port1_up):
         port0_name = port0_up[Interface.KEY][0][Interface.NAME]
         port1_name = port1_up[Interface.KEY][0][Interface.NAME]
@@ -248,6 +256,7 @@ class TestOvsLinkAggregation:
         assertlib.assert_absent(BOND1)
 
 
+@pytest.mark.tier1
 def test_ovs_vlan_access_tag():
     bridge = Bridge(BRIDGE1)
     bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})

--- a/tests/integration/profile_test.py
+++ b/tests/integration/profile_test.py
@@ -66,6 +66,7 @@ DUMMY_PROFILE_DIRECTORY = "/etc/NetworkManager/system-connections/"
 ETH_PROFILE_DIRECTORY = "/etc/sysconfig/network-scripts/"
 
 
+@pytest.mark.tier1
 def test_delete_new_interface_inactive_profiles(dummy_inactive_profile):
     with dummy_interface(dummy_inactive_profile):
         profile_exists = _profile_exists(
@@ -74,6 +75,7 @@ def test_delete_new_interface_inactive_profiles(dummy_inactive_profile):
         assert not profile_exists
 
 
+@pytest.mark.tier1
 def test_delete_existing_interface_inactive_profiles(eth1_up):
     with create_inactive_profile(eth1_up[Interface.KEY][0][Interface.NAME]):
         eth1_up[Interface.KEY][0][Interface.MTU] = 2000

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -75,6 +75,7 @@ ETH1_INTERFACE_STATE = {
 }
 
 
+@pytest.mark.tier1
 def test_add_static_routes(eth1_up):
     routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
     libnmstate.apply(
@@ -87,6 +88,7 @@ def test_add_static_routes(eth1_up):
     _assert_routes(routes, cur_state)
 
 
+@pytest.mark.tier1
 def test_add_gateway(eth1_up):
     routes = [_get_ipv4_gateways()[0], _get_ipv6_test_routes()[0]]
     libnmstate.apply(
@@ -145,6 +147,7 @@ def test_multiple_gateway(eth1_up):
     )
 
 
+@pytest.mark.tier1
 def test_change_gateway(eth1_up):
     libnmstate.apply(
         {
@@ -320,6 +323,7 @@ parametrize_ip_ver_routes = pytest.mark.parametrize(
 )
 
 
+@pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_remove_specific_route(eth1_up, get_routes_func):
     routes = get_routes_func()
@@ -347,6 +351,7 @@ def test_remove_specific_route(eth1_up, get_routes_func):
     _assert_routes(expected_routes, cur_state)
 
 
+@pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_remove_wildcast_route_with_iface(eth1_up, get_routes_func):
     routes = get_routes_func()
@@ -376,6 +381,7 @@ def test_remove_wildcast_route_with_iface(eth1_up, get_routes_func):
     _assert_routes(expected_routes, cur_state)
 
 
+@pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_remove_wildcast_route_without_iface(eth1_up, get_routes_func):
     routes = get_routes_func()
@@ -427,6 +433,7 @@ def test_disable_ipv4_with_routes_in_current(eth1_up):
     _assert_routes([], cur_state)
 
 
+@pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
     libnmstate.apply(
@@ -479,6 +486,7 @@ def eth1_static_gateway_dns(eth1_up):
     )
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=AssertionError,
     reason="https://bugzilla.redhat.com/1748389",
@@ -512,6 +520,7 @@ def route_rule_test_env(eth1_static_gateway_dns):
     )
 
 
+@pytest.mark.tier1
 def test_route_rule_add_without_from_or_to(route_rule_test_env):
     state = route_rule_test_env
     state[RouteRule.KEY] = {
@@ -525,6 +534,7 @@ def test_route_rule_add_without_from_or_to(route_rule_test_env):
         libnmstate.apply(state)
 
 
+@pytest.mark.tier1
 def test_route_rule_add_from_only(route_rule_test_env):
     state = route_rule_test_env
     rules = [
@@ -543,6 +553,7 @@ def test_route_rule_add_from_only(route_rule_test_env):
     _check_ip_rules(rules)
 
 
+@pytest.mark.tier1
 def test_route_rule_add_to_only(route_rule_test_env):
     state = route_rule_test_env
     rules = [
@@ -561,6 +572,7 @@ def test_route_rule_add_to_only(route_rule_test_env):
     _check_ip_rules(rules)
 
 
+@pytest.mark.tier1
 def test_route_rule_add(route_rule_test_env):
     state = route_rule_test_env
     rules = [
@@ -583,6 +595,7 @@ def test_route_rule_add(route_rule_test_env):
     _check_ip_rules(rules)
 
 
+@pytest.mark.tier1
 def test_route_rule_add_without_priority(route_rule_test_env):
     state = route_rule_test_env
     rules = [

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -125,6 +125,7 @@ def test_add_static_ipv4_with_full_state(eth1_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_add_static_ipv4_with_min_state(eth2_up):
     desired_state = {
         Interface.KEY: [
@@ -149,6 +150,7 @@ def test_add_static_ipv4_with_min_state(eth2_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_remove_static_ipv4(setup_eth1_ipv4):
     desired_state = {
         Interface.KEY: [
@@ -165,6 +167,7 @@ def test_remove_static_ipv4(setup_eth1_ipv4):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_edit_static_ipv4_address_and_prefix(setup_eth1_ipv4):
     desired_state = {
         Interface.KEY: [
@@ -231,6 +234,7 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_add_iface_with_same_static_ipv4_address_to_existing(
     setup_eth1_ipv4, eth2_up
 ):
@@ -257,6 +261,7 @@ def test_add_iface_with_same_static_ipv4_address_to_existing(
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_add_static_ipv6_with_full_state(eth1_up):
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]
@@ -339,6 +344,7 @@ def test_add_static_ipv6_with_link_local_only(eth1_up):
     )
 
 
+@pytest.mark.tier1
 def test_add_static_ipv6_with_no_address(eth1_up):
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]
@@ -377,6 +383,7 @@ def test_add_static_ipv6_with_min_state(eth2_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_disable_static_ipv6(setup_eth1_ipv6):
     desired_state = {
         Interface.KEY: [
@@ -393,6 +400,7 @@ def test_disable_static_ipv6(setup_eth1_ipv6):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
     desired_state = {
         Interface.KEY: [
@@ -411,6 +419,7 @@ def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
     assertlib.assert_state(setup_eth1_ipv6)
 
 
+@pytest.mark.tier1
 def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
     desired_state = {
         Interface.KEY: [
@@ -437,6 +446,7 @@ def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
     assertlib.assert_state(setup_eth1_ipv6_disable)
 
 
+@pytest.mark.tier1
 def test_edit_static_ipv6_address_and_prefix(setup_eth1_ipv6):
     eth1_setup = setup_eth1_ipv6[Interface.KEY][0]
     desired_state = {
@@ -566,6 +576,7 @@ def test_add_iface_with_static_ipv6_expanded_format(eth1_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
 @ip_monitor_assert_stable_link_up("eth1")
 def test_modify_ipv6_with_reapply(setup_eth1_ipv6):
     ipv6_addr = IPV6_ADDRESS2

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -56,6 +56,7 @@ def test_create_team_iface_without_slaves():
         assertlib.assert_state(team_state)
 
 
+@pytest.mark.tier1
 @pytest.mark.xfail(
     raises=NmstateLibnmError, reason="https://bugzilla.redhat.com/1798947"
 )

--- a/tests/integration/timeout_test.py
+++ b/tests/integration/timeout_test.py
@@ -29,6 +29,7 @@ from libnmstate.schema import LinuxBridge
 from libnmstate.schema import VLAN
 
 
+@pytest.mark.tier1
 @pytest.mark.slow
 def test_lot_of_vlans_with_bridges(eth1_up):
     interfaces = []

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -38,6 +38,7 @@ VLAN_IFNAME = "eth1.101"
 VLAN2_IFNAME = "eth1.102"
 
 
+@pytest.mark.tier1
 def test_add_and_remove_vlan(eth1_up):
     with vlan_interface(
         VLAN_IFNAME, 101, eth1_up[Interface.KEY][0][Interface.NAME]
@@ -60,6 +61,7 @@ def vlan_on_eth1(eth1_up):
         yield iface_states
 
 
+@pytest.mark.tier1
 def test_vlan_iface_uses_the_mac_of_base_iface(vlan_on_eth1):
     assert_mac_address(vlan_on_eth1)
 
@@ -73,6 +75,7 @@ def test_add_and_remove_two_vlans_on_same_iface(eth1_up):
     assert not current_state[Interface.KEY]
 
 
+@pytest.mark.tier1
 def test_two_vlans_on_eth1_change_mtu(eth1_up):
     with two_vlans_on_eth1() as desired_state:
         eth1_state = eth1_up[Interface.KEY][0]
@@ -94,6 +97,7 @@ def test_two_vlans_on_eth1_change_mtu(eth1_up):
         assert eth1_vlan_iface_cstate[Interface.KEY][0][Interface.MTU] == 2000
 
 
+@pytest.mark.tier1
 def test_two_vlans_on_eth1_change_base_iface_mtu(eth1_up):
     with two_vlans_on_eth1() as desired_state:
         eth1_state = eth1_up[Interface.KEY][0]
@@ -108,6 +112,7 @@ def test_two_vlans_on_eth1_change_base_iface_mtu(eth1_up):
         assert eth1_vlan_iface_cstate[Interface.KEY][0][Interface.MTU] == 2000
 
 
+@pytest.mark.tier1
 def test_two_vlans_on_eth1_change_mtu_rollback(eth1_up):
     with two_vlans_on_eth1() as desired_state:
         eth1_state = eth1_up[Interface.KEY][0]

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -52,6 +52,7 @@ def test_add_and_remove_vxlan(eth1_up):
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.tier1
 def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -66,6 +67,7 @@ def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     assertlib.assert_absent(vxlan_interfaces_name)
 
 
+@pytest.mark.tier1
 def test_rollback_for_vxlans(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     current_state = libnmstate.show()


### PR DESCRIPTION
Use `tier1` marker of pytest to group a list of important integration
test cases for QE or CI gating.
