### PR TITLE
nm applier: only create ethernet when explicitly

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -145,7 +145,10 @@ def _apply_ifaces_state(
             with _setup_providers():
                 state2edit = state.State(desired_state.state)
                 state2edit.merge_interfaces(current_state)
-                nm.applier.apply_changes(list(state2edit.interfaces.values()))
+                nm.applier.apply_changes(
+                    list(state2edit.interfaces.values()),
+                    original_desired_state,
+                )
             verified = False
             if verify_change:
                 for _ in range(VERIFY_RETRY_TIMEOUT):

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -23,7 +23,6 @@ import pytest
 import yaml
 
 import libnmstate
-from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import Bond
@@ -631,11 +630,6 @@ def test_create_bond_with_both_miimon_and_arp_internal():
             assertlib.assert_state_match(state)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="https://bugzilla.redhat.com/1810506",
-    raises=(NmstateLibnmError, NmstateVerificationError),
-)
 def test_change_2_slaves_bond_mode_from_1_to_5():
     with bond_interface(
         name=BOND99,

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -175,3 +175,20 @@ def test_change_mtu_with_stable_link_up(eth1_up):
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
+
+
+@pytest.fixture(scope="function")
+def eth1_up_with_mtu_1900(eth1_up):
+    desired_state = statelib.show_only(("eth1",))
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1900
+
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+def test_empty_state_preserve_the_old_mtu(eth1_up_with_mtu_1900):
+    desired_state = eth1_up_with_mtu_1900
+    libnmstate.apply({Interface.KEY: [{Interface.NAME: "eth1"}]})
+
+    assertlib.assert_state(desired_state)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -95,10 +95,6 @@ def _bridge0_with_port0(port0_up, use_port_mac=False):
     with linux_bridge(
         bridge_name, bridge_state, extra_iface_state
     ) as desired_state:
-        # Need to set twice so the wired setting will be explicitly set,
-        # allowing reapply to succeed.
-        # https://bugzilla.redhat.com/1703960
-        libnmstate.apply(desired_state)
         yield deepcopy(desired_state)
 
 

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -105,10 +105,7 @@ def _create_iface_settings(ipv4_state, con_profile):
     con_setting = nm.connection.ConnectionSetting()
     con_setting.import_by_profile(con_profile)
 
-    # Wired is required due to https://bugzilla.redhat.com/1703960
-    wired_setting = con_profile.profile.get_setting_wired()
-
     ipv4_setting = nm.ipv4.create_setting(ipv4_state, con_profile.profile)
     ipv6_setting = nm.ipv6.create_setting({}, None)
 
-    return con_setting.setting, wired_setting, ipv4_setting, ipv6_setting
+    return con_setting.setting, ipv4_setting, ipv6_setting

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -31,6 +31,7 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.state import State
 
 INTERFACES = Constants.INTERFACES
 BOND_TYPE = InterfaceType.BOND
@@ -93,7 +94,7 @@ def test_iface_admin_state_change(netinfo_nm_mock, netapplier_nm_mock):
 
     applier_mock = netapplier_nm_mock.applier
     applier_mock.apply_changes.assert_has_calls(
-        [mock.call(desired_config[INTERFACES],)]
+        [mock.call(desired_config[INTERFACES], State(desired_config))]
     )
 
 
@@ -124,7 +125,9 @@ def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config, verify_change=False)
 
     m_apply_changes = netapplier_nm_mock.applier.apply_changes
-    m_apply_changes.assert_called_once_with(desired_config[INTERFACES])
+    m_apply_changes.assert_called_once_with(
+        desired_config[INTERFACES], State(desired_config)
+    )
 
 
 def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
@@ -172,7 +175,9 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config, verify_change=False)
 
     m_apply_changes = netapplier_nm_mock.applier.apply_changes
-    m_apply_changes.assert_called_once_with(desired_config[INTERFACES])
+    m_apply_changes.assert_called_once_with(
+        desired_config[INTERFACES], State(desired_config)
+    )
 
 
 @mock.patch.object(netapplier, "_apply_ifaces_state", lambda *_: None)


### PR DESCRIPTION
Creating ethernet configuration when user not requested will
cause two major problems:
 * Adding slave to newly create bridge will cause bridge link down.
 * Cannot switch bond mode from 1(active-backup) to 5(balance-tlb).

To fix the problem, only create ethernet/wired setting when user
explicitly requested.

Remove the xfail of test case for changing bond mode from 1(active-backup)
to 5(balance-tlb).

Remove the workaround in test case for adding slave to newly created
bridge without link state down.