### PR TITLE
Linux bridge vlans merge bridge state

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -370,6 +370,7 @@ class State:
         self._capitalize_mac()
         self._remove_empty_description()
         self._remove_ip_stack_if_disabled()
+        self._normalize_linux_bridge_port_vlan()
 
     def merge_interfaces(self, other_state):
         """
@@ -770,6 +771,20 @@ class State:
                     other_state._config_route_rules
                 )
             }
+
+    def _normalize_linux_bridge_port_vlan(self):
+        linux_bridges = (
+            iface
+            for iface in self.interfaces.values()
+            if iface[Interface.TYPE] == InterfaceType.LINUX_BRIDGE
+        )
+        for lb in linux_bridges:
+            ports = lb.get(LinuxBridge.CONFIG_SUBTREE, {}).get(
+                LinuxBridge.PORT_SUBTREE, []
+            )
+            for port in ports:
+                if not port.get(LinuxBridge.Port.VLAN_SUBTREE):
+                    port[LinuxBridge.Port.VLAN_SUBTREE] = {}
 
 
 def dict_update(origin_data, to_merge_data):

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -35,6 +35,10 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 from libnmstate.schema import Team
 from libnmstate.schema import VXLAN
+
+from .testlib.bridgelib import generate_vlan_filtering_config
+from .testlib.bridgelib import generate_vlan_id_config
+from .testlib.bridgelib import generate_vlan_id_range_config
 
 
 INTERFACES = Constants.INTERFACES
@@ -455,7 +459,7 @@ class TestLinuxBridgeVlanFiltering:
         argvalues=[LB.Port.Vlan.Mode.TRUNK, LB.Port.Vlan.Mode.ACCESS],
     )
     def test_vlan_port_types(self, default_data, bridge_state, port_type):
-        valid_port_type = self._generate_vlan_filtering_config(port_type)
+        valid_port_type = generate_vlan_filtering_config(port_type)
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(valid_port_type)
         default_data[Interface.KEY].append(bridge_state)
@@ -463,7 +467,7 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_invalid_vlan_port_type(self, default_data, bridge_state):
-        invalid_port_type = self._generate_vlan_filtering_config("fake-type")
+        invalid_port_type = generate_vlan_filtering_config("fake-type")
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_port_type)
         default_data[Interface.KEY].append(bridge_state)
@@ -472,8 +476,8 @@ class TestLinuxBridgeVlanFiltering:
             libnmstate.validator.validate(default_data)
 
     def test_access_port_accepted(self, default_data, bridge_state):
-        vlan_access_port_state = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag=101
+        vlan_access_port_state = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag=101
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(vlan_access_port_state)
@@ -482,8 +486,8 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_wrong_access_port_tag_type(self, default_data, bridge_state):
-        invalid_access_port_tag_type = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag="holy-guacamole!"
+        invalid_access_port_tag_type = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag="holy-guacamole!"
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_access_port_tag_type)
@@ -493,8 +497,8 @@ class TestLinuxBridgeVlanFiltering:
             libnmstate.validator.validate(default_data)
 
     def test_wrong_access_tag_range(self, default_data, bridge_state):
-        invalid_vlan_id_range = self._generate_vlan_filtering_config(
-            LB.Port.Vlan.Mode.ACCESS, access_tag=48000
+        invalid_vlan_id_range = generate_vlan_filtering_config(
+            LB.Port.Vlan.Mode.ACCESS, tag=48000
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_vlan_id_range)
@@ -509,9 +513,9 @@ class TestLinuxBridgeVlanFiltering:
     def test_trunk_port_native_vlan(
         self, default_data, bridge_state, is_native_vlan
     ):
-        vlan_access_port_state = self._generate_vlan_filtering_config(
+        vlan_access_port_state = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK,
-            access_tag=101 if is_native_vlan else None,
+            tag=101 if is_native_vlan else None,
             native_vlan=is_native_vlan,
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
@@ -521,9 +525,9 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_trunk_ports(self, default_data, bridge_state):
-        trunk_tags = self._generate_vlan_id_config(101, 102, 103)
-        trunk_tags.append(self._generate_vlan_id_range_config(500, 1000))
-        vlan_trunk_tags_port_state = self._generate_vlan_filtering_config(
+        trunk_tags = generate_vlan_id_config(101, 102, 103)
+        trunk_tags.append(generate_vlan_id_range_config(500, 1000))
+        vlan_trunk_tags_port_state = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK, trunk_tags=trunk_tags
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
@@ -533,9 +537,9 @@ class TestLinuxBridgeVlanFiltering:
         libnmstate.validator.validate(default_data)
 
     def test_invalid_trunk_port_vlan_range(self, default_data, bridge_state):
-        invalid_port_vlan_configuration = self._generate_vlan_filtering_config(
+        invalid_port_vlan_configuration = generate_vlan_filtering_config(
             LB.Port.Vlan.Mode.TRUNK,
-            trunk_tags=[self._generate_vlan_id_range_config(100, 5000)],
+            trunk_tags=[generate_vlan_id_range_config(100, 5000)],
         )
         the_port = bridge_state[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         the_port.update(invalid_port_vlan_configuration)
@@ -543,35 +547,6 @@ class TestLinuxBridgeVlanFiltering:
 
         with pytest.raises(js.ValidationError):
             libnmstate.validator.validate(default_data)
-
-    @staticmethod
-    def _generate_vlan_filtering_config(
-        port_type, trunk_tags=None, access_tag=None, native_vlan=None
-    ):
-        vlan_filtering_state = {
-            LB.Port.Vlan.MODE: port_type,
-            LB.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
-        }
-
-        if access_tag:
-            vlan_filtering_state[LB.Port.Vlan.TAG] = access_tag
-        if native_vlan:
-            vlan_filtering_state[LB.Port.Vlan.ENABLE_NATIVE] = native_vlan
-
-        return {LB.Port.VLAN_SUBTREE: vlan_filtering_state}
-
-    @staticmethod
-    def _generate_vlan_id_config(*vlan_ids):
-        return [{LB.Port.Vlan.TrunkTags.ID: vlan_id} for vlan_id in vlan_ids]
-
-    @staticmethod
-    def _generate_vlan_id_range_config(min_vlan_id, max_vlan_id):
-        return {
-            LB.Port.Vlan.TrunkTags.ID_RANGE: {
-                LB.Port.Vlan.TrunkTags.MIN_RANGE: min_vlan_id,
-                LB.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
-            }
-        }
 
 
 class TestOvsBridgeVlan:

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -36,6 +36,8 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 from libnmstate.schema import Team
 
+from .testlib import bridgelib
+
 
 IFACE0 = "foo"
 
@@ -1292,4 +1294,266 @@ class TestComplementMasterRemoval:
                     }
                 ]
             }
+        )
+
+
+class TestLinuxBridgeState:
+    BRIDGE_NAME = "bridge0"
+    PORT1 = "eth1"
+    PORT2 = "eth2"
+
+    def test_add_port_to_bridge(self):
+        current_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME
+        )
+        current_state = state.State({Interface.KEY: [current_bridge_state]})
+
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[TestLinuxBridgeState.PORT1],
+        )
+        desired_state = state.State({Interface.KEY: [desired_bridge_state]})
+        desired_state.merge_interfaces(current_state)
+
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT1
+        } in desired_bridge_ports
+
+    def test_remove_port_from_bridge(self):
+        current_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[TestLinuxBridgeState.PORT1],
+        )
+        current_state = state.State({Interface.KEY: [current_bridge_state]})
+
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME
+        )
+        desired_state = state.State({Interface.KEY: [desired_bridge_state]})
+        desired_state.merge_interfaces(current_state)
+
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        assert desired_bridge_state.get(LinuxBridge.CONFIG_SUBTREE)
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+        assert not desired_bridge_ports
+
+    def test_linux_bridge_port_vlan_create(self):
+        port1_vlan_config = bridgelib.generate_vlan_filtering_config(
+            LinuxBridge.Port.Vlan.Mode.TRUNK,
+            bridgelib.generate_vlan_id_config(100, 200, 300),
+        )
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[
+                TestLinuxBridgeState.PORT1,
+                TestLinuxBridgeState.PORT2,
+            ],
+            ports_extra_state={TestLinuxBridgeState.PORT1: port1_vlan_config},
+        )
+        current_state = state.State({Interface.KEY: []})
+        desired_state_raw = {Interface.KEY: [desired_bridge_state]}
+
+        desired_state = state.State(desired_state_raw)
+
+        desired_state.merge_interfaces(current_state)
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+
+        assert TestLinuxBridgeState._is_vlan_filtering_enabled(
+            desired_bridge_ports
+        )
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT1,
+            LinuxBridge.Port.VLAN_SUBTREE: {
+                LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.TRUNK,
+                LinuxBridge.Port.Vlan.TRUNK_TAGS: [
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 100},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 200},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 300},
+                ],
+            },
+        } in desired_bridge_ports
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT2
+        } in desired_bridge_ports
+
+    def test_port_vlan_update_keep_vlan_filtering_enabled(self):
+        port1_vlan_config = bridgelib.generate_vlan_filtering_config(
+            LinuxBridge.Port.Vlan.Mode.TRUNK,
+            bridgelib.generate_vlan_id_config(100, 200, 300),
+        )
+        current_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[
+                TestLinuxBridgeState.PORT1,
+                TestLinuxBridgeState.PORT2,
+            ],
+            ports_extra_state={TestLinuxBridgeState.PORT1: port1_vlan_config},
+        )
+        current_state = state.State({Interface.KEY: [current_bridge_state]})
+
+        port2_vlan_config = bridgelib.generate_vlan_filtering_config(
+            LinuxBridge.Port.Vlan.Mode.TRUNK,
+            bridgelib.generate_vlan_id_config(1000, 1200, 1300),
+        )
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[
+                TestLinuxBridgeState.PORT1,
+                TestLinuxBridgeState.PORT2,
+            ],
+            ports_extra_state={TestLinuxBridgeState.PORT2: port2_vlan_config},
+        )
+        desired_state_raw = {Interface.KEY: [desired_bridge_state]}
+        desired_state = state.State(desired_state_raw)
+
+        desired_state.merge_interfaces(current_state)
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+
+        assert TestLinuxBridgeState._is_vlan_filtering_enabled(
+            desired_bridge_ports
+        )
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT1,
+            LinuxBridge.Port.VLAN_SUBTREE: {
+                LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.TRUNK,
+                LinuxBridge.Port.Vlan.TRUNK_TAGS: [
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 100},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 200},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 300},
+                ],
+            },
+        } in desired_bridge_ports
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT2,
+            LinuxBridge.Port.VLAN_SUBTREE: {
+                LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.TRUNK,
+                LinuxBridge.Port.Vlan.TRUNK_TAGS: [
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 1000},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 1200},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 1300},
+                ],
+            },
+        } in desired_bridge_ports
+
+    def test_port_vlan_update_disable_vlan_filtering(self):
+        port1_vlan_config = bridgelib.generate_vlan_filtering_config(
+            LinuxBridge.Port.Vlan.Mode.TRUNK,
+            bridgelib.generate_vlan_id_config(100, 200, 300),
+        )
+        current_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[
+                TestLinuxBridgeState.PORT1,
+                TestLinuxBridgeState.PORT2,
+            ],
+            ports_extra_state={TestLinuxBridgeState.PORT1: port1_vlan_config},
+        )
+        current_state = state.State({Interface.KEY: [current_bridge_state]})
+
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[
+                TestLinuxBridgeState.PORT1,
+                TestLinuxBridgeState.PORT2,
+            ],
+            ports_extra_state={
+                TestLinuxBridgeState.PORT1: {LinuxBridge.Port.VLAN_SUBTREE: {}}
+            },
+        )
+        desired_state_raw = {Interface.KEY: [desired_bridge_state]}
+        desired_state = state.State(desired_state_raw)
+
+        desired_state.merge_interfaces(current_state)
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+
+        # this would assure that none of the ports have a port vlan subtree
+        assert not TestLinuxBridgeState._is_vlan_filtering_enabled(
+            desired_bridge_ports
+        )
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT1,
+            LinuxBridge.Port.VLAN_SUBTREE: {},
+        } in desired_bridge_ports
+        assert {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT2
+        } in desired_bridge_ports
+
+    def test_update_port_stp_priority_preserves_vlan_config(self):
+        port1_vlan_config = bridgelib.generate_vlan_filtering_config(
+            LinuxBridge.Port.Vlan.Mode.TRUNK,
+            bridgelib.generate_vlan_id_config(100, 200, 300),
+        )
+        current_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[TestLinuxBridgeState.PORT1],
+            ports_extra_state={TestLinuxBridgeState.PORT1: port1_vlan_config},
+        )
+        current_state = state.State({Interface.KEY: [current_bridge_state]})
+
+        desired_bridge_state = bridgelib.generate_bridge_iface_state(
+            TestLinuxBridgeState.BRIDGE_NAME,
+            port_names=[TestLinuxBridgeState.PORT1],
+            ports_extra_state={
+                TestLinuxBridgeState.PORT1: {
+                    LinuxBridge.Port.STP_PRIORITY: "100"
+                }
+            },
+        )
+        desired_state_raw = {Interface.KEY: [desired_bridge_state]}
+        desired_state = state.State(desired_state_raw)
+
+        desired_state.merge_interfaces(current_state)
+        desired_bridge_state = desired_state.interfaces[
+            TestLinuxBridgeState.BRIDGE_NAME
+        ]
+        desired_bridge_ports = desired_bridge_state.get(
+            LinuxBridge.CONFIG_SUBTREE, {}
+        ).get(LinuxBridge.PORT_SUBTREE, [])
+
+        assert TestLinuxBridgeState._is_vlan_filtering_enabled(
+            desired_bridge_ports
+        )
+        assert desired_bridge_ports[0] == {
+            LinuxBridge.Port.NAME: TestLinuxBridgeState.PORT1,
+            LinuxBridge.Port.STP_PRIORITY: "100",
+            LinuxBridge.Port.VLAN_SUBTREE: {
+                LinuxBridge.Port.Vlan.MODE: LinuxBridge.Port.Vlan.Mode.TRUNK,
+                LinuxBridge.Port.Vlan.TRUNK_TAGS: [
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 100},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 200},
+                    {LinuxBridge.Port.Vlan.TrunkTags.ID: 300},
+                ],
+            },
+        }
+
+    @staticmethod
+    def _is_vlan_filtering_enabled(bridge_ports):
+        return any(
+            port.get(LinuxBridge.Port.VLAN_SUBTREE, {}) != {}
+            for port in bridge_ports
         )

--- a/tests/lib/testlib/__init__.py
+++ b/tests/lib/testlib/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#

--- a/tests/lib/testlib/bridgelib.py
+++ b/tests/lib/testlib/bridgelib.py
@@ -18,7 +18,27 @@
 #
 
 
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import LinuxBridge
+
+
+def generate_bridge_iface_state(
+    bridge_name, port_names=None, ports_extra_state=None
+):
+    bridge_state = {
+        Interface.NAME: bridge_name,
+        Interface.TYPE: LinuxBridge.TYPE,
+        Interface.STATE: InterfaceState.UP,
+        LinuxBridge.CONFIG_SUBTREE: {LinuxBridge.PORT_SUBTREE: []},
+    }
+    for port_name in port_names or []:
+        bridge_config = bridge_state[LinuxBridge.CONFIG_SUBTREE]
+        port_state = {LinuxBridge.Port.NAME: port_name}
+        port_extra_state = (ports_extra_state or {}).get(port_name, {})
+        port_state.update(port_extra_state)
+        bridge_config[LinuxBridge.PORT_SUBTREE].append(port_state)
+    return bridge_state
 
 
 def generate_vlan_filtering_config(

--- a/tests/lib/testlib/bridgelib.py
+++ b/tests/lib/testlib/bridgelib.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+from libnmstate.schema import LinuxBridge
+
+
+def generate_vlan_filtering_config(
+    port_type, trunk_tags=None, tag=None, native_vlan=None
+):
+    vlan_filtering_state = {
+        LinuxBridge.Port.Vlan.MODE: port_type,
+        LinuxBridge.Port.Vlan.TRUNK_TAGS: trunk_tags or [],
+    }
+
+    if tag:
+        vlan_filtering_state[LinuxBridge.Port.Vlan.TAG] = tag
+    if native_vlan is not None:
+        vlan_filtering_state[LinuxBridge.Port.Vlan.ENABLE_NATIVE] = native_vlan
+
+    return {LinuxBridge.Port.VLAN_SUBTREE: vlan_filtering_state}
+
+
+def generate_vlan_id_config(*vlan_ids):
+    return [
+        {LinuxBridge.Port.Vlan.TrunkTags.ID: vlan_id} for vlan_id in vlan_ids
+    ]
+
+
+def generate_vlan_id_range_config(min_vlan_id, max_vlan_id):
+    return {
+        LinuxBridge.Port.Vlan.TrunkTags.ID_RANGE: {
+            LinuxBridge.Port.Vlan.TrunkTags.MIN_RANGE: min_vlan_id,
+            LinuxBridge.Port.Vlan.TrunkTags.MAX_RANGE: max_vlan_id,
+        }
+    }


### PR DESCRIPTION
Enable / disable vlan filtering on linux bridge interfaces via interface state merging.

This allows for a user to partially update the port configuration.

Considering the current state:
```yaml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
  - name: linux-br0
    type: linux-bridge
    state: up
    bridge:
      port:
        - name: eth1
          stp-hairpin-mode: false
          stp-path-cost: 100
          stp-priority: 32
          vlan:
            mode: trunk
            trunk-tags:
            - id: 101
            - id-range:
                min: 500
                max: 599
            tag: 100
            enable-native: true
```

If the user wants to remove the port vlan configuration on port
eth1 - and as a result disable port vlan filtering on the whose
bridge - the following yaml should be used:
```yaml
---
interfaces:
  - name: linux-br0
    type: linux-bridge
    state: up
    bridge:
      port:
        - name: eth1
          vlan: {}
```

This is part of the split from PR #576 .
Depends on: #913 