### PR TITLE
automation: compare packaging againts upstream branch

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -180,7 +180,14 @@ function open_shell {
 
 # Return 0 if file is changed else 1
 function is_file_changed {
-    git diff --exit-code --name-only origin/master -- $1
+    git remote add upstream https://github.com/nmstate/nmstate.git
+    git fetch upstream
+    if [ -n "$TRAVIS_BRANCH" ]; then
+        git diff --exit-code --name-only upstream/$TRAVIS_BRANCH -- $1
+    else
+        git diff -exit-code --name-only upstream/master -- $1
+    fi
+
     if [ $? -eq 0 ];then
         return 1
     else


### PR DESCRIPTION
Travis is only taking the contributor branch, in order to do the diff
over the packaging folder we must compare againts the upstream repository.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>