### PR TITLE
Backport: nm sriov: Properly return when device not exists

### DIFF
--- a/examples/eth1_with_sriov.yml
+++ b/examples/eth1_with_sriov.yml
@@ -1,0 +1,13 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ethernet:
+    sr-iov:
+      total-vfs: 1
+      vfs:
+      - id: 0
+        mac-address: ee:2a:4e:8e:71:f5
+        spoof-check: true
+        trust: false

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -129,10 +129,9 @@ def _remove_sriov_vfs_in_setting(vfs_config, sriov_setting, vf_ids_to_remove):
 
 def _has_sriov_capability(ifname):
     dev = device.get_device_by_name(ifname)
-    if nmclient.NM.DeviceCapabilities.SRIOV & dev.props.capabilities:
-        return True
-
-    return False
+    return dev and (
+        nmclient.NM.DeviceCapabilities.SRIOV & dev.props.capabilites
+    )
 
 
 def get_info(device):

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -26,6 +26,7 @@ from .testlib.examplelib import example_state
 
 from libnmstate import netinfo
 from libnmstate.error import NmstateLibnmError
+from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import DNS
 
 
@@ -134,3 +135,16 @@ def test_add_remove_team_with_slaves(eth1_up, eth2_up):
         assertlib.assert_state_match(desired_state)
 
     assertlib.assert_absent("team0")
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="SR-IOV device required for this test case",
+)
+@pytest.mark.xfail(
+    raises=NmstateNotSupportedError,
+    reason="The device does not support SR-IOV.",
+)
+def test_set_ethernet_sriov(eth1_up):
+    with example_state("eth1_with_sriov.yml") as desired_state:
+        assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
When interface does not exists, the `nm.sriov._has_sriov_capability()`
will raise:

```python
    def _has_sriov_capability(ifname):
        dev = device.get_device_by_name(ifname)
>       if nmclient.NM.DeviceCapabilities.SRIOV & dev.props.capabilities:
E       AttributeError: 'NoneType' object has no attribute 'props'
```

Fixed by add additional check on whether device is None.

Also fixed the integration test which incorrectly using eth0 which is
not test NIC, changed to eth1.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>