### PR TITLE
state: An empty dict value is treated as an overwrite

### DIFF
--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -200,7 +200,6 @@ class State:
         self._state = copy.deepcopy(state)
 
         self._ifaces_state = self._index_interfaces_state_by_name()
-        self._complement_interface_empty_ip_subtrees()
 
         self._config_iface_routes = self._index_routes_by_iface()
 
@@ -298,7 +297,7 @@ class State:
         """
         for iface_state in self.interfaces.values():
             for family in ("ipv4", "ipv6"):
-                ip = iface_state[family]
+                ip = iface_state.get(family, {})
                 if ip.get(InterfaceIP.ENABLED) and (
                     ip.get(InterfaceIP.DHCP) or ip.get(InterfaceIPv6.AUTOCONF)
                 ):
@@ -687,14 +686,16 @@ class State:
 
     def _remove_iface_ipv6_link_local_addr(self):
         for ifstate in self.interfaces.values():
-            ifstate["ipv6"][InterfaceIPv6.ADDRESS] = list(
-                addr
-                for addr in ifstate["ipv6"][InterfaceIPv6.ADDRESS]
-                if not iplib.is_ipv6_link_local_addr(
-                    addr[InterfaceIPv6.ADDRESS_IP],
-                    addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
+            ipv6_state = ifstate.get(Interface.IPV6)
+            if ipv6_state and InterfaceIPv6.ADDRESS in ipv6_state:
+                ipv6_state[InterfaceIPv6.ADDRESS] = list(
+                    addr
+                    for addr in ipv6_state[InterfaceIPv6.ADDRESS]
+                    if not iplib.is_ipv6_link_local_addr(
+                        addr[InterfaceIPv6.ADDRESS_IP],
+                        addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
+                    )
                 )
-            )
 
     def _remove_ip_stack_if_disabled(self):
         for ifstate in self.interfaces.values():
@@ -706,7 +707,7 @@ class State:
     def _sort_ip_addresses(self):
         for ifstate in self.interfaces.values():
             for family in ("ipv4", "ipv6"):
-                ifstate[family].get(InterfaceIP.ADDRESS, []).sort(
+                ifstate.get(family, {}).get(InterfaceIP.ADDRESS, []).sort(
                     key=itemgetter(InterfaceIP.ADDRESS_IP)
                 )
 
@@ -767,6 +768,9 @@ class State:
 
 def dict_update(origin_data, to_merge_data):
     """Recursevely performes a dict update (merge)"""
+
+    if not to_merge_data:
+        return to_merge_data
 
     for key, val in to_merge_data.items():
         if isinstance(val, Mapping):

--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -39,12 +39,14 @@ def linux_bridge(
                 Interface.STATE: InterfaceState.UP,
                 Interface.IPV4: {InterfaceIPv4.ENABLED: False},
                 Interface.IPV6: {InterfaceIPv6.ENABLED: False},
-                LinuxBridge.CONFIG_SUBTREE: bridge_subtree_state or {},
             }
         ]
     }
+    desired_iface_state = desired_state[Interface.KEY][0]
+    if bridge_subtree_state:
+        desired_iface_state[LinuxBridge.CONFIG_SUBTREE] = bridge_subtree_state
     if extra_iface_state:
-        desired_state[Interface.KEY][0].update(extra_iface_state)
+        desired_iface_state.update(extra_iface_state)
 
     if create:
         libnmstate.apply(desired_state)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -243,12 +243,14 @@ def _dict_update(origin_data, to_merge_data):
     updating the origin_data.
     The function changes the origin_data in-place.
     """
+    if not to_merge_data:
+        return to_merge_data
+
     for key, val in to_merge_data.items():
         if isinstance(val, Mapping):
             origin_data[key] = _dict_update(origin_data.get(key, {}), val)
         else:
             origin_data[key] = val
-
     return origin_data
 
 

--- a/tests/lib/state_test.py
+++ b/tests/lib/state_test.py
@@ -306,6 +306,21 @@ class TestAssertIfaceState:
 
         desired_state.verify_interfaces(current_state)
 
+    def test_initialize_subtree(self):
+        current_state = self._base_state
+        desired_state = state.State(
+            {
+                Interface.KEY: [
+                    {Interface.NAME: "foo-name", OVSBridge.CONFIG_SUBTREE: {}}
+                ]
+            }
+        )
+
+        desired_state.merge_interfaces(current_state)
+
+        desired_iface_state = desired_state.interfaces["foo-name"]
+        assert desired_iface_state[OVSBridge.CONFIG_SUBTREE] == {}
+
     @property
     def _base_state(self):
         return state.State(
@@ -578,13 +593,7 @@ class TestRouteStateMerge:
         iface_only_state.merge_routes(state_with_route0)
 
         expected = {
-            Interface.KEY: [
-                {
-                    Interface.NAME: route0_obj.next_hop_interface,
-                    Interface.IPV4: {},
-                    Interface.IPV6: {},
-                }
-            ],
+            Interface.KEY: [{Interface.NAME: route0_obj.next_hop_interface}],
             Route.KEY: {Route.CONFIG: [route0]},
         }
         assert expected == iface_only_state.state
@@ -614,8 +623,6 @@ class TestRouteStateMerge:
                 {
                     Interface.NAME: route0_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.DOWN,
-                    Interface.IPV4: {},
-                    Interface.IPV6: {},
                 }
             ],
             Route.KEY: {Route.CONFIG: []},
@@ -647,7 +654,6 @@ class TestRouteStateMerge:
                     Interface.NAME: route0_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
                     Interface.IPV4: {InterfaceIPv4.ENABLED: False},
-                    Interface.IPV6: {},
                 }
             ],
             Route.KEY: {Route.CONFIG: []},
@@ -678,7 +684,6 @@ class TestRouteStateMerge:
                 {
                     Interface.NAME: route1_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
-                    Interface.IPV4: {},
                     Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                 }
             ],
@@ -710,7 +715,6 @@ class TestRouteStateMerge:
                 {
                     Interface.NAME: route0_obj.next_hop_interface,
                     Interface.STATE: InterfaceState.UP,
-                    Interface.IPV4: {},
                     Interface.IPV6: {InterfaceIPv6.ENABLED: False},
                 }
             ],

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -644,6 +644,7 @@ class TestLinuxBondValidator:
         iface_state[Interface.MAC] = MAC0
         bond_config = iface_state[Bond.CONFIG_SUBTREE]
         bond_config.pop(Bond.MODE)
+        bond_config.pop(Bond.OPTIONS_SUBTREE)
         original_desired_state = state.State({Interface.KEY: [iface_state]})
 
         with pytest.raises(NmstateValueError):


### PR DESCRIPTION
The recursive dict update is used to merge two dicts that represent
states.
When the data to-be-merge includes an empty dict as the value, it will
overwrite any existing data.

This change allows a client to overwrite a whole subtree from the existing
state.