### PR TITLE
[nmstate-0.2] nm bond: workaround on miimon=100 option

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -86,6 +86,9 @@ def _get_options(nm_device):
                 if option == "arp_ip_target":
                     value = value.replace(" ", ",")
                 options[option] = value
+    # Workaround of https://bugzilla.redhat.com/show_bug.cgi?id=1806549
+    if "miimon" not in options:
+        options["miimon"] = bond_setting.get_option_default("miimon")
     return options
 
 

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -545,3 +545,11 @@ def test_change_2_slaves_bond_mode_from_1_to_5():
     ) as state:
         state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.MODE] = BondMode.TLB
         libnmstate.apply(state)
+
+
+def test_set_miimon_100_on_existing_bond(bond99_with_2_slaves):
+    state = bond99_with_2_slaves
+    bond_config = state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
+    bond_config[Bond.OPTIONS_SUBTREE] = {"miimon": 100}
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)


### PR DESCRIPTION
The NM will ignore the `miimon=100`(the default option) when
wired/ethernet setting not included due to bug:
    https://bugzilla.redhat.com/show_bug.cgi?id=1806549

This cause verification error when user try to set `miimon=100` on
existing bond.

To workaround that, always include `miimon` option when querying bond
options.

Integration test case included.