### PR TITLE
nm applier: only create ethernet when explicitly

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -152,7 +152,9 @@ def _apply_ifaces_state(
                 state2edit = _create_editable_desired_state(
                     desired_state, current_state, new_interfaces
                 )
-                ifaces2edit, ifaces_edit_configs = _edit_interfaces(state2edit)
+                ifaces2edit, ifaces_edit_configs = _edit_interfaces(
+                    state2edit, original_desired_state
+                )
                 nm.applier.set_ifaces_admin_state(
                     ifaces2add + ifaces2edit,
                     con_profiles=ifaces_add_configs + ifaces_edit_configs,
@@ -231,7 +233,7 @@ def _add_interfaces(new_interfaces, desired_state):
     return (ifaces2add, ifaces_configs)
 
 
-def _edit_interfaces(state2edit):
+def _edit_interfaces(state2edit, original_desired_state):
     logging.debug("Editing interfaces: %s", list(state2edit.interfaces))
 
     ifaces2edit = list(state2edit.interfaces.values())
@@ -244,7 +246,7 @@ def _edit_interfaces(state2edit):
     )
     proxy_ifaces = nm.applier.prepare_proxy_ifaces_desired_state(iface2prepare)
     ifaces_configs = nm.applier.prepare_edited_ifaces_configuration(
-        iface2prepare + proxy_ifaces
+        iface2prepare + proxy_ifaces, original_desired_state
     )
     nm.applier.edit_existing_ifaces(ifaces_configs)
 

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -533,3 +533,15 @@ def test_create_bond_with_default_miimon_explicitly():
         },
     ) as state:
         assertlib.assert_state_match(state)
+
+
+def test_change_2_slaves_bond_mode_from_1_to_5():
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {Bond.MODE: BondMode.ACTIVE_BACKUP}
+        },
+    ) as state:
+        state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.MODE] = BondMode.TLB
+        libnmstate.apply(state)

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -171,3 +171,20 @@ def test_change_mtu_with_stable_link_up(eth1_up):
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
+
+
+@pytest.fixture(scope="function")
+def eth1_up_with_mtu_1900(eth1_up):
+    desired_state = statelib.show_only(("eth1",))
+    eth1_desired_state = desired_state[Interface.KEY][0]
+    eth1_desired_state[Interface.MTU] = 1900
+
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+def test_empty_state_preserve_the_old_mtu(eth1_up_with_mtu_1900):
+    desired_state = eth1_up_with_mtu_1900
+    libnmstate.apply({Interface.KEY: [{Interface.NAME: "eth1"}]})
+
+    assertlib.assert_state(desired_state)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -95,10 +95,6 @@ def _bridge0_with_port0(port0_up, use_port_mac=False):
     with linux_bridge(
         bridge_name, bridge_state, extra_iface_state
     ) as desired_state:
-        # Need to set twice so the wired setting will be explicitly set,
-        # allowing reapply to succeed.
-        # https://bugzilla.redhat.com/1703960
-        libnmstate.apply(desired_state)
         yield deepcopy(desired_state)
 
 

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -106,10 +106,7 @@ def _create_iface_settings(ipv4_state, con_profile):
     con_setting = nm.connection.ConnectionSetting()
     con_setting.import_by_profile(con_profile)
 
-    # Wired is required due to https://bugzilla.redhat.com/1703960
-    wired_setting = con_profile.profile.get_setting_wired()
-
     ipv4_setting = nm.ipv4.create_setting(ipv4_state, con_profile.profile)
     ipv6_setting = nm.ipv6.create_setting({}, None)
 
-    return con_setting.setting, wired_setting, ipv4_setting, ipv6_setting
+    return con_setting.setting, ipv4_setting, ipv6_setting

--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -43,6 +43,10 @@ def bond_interface(name, slaves, extra_iface_state=None, create=True):
     }
     if extra_iface_state:
         desired_state[Interface.KEY][0].update(extra_iface_state)
+        if slaves:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.SLAVES
+            ] = slaves
 
     if create:
         libnmstate.apply(desired_state)

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -31,6 +31,7 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.state import State
 
 INTERFACES = Constants.INTERFACES
 BOND_TYPE = InterfaceType.BOND
@@ -135,7 +136,7 @@ def test_add_new_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config, verify_change=False)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_once_with([])
+    m_prepare.assert_called_once_with([], State(desired_config))
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
     m_prepare.assert_called_once_with(desired_config[INTERFACES])
@@ -186,7 +187,9 @@ def test_edit_existing_bond(netinfo_nm_mock, netapplier_nm_mock):
     netapplier.apply(desired_config, verify_change=False)
 
     m_prepare = netapplier_nm_mock.applier.prepare_edited_ifaces_configuration
-    m_prepare.assert_called_once_with(desired_config[INTERFACES])
+    m_prepare.assert_called_once_with(
+        desired_config[INTERFACES], State(desired_config)
+    )
 
     m_prepare = netapplier_nm_mock.applier.prepare_new_ifaces_configuration
     m_prepare.assert_called_once_with([])

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -28,6 +28,7 @@ from libnmstate.schema import BondMode
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.state import State
 
 
 @pytest.fixture
@@ -168,7 +169,9 @@ def test_prepare_edited_ifaces_configuration(
             Interface.STATE: InterfaceState.UP,
         }
     ]
-    cons = nm.applier.prepare_edited_ifaces_configuration(ifaces_desired_state)
+    cons = nm.applier.prepare_edited_ifaces_configuration(
+        ifaces_desired_state, State({Interface.KEY: ifaces_desired_state})
+    )
 
     assert len(cons) == 1
 


### PR DESCRIPTION
Creating ethernet configuration when user not requested will
cause two major problems:

 * Adding slave to newly create bridge will cause bridge link down.
 * Cannot switch bond mode from 1(active-backup) to 5(balance-tlb).

To fix the problem, only create ethernet/wired setting when user
explicitly requested.

Remove the xfail of test case for changing bond mode from 1(active-backup)
to 5(balance-tlb).

Remove the workaround in test case for adding slave to newly created
bridge without link state down.

Add test case showing old ethernet configuration will not be removed when
desire state does not include so.