### PR TITLE
Checking the libnm and nm version mismatch

### DIFF
--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -32,6 +32,8 @@ from .prettystate import PrettyState
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+_MINIMUM_NM_VERSION = "1.22.8"
+
 __all__ = [
     "show",
     "apply",

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -37,6 +37,7 @@ from gi.repository import GLib
 from gi.repository import GObject
 
 from libnmstate import error
+from libnmstate import _MINIMUM_NM_VERSION
 
 GObject
 
@@ -52,10 +53,34 @@ def nm_version():
 
 
 def libnm_nm_version_mismatch_check():
-    if StrictVersion(NM.utils_version()) < StrictVersion(
+    if StrictVersion(NM.Client.get_version()) < StrictVersion(
+        _MINIMUM_NM_VERSION
+    ):
+        warnings.warn(
+            "NetworkManager version ("
+            + NM.Client.get_version()
+            + ") is too old, atleast version ("
+            + _MINIMUM_NM_VERSION
+            + ") is required."
+        )
+    if StrictVersion(NM.utils_version()) < StrictVersion(_MINIMUM_NM_VERSION):
+        warnings.warn(
+            "Libnm version ("
+            + NM.utils_version()
+            + ") is too old, atleast version ("
+            + _MINIMUM_NM_VERSION
+            + ") is required."
+        )
+    if StrictVersion(NM.utils_version()) != StrictVersion(
         NM.Client.get_version()
     ):
-        warnings.warn("Version mismatch")
+        warnings.warn(
+            "NetworkManager version ("
+            + NM.Client.get_version()
+            + ") does not match libnm version ("
+            + NM.utils_version()
+            + ")."
+        )
 
 
 def _delete_client():
@@ -257,6 +282,7 @@ class _MainLoop:
 class _NmClient:
     def __init__(self):
         self._client = NM.Client.new(None)
+        libnm_nm_version_mismatch_check()
 
     @property
     def client(self):

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -23,6 +23,7 @@ import logging
 import sys
 
 import gi
+import warnings
 
 try:
     gi.require_version("NM", "1.0")  # NOQA: F402
@@ -47,6 +48,15 @@ _NMCLIENT_CLEANUP_TIMEOUT = 5
 
 def nm_version():
     return NM.Client.get_version(client())
+
+
+def libnm_nm_version_mismatch_check():
+    if NM.utils_version() < nm_encode_version(1, 20, 0):
+        warnings.warn("Version mismatch")
+
+
+def nm_encode_version(major, minor, micro):
+    return (major << 16) | (minor << 8) | micro
 
 
 def _delete_client():

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -57,29 +57,23 @@ def libnm_nm_version_mismatch_check():
         _MINIMUM_NM_VERSION
     ):
         warnings.warn(
-            "NetworkManager version ("
-            + NM.Client.get_version()
-            + ") is too old, atleast version ("
-            + _MINIMUM_NM_VERSION
-            + ") is required."
+            "NetworkManager version ({}) is too old, atleast version ({}) is required.".format(
+                NM.Client.get_version(), _MINIMUM_NM_VERSION
+            )
         )
     if StrictVersion(NM.utils_version()) < StrictVersion(_MINIMUM_NM_VERSION):
         warnings.warn(
-            "Libnm version ("
-            + NM.utils_version()
-            + ") is too old, atleast version ("
-            + _MINIMUM_NM_VERSION
-            + ") is required."
+            "Libnm version ({}) is too old, atleast version ({}) is required.".format(
+                NM.utils_version(), _MINIMUM_NM_VERSION
+            )
         )
     if StrictVersion(NM.utils_version()) != StrictVersion(
         NM.Client.get_version()
     ):
         warnings.warn(
-            "NetworkManager version ("
-            + NM.Client.get_version()
-            + ") does not match libnm version ("
-            + NM.utils_version()
-            + ")."
+            "NetworkManager version ({}) does not match libnm version ({}).".format(
+                NM.Client.get_version(), NM.utils_version()
+            )
         )
 
 

--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -18,6 +18,7 @@
 #
 from collections import deque
 from contextlib import contextmanager
+from distutils.version import StrictVersion
 import functools
 import logging
 import sys
@@ -51,12 +52,10 @@ def nm_version():
 
 
 def libnm_nm_version_mismatch_check():
-    if NM.utils_version() < nm_encode_version(1, 20, 0):
+    if StrictVersion(NM.utils_version()) < StrictVersion(
+        NM.Client.get_version()
+    ):
         warnings.warn("Version mismatch")
-
-
-def nm_encode_version(major, minor, micro):
-    return (major << 16) | (minor << 8) | micro
 
 
 def _delete_client():


### PR DESCRIPTION
Adding nm_encode_version() and libnm_nm_version_mismatch_check() functions to give warning in case of mismatch between libnm and nm versions.
