### PR TITLE
validator: Check IP config in bond slaves.

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -30,6 +30,7 @@ from libnmstate.schema import BondMode
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 
@@ -839,3 +840,15 @@ def test_bond_switch_mode_with_conflict_option(
     current_bond_config = current_state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
 
     assert "lacp_rate" not in current_bond_config[Bond.OPTIONS_SUBTREE]
+
+
+def test_add_invalid_slave_ip_config(eth1_up):
+    d_state = eth1_up
+    d_state[Interface.KEY][0][Interface.IPV4][InterfaceIPv4.ENABLED] = True
+    d_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.DHCP] = True
+    with pytest.raises(NmstateValueError):
+        with bond_interface(
+            name=BOND99, slaves=[ETH1], create=False
+        ) as bond_state:
+            d_state[Interface.KEY].append(bond_state[Interface.KEY][0])
+            libnmstate.apply(d_state)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -23,6 +23,7 @@ import pytest
 
 import libnmstate
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
@@ -293,3 +294,15 @@ def test_ovs_vlan_access_tag():
 
     assertlib.assert_absent(BRIDGE1)
     assertlib.assert_absent(PORT1)
+
+
+def test_add_invalid_slave_ip_config(eth1_up):
+    desired_state = eth1_up
+    desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.ENABLED] = True
+    desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.DHCP] = True
+    with pytest.raises(NmstateValueError):
+        bridge = Bridge(name=BRIDGE1)
+        bridge.add_system_port("eth1")
+        with bridge.create() as state:
+            desired_state[Interface.KEY].append(state[Interface.KEY][0])
+            libnmstate.apply(desired_state)

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -26,9 +26,11 @@ import pytest
 import libnmstate
 from libnmstate.error import NmstateDependencyError
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import Team
+from libnmstate.error import NmstateValueError
 
 from .testlib import assertlib
 from .testlib.cmdlib import exec_cmd
@@ -86,6 +88,16 @@ def test_nm_team_plugin_missing():
                     ]
                 }
             )
+
+
+def test_add_invalid_slave_ip_config(eth1_up):
+    desired_state = eth1_up
+    desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.ENABLED] = True
+    desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.DHCP] = True
+    with pytest.raises(NmstateValueError):
+        with team_interface(TEAM0, slaves=("eth1",)) as state:
+            desired_state[Interface.KEY].append(state[Interface.KEY][0])
+            libnmstate.apply(desired_state)
 
 
 @contextmanager


### PR DESCRIPTION
When a bond interface is created, the slaves cannot have their IP
configuration enabled. In order to fix this problem, this patch
introduces a validation check to see whether the slave interfaces had
their IP enabled and if so, it raises an NmstateValueError.

Ref: https://bugzilla.redhat.com/1782674

This fixes #774 

Signed-off-by: Elvira García Ruiz <elviragr@riseup.net>