### PR TITLE
Update Travis CI on nmstate-0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,32 @@ env:
     global:
         - use_coveralls=true
     matrix:
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type integ --pytest-args='-x'"
           use_codecov=true
           use_coveralls=false
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type integ_slow --pytest-args='-x'"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type format"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type lint"
-        - CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type unit_py36"
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - env: CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-1.22-git"
-        - env: CONTAINER_IMAGE=nmstate/centos8-nmstate-dev
+        - env: CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ env:
         - use_coveralls=true
     matrix:
         - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
-          testflags="--test-type integ --pytest-args='-x'"
+          testflags="--test-type integ --pytest-args='-x'
+              --copr networkmanager/NetworkManager-1.22-git"
           use_codecov=true
           use_coveralls=false
         - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
-          testflags="--test-type integ_slow --pytest-args='-x'"
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
-          testflags="--test-type integ --pytest-args='-x'
+          testflags="--test-type integ_slow --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
         - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type integ --pytest-args='-x'
@@ -27,9 +26,6 @@ env:
 matrix:
     fast_finish: true
     allow_failures:
-        - env: CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
-               testflags="--test-type integ --pytest-args='-x'
-                   --copr networkmanager/NetworkManager-1.22-git"
         - env: CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev:nmstate-0.2
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -180,7 +180,14 @@ function open_shell {
 
 # Return 0 if file is changed else 1
 function is_file_changed {
-    git diff --exit-code --name-only origin/master -- $1
+    git remote add upstream https://github.com/nmstate/nmstate.git
+    git fetch upstream
+    if [ -n "$TRAVIS_BRANCH" ]; then
+        git diff --exit-code --name-only upstream/$TRAVIS_BRANCH -- $1
+    else
+        git diff -exit-code --name-only upstream/nmstate-0.2 -- $1
+    fi
+
     if [ $? -eq 0 ];then
         return 1
     else


### PR DESCRIPTION
This is needed in order to avoid CI blocking when backporting patches to nmstate-0.2