### PR TITLE
validator: raise if the necessary services are not running

### DIFF
--- a/libnmstate/appliers/ovs_bridge.py
+++ b/libnmstate/appliers/ovs_bridge.py
@@ -17,11 +17,14 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import subprocess
+
 from libnmstate.schema import Interface
 from libnmstate.schema import OVSBridge
 
 
 BRPORT_OPTIONS = "_brport_options"
+SYSTEMCTL_TIMEOUT_SECONDS = 5
 
 
 def get_ovs_slaves_from_state(iface_state, default=()):
@@ -68,3 +71,17 @@ def _is_ovs_lag_slave(lag_state, iface_name):
         if slave[OVSBridge.Port.LinkAggregation.Slave.NAME] == iface_name:
             return True
     return False
+
+
+def is_ovs_running():
+    try:
+        subprocess.run(
+            ("systemctl", "status", "openvswitch"),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            timeout=SYSTEMCTL_TIMEOUT_SECONDS,
+        )
+        return True
+    except Exception:
+        return False

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 
 from libnmstate import nm
 from libnmstate import validator
+from libnmstate.appliers.ovs_bridge import is_ovs_running
 from libnmstate.deprecation import _warn_keyword_as_positional
 from libnmstate.nm import dns as nm_dns
 from libnmstate.nm.nmclient import nmclient_context
@@ -78,7 +79,7 @@ def show(include_status_data=False):
 def capabilities():
     caps = set()
 
-    if nm.ovs.has_ovs_capability():
+    if nm.ovs.has_ovs_capability() and is_ovs_running():
         caps.add(nm.ovs.CAPABILITY)
 
     if nm.team.has_team_capability():

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -25,6 +25,7 @@ import jsonschema as js
 from . import nm
 from . import schema
 from libnmstate.appliers.bond import is_in_mac_restricted_mode
+from libnmstate.appliers.ovs_bridge import is_ovs_running
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
@@ -84,11 +85,16 @@ def validate_interface_capabilities(ifaces_state, capabilities):
             nm.ovs.INTERNAL_INTERFACE_TYPE,
         )
         if is_ovs_type and not has_ovs_capability:
-            raise NmstateDependencyError(
-                "Open vSwitch NetworkManager support not installed "
-                "and started"
-            )
-        if iface_type == InterfaceType.TEAM and not has_team_capability:
+            if not is_ovs_running():
+                raise NmstateDependencyError(
+                    "openvswitch service is not started."
+                )
+            else:
+                raise NmstateDependencyError(
+                    "Open vSwitch NetworkManager support not installed "
+                    "and started"
+                )
+        elif iface_type == InterfaceType.TEAM and not has_team_capability:
             raise NmstateDependencyError(
                 "NetworkManager-team plugin not installed and started"
             )

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -34,6 +34,7 @@ from .testlib import statelib
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.ovslib import Bridge
 from .testlib.ovslib import get_proxy_port_name_of_ovs_interface
+from .testlib.servicelib import disable_service
 from .testlib.vlan import vlan_interface
 
 
@@ -191,6 +192,33 @@ def test_nm_ovs_plugin_missing():
                     ]
                 }
             )
+
+
+def test_ovs_service_missing():
+    with disable_service("openvswitch"):
+        with pytest.raises(NmstateDependencyError):
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: BRIDGE1,
+                            Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                            Interface.STATE: InterfaceState.UP,
+                        }
+                    ]
+                }
+            )
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BRIDGE1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
 
 
 @pytest.mark.tier1

--- a/tests/integration/testlib/servicelib.py
+++ b/tests/integration/testlib/servicelib.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+import time
+
+from . import cmdlib
+
+
+@contextmanager
+def disable_service(service):
+    cmdlib.exec_cmd(("systemctl", "stop", service), check=True)
+    try:
+        yield
+    finally:
+        cmdlib.exec_cmd(("systemctl", "start", service), check=True)
+        ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service))
+        timeout = 5
+        while timeout > 0:
+            if ret == 0:
+                break
+            time.sleep(1)
+            timeout -= 1
+            ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service))


### PR DESCRIPTION
OVS interfaces require openvswitch service started and running. If it is
not running and the desired state contains OVS interfaces then nmstate
is going to raise an error in the validation.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>