### PR TITLE
test: Fix the memory leak test

### DIFF
--- a/tests/integration/mem_leak_test.py
+++ b/tests/integration/mem_leak_test.py
@@ -48,7 +48,7 @@ def test_libnmstate_show_fd_leak(disable_logging):
     original_fd = get_current_open_fd()
     for x in range(0, 100):
         libnmstate.show()
-    assert get_current_open_fd() == original_fd
+    assert get_current_open_fd() <= original_fd
 
 
 @pytest.mark.tier1
@@ -57,4 +57,4 @@ def test_libnmstate_apply_fd_leak(disable_logging):
     for x in range(0, 10):
         with ifacelib.iface_up("eth1"):
             pass
-    assert get_current_open_fd() == original_fd
+    assert get_current_open_fd() <= original_fd


### PR DESCRIPTION
After repeat call of `libnmstate.show()` or `libnmstate.apply()`,
the opened file descriptor could be less than before as pytest might
close some file descriptor used for logging of previous test case.