### PR TITLE
dns: support static DNS with dynamic IP

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -242,12 +242,8 @@ def _generate_dns_metadata(desired_state, current_state):
     if _dns_config_not_changed(desired_state, current_state):
         _preserve_current_dns_metadata(desired_state, current_state)
     else:
-        ifaces_routes = {
-            ifname: [r.to_dict() for r in routes]
-            for ifname, routes in desired_state.config_iface_routes.items()
-        }
         ipv4_iface, ipv6_iface = nm.dns.find_interfaces_for_name_servers(
-            ifaces_routes
+            desired_state
         )
         _save_dns_metadata(
             desired_state,

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -27,6 +27,8 @@ from libnmstate.nm import active_connection as nm_ac
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv6
 
 
 DNS_DEFAULT_PRIORITY_VPN = 50
@@ -129,17 +131,26 @@ def get_dns_config_iface_names(acs_and_ipv4_profiles, acs_and_ipv6_profiles):
     return iface_names
 
 
-def find_interfaces_for_name_servers(iface_routes):
+def find_interfaces_for_name_servers(desired_state):
     """
     Find interfaces to store the DNS configurations:
         * Interface with static gateway configured.
+        * Interface with dynamic IP and auto-dns: False.
     Return two interface names for IPv4 and IPv6 name servers.
     The interface name will be None if failed to find proper interface.
     """
-    return (
-        nm_route.get_static_gateway_iface(Interface.IPV4, iface_routes),
-        nm_route.get_static_gateway_iface(Interface.IPV6, iface_routes),
-    )
+    iface_routes = {
+        ifname: [r.to_dict() for r in routes]
+        for ifname, routes in desired_state.config_iface_routes.items()
+    }
+    ipv4_iface = nm_route.get_static_gateway_iface(
+        Interface.IPV4, iface_routes
+    ) or _get_auto_dns_false_iface(Interface.IPV4, desired_state.interfaces)
+
+    ipv6_iface = nm_route.get_static_gateway_iface(
+        Interface.IPV6, iface_routes
+    ) or _get_auto_dns_false_iface(Interface.IPV6, desired_state.interfaces)
+    return ipv4_iface, ipv6_iface
 
 
 def get_indexed_dns_config_by_iface(
@@ -185,3 +196,16 @@ def _get_ip_profile_dns_config(ip_profile):
         DNS.SEARCH: ip_profile.props.dns_search,
         DNS_METADATA_PRIORITY: ip_profile.props.dns_priority,
     }
+
+
+def _get_auto_dns_false_iface(family, iface_states):
+    for iface_name, iface_state in iface_states.items():
+        ip_state = iface_state.get(family, {})
+        if ip_state.get(InterfaceIP.ENABLED) and not ip_state.get(
+            InterfaceIP.AUTO_DNS
+        ):
+            if ip_state.get(InterfaceIP.DHCP) or ip_state.get(
+                InterfaceIPv6.AUTOCONF
+            ):
+                return iface_name
+    return None

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -78,6 +78,10 @@ DHCP_SRV_IP6_NETWORK = "{}::/64".format(DHCP_SRV_IP6_PREFIX)
 IPV6_DEFAULT_GATEWAY = "::/0"
 IPV4_DEFAULT_GATEWAY = "0.0.0.0/0"
 
+IPV4_DNS_NAMESERVER = "8.8.8.8"
+IPV6_DNS_NAMESERVER = "2001:4860:4860::8888"
+EXAMPLE_SEARCHES = ["example.org", "example.com"]
+
 DNSMASQ_CONF_STR = """
 leasefile-ro
 interface={iface}
@@ -1140,3 +1144,42 @@ def test_switch_from_dynamic_ip_without_dhcp_srv_to_static_ipv6(
     }
     libnmstate.apply({Interface.KEY: [iface_state]})
     assertlib.assert_state_match({Interface.KEY: [iface_state]})
+
+
+@pytest.fixture
+def dhcpcli_up_with_dns_cleanup(dhcpcli_up):
+    yield dhcpcli_up
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {}}})
+
+
+def test_dynamic_ip_with_static_dns(dhcpcli_up_with_dns_cleanup):
+    iface_state = {
+        Interface.NAME: DHCP_CLI_NIC,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: create_ipv4_state(
+            enabled=True, dhcp=True, auto_dns=False
+        ),
+        Interface.IPV6: create_ipv6_state(
+            enabled=True, dhcp=True, autoconf=True, auto_dns=False
+        ),
+    }
+    dns_config = {
+        DNS.CONFIG: {
+            DNS.SERVER: [IPV6_DNS_NAMESERVER, IPV4_DNS_NAMESERVER],
+            DNS.SEARCH: EXAMPLE_SEARCHES,
+        }
+    }
+    desired_state = {Interface.KEY: [iface_state], DNS.KEY: dns_config}
+
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+    assert _poll(_has_ipv4_dhcp_gateway)
+    assert _poll(_has_ipv6_auto_gateway)
+    assert _poll(_has_dhcpv4_addr)
+    assert _poll(_has_dhcpv6_addr)
+    assert not _has_ipv4_dhcp_nameserver()
+    assert not _has_ipv6_auto_nameserver()
+    new_state = libnmstate.show()
+    assert dns_config[DNS.CONFIG] == new_state[DNS.KEY][DNS.CONFIG]
+    assert dns_config[DNS.CONFIG] == new_state[DNS.KEY][DNS.RUNNING]

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -25,14 +25,21 @@ import libnmstate.nm.connection as nm_connection
 import libnmstate.nm.dns as nm_dns
 import libnmstate.nm.ipv4 as nm_ipv4
 import libnmstate.nm.ipv6 as nm_ipv6
+from libnmstate.state import State
 from libnmstate.schema import DNS
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route
 
 
 TEST_IPV4_GATEWAY_IFACE = "eth1"
 TEST_IPV6_GATEWAY_IFACE = "eth2"
 TEST_STATIC_ROUTE_IFACE = "eth3"
+
+TEST_IFACE1 = "eth4"
 
 
 def _get_test_dns_v4():
@@ -159,72 +166,118 @@ def _assert_dns(setting_ip, dns_conf):
     assert setting_ip.props.dns_priority == priority
 
 
-def test_find_interfaces_for_dns_with_ipv6_and_ipv4_static_gateways():
-    iface_routes = _get_test_iface_routes()
-    assert (
-        TEST_IPV4_GATEWAY_IFACE,
-        TEST_IPV6_GATEWAY_IFACE,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
+parametrize_ip_ver = pytest.mark.parametrize(
+    "families",
+    [(Interface.IPV4,), (Interface.IPV6,), (Interface.IPV4, InterfaceIPv6)],
+    ids=["ipv4", "ipv6", "ipv4&ipv6"],
+)
 
 
-def test_find_interfaces_for_dns_with_ipv6_static_gateway_only():
-    iface_routes = {
-        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
-    }
-    assert (
-        None,
-        TEST_IPV6_GATEWAY_IFACE,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
-
-
-def test_find_interfaces_for_dns_with_ipv4_static_gateway_only():
-    iface_routes = {
-        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
-    }
-    assert (
-        TEST_IPV4_GATEWAY_IFACE,
-        None,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_static_gateways(families):
+    state = _get_test_desired_state_static_gateway(families)
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IPV4_GATEWAY_IFACE
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IPV6_GATEWAY_IFACE
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(
+        State(state)
+    )
 
 
 def test_find_interfaces_for_dns_with_no_routes():
-    iface_routes = {}
-    assert (None, None) == nm_dns.find_interfaces_for_name_servers(
-        iface_routes
+    state = State(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_IPV4_GATEWAY_IFACE,
+                    Interface.STATE: InterfaceState.UP,
+                },
+                {
+                    Interface.NAME: TEST_IPV6_GATEWAY_IFACE,
+                    Interface.STATE: InterfaceState.UP,
+                },
+            ],
+        }
     )
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
 
 
 def test_find_interfaces_for_dns_with_no_gateway():
-    iface_routes = {TEST_STATIC_ROUTE_IFACE: _get_test_static_routes()}
-    assert (None, None) == nm_dns.find_interfaces_for_name_servers(
-        iface_routes
-    )
+    state = State(_get_test_desired_state_static_gateway(()))
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_dynamic_ip_but_no_auto_dns(families):
+    state = State(_get_test_desired_state_dynamic_ip_but_no_auto_dns(families))
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IFACE1
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IFACE1
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_dynamic_ip_and_auto_dns(families):
+    iface_state = {
+        Interface.NAME: TEST_IFACE1,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: {InterfaceIPv4.ENABLED: False},
+        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
+    }
+    if Interface.IPV4 in families:
+        iface_state[Interface.IPV4][InterfaceIPv4.ENABLED] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.DHCP] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.AUTO_DNS] = True
+
+    if Interface.IPV6 in families:
+        iface_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.DHCP] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTOCONF] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTO_DNS] = True
+    state = State({Interface.KEY: [iface_state]})
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_prefer_static_gateway(families):
+    state = _get_test_desired_state_static_gateway(families)
+    state2 = _get_test_desired_state_dynamic_ip_but_no_auto_dns(families)
+    state[Interface.KEY].extend(state2[Interface.KEY])
+    state = State(state)
+
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IPV4_GATEWAY_IFACE
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IPV6_GATEWAY_IFACE
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(state)
 
 
 def _get_test_ipv4_gateway():
-    return [
-        {
-            Route.DESTINATION: "0.0.0.0/0",
-            Route.METRIC: 200,
-            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
-            Route.NEXT_HOP_INTERFACE: TEST_IPV4_GATEWAY_IFACE,
-            Route.TABLE_ID: 54,
-        }
-    ]
+    return {
+        Route.DESTINATION: "0.0.0.0/0",
+        Route.METRIC: 200,
+        Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        Route.NEXT_HOP_INTERFACE: TEST_IPV4_GATEWAY_IFACE,
+        Route.TABLE_ID: 54,
+    }
 
 
 def _get_test_ipv6_gateway():
-    return [
-        {
-            Route.DESTINATION: "::/0",
-            Route.METRIC: 201,
-            Route.NEXT_HOP_ADDRESS: "2001:db8:2::f",
-            Route.NEXT_HOP_INTERFACE: TEST_IPV6_GATEWAY_IFACE,
-            Route.TABLE_ID: 54,
-        }
-    ]
+    return {
+        Route.DESTINATION: "::/0",
+        Route.METRIC: 201,
+        Route.NEXT_HOP_ADDRESS: "2001:db8:2::f",
+        Route.NEXT_HOP_INTERFACE: TEST_IPV6_GATEWAY_IFACE,
+        Route.TABLE_ID: 54,
+    }
 
 
 def _get_test_static_routes():
@@ -246,12 +299,50 @@ def _get_test_static_routes():
     ]
 
 
-def _get_test_iface_routes():
-    return {
-        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
-        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
+def _get_test_desired_state_static_gateway(families):
+    state = {
+        Route.KEY: {Route.CONFIG: _get_test_static_routes()},
+        Interface.KEY: [
+            {
+                Interface.NAME: TEST_IPV4_GATEWAY_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+            {
+                Interface.NAME: TEST_IPV6_GATEWAY_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+            {
+                Interface.NAME: TEST_STATIC_ROUTE_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+        ],
     }
+    if Interface.IPV4 in families:
+        state[Route.KEY][Route.CONFIG].append(_get_test_ipv4_gateway())
+    if Interface.IPV6 in families:
+        state[Route.KEY][Route.CONFIG].append(_get_test_ipv6_gateway())
+    return state
+
+
+def _get_test_desired_state_dynamic_ip_but_no_auto_dns(families):
+    iface_state = {
+        Interface.NAME: TEST_IFACE1,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: {InterfaceIPv4.ENABLED: False},
+        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
+    }
+    if Interface.IPV4 in families:
+        iface_state[Interface.IPV4][InterfaceIPv4.ENABLED] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.DHCP] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.AUTO_DNS] = False
+
+    if Interface.IPV6 in families:
+        iface_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.DHCP] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTOCONF] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTO_DNS] = False
+
+    return {Interface.KEY: [iface_state]}
 
 
 class mock_nm_dns_entry:


### PR DESCRIPTION
Added the support of static DNS configuration with dynamic IP interface as
long as specified interface has `InterfaceIP.AUTO_DNS` set to False.

When choosing interface to storing DNS configuration, the interface with
static address and gateway is preferred over dynamic interface with
`InterfaceIP.AUTO_DNS` set to False.

Added Unit test cases and integration test cases.