### PR TITLE
travis: fix rpmdb problem

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -205,7 +205,9 @@ function upgrade_nm_from_copr {
     # Workaround for dnf failure:
     # [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
     if [[ "$CI" == "true" ]];then
-        container_exec "rm -f /var/cache/dnf/metadata_lock.pid"
+        container_exec "rm -fv /var/cache/dnf/metadata_lock.pid"
+        container_exec "dnf clean all"
+        container_exec "dnf makecache || :"
     fi
     container_exec "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
     container_exec "yum copr enable --assumeyes ${copr_repo}"

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -36,6 +36,8 @@ RUN dnf -y install dnf-plugins-core epel-release && \
     -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
     /etc/systemd/journald.conf
 
+RUN rpm --verifydb
+
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
 

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -45,6 +45,8 @@ RUN dnf -y install --setopt=install_weak_deps=False \
     -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
     /etc/systemd/journald.conf
 
+RUN rpm --verifydb
+
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
 


### PR DESCRIPTION
Travis might fail with

```
error: db5 error(2) from dbenv->open: No such file or directory
error: cannot open Packages index using db5 - No such file or directory (2)
error: cannot open Packages database in /var/lib/rpm
Error: Error: rpmdb open failed
Error: non zero exit code: 1: OCI runtime error
```

According to https://github.com/dogtagpki/pki/blob/master/travis/pki-init.sh
also need to rebuild the dnf cache.