### PR TITLE
test: Add test case for switching bond mode

### DIFF
--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -43,6 +43,10 @@ def bond_interface(name, slaves, extra_iface_state=None, create=True):
     }
     if extra_iface_state:
         desired_state[Interface.KEY][0].update(extra_iface_state)
+        if slaves:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.SLAVES
+            ] = slaves
 
     if create:
         libnmstate.apply(desired_state)


### PR DESCRIPTION
Add xfail test case for know issue of NetworkManager when switching
2 slaves bond from mode 1 to 5.

Fixed the testlib `bond_interface()` function to include slaves
when both `extra_iface_state` and `slaves` is defined.