### PR TITLE
Revert "travis: use quay.io repository in travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,28 +5,28 @@ env:
     global:
         - use_coveralls=true
     matrix:
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
           use_codecov=true
           use_coveralls=false
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ_slow --pytest-args='-x'
               --copr networkmanager/NetworkManager-1.22-git"
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ --pytest-args='-x'
               --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type format"
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type lint"
-        - CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type unit_py36"
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: CONTAINER_IMAGE=quay.io/nmstate/centos8-nmstate-dev
+        - env: CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
 


### PR DESCRIPTION
[The quay.io does not provides a way to disable the build cache][1],
switching back to docker.io which can.

[1]: https://issues.redhat.com/browse/PROJQUAY-474

This reverts commit 6f55152db0f54805f2b10362615ab4063561bac5.

Signed-off-by: Gris Ge <fge@redhat.com>