### PR TITLE
[nmstate-0.2] nm applier: Sort interface creation/modification order

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -20,6 +20,7 @@
 import base64
 import hashlib
 import itertools
+from operator import attrgetter
 
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
@@ -57,7 +58,11 @@ IFACE_NAME_METADATA = "_iface_name"
 
 
 def create_new_ifaces(con_profiles):
-    for connection_profile in con_profiles:
+    # By default, NetworkManager will activate the slave profiles in the order
+    # of sorted interface name. To make sure user get the same MAC address
+    # after reboot for bond/bridge/etc, sort the interfaces to be created
+    # as autoconnect=True will activate the profile at the creation time.
+    for connection_profile in sorted(con_profiles, key=attrgetter("con_id")):
         connection_profile.add(save_to_disk=True)
 
 
@@ -78,7 +83,11 @@ def prepare_new_ifaces_configuration(ifaces_desired_state):
 
 
 def edit_existing_ifaces(con_profiles):
-    for connection_profile in con_profiles:
+    # By default, NetworkManager will activate the slave profiles in the order
+    # of sorted interface name. To make sure user get the same MAC address
+    # after reboot for bond/bridge/etc, sort the interfaces to be updated
+    # as autoconnect=True will activate the profile at the profile update time.
+    for connection_profile in sorted(con_profiles, key=attrgetter("con_id")):
         devname = connection_profile.devname
         nmdev = device.get_device_by_name(devname)
         cur_con_profile = None

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -34,9 +34,12 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 
 from .testlib import assertlib
+from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.assertlib import assert_mac_address
 from .testlib.bondlib import bond_interface
+from .testlib.ifacelib import get_mac_address
+from .testlib.ifacelib import ifaces_init
 from .testlib.vlan import vlan_interface
 
 from .testlib.bridgelib import linux_bridge
@@ -321,7 +324,7 @@ def test_set_bond_mac_address(eth1_up):
         assert_mac_address(current_state, MAC1)
 
 
-def test_reordering_the_slaves_does_not_change_the_mac(bond99_with_2_slaves):
+def test_changing_slave_order_keeps_mac_of_existing_bond(bond99_with_2_slaves):
     bond_state = bond99_with_2_slaves[Interface.KEY][0]
     bond_slaves = bond_state[Bond.CONFIG_SUBTREE][Bond.SLAVES]
     ifaces_names = [bond_state[Interface.NAME]] + bond_slaves
@@ -553,3 +556,53 @@ def test_set_miimon_100_on_existing_bond(bond99_with_2_slaves):
     bond_config[Bond.OPTIONS_SUBTREE] = {"miimon": 100}
     libnmstate.apply(state)
     assertlib.assert_state_match(state)
+
+
+@pytest.fixture
+def eth1_eth2_with_no_profile():
+    yield
+    ifaces_init(ETH1, ETH2)
+
+
+def _nmcli_simulate_boot(ifname):
+    """
+    Use nmcli to reactivate the profile to simulate the server reboot.
+    """
+    cmdlib.exec_cmd(["nmcli", "connection", "down", ifname], check=True)
+    # Wait slave been deactivated
+    time.sleep(1)
+    cmdlib.exec_cmd(["nmcli", "connection", "up", ifname], check=True)
+    # Wait slave been activated
+    time.sleep(1)
+
+
+def test_new_bond_uses_mac_of_first_slave_by_name(eth1_eth2_with_no_profile):
+    """
+    On system boot, NetworkManager will by default activate slaves in the
+    order of their name. Nmstate should provide the consistent MAC address for
+    bond regardless the order of slaves.
+    """
+    eth1_mac = get_mac_address(ETH1)
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH2, ETH1],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {Bond.MODE: BondMode.ROUND_ROBIN}
+        },
+    ):
+        assert get_mac_address(BOND99) == eth1_mac
+        _nmcli_simulate_boot(BOND99)
+        assert get_mac_address(BOND99) == eth1_mac
+
+    ifaces_init(ETH1, ETH2)
+
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {Bond.MODE: BondMode.ROUND_ROBIN}
+        },
+    ):
+        assert get_mac_address(BOND99) == eth1_mac
+        _nmcli_simulate_boot(BOND99)
+        assert get_mac_address(BOND99) == eth1_mac

--- a/tests/lib/nm/applier_test.py
+++ b/tests/lib/nm/applier_test.py
@@ -67,9 +67,12 @@ def nm_ovs_mock():
         yield m
 
 
-@mock.patch.object(nm.connection, "ConnectionProfile")
-def test_create_new_ifaces(con_profile_mock):
-    con_profiles = [con_profile_mock(), con_profile_mock()]
+def test_create_new_ifaces():
+    con_profile_1 = mock.MagicMock()
+    con_profile_1.con_id = 1
+    con_profile_2 = mock.MagicMock()
+    con_profile_2.con_id = 2
+    con_profiles = [con_profile_1, con_profile_2]
 
     nm.applier.create_new_ifaces(con_profiles)
 
@@ -131,9 +134,12 @@ def test_prepare_new_ifaces_configuration(
     )
 
 
-@mock.patch.object(nm.connection, "ConnectionProfile")
-def test_edit_existing_ifaces_with_profile(con_profile_mock, nm_device_mock):
-    con_profiles = [con_profile_mock(), con_profile_mock()]
+def test_edit_existing_ifaces_with_profile(nm_device_mock):
+    con_profile_1 = mock.MagicMock()
+    con_profile_1.con_id = 1
+    con_profile_2 = mock.MagicMock()
+    con_profile_2.con_id = 2
+    con_profiles = [con_profile_1, con_profile_2]
 
     nm.applier.edit_existing_ifaces(con_profiles)
 
@@ -147,7 +153,11 @@ def test_edit_existing_ifaces_with_profile(con_profile_mock, nm_device_mock):
 def test_edit_existing_ifaces_without_profile(
     con_profile_mock, nm_device_mock
 ):
-    con_profiles = [mock.MagicMock(), mock.MagicMock()]
+    con_profile_1 = mock.MagicMock()
+    con_profile_1.con_id = 1
+    con_profile_2 = mock.MagicMock()
+    con_profile_2.con_id = 2
+    con_profiles = [con_profile_1, con_profile_2]
     con_profile_mock.return_value.profile = None
 
     nm.applier.edit_existing_ifaces(con_profiles)


### PR DESCRIPTION
The bond or bridge will take its first slave's MAC address, hence
NetworkManager by default will activate the slaves in the order of its
interface name.

When nmstate create or editing bond/bridge, the `autoconnect` feature
will cause NetworkManager activating the slaves in unexpected order
which then generate different MAC address of bond and bridge.

To fix this problem, sort the interface creation and modification order.

New integration test case has been included.