### PR TITLE
test: Add file descriptor leak check on libnmstate.apply()

### DIFF
--- a/tests/integration/mem_leak_test.py
+++ b/tests/integration/mem_leak_test.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import logging
 import os
 import time
 
@@ -24,15 +25,36 @@ import pytest
 
 import libnmstate
 
+from .testlib import ifacelib
+
 
 def get_current_open_fd():
+    time.sleep(0.1)  # Wait sysfs/proc been updated.
     return len(os.listdir("/proc/self/fd"))
 
 
+@pytest.fixture(scope="function")
+def disable_logging():
+    logger = logging.getLogger()
+    logger.disabled = True
+    try:
+        yield
+    finally:
+        logger.disabled = False
+
+
 @pytest.mark.tier1
-def test_libnmstate_show_fd_leak():
+def test_libnmstate_show_fd_leak(disable_logging):
     original_fd = get_current_open_fd()
     for x in range(0, 100):
         libnmstate.show()
-    time.sleep(0.1)  # Wait sysfs/proc been updated.
+    assert get_current_open_fd() == original_fd
+
+
+@pytest.mark.tier1
+def test_libnmstate_apply_fd_leak(disable_logging):
+    original_fd = get_current_open_fd()
+    for x in range(0, 10):
+        with ifacelib.iface_up("eth1"):
+            pass
     assert get_current_open_fd() == original_fd


### PR DESCRIPTION
Added integration test case for checking opened file descriptor after
10 times of interface up and down via `libnmstate.apply()`.

Disable the logging during test as pytest will hold the logger which
cause false alarm on leaking opened file descriptor.