### PR TITLE
nm.bridge: get ports from sysfs

### DIFF
--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -154,7 +154,12 @@ def _modify_ports(ports_state):
 @nmclient_context
 def _get_bridge_current_state():
     nmdev = nm.device.get_device_by_name(BRIDGE0)
-    return nm.bridge.get_info(nmdev) if nmdev else {}
+    state = nm.bridge.get_info(nmdev) if nmdev else {}
+    if state:
+        slaves = state.get(LB.CONFIG_SUBTREE, {}).get(LB.PORT_SUBTREE, [])
+        slaves.sort(key=lambda d: d[LB.Port.NAME])
+
+    return state
 
 
 @mainloop_run


### PR DESCRIPTION
Unmanaged ports were not being shown when showing or editting the
bridge. In order to fix that, nmstate is retrieving the bridge ports
from sysfs instead of NetworkManager on-disk configuration.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1806452

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>