### PR TITLE
[Plugin design] Remove global NM.Client

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -40,7 +40,7 @@ DNS_METADATA_PRIORITY = "_priority"
 ROUTE_RULES_METADATA = "_route_rules"
 
 
-def generate_ifaces_metadata(desired_state, current_state):
+def generate_ifaces_metadata(nm_client, desired_state, current_state):
     """
     The described desired state for each interface may include references to
     other interfaces. As the provider handles the interface setting in an
@@ -82,7 +82,7 @@ def generate_ifaces_metadata(desired_state, current_state):
         get_slaves_func=team.get_slaves_from_state,
         set_metadata_func=lambda *args: None,
     )
-    _generate_dns_metadata(desired_state, current_state)
+    _generate_dns_metadata(nm_client, desired_state, current_state)
     _generate_route_metadata(desired_state, current_state)
     _generate_route_rule_metadata(desired_state)
 
@@ -232,17 +232,17 @@ def _init_iface_route_metadata(iface_state, ip_key):
     ip_state[ROUTES] = []
 
 
-def _generate_dns_metadata(desired_state, current_state):
+def _generate_dns_metadata(nm_client, desired_state, current_state):
     """
     Save DNS configuration on chosen interfaces as metadata.
     """
-    _clear_current_dns_config(desired_state, current_state)
+    _clear_current_dns_config(nm_client, desired_state, current_state)
     servers = desired_state.config_dns.get(DNS.SERVER, [])
     searches = desired_state.config_dns.get(DNS.SEARCH, [])
     if not servers and not searches:
         return
-    if _dns_config_not_changed(desired_state, current_state):
-        _preserve_current_dns_metadata(desired_state, current_state)
+    if _dns_config_not_changed(nm_client, desired_state, current_state):
+        _preserve_current_dns_metadata(nm_client, desired_state, current_state)
     else:
         ipv4_iface, ipv6_iface = nm.dns.find_interfaces_for_name_servers(
             desired_state
@@ -310,18 +310,17 @@ def _include_name_only_iface_state(desired_state, current_state, iface_names):
             desired_state.interfaces[iface_name] = {Interface.NAME: iface_name}
 
 
-def _clear_current_dns_config(desired_state, current_state):
-    client = nm.nmclient.client()
+def _clear_current_dns_config(nm_client, desired_state, current_state):
     current_dns_ifaces = nm.dns.get_dns_config_iface_names(
-        nm.ipv4.acs_and_ip_profiles(client),
-        nm.ipv6.acs_and_ip_profiles(client),
+        nm.ipv4.acs_and_ip_profiles(nm_client),
+        nm.ipv6.acs_and_ip_profiles(nm_client),
     )
     _include_name_only_iface_state(
         desired_state, current_state, current_dns_ifaces
     )
 
 
-def _dns_config_not_changed(desired_state, current_state):
+def _dns_config_not_changed(nm_client, desired_state, current_state):
     """
     Return True if desired_state DNS config equal to current_state and
     interface holding current DNS config is UP and corresponding IP family
@@ -329,10 +328,9 @@ def _dns_config_not_changed(desired_state, current_state):
     """
     if desired_state.config_dns != current_state.config_dns:
         return False
-    client = nm.nmclient.client()
     iface_dns_configs = nm.dns.get_indexed_dns_config_by_iface(
-        nm.ipv4.acs_and_ip_profiles(client),
-        nm.ipv6.acs_and_ip_profiles(client),
+        nm.ipv4.acs_and_ip_profiles(nm_client),
+        nm.ipv6.acs_and_ip_profiles(nm_client),
     )
     for iface_name, iface_dns_config in iface_dns_configs.items():
         if iface_name not in desired_state.interfaces:
@@ -351,11 +349,10 @@ def _dns_config_not_changed(desired_state, current_state):
     return True
 
 
-def _preserve_current_dns_metadata(desired_state, current_state):
-    client = nm.nmclient.client()
+def _preserve_current_dns_metadata(nm_client, desired_state, current_state):
     iface_dns_configs = nm.dns.get_indexed_dns_config_by_iface(
-        nm.ipv4.acs_and_ip_profiles(client),
-        nm.ipv6.acs_and_ip_profiles(client),
+        nm.ipv4.acs_and_ip_profiles(nm_client),
+        nm.ipv6.acs_and_ip_profiles(nm_client),
     )
     for iface_name, iface_dns_config in iface_dns_configs.items():
         if iface_name not in desired_state.interfaces:

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -16,21 +16,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
-from operator import itemgetter
 
-from libnmstate import nm
-from libnmstate import validator
-from libnmstate.appliers.ovs_bridge import is_ovs_running
-from libnmstate.nm import dns as nm_dns
-from libnmstate.nm.nmclient import nmclient_context
-from libnmstate.schema import Constants
-from libnmstate.schema import DNS
-from libnmstate.schema import Interface
-from libnmstate.schema import Route
-from libnmstate.schema import RouteRule
+from .nmstate import show_with_plugin
+from .nmstate import plugin_context
 
 
-@nmclient_context
 def show(*, include_status_data=False):
     """
     Reports configuration and status data on the system.
@@ -41,106 +31,5 @@ def show(*, include_status_data=False):
     When include_status_data is set, both are reported, otherwise only the
     configuration data is reported.
     """
-    client = nm.nmclient.client()
-    report = {Constants.INTERFACES: _interfaces()}
-    if include_status_data:
-        report["capabilities"] = capabilities()
-
-    report[Constants.ROUTES] = {
-        Route.RUNNING: (
-            nm.ipv4.get_route_running() + nm.ipv6.get_route_running()
-        ),
-        Route.CONFIG: (
-            nm.ipv4.get_route_config() + nm.ipv6.get_route_config()
-        ),
-    }
-
-    report[RouteRule.KEY] = {
-        RouteRule.CONFIG: (
-            nm.ipv4.get_routing_rule_config()
-            + nm.ipv6.get_routing_rule_config()
-        )
-    }
-
-    report[Constants.DNS] = {
-        DNS.RUNNING: nm_dns.get_running(),
-        DNS.CONFIG: nm_dns.get_config(
-            nm.ipv4.acs_and_ip_profiles(client),
-            nm.ipv6.acs_and_ip_profiles(client),
-        ),
-    }
-
-    validator.validate(report)
-    return report
-
-
-def capabilities():
-    caps = set()
-
-    if nm.ovs.has_ovs_capability() and is_ovs_running():
-        caps.add(nm.ovs.CAPABILITY)
-
-    if nm.team.has_team_capability():
-        caps.add(nm.team.CAPABILITY)
-
-    return list(caps)
-
-
-def _interfaces():
-    info = []
-
-    devices_info = [
-        (dev, nm.device.get_device_common_info(dev))
-        for dev in nm.device.list_devices()
-    ]
-
-    for dev, devinfo in devices_info:
-        type_id = devinfo["type_id"]
-
-        iface_info = nm.translator.Nm2Api.get_common_device_info(devinfo)
-
-        act_con = nm.connection.get_device_active_connection(dev)
-        iface_info["ipv4"] = nm.ipv4.get_info(act_con)
-        iface_info["ipv6"] = nm.ipv6.get_info(act_con)
-        iface_info.update(nm.wired.get_info(dev))
-        iface_info.update(nm.user.get_info(dev))
-        iface_info.update(nm.vlan.get_info(dev))
-        iface_info.update(nm.vxlan.get_info(dev))
-        iface_info.update(nm.bridge.get_info(dev))
-        iface_info.update(nm.team.get_info(dev))
-
-        if nm.bond.is_bond_type_id(type_id):
-            bondinfo = nm.bond.get_bond_info(dev)
-            iface_info.update(_ifaceinfo_bond(bondinfo))
-        elif nm.ovs.has_ovs_capability():
-            if nm.ovs.is_ovs_bridge_type_id(type_id):
-                iface_info["bridge"] = nm.ovs.get_ovs_info(dev, devices_info)
-                iface_info = _remove_ovs_bridge_unsupported_entries(iface_info)
-            elif nm.ovs.is_ovs_port_type_id(type_id):
-                continue
-
-        info.append(iface_info)
-
-    info.sort(key=itemgetter("name"))
-
-    return info
-
-
-def _ifaceinfo_bond(devinfo):
-    # TODO: What about unmanaged devices?
-    bondinfo = nm.translator.Nm2Api.get_bond_info(devinfo)
-    if "link-aggregation" in bondinfo:
-        return bondinfo
-    return {}
-
-
-def _remove_ovs_bridge_unsupported_entries(iface_info):
-    """
-    OVS bridges are not supporting several common interface key entries.
-    These entries are removed explicitly.
-    """
-    iface_info.pop(Interface.IPV4, None)
-    iface_info.pop(Interface.IPV6, None)
-    iface_info.pop(Interface.MTU, None)
-
-    return iface_info
+    with plugin_context() as plugin:
+        return show_with_plugin(plugin, include_status_data)

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -34,7 +34,6 @@ from . import connection
 from . import device
 from . import ipv4
 from . import ipv6
-from . import nmclient
 from . import ovs
 from . import sriov
 from . import team
@@ -43,6 +42,7 @@ from . import user
 from . import vlan
 from . import vxlan
 from . import wired
+from .common import NM
 
 
 MAXIMUM_INTERFACE_LENGTH = 15
@@ -54,7 +54,7 @@ MASTER_IFACE_TYPES = ovs.BRIDGE_TYPE, bond.BOND_TYPE, LB.TYPE
 BRPORT_OPTIONS_METADATA = "_brport_options"
 
 
-def apply_changes(ifaces_desired_state, original_desired_state):
+def apply_changes(nm_client, ifaces_desired_state, original_desired_state):
     con_profiles = []
 
     ifaces_desired_state.extend(
@@ -67,16 +67,19 @@ def apply_changes(ifaces_desired_state, original_desired_state):
     ):
 
         ifname = iface_desired_state[Interface.NAME]
-        nmdev = device.get_device_by_name(ifname)
+        nmdev = device.get_device_by_name(nm_client, ifname)
         cur_con_profile = None
         if nmdev:
-            cur_con_profile = connection.ConnectionProfile()
+            cur_con_profile = connection.ConnectionProfile(nm_client)
             cur_con_profile.import_by_device(nmdev)
         original_desired_iface_state = original_desired_state.interfaces.get(
             ifname, {}
         )
         new_con_profile = _build_connection_profile(
-            iface_desired_state, cur_con_profile, original_desired_iface_state
+            nm_client,
+            iface_desired_state,
+            cur_con_profile,
+            original_desired_iface_state,
         )
         if not new_con_profile.devname:
             set_conn = new_con_profile.profile.get_setting_connection()
@@ -86,14 +89,14 @@ def apply_changes(ifaces_desired_state, original_desired_state):
             con_profiles.append(new_con_profile)
         else:
             # Missing connection, attempting to create a new one.
-            connection.delete_iface_inactive_connections(ifname)
+            connection.delete_iface_inactive_connections(nm_client, ifname)
             new_con_profile.add(save_to_disk=True)
             con_profiles.append(new_con_profile)
 
-    _set_ifaces_admin_state(ifaces_desired_state, con_profiles)
+    _set_ifaces_admin_state(nm_client, ifaces_desired_state, con_profiles)
 
 
-def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
+def _set_ifaces_admin_state(nm_client, ifaces_desired_state, con_profiles):
     """
     Control interface admin state by activating, deactivating and deleting
     devices connection profiles.
@@ -115,7 +118,7 @@ def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
     - All the rest.
     """
     con_profiles_by_devname = _index_profiles_by_devname(con_profiles)
-    new_ifaces = _get_new_ifaces(con_profiles)
+    new_ifaces = _get_new_ifaces(nm_client, con_profiles)
     new_ifaces_to_activate = set()
     new_vlan_ifaces_to_activate = set()
     new_vxlan_ifaces_to_activate = set()
@@ -129,7 +132,7 @@ def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
 
     for iface_desired_state in ifaces_desired_state:
         ifname = iface_desired_state[Interface.NAME]
-        nmdev = device.get_device_by_name(ifname)
+        nmdev = device.get_device_by_name(nm_client, ifname)
         if not nmdev:
             if (
                 ifname in new_ifaces
@@ -180,7 +183,7 @@ def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
                 InterfaceState.DOWN,
                 InterfaceState.ABSENT,
             ):
-                nmdevs = _get_affected_devices(iface_desired_state)
+                nmdevs = _get_affected_devices(nm_client, iface_desired_state)
                 for affected_nmdev in nmdevs:
                     remove_devs_actions[affected_nmdev] = [
                         device.deactivate,
@@ -188,7 +191,7 @@ def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
                     ]
                 if (
                     nmdev.is_software()
-                    and nmdev.get_device_type() != nmclient.NM.DeviceType.VETH
+                    and nmdev.get_device_type() != NM.DeviceType.VETH
                 ):
                     remove_devs_actions[nmdev].append(device.delete_device)
             else:
@@ -200,50 +203,50 @@ def _set_ifaces_admin_state(ifaces_desired_state, con_profiles):
                 )
 
     for dev in devs_to_deactivate_beforehand:
-        device.deactivate(dev)
+        device.deactivate(nm_client, dev)
 
     # Do not remove devices that are marked for editing.
     for dev, _ in itertools.chain(master_ifaces_to_edit, ifaces_to_edit):
         remove_devs_actions.pop(dev, None)
 
     for ifname in new_master_not_enslaved_ifaces:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for ifname in new_ifaces_to_activate:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for dev, con_profile in master_ifaces_to_edit:
-        device.modify(dev, con_profile)
+        device.modify(nm_client, dev, con_profile)
 
     for ifname in new_ovs_port_to_activate:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for ifname in new_ovs_interface_to_activate:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for dev, con_profile in ifaces_to_edit:
-        device.modify(dev, con_profile)
+        device.modify(nm_client, dev, con_profile)
 
     for ifname in new_vlan_ifaces_to_activate:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for ifname in new_vxlan_ifaces_to_activate:
-        device.activate(dev=None, connection_id=ifname)
+        device.activate(nm_client, dev=None, connection_id=ifname)
 
     for dev, actions in remove_devs_actions.items():
         for action in actions:
-            action(dev)
+            action(nm_client, dev)
 
 
 def _index_profiles_by_devname(con_profiles):
     return {con_profile.devname: con_profile for con_profile in con_profiles}
 
 
-def _get_new_ifaces(con_profiles):
+def _get_new_ifaces(nm_client, con_profiles):
     ifaces_without_device = set()
     for con_profile in con_profiles:
         ifname = con_profile.devname
-        nmdev = device.get_device_by_name(ifname)
+        nmdev = device.get_device_by_name(nm_client, ifname)
         if not nmdev:
             # When the profile id is different from the iface name, use the
             # profile id.
@@ -261,8 +264,8 @@ def _is_slave_iface(iface_state):
     return iface_state.get(MASTER_METADATA)
 
 
-def _get_affected_devices(iface_state):
-    nmdev = device.get_device_by_name(iface_state[Interface.NAME])
+def _get_affected_devices(nm_client, iface_state):
+    nmdev = device.get_device_by_name(nm_client, iface_state[Interface.NAME])
     devs = []
     if nmdev:
         devs += [nmdev]
@@ -341,7 +344,10 @@ def _is_ovs_lag_port(port_state):
 
 
 def _build_connection_profile(
-    iface_desired_state, base_con_profile, original_desired_iface_state
+    nm_client,
+    iface_desired_state,
+    base_con_profile,
+    original_desired_iface_state,
 ):
     iface_type = translator.Api2Nm.get_iface_type(
         iface_desired_state[Interface.TYPE]
@@ -358,7 +364,7 @@ def _build_connection_profile(
         ),
     ]
 
-    con_setting = connection.ConnectionSetting()
+    con_setting = connection.ConnectionSetting(nm_client)
     if base_profile:
         con_setting.import_by_profile(base_con_profile)
     else:
@@ -424,7 +430,9 @@ def _build_connection_profile(
     if vxlan_setting:
         settings.append(vxlan_setting)
 
-    sriov_setting = sriov.create_setting(iface_desired_state, base_con_profile)
+    sriov_setting = sriov.create_setting(
+        nm_client, iface_desired_state, base_con_profile
+    )
     if sriov_setting:
         settings.append(sriov_setting)
 
@@ -432,7 +440,7 @@ def _build_connection_profile(
     if team_setting:
         settings.append(team_setting)
 
-    new_profile = connection.ConnectionProfile()
+    new_profile = connection.ConnectionProfile(nm_client)
     new_profile.create(settings)
     return new_profile
 

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -22,24 +22,24 @@ import os
 import glob
 import re
 
-from . import nmclient
 from libnmstate.error import NmstateValueError
 from libnmstate.appliers.bond import is_in_mac_restricted_mode
+from .common import NM
 
 
 BOND_TYPE = "bond"
 
 SYSFS_EMPTY_VALUE = ""
 
-NM_SUPPORTED_BOND_OPTIONS = nmclient.NM.SettingBond.get_valid_options(
-    nmclient.NM.SettingBond.new()
+NM_SUPPORTED_BOND_OPTIONS = NM.SettingBond.get_valid_options(
+    NM.SettingBond.new()
 )
 
 SYSFS_BOND_OPTION_FOLDER_FMT = "/sys/class/net/{ifname}/bonding"
 
 
 def create_setting(options, wired_setting):
-    bond_setting = nmclient.NM.SettingBond.new()
+    bond_setting = NM.SettingBond.new()
     _fix_bond_option_arp_interval(options)
     for option_name, option_value in options.items():
         if wired_setting and is_in_mac_restricted_mode(options):
@@ -58,7 +58,7 @@ def create_setting(options, wired_setting):
 
 
 def is_bond_type_id(type_id):
-    return type_id == nmclient.NM.DeviceType.BOND
+    return type_id == NM.DeviceType.BOND
 
 
 def get_bond_info(nm_device):
@@ -84,7 +84,7 @@ def _get_options(nm_device):
     sysfs_folder = SYSFS_BOND_OPTION_FOLDER_FMT.format(ifname=ifname)
     mode = _read_sysfs_file(f"{sysfs_folder}/mode")
 
-    bond_setting = nmclient.NM.SettingBond.new()
+    bond_setting = NM.SettingBond.new()
     bond_setting.add_option("mode", mode)
 
     options = {"mode": mode}

--- a/libnmstate/nm/bridge_port_vlan.py
+++ b/libnmstate/nm/bridge_port_vlan.py
@@ -17,9 +17,9 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-
-from libnmstate.nm import nmclient
 from libnmstate.schema import LinuxBridge as LB
+
+from .common import NM
 
 
 class PortVlanFilter:
@@ -195,14 +195,14 @@ class PortVlanFilter:
             ranged_vlan_tags = trunk_port.get(LB.Port.Vlan.TrunkTags.ID_RANGE)
             min_range = ranged_vlan_tags[LB.Port.Vlan.TrunkTags.MIN_RANGE]
             max_range = ranged_vlan_tags[LB.Port.Vlan.TrunkTags.MAX_RANGE]
-        port_vlan = nmclient.NM.BridgeVlan.new(min_range, max_range)
+        port_vlan = NM.BridgeVlan.new(min_range, max_range)
         port_vlan.set_untagged(False)
         port_vlan.set_pvid(False)
         return port_vlan
 
     @staticmethod
     def _generate_vlan_access_port_config(vlan_tag):
-        port_vlan = nmclient.NM.BridgeVlan.new(vlan_tag, vlan_tag)
+        port_vlan = NM.BridgeVlan.new(vlan_tag, vlan_tag)
         port_vlan.set_untagged(True)
         port_vlan.set_pvid(True)
         return port_vlan

--- a/libnmstate/nm/common.py
+++ b/libnmstate/nm/common.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -17,37 +17,21 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from . import applier
-from . import bond
-from . import bridge
-from . import checkpoint
-from . import connection
-from . import device
-from . import dns
-from . import ipv4
-from . import ipv6
-from . import mainloop
-from . import ovs
-from . import translator
-from . import user
-from . import vlan
-from . import wired
-from .plugin import NetworkManagerPlugin
+import gi
+
+try:
+    gi.require_version("NM", "1.0")  # NOQA: F402
+    from gi.repository import NM  # pylint: disable=no-name-in-module
+except ValueError:
+    NM = None
+
+from gi.repository import GLib
+from gi.repository import GObject
+from gi.repository import Gio
 
 
-applier
-bond
-bridge
-checkpoint
-connection
-device
-dns
-ipv4
-ipv6
-ovs
-translator
-user
-vlan
-wired
-mainloop
-NetworkManagerPlugin
+# To suppress the "import not used" error
+NM
+GLib
+GObject
+Gio

--- a/libnmstate/nm/context.py
+++ b/libnmstate/nm/context.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+import logging
+
+from .common import NM
+from .common import GLib
+
+
+class NmContext:
+    def __init__(self):
+        self._client = NM.Client.new(cancellable=None)
+        self._context = self._client.get_main_context()
+        self._quiting = False
+
+    @property
+    def client(self):
+        if self._quiting:
+            return None
+        return self._client
+
+    @property
+    def context(self):
+        return self._context
+
+    def refresh_content(self):
+        if self.context:
+            while self.context.iteration(False):
+                pass
+
+    def clean_up(self):
+        self._del_client()
+
+    def _del_client(self):
+        if self._client:
+            is_done = []
+            is_timeout = []
+            self._client.get_context_busy_watcher().weak_ref(
+                lambda: is_done.append(1)
+            )
+            self._client = None
+            self._quiting = True
+
+            self.refresh_content()
+
+            if not is_done:
+                timeout_source = GLib.timeout_source_new(50)
+                try:
+                    timeout_source.set_callback(lambda x: is_timeout.append(1))
+                    timeout_source.attach(self._context)
+                    while not is_done and not is_timeout:
+                        self._context.iteration(True)
+                finally:
+                    timeout_source.destroy()
+
+            if not is_done:
+                logging.error("BUG: NM.Client is not cleaned")
+            self._context = None

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -22,7 +22,6 @@ from operator import itemgetter
 
 from libnmstate import iplib
 from libnmstate.error import NmstateInternalError
-from libnmstate.nm import nmclient
 from libnmstate.nm import active_connection as nm_ac
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import DNS
@@ -43,10 +42,9 @@ DNS_PRIORITY_STATIC_BASE = 40
 IPV6_ADDRESS_LENGTH = 128
 
 
-def get_running():
+def get_running(nm_client):
     dns_state = {DNS.SERVER: [], DNS.SEARCH: []}
-    client = nmclient.client()
-    for dns_conf in client.get_dns_configuration():
+    for dns_conf in nm_client.get_dns_configuration():
         iface_name = dns_conf.get_interface()
         for ns in dns_conf.get_nameservers():
             if iplib.is_ipv6_link_local_addr(ns, IPV6_ADDRESS_LENGTH):
@@ -127,7 +125,9 @@ def get_dns_config_iface_names(acs_and_ipv4_profiles, acs_and_ipv6_profiles):
     iface_names = []
     for ac, ip_profile in chain(acs_and_ipv6_profiles, acs_and_ipv4_profiles):
         if ip_profile.props.dns or ip_profile.props.dns_search:
-            iface_names.append(nm_ac.ActiveConnection(ac).devname)
+            iface_names.append(
+                nm_ac.ActiveConnection(active_connection=ac).devname
+            )
     return iface_names
 
 
@@ -176,13 +176,13 @@ def get_indexed_dns_config_by_iface(
     iface_dns_configs = defaultdict(dict)
     for ac, ip_profile in acs_and_ipv6_profiles:
         if ip_profile.props.dns or ip_profile.props.dns_search:
-            iface_name = nm_ac.ActiveConnection(ac).devname
+            iface_name = nm_ac.ActiveConnection(active_connection=ac).devname
             iface_dns_configs[iface_name][
                 Interface.IPV6
             ] = _get_ip_profile_dns_config(ip_profile)
     for ac, ip_profile in acs_and_ipv4_profiles:
         if ip_profile.props.dns or ip_profile.props.dns_search:
-            iface_name = nm_ac.ActiveConnection(ac).devname
+            iface_name = nm_ac.ActiveConnection(active_connection=ac).devname
             iface_dns_configs[iface_name][
                 Interface.IPV4
             ] = _get_ip_profile_dns_config(ip_profile)

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -19,7 +19,7 @@
 
 import socket
 
-from . import nmclient
+from .common import NM
 from libnmstate.nm import dns as nm_dns
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import InterfaceIPv4
@@ -48,15 +48,13 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ipv4:
-        setting_ipv4 = nmclient.NM.SettingIP4Config.new()
+        setting_ipv4 = NM.SettingIP4Config.new()
 
     setting_ipv4.props.dhcp_client_id = "mac"
-    setting_ipv4.props.method = nmclient.NM.SETTING_IP4_CONFIG_METHOD_DISABLED
+    setting_ipv4.props.method = NM.SETTING_IP4_CONFIG_METHOD_DISABLED
     if config and config.get(InterfaceIPv4.ENABLED):
         if config.get(InterfaceIPv4.DHCP):
-            setting_ipv4.props.method = (
-                nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO
-            )
+            setting_ipv4.props.method = NM.SETTING_IP4_CONFIG_METHOD_AUTO
             setting_ipv4.props.ignore_auto_routes = not config.get(
                 InterfaceIPv4.AUTO_ROUTES, True
             )
@@ -71,9 +69,7 @@ def create_setting(config, base_con_profile):
             # make this unlikely.
             setting_ipv4.props.dhcp_timeout = INT32_MAX
         elif config.get(InterfaceIPv4.ADDRESS):
-            setting_ipv4.props.method = (
-                nmclient.NM.SETTING_IP4_CONFIG_METHOD_MANUAL
-            )
+            setting_ipv4.props.method = NM.SETTING_IP4_CONFIG_METHOD_MANUAL
             _add_addresses(setting_ipv4, config[InterfaceIPv4.ADDRESS])
         nm_route.add_routes(
             setting_ipv4, config.get(nm_route.ROUTE_METADATA, [])
@@ -89,7 +85,7 @@ def create_setting(config, base_con_profile):
 
 def _add_addresses(setting_ipv4, addresses):
     for address in addresses:
-        naddr = nmclient.NM.IPAddress.new(
+        naddr = NM.IPAddress.new(
             socket.AF_INET,
             address[InterfaceIPv4.ADDRESS_IP],
             address[InterfaceIPv4.ADDRESS_PREFIX_LENGTH],
@@ -111,7 +107,7 @@ def get_info(active_connection):
     ip_profile = get_ip_profile(active_connection)
     if ip_profile:
         info[InterfaceIPv4.DHCP] = ip_profile.get_method() == (
-            nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO
+            NM.SETTING_IP4_CONFIG_METHOD_AUTO
         )
         props = ip_profile.props
         if info["dhcp"]:
@@ -155,24 +151,24 @@ def get_ip_profile(active_connection):
     return None
 
 
-def get_route_running():
-    return nm_route.get_running(_acs_and_ip_cfgs(nmclient.client()))
+def get_route_running(nm_client):
+    return nm_route.get_running(_acs_and_ip_cfgs(nm_client))
 
 
-def get_route_config():
-    return nm_route.get_config(acs_and_ip_profiles(nmclient.client()))
+def get_route_config(nm_client):
+    return nm_route.get_config(acs_and_ip_profiles(nm_client))
 
 
-def _acs_and_ip_cfgs(client):
-    for ac in client.get_active_connections():
+def _acs_and_ip_cfgs(nm_client):
+    for ac in nm_client.get_active_connections():
         ip_cfg = ac.get_ip4_config()
         if not ip_cfg:
             continue
         yield ac, ip_cfg
 
 
-def acs_and_ip_profiles(client):
-    for ac in client.get_active_connections():
+def acs_and_ip_profiles(nm_client):
+    for ac in nm_client.get_active_connections():
         ip_profile = get_ip_profile(ac)
         if not ip_profile:
             continue
@@ -182,13 +178,9 @@ def acs_and_ip_profiles(client):
 def is_dynamic(active_connection):
     ip_profile = get_ip_profile(active_connection)
     if ip_profile:
-        return ip_profile.get_method() == (
-            nmclient.NM.SETTING_IP4_CONFIG_METHOD_AUTO
-        )
+        return ip_profile.get_method() == NM.SETTING_IP4_CONFIG_METHOD_AUTO
     return False
 
 
-def get_routing_rule_config():
-    return nm_route.get_routing_rule_config(
-        acs_and_ip_profiles(nmclient.client())
-    )
+def get_routing_rule_config(nm_client):
+    return nm_route.get_routing_rule_config(acs_and_ip_profiles(nm_client))

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -22,11 +22,11 @@ import socket
 
 from libnmstate import iplib
 from libnmstate.error import NmstateNotImplementedError
-from libnmstate.nm import nmclient
 from libnmstate.nm import dns as nm_dns
 from libnmstate.nm import route as nm_route
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import Route
+from .common import NM
 
 
 IPV6_DEFAULT_ROUTE_METRIC = 1024
@@ -45,15 +45,15 @@ def get_info(active_connection):
     ip_profile = get_ip_profile(active_connection)
     if ip_profile:
         method = ip_profile.get_method()
-        if method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO:
+        if method == NM.SETTING_IP6_CONFIG_METHOD_AUTO:
             info[InterfaceIPv6.DHCP] = True
             info[InterfaceIPv6.AUTOCONF] = True
-        elif method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP:
+        elif method == NM.SETTING_IP6_CONFIG_METHOD_DHCP:
             info[InterfaceIPv6.DHCP] = True
             info[InterfaceIPv6.AUTOCONF] = False
-        elif method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL:
+        elif method == NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL:
             is_link_local_method = True
-        elif method == nmclient.NM.SETTING_IP6_CONFIG_METHOD_DISABLED:
+        elif method == NM.SETTING_IP6_CONFIG_METHOD_DISABLED:
             return info
 
         if info[InterfaceIPv6.DHCP] or info[InterfaceIPv6.AUTOCONF]:
@@ -113,19 +113,15 @@ def create_setting(config, base_con_profile):
             setting_ip.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ip:
-        setting_ip = nmclient.NM.SettingIP6Config.new()
+        setting_ip = NM.SettingIP6Config.new()
 
     # Ensure IPv6 RA and DHCPv6 is based on MAC address only
-    setting_ip.props.addr_gen_mode = (
-        nmclient.NM.SettingIP6ConfigAddrGenMode.EUI64
-    )
+    setting_ip.props.addr_gen_mode = NM.SettingIP6ConfigAddrGenMode.EUI64
     setting_ip.props.dhcp_duid = "ll"
     setting_ip.props.dhcp_iaid = "mac"
 
     if not config or not config.get(InterfaceIPv6.ENABLED):
-        setting_ip.props.method = (
-            nmclient.NM.SETTING_IP6_CONFIG_METHOD_DISABLED
-        )
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_DISABLED
         return setting_ip
 
     is_dhcp = config.get(InterfaceIPv6.DHCP, False)
@@ -150,9 +146,7 @@ def create_setting(config, base_con_profile):
     elif ip_addresses:
         _set_static(setting_ip, ip_addresses)
     else:
-        setting_ip.props.method = (
-            nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL
-        )
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL
 
     nm_route.add_routes(setting_ip, config.get(nm_route.ROUTE_METADATA, []))
     nm_dns.add_dns(setting_ip, config.get(nm_dns.DNS_METADATA, {}))
@@ -171,9 +165,9 @@ def _set_dynamic(setting_ip, is_dhcp, is_autoconf):
         )
 
     if is_dhcp and is_autoconf:
-        setting_ip.props.method = nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_AUTO
     elif is_dhcp and not is_autoconf:
-        setting_ip.props.method = nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_DHCP
 
 
 def _set_static(setting_ip, ip_addresses):
@@ -188,7 +182,7 @@ def _set_static(setting_ip, ip_addresses):
                 "when applying desired state".format(a=address)
             )
         else:
-            naddr = nmclient.NM.IPAddress.new(
+            naddr = NM.IPAddress.new(
                 socket.AF_INET6,
                 address[InterfaceIPv6.ADDRESS_IP],
                 address[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
@@ -196,11 +190,9 @@ def _set_static(setting_ip, ip_addresses):
             setting_ip.add_address(naddr)
 
     if setting_ip.props.addresses:
-        setting_ip.props.method = nmclient.NM.SETTING_IP6_CONFIG_METHOD_MANUAL
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_MANUAL
     else:
-        setting_ip.props.method = (
-            nmclient.NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL
-        )
+        setting_ip.props.method = NM.SETTING_IP6_CONFIG_METHOD_LINK_LOCAL
 
 
 def get_ip_profile(active_connection):
@@ -214,12 +206,12 @@ def get_ip_profile(active_connection):
     return None
 
 
-def get_route_running():
-    return nm_route.get_running(_acs_and_ip_cfgs(nmclient.client()))
+def get_route_running(nm_client):
+    return nm_route.get_running(_acs_and_ip_cfgs(nm_client))
 
 
-def get_route_config():
-    routes = nm_route.get_config(acs_and_ip_profiles(nmclient.client()))
+def get_route_config(nm_client):
+    routes = nm_route.get_config(acs_and_ip_profiles(nm_client))
     for route in routes:
         if route[Route.METRIC] == 0:
             # Kernel will convert 0 to IPV6_DEFAULT_ROUTE_METRIC.
@@ -228,16 +220,16 @@ def get_route_config():
     return routes
 
 
-def _acs_and_ip_cfgs(client):
-    for ac in client.get_active_connections():
+def _acs_and_ip_cfgs(nm_client):
+    for ac in nm_client.get_active_connections():
         ip_cfg = ac.get_ip6_config()
         if not ip_cfg:
             continue
         yield ac, ip_cfg
 
 
-def acs_and_ip_profiles(client):
-    for ac in client.get_active_connections():
+def acs_and_ip_profiles(nm_client):
+    for ac in nm_client.get_active_connections():
         ip_profile = get_ip_profile(ac)
         if not ip_profile:
             continue
@@ -249,13 +241,11 @@ def is_dynamic(active_connection):
     if ip_profile:
         method = ip_profile.get_method()
         return method in (
-            nmclient.NM.SETTING_IP6_CONFIG_METHOD_AUTO,
-            nmclient.NM.SETTING_IP6_CONFIG_METHOD_DHCP,
+            NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            NM.SETTING_IP6_CONFIG_METHOD_DHCP,
         )
     return False
 
 
-def get_routing_rule_config():
-    return nm_route.get_routing_rule_config(
-        acs_and_ip_profiles(nmclient.client())
-    )
+def get_routing_rule_config(nm_client):
+    return nm_route.get_routing_rule_config(acs_and_ip_profiles(nm_client))

--- a/libnmstate/nm/mainloop.py
+++ b/libnmstate/nm/mainloop.py
@@ -18,83 +18,14 @@
 #
 from collections import deque
 from contextlib import contextmanager
-import functools
 import logging
-import sys
-
-import gi
-
-try:
-    gi.require_version("NM", "1.0")  # NOQA: F402
-    from gi.repository import NM  # pylint: disable=no-name-in-module
-except ValueError:
-    NM = None
-
-from gi.repository import Gio
-from gi.repository import GLib
-from gi.repository import GObject
 
 from libnmstate import error
 
-GObject
+from .common import GLib
+from .common import Gio
 
 _mainloop = None
-_nmclient = None
-
-NM_MANAGER_ERROR_DOMAIN = "nm-manager-error-quark"
-_NMCLIENT_CLEANUP_TIMEOUT = 5
-
-
-def _delete_client():
-    global _nmclient
-    if _nmclient:
-        _nmclient.delete_client()
-        _nmclient = None
-
-
-def client():
-    global _nmclient
-    if _nmclient is None:
-        if NM:
-            _nmclient = _NmClient()
-            if not _nmclient.client.get_nm_running():
-                logging.error(
-                    "NetworkManager is not running, please make sure"
-                    "it is installed and running prior to running nmstate.\n"
-                    "Check the documentation for more information."
-                )
-                raise error.NmstateDependencyError(
-                    "NetworkManager is not running"
-                )
-        else:
-            logging.error(
-                "Missing introspection data for libnm"
-                "please make sure to install it prior to running nmstate.\n"
-                "Check the documentation for more information."
-            )
-            raise error.NmstateDependencyError(
-                "Missing introspection data for libnm"
-            )
-    return _nmclient.client
-
-
-def nmclient_context(func):
-    """
-    Decorator for handling NM.Client creation and clean up
-    """
-
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        try:
-            _delete_client()
-            # Delete NM.Client is required, if not, previous changed interfaces
-            # might not updated in current NM.Client caches.
-            ret = func(*args, **kwargs)
-        finally:
-            _delete_client()
-        return ret
-
-    return wrapped
 
 
 def mainloop(refresh=False):
@@ -239,69 +170,3 @@ class _MainLoop:
         with self._idle_timeout(timeout):
             self.execute_next_action()
         return False
-
-
-class _NmClient:
-    def __init__(self):
-        self._client = NM.Client.new(None)
-
-    @property
-    def client(self):
-        return self._client
-
-    def delete_client(self):
-        if not self._client:
-            return
-        try:
-            ref_count = sys.getrefcount(self._client)
-            if ref_count != 2:
-                # The getrefcount() hold 1 reference and self.client itself
-                # hold 1 reference.
-                raise error.NmstateInternalError(
-                    "_NmClient.delete_client() cannot release resources "
-                    "of NM.Client duo to other unreleased use."
-                )
-            self._nmclient_cleanup()
-        except Exception:
-            pass
-
-    def __del__(self):
-        if self._client:
-            raise error.NmstateInternalError(
-                "_NmClient.delete_client() should be explicitly called "
-                "before python GC clean up the object."
-            )
-
-    def _nmclient_cleanup(self):
-        if self._client:
-            is_done = []
-            try:
-                context = self.client.get_main_context()
-                self.client.get_context_busy_watcher().weak_ref(
-                    lambda: is_done.append(1)
-                )
-            except AttributeError:
-                # For NM 1.20 which don't have get_context_busy_watcher()
-                # or get_main_context().
-                context = GLib.MainContext.default()
-                is_done.append(1)
-
-            self._client = None
-
-            while context.iteration(False):
-                pass
-
-            if not is_done:
-                logging.debug(
-                    "context.iteration() does not delete "
-                    "the context_busy_watcher, "
-                    "waiting 50 milliseconds"
-                )
-                timeout_source = GLib.timeout_source_new(50)
-                try:
-                    timeout_source.set_callback(lambda x: is_done.append(1))
-                    timeout_source.attach(context)
-                    while not is_done:
-                        context.iteration(True)
-                finally:
-                    timeout_source.destroy()

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -1,0 +1,161 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+from operator import itemgetter
+
+from libnmstate.appliers.ovs_bridge import is_ovs_running
+from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import Route
+from libnmstate.schema import RouteRule
+
+from . import bond as nm_bond
+from . import bridge as nm_bridge
+from . import connection as nm_connection
+from . import device as nm_device
+from . import ipv4 as nm_ipv4
+from . import ipv6 as nm_ipv6
+from . import ovs as nm_ovs
+from . import translator as nm_translator
+from . import wired as nm_wired
+from . import user as nm_user
+from . import vlan as nm_vlan
+from . import vxlan as nm_vxlan
+from . import team as nm_team
+from . import dns as nm_dns
+from .context import NmContext
+
+
+class NetworkManagerPlugin:
+    def __init__(self):
+        self._ctx = NmContext()
+
+    def unload(self):
+        self._ctx.clean_up()
+
+    @property
+    def client(self):
+        return self._ctx.client if self._ctx else None
+
+    @property
+    def context(self):
+        return self._ctx
+
+    @property
+    def capabilities(self):
+        capabilities = []
+        if nm_ovs.has_ovs_capability(self.client) and is_ovs_running():
+            capabilities.append(nm_ovs.CAPABILITY)
+        if nm_team.has_team_capability(self.client):
+            capabilities.append(nm_team.CAPABILITY)
+        return capabilities
+
+    def get_interfaces(self):
+        info = []
+
+        devices_info = [
+            (dev, nm_device.get_device_common_info(dev))
+            for dev in nm_device.list_devices(self.client)
+        ]
+
+        for dev, devinfo in devices_info:
+            type_id = devinfo["type_id"]
+
+            iface_info = nm_translator.Nm2Api.get_common_device_info(devinfo)
+
+            act_con = nm_connection.get_device_active_connection(dev)
+            iface_info[Interface.IPV4] = nm_ipv4.get_info(act_con)
+            iface_info[Interface.IPV6] = nm_ipv6.get_info(act_con)
+            iface_info.update(nm_wired.get_info(dev))
+            iface_info.update(nm_user.get_info(self.client, dev))
+            iface_info.update(nm_vlan.get_info(dev))
+            iface_info.update(nm_vxlan.get_info(dev))
+            iface_info.update(nm_bridge.get_info(self.client, dev))
+            iface_info.update(nm_team.get_info(dev))
+
+            if nm_bond.is_bond_type_id(type_id):
+                bondinfo = nm_bond.get_bond_info(dev)
+                iface_info.update(_ifaceinfo_bond(bondinfo))
+            elif nm_ovs.CAPABILITY in self.capabilities:
+                if nm_ovs.is_ovs_bridge_type_id(type_id):
+                    iface_info["bridge"] = nm_ovs.get_ovs_info(
+                        self.client, dev, devices_info
+                    )
+                    iface_info = _remove_ovs_bridge_unsupported_entries(
+                        iface_info
+                    )
+                elif nm_ovs.is_ovs_port_type_id(type_id):
+                    continue
+
+            info.append(iface_info)
+
+        info.sort(key=itemgetter("name"))
+
+        return info
+
+    def get_routes(self):
+        return {
+            Route.RUNNING: (
+                nm_ipv4.get_route_running(self.client)
+                + nm_ipv6.get_route_running(self.client)
+            ),
+            Route.CONFIG: (
+                nm_ipv4.get_route_config(self.client)
+                + nm_ipv6.get_route_config(self.client)
+            ),
+        }
+
+    def get_route_rules(self):
+        return {
+            RouteRule.CONFIG: (
+                nm_ipv4.get_routing_rule_config(self.client)
+                + nm_ipv6.get_routing_rule_config(self.client)
+            )
+        }
+
+    def get_dns_client_config(self):
+        return {
+            DNS.RUNNING: nm_dns.get_running(self.client),
+            DNS.CONFIG: nm_dns.get_config(
+                nm_ipv4.acs_and_ip_profiles(self.client),
+                nm_ipv6.acs_and_ip_profiles(self.client),
+            ),
+        }
+
+    def refresh_content(self):
+        self._ctx.refresh_content()
+
+
+def _ifaceinfo_bond(devinfo):
+    # TODO: What about unmanaged devices?
+    bondinfo = nm_translator.Nm2Api.get_bond_info(devinfo)
+    if "link-aggregation" in bondinfo:
+        return bondinfo
+    return {}
+
+
+def _remove_ovs_bridge_unsupported_entries(iface_info):
+    """
+    OVS bridges are not supporting several common interface key entries.
+    These entries are removed explicitly.
+    """
+    iface_info.pop(Interface.IPV4, None)
+    iface_info.pop(Interface.IPV6, None)
+    iface_info.pop(Interface.MTU, None)
+
+    return iface_info

--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -20,19 +20,18 @@
 import copy
 import json
 
-from libnmstate.nm import nmclient
 from libnmstate.schema import Interface
 from libnmstate.schema import Team
 
+from .common import NM
 
 CAPABILITY = "team"
 TEAMD_JSON_DEVICE = "device"
 TEAMD_JSON_PORTS = "ports"
 
 
-def has_team_capability():
-    nm_client = nmclient.client()
-    return nmclient.NM.Capability.TEAM in nm_client.get_capabilities()
+def has_team_capability(nm_client):
+    return NM.Capability.TEAM in nm_client.get_capabilities()
 
 
 def create_setting(iface_state, base_con_profile):
@@ -44,11 +43,11 @@ def create_setting(iface_state, base_con_profile):
 
     if base_con_profile:
         team_setting = base_con_profile.get_setting_duplicate(
-            nmclient.NM.SETTING_TEAM_SETTING_NAME
+            NM.SETTING_TEAM_SETTING_NAME
         )
 
     if not team_setting:
-        team_setting = nmclient.NM.SettingTeam.new()
+        team_setting = NM.SettingTeam.new()
 
     teamd_config = _convert_team_config_to_teamd_format(
         team_config, iface_state[Interface.NAME]
@@ -85,7 +84,7 @@ def get_info(device):
     """
     info = {}
 
-    if device.get_device_type() == nmclient.NM.DeviceType.TEAM:
+    if device.get_device_type() == NM.DeviceType.TEAM:
         teamd_json = device.get_config()
         if teamd_json:
             teamd_config = json.loads(teamd_json)

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -19,7 +19,7 @@
 
 import copy
 
-from . import nmclient
+from .common import NM
 
 
 IFACE_TYPE_UNKNOWN = "unknown"
@@ -41,21 +41,19 @@ class Api2Nm:
     def get_iface_type_map():
         if Api2Nm._iface_types_map is None:
             Api2Nm._iface_types_map = {
-                "ethernet": nmclient.NM.SETTING_WIRED_SETTING_NAME,
-                "bond": nmclient.NM.SETTING_BOND_SETTING_NAME,
-                "dummy": nmclient.NM.SETTING_DUMMY_SETTING_NAME,
-                "team": nmclient.NM.SETTING_TEAM_SETTING_NAME,
-                "vlan": nmclient.NM.SETTING_VLAN_SETTING_NAME,
-                "vxlan": nmclient.NM.SETTING_VXLAN_SETTING_NAME,
-                "linux-bridge": nmclient.NM.SETTING_BRIDGE_SETTING_NAME,
+                "ethernet": NM.SETTING_WIRED_SETTING_NAME,
+                "bond": NM.SETTING_BOND_SETTING_NAME,
+                "dummy": NM.SETTING_DUMMY_SETTING_NAME,
+                "team": NM.SETTING_TEAM_SETTING_NAME,
+                "vlan": NM.SETTING_VLAN_SETTING_NAME,
+                "vxlan": NM.SETTING_VXLAN_SETTING_NAME,
+                "linux-bridge": NM.SETTING_BRIDGE_SETTING_NAME,
             }
             try:
                 ovs_types = {
-                    "ovs-bridge": nmclient.NM.SETTING_OVS_BRIDGE_SETTING_NAME,
-                    "ovs-port": nmclient.NM.SETTING_OVS_PORT_SETTING_NAME,
-                    "ovs-interface": (
-                        nmclient.NM.SETTING_OVS_INTERFACE_SETTING_NAME
-                    ),
+                    "ovs-bridge": NM.SETTING_OVS_BRIDGE_SETTING_NAME,
+                    "ovs-port": NM.SETTING_OVS_PORT_SETTING_NAME,
+                    "ovs-interface": NM.SETTING_OVS_INTERFACE_SETTING_NAME,
                 }
                 Api2Nm._iface_types_map.update(ovs_types)
             except AttributeError:
@@ -118,11 +116,7 @@ class Nm2Api:
 
     @staticmethod
     def get_iface_admin_state(dev_state):
-        if (
-            nmclient.NM.DeviceState.IP_CONFIG
-            <= dev_state
-            <= nmclient.NM.DeviceState.ACTIVATED
-        ):
+        if NM.DeviceState.IP_CONFIG <= dev_state <= NM.DeviceState.ACTIVATED:
             return ApiIfaceAdminState.UP
         return ApiIfaceAdminState.DOWN
 

--- a/libnmstate/nm/user.py
+++ b/libnmstate/nm/user.py
@@ -24,7 +24,7 @@ https://lazka.github.io/pgi-docs/#NM-1.0/classes/SettingUser.html
 
 from libnmstate.error import NmstateValueError
 from libnmstate.nm import connection as nm_connection
-from libnmstate.nm import nmclient
+from .common import NM
 
 NMSTATE_DESCRIPTION = "nmstate.interface.description"
 
@@ -35,38 +35,38 @@ def create_setting(iface_state, base_con_profile):
     if not description:
         return None
 
-    if not nmclient.NM.SettingUser.check_val(description):
+    if not NM.SettingUser.check_val(description):
         raise NmstateValueError("Invalid description")
 
     user_setting = None
     if base_con_profile:
         user_setting = base_con_profile.get_setting_by_name(
-            nmclient.NM.SETTING_USER_SETTING_NAME
+            NM.SETTING_USER_SETTING_NAME
         )
         if user_setting:
             user_setting = user_setting.duplicate()
 
     if not user_setting:
-        user_setting = nmclient.NM.SettingUser.new()
+        user_setting = NM.SettingUser.new()
 
     user_setting.set_data(NMSTATE_DESCRIPTION, description)
     return user_setting
 
 
-def get_info(device):
+def get_info(nm_client, device):
     """
     Get description from user settings for a connection
     """
     info = {}
 
-    connection = nm_connection.ConnectionProfile()
+    connection = nm_connection.ConnectionProfile(nm_client)
     connection.import_by_device(device)
     if not connection.profile:
         return info
 
     try:
         user_setting = connection.profile.get_setting_by_name(
-            nmclient.NM.SETTING_USER_SETTING_NAME
+            NM.SETTING_USER_SETTING_NAME
         )
         description = user_setting.get_data(NMSTATE_DESCRIPTION)
         if description:

--- a/libnmstate/nm/vlan.py
+++ b/libnmstate/nm/vlan.py
@@ -17,8 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.nm import nmclient
 from libnmstate.schema import VLAN
+from .common import NM
 
 
 def create_setting(iface_state, base_con_profile):
@@ -36,7 +36,7 @@ def create_setting(iface_state, base_con_profile):
             vlan_setting = vlan_setting.duplicate()
 
     if not vlan_setting:
-        vlan_setting = nmclient.NM.SettingVlan.new()
+        vlan_setting = NM.SettingVlan.new()
 
     vlan_setting.props.id = vlan_id
     vlan_setting.props.parent = vlan_base_iface
@@ -49,7 +49,7 @@ def get_info(device):
     Provides the current active values for a device
     """
     info = {}
-    if device.get_device_type() == nmclient.NM.DeviceType.VLAN:
+    if device.get_device_type() == NM.DeviceType.VLAN:
         info[VLAN.CONFIG_SUBTREE] = {
             VLAN.ID: device.props.vlan_id,
             VLAN.BASE_IFACE: device.props.parent.get_iface(),

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -17,8 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.nm import nmclient
 from libnmstate.schema import VXLAN
+from .common import NM
 
 
 def create_setting(iface_state, base_con_profile):
@@ -33,7 +33,7 @@ def create_setting(iface_state, base_con_profile):
             vxlan_setting = vxlan_setting.duplicate()
 
     if not vxlan_setting:
-        vxlan_setting = nmclient.NM.SettingVxlan.new()
+        vxlan_setting = NM.SettingVxlan.new()
 
     vxlan_setting.props.id = vxlan[VXLAN.ID]
     vxlan_setting.props.parent = vxlan[VXLAN.BASE_IFACE]
@@ -51,7 +51,7 @@ def get_info(device):
     """
     Provides the current active values for a device
     """
-    if device.get_device_type() == nmclient.NM.DeviceType.VXLAN:
+    if device.get_device_type() == NM.DeviceType.VXLAN:
         base_iface = ""
         if device.props.parent:
             base_iface = device.props.parent.get_iface()
@@ -72,11 +72,5 @@ def get_info(device):
 def _get_destination_port(device):
     """
     Retrieve the destination port.
-
-    The destination port is retrieved from the profile settings instead
-    of the device (which represents the kernel state)
-    due to an existing issue [1].
-
-    [1] https://bugzilla.redhat.com/show_bug.cgi?id=1768388
     """
     return device.get_dst_port()

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -18,10 +18,10 @@
 #
 
 from libnmstate.ethtool import minimal_ethtool
-from libnmstate.nm import nmclient
 from libnmstate.nm import sriov
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
+from .common import NM
 
 
 ZEROED_MAC = "00:00:00:00:00:00"
@@ -78,7 +78,7 @@ def create_setting(iface_state, base_con_profile):
         return nm_wired_setting
 
     if not nm_wired_setting:
-        nm_wired_setting = nmclient.NM.SettingWired.new()
+        nm_wired_setting = NM.SettingWired.new()
 
     if setting.mac:
         nm_wired_setting.props.cloned_mac_address = setting.mac
@@ -136,7 +136,7 @@ def get_info(device):
     if mac and mac != ZEROED_MAC:
         info[Interface.MAC] = mac
 
-    if device.get_device_type() == nmclient.NM.DeviceType.ETHERNET:
+    if device.get_device_type() == NM.DeviceType.ETHERNET:
         ethernet = _get_ethernet_info(device, iface)
         if ethernet:
             info[Ethernet.CONFIG_SUBTREE] = ethernet

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+
+from libnmstate import validator
+from libnmstate.nm import NetworkManagerPlugin
+from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import Route
+from libnmstate.schema import RouteRule
+
+
+@contextmanager
+def plugin_context():
+    nm_plugin = NetworkManagerPlugin()
+    try:
+        yield nm_plugin
+    finally:
+        nm_plugin.unload()
+
+
+def show_with_plugin(plugin, include_status_data=None):
+    plugin.refresh_content()
+    report = {}
+    if include_status_data:
+        report["capabilities"] = plugin.capabilities
+
+    report[Interface.KEY] = plugin.get_interfaces()
+    report[Route.KEY] = plugin.get_routes()
+    report[RouteRule.KEY] = plugin.get_route_rules()
+    report[DNS.KEY] = plugin.get_dns_client_config()
+
+    validator.validate(report)
+    return report

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -44,6 +44,7 @@ from .testlib.ifacelib import get_mac_address
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
+from .testlib.retry import retry_till_true_or_timeout
 
 ETH1 = "eth1"
 
@@ -706,15 +707,7 @@ def _get_running_routes():
 
 
 def _poll(func, *args, **kwargs):
-    ret = func(*args, **kwargs)
-    timeout = DEFAULT_TIMEOUT
-    while timeout > 0:
-        if ret:
-            break
-        time.sleep(1)
-        timeout -= 1
-        ret = func(*args, **kwargs)
-    return ret
+    return retry_till_true_or_timeout(DEFAULT_TIMEOUT, func, *args, **kwargs)
 
 
 def _has_ipv6_auto_gateway(nic=DHCP_CLI_NIC):

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -21,25 +21,27 @@ from contextlib import contextmanager
 
 from libnmstate import nm
 from libnmstate import schema
-from libnmstate.nm.nmclient import nmclient_context
+from libnmstate.nm.common import NM
 from libnmstate.schema import Bond
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
-from .testlib import mainloop_run
+from .testlib import mainloop
 
 
 BOND0 = "bondtest0"
 
 
-def test_create_and_remove_bond(eth1_up):
+def test_create_and_remove_bond(eth1_up, nm_plugin):
     bond_options = {
         schema.Bond.MODE: schema.BondMode.ROUND_ROBIN,
         "miimon": "140",
     }
 
-    with _bond_interface(BOND0, bond_options):
-        bond_current_state = _get_bond_current_state(BOND0, "miimon")
+    with _bond_interface(nm_plugin.client, BOND0, bond_options):
+        bond_current_state = _get_bond_current_state(
+            nm_plugin, BOND0, "miimon"
+        )
 
         bond_desired_state = {
             schema.Bond.SLAVES: [],
@@ -47,17 +49,17 @@ def test_create_and_remove_bond(eth1_up):
         }
         assert bond_current_state == bond_desired_state
 
-    assert not _get_bond_current_state(BOND0)
+    assert not _get_bond_current_state(nm_plugin, BOND0)
 
 
-def test_bond_with_a_slave(eth1_up):
+def test_bond_with_a_slave(eth1_up, nm_plugin):
     bond_options = {schema.Bond.MODE: schema.BondMode.ROUND_ROBIN}
 
-    with _bond_interface(BOND0, bond_options):
+    with _bond_interface(nm_plugin.client, BOND0, bond_options):
         nic_name = eth1_up[Interface.KEY][0][Interface.NAME]
-        _attach_slave_to_bond(BOND0, nic_name)
+        _attach_slave_to_bond(nm_plugin.client, BOND0, nic_name)
 
-        bond_current_state = _get_bond_current_state(BOND0)
+        bond_current_state = _get_bond_current_state(nm_plugin, BOND0)
 
         bond_desired_state = {
             schema.Bond.SLAVES: [nic_name],
@@ -65,27 +67,27 @@ def test_bond_with_a_slave(eth1_up):
         }
         assert bond_current_state == bond_desired_state
 
-    assert not _get_bond_current_state(BOND0)
+    assert not _get_bond_current_state(nm_plugin, BOND0)
 
 
 @contextmanager
-def _bond_interface(name, options):
+def _bond_interface(client, name, options):
     try:
-        _create_bond(name, options)
+        _create_bond(client, name, options)
         yield
     finally:
-        _delete_bond(name)
+        _delete_bond(client, name)
 
 
-@nmclient_context
-def _get_bond_current_state(name, option=None):
+def _get_bond_current_state(plugin, name, option=None):
     """
     When option defined, the returned state will only contains the
     specified bond option and the bond mode.
     When option not defined, the return state will only contains bond mode.
     This is needed for assert check.
     """
-    nmdev = nm.device.get_device_by_name(name)
+    plugin.refresh_content()
+    nmdev = nm.device.get_device_by_name(plugin.client, name)
     nm_bond_info = nm.bond.get_bond_info(nmdev) if nmdev else {}
     if not nm_bond_info:
         return {}
@@ -100,45 +102,46 @@ def _get_bond_current_state(name, option=None):
     return _convert_slaves_devices_to_iface_names(nm_bond_info)
 
 
-@mainloop_run
-def _create_bond(name, options):
-    con_setting = nm.connection.ConnectionSetting()
+def _create_bond(client, name, options):
+    con_setting = nm.connection.ConnectionSetting(client)
     con_setting.create(
         con_name=name,
         iface_name=name,
-        iface_type=nm.nmclient.NM.SETTING_BOND_SETTING_NAME,
+        iface_type=NM.SETTING_BOND_SETTING_NAME,
     )
     bond_setting = nm.bond.create_setting(options, wired_setting=None)
     ipv4_setting = nm.ipv4.create_setting({}, None)
     ipv6_setting = nm.ipv6.create_setting({}, None)
 
-    con_profile = nm.connection.ConnectionProfile()
+    con_profile = nm.connection.ConnectionProfile(client)
     con_profile.create(
         (con_setting.setting, bond_setting, ipv4_setting, ipv6_setting)
     )
-    con_profile.add(save_to_disk=False)
-    nm.device.activate(connection_id=name)
+    with mainloop():
+        con_profile.add(save_to_disk=False)
+        nm.device.activate(client, connection_id=name)
 
 
-@mainloop_run
-def _delete_bond(devname):
-    nmdev = nm.device.get_device_by_name(devname)
-    nm.device.deactivate(nmdev)
-    nm.device.delete(nmdev)
+def _delete_bond(client, devname):
+    with mainloop():
+        nmdev = nm.device.get_device_by_name(client, devname)
+        nm.device.deactivate(client, nmdev)
+        nm.device.delete(client, nmdev)
+        nm.device.delete_device(client, nmdev)
 
 
-@mainloop_run
-def _attach_slave_to_bond(bond, slave):
-    slave_nmdev = nm.device.get_device_by_name(slave)
-    curr_slave_con_profile = nm.connection.ConnectionProfile()
+def _attach_slave_to_bond(client, bond, slave):
+    slave_nmdev = nm.device.get_device_by_name(client, slave)
+    curr_slave_con_profile = nm.connection.ConnectionProfile(client)
     curr_slave_con_profile.import_by_device(slave_nmdev)
 
-    slave_con_profile = nm.connection.ConnectionProfile()
+    slave_con_profile = nm.connection.ConnectionProfile(client)
     slave_settings = [_create_connection_setting(bond, curr_slave_con_profile)]
     slave_con_profile.create(slave_settings)
 
-    curr_slave_con_profile.update(slave_con_profile)
-    nm.device.activate(connection_id=slave)
+    with mainloop():
+        curr_slave_con_profile.update(slave_con_profile)
+        nm.device.activate(client, connection_id=slave)
 
 
 def _create_connection_setting(bond, port_con_profile):

--- a/tests/integration/nm/conftest.py
+++ b/tests/integration/nm/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -16,38 +16,21 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
+import pytest
 
-from . import applier
-from . import bond
-from . import bridge
-from . import checkpoint
-from . import connection
-from . import device
-from . import dns
-from . import ipv4
-from . import ipv6
-from . import mainloop
-from . import ovs
-from . import translator
-from . import user
-from . import vlan
-from . import wired
-from .plugin import NetworkManagerPlugin
+from libnmstate.nm.plugin import NetworkManagerPlugin
+from libnmstate.nm.context import NmContext
 
 
-applier
-bond
-bridge
-checkpoint
-connection
-device
-dns
-ipv4
-ipv6
-ovs
-translator
-user
-vlan
-wired
-mainloop
-NetworkManagerPlugin
+@pytest.fixture(scope="function")
+def nm_plugin():
+    plugin = NetworkManagerPlugin()
+    yield plugin
+    plugin.unload()
+
+
+@pytest.fixture(scope="function")
+def nm_context():
+    ctx = NmContext()
+    yield ctx
+    ctx.clean_up()

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -18,21 +18,30 @@
 #
 
 from libnmstate import nm
-from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import InterfaceIPv4
 
 from ..testlib import iproutelib
-from .testlib import mainloop_run
+from ..testlib.retry import retry_till_true_or_timeout
+from .testlib import mainloop
 
 
 TEST_IFACE = "eth1"
 
 IPV4_ADDRESS1 = "192.0.2.251"
 
+RETRY_TIMEOUT = 5
+
+
+def _ip_state_is_expected(nm_plugin, expected_state):
+    nm_plugin.refresh_content()
+    ipv4_current_state = _get_ipv4_current_state(nm_plugin.client, TEST_IFACE)
+    return ipv4_current_state == expected_state
+
 
 @iproutelib.ip_monitor_assert_stable_link_up(TEST_IFACE)
-def test_interface_ipv4_change(eth1_up):
+def test_interface_ipv4_change(eth1_up, nm_plugin):
     _modify_interface(
+        nm_plugin.client,
         ipv4_state={
             InterfaceIPv4.ENABLED: True,
             InterfaceIPv4.DHCP: False,
@@ -42,12 +51,10 @@ def test_interface_ipv4_change(eth1_up):
                     InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
                 }
             ],
-        }
+        },
     )
 
-    ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
-
-    ip4_expected_state = {
+    expected_ipv4_state = {
         InterfaceIPv4.ENABLED: True,
         InterfaceIPv4.DHCP: False,
         InterfaceIPv4.ADDRESS: [
@@ -57,19 +64,21 @@ def test_interface_ipv4_change(eth1_up):
             }
         ],
     }
-    assert ip4_expected_state == ipv4_current_state
+    assert retry_till_true_or_timeout(
+        RETRY_TIMEOUT, _ip_state_is_expected, nm_plugin, expected_ipv4_state
+    )
 
 
-def test_enable_dhcp_with_no_server(eth1_up):
+def test_enable_dhcp_with_no_server(eth1_up, nm_plugin):
     _modify_interface(
+        nm_plugin.client,
         ipv4_state={
             InterfaceIPv4.ENABLED: True,
             InterfaceIPv4.DHCP: True,
             InterfaceIPv4.ADDRESS: [],
-        }
+        },
     )
 
-    ipv4_current_state = _get_ipv4_current_state(TEST_IFACE)
     expected_ipv4_state = {
         InterfaceIPv4.ENABLED: True,
         InterfaceIPv4.DHCP: True,
@@ -78,25 +87,25 @@ def test_enable_dhcp_with_no_server(eth1_up):
         InterfaceIPv4.AUTO_GATEWAY: True,
         InterfaceIPv4.AUTO_ROUTES: True,
     }
-    assert ipv4_current_state == expected_ipv4_state
+    assert retry_till_true_or_timeout(
+        RETRY_TIMEOUT, _ip_state_is_expected, nm_plugin, expected_ipv4_state
+    )
 
 
-@mainloop_run
-def _modify_interface(ipv4_state):
-    conn = nm.connection.ConnectionProfile()
+def _modify_interface(client, ipv4_state):
+    conn = nm.connection.ConnectionProfile(client)
     conn.import_by_id(TEST_IFACE)
     settings = _create_iface_settings(ipv4_state, conn)
-    new_conn = nm.connection.ConnectionProfile()
+    new_conn = nm.connection.ConnectionProfile(client)
     new_conn.create(settings)
-    conn.update(new_conn)
+    with mainloop():
+        conn.update(new_conn)
+        nmdev = nm.device.get_device_by_name(client, TEST_IFACE)
+        nm.device.modify(client, nmdev, new_conn.profile)
 
-    nmdev = nm.device.get_device_by_name(TEST_IFACE)
-    nm.device.modify(nmdev, new_conn.profile)
 
-
-@nmclient_context
-def _get_ipv4_current_state(ifname):
-    nmdev = nm.device.get_device_by_name(ifname)
+def _get_ipv4_current_state(client, ifname):
+    nmdev = nm.device.get_device_by_name(client, ifname)
     active_connection = nm.connection.get_device_active_connection(nmdev)
     return nm.ipv4.get_info(active_connection)
 

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -17,11 +17,9 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 from contextlib import contextmanager
-import functools
 
 from libnmstate import error
 from libnmstate import nm
-from libnmstate.nm.nmclient import nmclient_context
 
 
 class MainloopTestError(Exception):
@@ -30,21 +28,10 @@ class MainloopTestError(Exception):
 
 @contextmanager
 def mainloop():
-    mloop = nm.nmclient.mainloop()
+    mloop = nm.mainloop.mainloop()
     yield
     try:
         mloop.run(timeout=15)
     except error.NmstateLibnmError as ex:
-        nm.nmclient.mainloop(refresh=True)
+        nm.mainloop.mainloop(refresh=True)
         raise MainloopTestError(str(ex.args))
-
-
-def mainloop_run(func):
-    @nmclient_context
-    @functools.wraps(func)
-    def wrapper_mainloop(*args, **kwargs):
-        with mainloop():
-            ret = func(*args, **kwargs)
-        return ret
-
-    return wrapper_mainloop

--- a/tests/integration/nm/vxlan_test.py
+++ b/tests/integration/nm/vxlan_test.py
@@ -20,28 +20,27 @@
 from contextlib import contextmanager
 
 from libnmstate import nm
-from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Interface
 from libnmstate.schema import VXLAN
 
-from .testlib import mainloop_run
+from .testlib import mainloop
 
 
-def test_create_and_remove_vxlan(eth1_up):
+def test_create_and_remove_vxlan(eth1_up, nm_plugin):
     vxlan_desired_state = _create_vxlan_state(eth1_up)
-    with _vxlan_interface(vxlan_desired_state):
+    with _vxlan_interface(nm_plugin.client, vxlan_desired_state):
         vxlan_name = _vxlan_ifname(vxlan_desired_state)
-        vxlan_current_state = _get_vxlan_current_state(vxlan_name)
+        vxlan_current_state = _get_vxlan_current_state(nm_plugin, vxlan_name)
         assert vxlan_desired_state == vxlan_current_state
 
-    assert not _get_vxlan_current_state(vxlan_name)
+    assert not _get_vxlan_current_state(nm_plugin, vxlan_name)
 
 
-def test_read_destination_port_from_libnm(eth1_up):
+def test_read_destination_port_from_libnm(eth1_up, nm_plugin):
     vxlan_desired_state = _create_vxlan_state(eth1_up)
-    with _vxlan_interface(vxlan_desired_state):
+    with _vxlan_interface(nm_plugin.client, vxlan_desired_state):
         vxlan_name = _vxlan_ifname(vxlan_desired_state)
-        vxlan_device = _get_vxlan_device(vxlan_name)
+        vxlan_device = _get_vxlan_device(nm_plugin.client, vxlan_name)
         assert vxlan_device is not None
         obtained_destination_port = vxlan_device.props.dst_port
         expected_destination_port = vxlan_desired_state[VXLAN.CONFIG_SUBTREE][
@@ -63,52 +62,52 @@ def _create_vxlan_state(eth1_up):
 
 
 @contextmanager
-def _vxlan_interface(state):
-    _create_vxlan(state)
+def _vxlan_interface(client, state):
+    _create_vxlan(client, state)
     try:
         yield state
     finally:
-        _delete_vxlan(_vxlan_ifname(state))
+        _delete_vxlan(client, _vxlan_ifname(state))
 
 
-@mainloop_run
-def _create_vxlan(vxlan_desired_state):
+def _create_vxlan(client, vxlan_desired_state):
     ifname = _vxlan_ifname(vxlan_desired_state)
     con_setting = nm.connection.ConnectionSetting()
     con_setting.create(
         con_name=ifname,
         iface_name=ifname,
-        iface_type=nm.nmclient.NM.SETTING_VXLAN_SETTING_NAME,
+        iface_type=nm.common.NM.SETTING_VXLAN_SETTING_NAME,
     )
     vxlan_setting = nm.vxlan.create_setting(
         vxlan_desired_state, base_con_profile=None
     )
     ipv4_setting = nm.ipv4.create_setting({}, None)
     ipv6_setting = nm.ipv6.create_setting({}, None)
-    con_profile = nm.connection.ConnectionProfile()
+    con_profile = nm.connection.ConnectionProfile(client)
     con_profile.create(
         (con_setting.setting, vxlan_setting, ipv4_setting, ipv6_setting)
     )
-    con_profile.add(save_to_disk=False)
-    nm.device.activate(connection_id=ifname)
+    with mainloop():
+        con_profile.add(save_to_disk=False)
+        nm.device.activate(client, connection_id=ifname)
 
 
-@mainloop_run
-def _delete_vxlan(devname):
-    nmdev = nm.device.get_device_by_name(devname)
-    nm.device.deactivate(nmdev)
-    nm.device.delete(nmdev)
-    nm.device.delete_device(nmdev)
+def _delete_vxlan(client, devname):
+    nmdev = nm.device.get_device_by_name(client, devname)
+    with mainloop():
+        nm.device.deactivate(client, nmdev)
+        nm.device.delete(client, nmdev)
+        nm.device.delete_device(client, nmdev)
 
 
-@nmclient_context
-def _get_vxlan_current_state(ifname):
-    nmdev = _get_vxlan_device(ifname)
+def _get_vxlan_current_state(nm_plugin, ifname):
+    nm_plugin.refresh_content()
+    nmdev = _get_vxlan_device(nm_plugin.client, ifname)
     return nm.vxlan.get_info(nmdev) if nmdev else {}
 
 
-def _get_vxlan_device(ifname):
-    dev = nm.device.get_device_by_name(ifname)
+def _get_vxlan_device(client, ifname):
+    dev = nm.device.get_device_by_name(client, ifname)
     return dev
 
 

--- a/tests/integration/testlib/retry.py
+++ b/tests/integration/testlib/retry.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -17,37 +17,15 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from . import applier
-from . import bond
-from . import bridge
-from . import checkpoint
-from . import connection
-from . import device
-from . import dns
-from . import ipv4
-from . import ipv6
-from . import mainloop
-from . import ovs
-from . import translator
-from . import user
-from . import vlan
-from . import wired
-from .plugin import NetworkManagerPlugin
+import time
 
 
-applier
-bond
-bridge
-checkpoint
-connection
-device
-dns
-ipv4
-ipv6
-ovs
-translator
-user
-vlan
-wired
-mainloop
-NetworkManagerPlugin
+def retry_till_true_or_timeout(timeout, func, *args, **kwargs):
+    ret = func(*args, **kwargs)
+    while timeout > 0:
+        if ret:
+            break
+        time.sleep(1)
+        timeout -= 1
+        ret = func(*args, **kwargs)
+    return ret

--- a/tests/lib/metadata_linux_bridge_test.py
+++ b/tests/lib/metadata_linux_bridge_test.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from unittest import mock
+
 from libnmstate import metadata
 from libnmstate import state
 from libnmstate.schema import Interface
@@ -62,7 +64,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -102,7 +107,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -131,7 +139,10 @@ class TestLinuxBridgeMetadata:
         expected_desired_state = state.State(desired_state.state)
         expected_current_state = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_desired_state
         assert current_state == expected_current_state
@@ -177,7 +188,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -214,7 +228,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -250,7 +267,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -291,7 +311,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate
@@ -327,7 +350,10 @@ class TestLinuxBridgeMetadata:
         )
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert state.State(desired_state.state) == expected_dstate
         assert current_state == expected_cstate

--- a/tests/lib/metadata_ovs_test.py
+++ b/tests/lib/metadata_ovs_test.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
+from unittest import mock
 
 import pytest
 
@@ -81,7 +82,10 @@ class TestDesiredStateOvsMetadata:
             desired_p1 = _get_bridge_port_state(desired_state, OVS_NAME, 1)
         expected_dstate.interfaces[PORT1][metadata.BRPORT_OPTIONS] = desired_p1
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -146,7 +150,10 @@ class TestDesiredStateOvsMetadata:
             desired_p1 = _get_bridge_port_state(desired_state, OVS_NAME, 1)
         expected_dstate.interfaces[PORT1][metadata.BRPORT_OPTIONS] = desired_p1
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -195,7 +202,10 @@ class TestDesiredStateOvsMetadata:
         expected_desired_state = state.State(desired_state.state)
         expected_current_state = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_desired_state
         assert current_state == expected_current_state
@@ -256,7 +266,10 @@ class TestDesiredStateOvsMetadata:
             desired_p1 = _get_bridge_port_state(desired_state, OVS_NAME, 1)
         expected_dstate.interfaces[PORT1][metadata.BRPORT_OPTIONS] = desired_p1
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -320,7 +333,10 @@ class TestDesiredStateOvsMetadata:
         desired_p0 = _get_bridge_port_state(desired_state, OVS_NAME, 0)
         expected_dstate.interfaces[PORT0][metadata.BRPORT_OPTIONS] = desired_p0
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -373,7 +389,10 @@ class TestDesiredStateOvsMetadata:
         current_p0 = _get_bridge_port_state(current_state, OVS_NAME, 0)
         expected_dstate.interfaces[PORT0][metadata.BRPORT_OPTIONS] = current_p0
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -437,7 +456,10 @@ class TestDesiredStateOvsMetadata:
         desired_p0 = _get_bridge_port_state(desired_state, OVS2_NAME, 0)
         expected_dstate.interfaces[PORT0][metadata.BRPORT_OPTIONS] = desired_p0
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate

--- a/tests/lib/metadata_test.py
+++ b/tests/lib/metadata_test.py
@@ -65,7 +65,10 @@ class TestDesiredStateMetadata:
         desired_state = state.State({})
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state.state == {Interface.KEY: []}
         assert current_state.state == {Interface.KEY: []}
@@ -96,7 +99,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth0"][metadata.MASTER_TYPE] = TYPE_BOND
         expected_dstate.interfaces["eth1"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state.state == expected_dstate.state
         assert current_state == expected_cstate
@@ -138,7 +144,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth1"][metadata.MASTER] = BOND_NAME
         expected_dstate.interfaces["eth1"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -173,7 +182,10 @@ class TestDesiredStateBondMetadata:
         expected_desired_state = state.State(desired_state.state)
         expected_current_state = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_desired_state
         assert current_state == expected_current_state
@@ -212,7 +224,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth0"][metadata.MASTER_TYPE] = TYPE_BOND
         expected_dstate.interfaces["eth1"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -248,7 +263,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth0"][metadata.MASTER_TYPE] = TYPE_BOND
         expected_dstate.interfaces["eth1"] = {Interface.NAME: "eth1"}
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -285,7 +303,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth0"][metadata.MASTER] = BOND_NAME
         expected_dstate.interfaces["eth0"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -321,7 +342,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth0"][metadata.MASTER] = BOND2_NAME
         expected_dstate.interfaces["eth0"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -369,7 +393,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate.interfaces["eth1"][metadata.MASTER] = BOND_NAME
         expected_dstate.interfaces["eth1"][metadata.MASTER_TYPE] = TYPE_BOND
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -410,7 +437,10 @@ class TestDesiredStateBondMetadata:
         expected_dstate = state.State(desired_state.state)
         expected_cstate = state.State(current_state.state)
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert desired_state == expected_dstate
         assert current_state == expected_cstate
@@ -434,7 +464,10 @@ class TestRouteMetadata:
         desired_state = state.State({})
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert {} == desired_state.interfaces
 
@@ -446,7 +479,10 @@ class TestRouteMetadata:
             {Interface.KEY: [], Route.KEY: {Route.CONFIG: []}}
         )
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert {} == desired_state.interfaces
 
@@ -457,7 +493,10 @@ class TestRouteMetadata:
         )
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert {} == desired_state.interfaces
 
@@ -476,7 +515,10 @@ class TestRouteMetadata:
             }
         )
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert "foo" in desired_state.interfaces
         assert metadata.ROUTES not in desired_state.interfaces["foo"]
@@ -491,7 +533,10 @@ class TestRouteMetadata:
         )
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         iface_state = desired_state.interfaces["eth1"]
         (route_metadata,) = iface_state[Interface.IPV4][metadata.ROUTES]
@@ -509,7 +554,10 @@ class TestRouteMetadata:
             }
         )
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         iface_state = desired_state.interfaces["eth1"]
         (route_metadata,) = iface_state[Interface.IPV4][metadata.ROUTES]
@@ -533,7 +581,10 @@ class TestRouteMetadata:
             }
         )
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         iface0_state = desired_state.interfaces["eth1"]
         iface1_state = desired_state.interfaces["eth2"]
@@ -578,7 +629,8 @@ def test_dns_metadata_empty():
     )
     current_state = state.State({})
 
-    metadata.generate_ifaces_metadata(desired_state, current_state)
+    nmclient = mock.MagicMock()
+    metadata.generate_ifaces_metadata(nmclient, desired_state, current_state)
     assert (
         nm_dns.DNS_METADATA
         not in desired_state.interfaces[TEST_IFACE1][Interface.IPV4]
@@ -606,7 +658,8 @@ def test_dns_gen_metadata_static_gateway_ipv6_name_server_before_ipv4(
     )
     current_state = state.State({})
 
-    metadata.generate_ifaces_metadata(desired_state, current_state)
+    nmclient = mock.MagicMock()
+    metadata.generate_ifaces_metadata(nmclient, desired_state, current_state)
     ipv4_dns_config = {
         DNS.SERVER: ["8.8.8.8"],
         DNS.SEARCH: [],
@@ -639,7 +692,8 @@ def test_dns_gen_metadata_static_gateway_ipv6_name_server_after_ipv4(
     )
     current_state = state.State({})
 
-    metadata.generate_ifaces_metadata(desired_state, current_state)
+    nmclient = mock.MagicMock()
+    metadata.generate_ifaces_metadata(nmclient, desired_state, current_state)
     ipv4_dns_config = {
         DNS.SERVER: ["8.8.8.8"],
         DNS.SEARCH: ["example.org", "example.com"],
@@ -674,7 +728,8 @@ def test_dns_metadata_interface_not_included_in_desire(nm_dns_mock):
             Route.KEY: {Route.CONFIG: _gen_default_gateway_route(TEST_IFACE1)},
         }
     )
-    metadata.generate_ifaces_metadata(desired_state, current_state)
+    nmclient = mock.MagicMock()
+    metadata.generate_ifaces_metadata(nmclient, desired_state, current_state)
     iface_state = desired_state.interfaces[TEST_IFACE1]
     ipv4_dns_config = {
         DNS.SERVER: ["8.8.8.8"],
@@ -773,7 +828,10 @@ class TestRouteRuleMetadata:
         desired_state = state.State({})
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert {} == desired_state.interfaces
 
@@ -785,7 +843,10 @@ class TestRouteRuleMetadata:
             {Interface.KEY: [], RouteRule.KEY: {RouteRule.CONFIG: []}}
         )
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         assert {} == desired_state.interfaces
 
@@ -800,7 +861,10 @@ class TestRouteRuleMetadata:
         current_state = state.State({})
 
         with pytest.raises(NmstateValueError):
-            metadata.generate_ifaces_metadata(desired_state, current_state)
+            nmclient = mock.MagicMock()
+            metadata.generate_ifaces_metadata(
+                nmclient, desired_state, current_state
+            )
 
     def test_rule_with_no_matching_route_table(self):
         rule0 = self._create_rule0()
@@ -847,7 +911,10 @@ class TestRouteRuleMetadata:
         )
 
         with pytest.raises(NmstateValueError):
-            metadata.generate_ifaces_metadata(desired_state, current_state)
+            nmclient = mock.MagicMock()
+            metadata.generate_ifaces_metadata(
+                nmclient, desired_state, current_state
+            )
 
     def test_rule_with_matching_route_table(self):
         rule0 = self._create_rule0()
@@ -879,7 +946,10 @@ class TestRouteRuleMetadata:
         )
         current_state = state.State({})
 
-        metadata.generate_ifaces_metadata(desired_state, current_state)
+        nmclient = mock.MagicMock()
+        metadata.generate_ifaces_metadata(
+            nmclient, desired_state, current_state
+        )
 
         iface_state = desired_state.interfaces["eth1"]
         (rule0_metadata,) = iface_state[Interface.IPV4][

--- a/tests/lib/nm/active_connection_test.py
+++ b/tests/lib/nm/active_connection_test.py
@@ -17,9 +17,9 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.nm.nmclient import NM
-from libnmstate.nm.nmclient import NM_MANAGER_ERROR_DOMAIN
-from libnmstate.nm.nmclient import GLib
+from libnmstate.nm.common import NM
+from libnmstate.nm.active_connection import NM_MANAGER_ERROR_DOMAIN
+from libnmstate.nm.common import GLib
 
 
 def test_nm_manager_error_domain_str():

--- a/tests/lib/nm/bond_test.py
+++ b/tests/lib/nm/bond_test.py
@@ -26,14 +26,14 @@ from libnmstate.schema import Bond
 from libnmstate.schema import BondMode
 
 
-@pytest.fixture()
-def dev_mock():
-    return mock.MagicMock()
+@pytest.fixture
+def nm_mock():
+    with mock.patch.object(nm.bond, "NM") as m:
+        yield m
 
 
-@mock.patch.object(nm.bond.nmclient, "NM")
-def test_create_setting(NM_mock):
-    bond_setting_mock = NM_mock.SettingBond.new.return_value
+def test_create_setting(nm_mock):
+    bond_setting_mock = nm_mock.SettingBond.new.return_value
     bond_setting_mock.add_option.return_value = True
 
     options = {Bond.MODE: BondMode.ROUND_ROBIN, "miimon": "100"}
@@ -48,9 +48,8 @@ def test_create_setting(NM_mock):
     )
 
 
-@mock.patch.object(nm.bond.nmclient, "NM")
-def test_create_setting_with_invalid_bond_option(NM_mock):
-    bond_setting_mock = NM_mock.SettingBond.new.return_value
+def test_create_setting_with_invalid_bond_option(nm_mock):
+    bond_setting_mock = nm_mock.SettingBond.new.return_value
     bond_setting_mock.add_option.return_value = False
 
     options = {Bond.MODE: BondMode.ROUND_ROBIN, "foo": "100"}
@@ -59,16 +58,14 @@ def test_create_setting_with_invalid_bond_option(NM_mock):
         nm.bond.create_setting(options, wired_setting=None)
 
 
-@mock.patch.object(nm.bond.nmclient, "NM")
-def test_is_bond_type_id(NM_mock):
-    type_id = NM_mock.DeviceType.BOND
+def test_is_bond_type_id(nm_mock):
+    type_id = nm_mock.DeviceType.BOND
 
     assert nm.bond.is_bond_type_id(type_id)
 
 
-@mock.patch.object(nm.bond.nmclient, "NM")
-def test_create_setting_with_mac_restriction(NM_mock):
-    bond_setting_mock = NM_mock.SettingBond.new.return_value
+def test_create_setting_with_mac_restriction(nm_mock):
+    bond_setting_mock = nm_mock.SettingBond.new.return_value
     bond_setting_mock.add_option.return_value = True
 
     options = {Bond.MODE: BondMode.ACTIVE_BACKUP, "fail_over_mac": "active"}

--- a/tests/lib/nm/bridge_port_vlan_test.py
+++ b/tests/lib/nm/bridge_port_vlan_test.py
@@ -31,7 +31,7 @@ ACCESS_TAG = 4000
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.user.nmclient, "NM") as m:
+    with mock.patch.object(nm.bridge_port_vlan, "NM") as m:
         yield m
 
 

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -29,7 +29,7 @@ IPV4_ADDRESS1 = "192.0.2.251"
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.ipv4.nmclient, "NM") as m:
+    with mock.patch.object(nm.ipv4, "NM") as m:
         yield m
 
 

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -32,7 +32,7 @@ IPV6_LINK_LOCAL_ADDRESS1 = "fe80::1"
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.ipv6.nmclient, "NM") as m:
+    with mock.patch.object(nm.ipv6, "NM") as m:
         yield m
 
 

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -27,8 +27,13 @@ from libnmstate.schema import OVSBridge
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.ovs.nmclient, "NM") as m:
+    with mock.patch.object(nm.ovs, "NM") as m:
         yield m
+
+
+@pytest.fixture
+def client_mock():
+    yield mock.MagicMock()
 
 
 @pytest.fixture
@@ -58,12 +63,12 @@ def test_is_ovs_interface_type_id(NM_mock):
     assert nm.ovs.is_ovs_interface_type_id(type_id)
 
 
-def test_get_ovs_info_without_ports(nm_connection_mock, NM_mock):
+def test_get_ovs_info_without_ports(client_mock, nm_connection_mock, NM_mock):
     bridge_device = mock.MagicMock()
     _mock_port_profile(nm_connection_mock)
 
     device_info = [(bridge_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
+    info = nm.ovs.get_ovs_info(client_mock, bridge_device, device_info)
 
     expected_info = {
         OVSBridge.PORT_SUBTREE: [],
@@ -78,7 +83,7 @@ def test_get_ovs_info_without_ports(nm_connection_mock, NM_mock):
 
 
 def test_get_ovs_info_with_ports_without_interfaces(
-    nm_connection_mock, nm_device_mock, NM_mock
+    nm_connection_mock, nm_device_mock, NM_mock, client_mock
 ):
     bridge_device = mock.MagicMock()
     port_device = mock.MagicMock()
@@ -87,7 +92,7 @@ def test_get_ovs_info_with_ports_without_interfaces(
     active_con.props.master = bridge_device
 
     device_info = [(bridge_device, None), (port_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
+    info = nm.ovs.get_ovs_info(client_mock, bridge_device, device_info)
 
     expected_info = {
         OVSBridge.PORT_SUBTREE: [],
@@ -102,7 +107,7 @@ def test_get_ovs_info_with_ports_without_interfaces(
 
 
 def test_get_ovs_info_with_ports_with_interfaces(
-    nm_connection_mock, nm_device_mock, NM_mock
+    nm_connection_mock, nm_device_mock, NM_mock, client_mock
 ):
     bridge_device = mock.MagicMock()
     port_device = mock.MagicMock()
@@ -119,7 +124,7 @@ def test_get_ovs_info_with_ports_with_interfaces(
     port_active_con.props.master = port_device
 
     device_info = [(bridge_device, None), (port_device, None)]
-    info = nm.ovs.get_ovs_info(bridge_device, device_info)
+    info = nm.ovs.get_ovs_info(client_mock, bridge_device, device_info)
 
     assert len(info[OVSBridge.PORT_SUBTREE]) == 1
     port_state = info[OVSBridge.PORT_SUBTREE][0]

--- a/tests/lib/nm/route_test.py
+++ b/tests/lib/nm/route_test.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
+
 import copy
+from unittest import mock
 
 import pytest
 
@@ -68,6 +70,11 @@ parametrize_ip_ver_routes = pytest.mark.parametrize(
     ],
     ids=["ipv4", "ipv6"],
 )
+
+
+@pytest.fixture
+def client_mock():
+    yield mock.MagicMock()
 
 
 def _get_test_ipv4_gateways():
@@ -135,12 +142,12 @@ def test_add_duplicate_routes(nm_ip, routes):
 
 
 @parametrize_ip_ver_routes
-def test_clear_route(nm_ip, routes):
+def test_clear_route(nm_ip, routes, client_mock):
     setting_ip = nm_ip.create_setting(
         {InterfaceIP.ENABLED: True, metadata.ROUTES: routes},
         base_con_profile=None,
     )
-    con_profile = nm_connection.ConnectionProfile()
+    con_profile = nm_connection.ConnectionProfile(client_mock)
     con_profile.create([setting_ip])
     new_setting_ip = nm_ip.create_setting(
         {InterfaceIP.ENABLED: True, metadata.ROUTES: []},
@@ -245,12 +252,12 @@ def test_change_gateway_without_table_id(nm_ip, routes, gateways):
 
 
 @parametrize_ip_ver_routes_gw
-def test_clear_gateway(nm_ip, routes, gateways):
+def test_clear_gateway(nm_ip, routes, gateways, client_mock):
     setting_ip = nm_ip.create_setting(
         {InterfaceIP.ENABLED: True, metadata.ROUTES: routes + gateways[:1]},
         base_con_profile=None,
     )
-    con_profile = nm_connection.ConnectionProfile()
+    con_profile = nm_connection.ConnectionProfile(client_mock)
     con_profile.create([setting_ip])
     setting_ip = nm_ip.create_setting(
         {InterfaceIP.ENABLED: True, metadata.ROUTES: routes},

--- a/tests/lib/nm/translator_test.py
+++ b/tests/lib/nm/translator_test.py
@@ -36,7 +36,7 @@ def NM_mock():
     nm.translator.Api2Nm._iface_types_map = None
     nm.translator.Nm2Api._iface_types_map = None
 
-    with mock.patch.object(nm.translator.nmclient, "NM") as m:
+    with mock.patch.object(nm.translator, "NM") as m:
         yield m
 
     nm.translator.Api2Nm._iface_types_map = saved_api2nm_map
@@ -89,12 +89,12 @@ def test_api2nm_bond_options():
 def test_nm2api_common_device_info(NM_mock):
     NM_mock.DeviceState.ACTIVATED = 100
     NM_mock.DeviceState.IP_CONFIG = 70
-    nm.nmclient.NM.DeviceState.DISCONNECTED = 30
+    nm.common.NM.DeviceState.DISCONNECTED = 30
     devinfo = {
         "name": "devname",
         "type_id": "devtypeid",
         "type_name": "devtypename",
-        "state": nm.nmclient.NM.DeviceState.DISCONNECTED,
+        "state": nm.common.NM.DeviceState.DISCONNECTED,
     }
     info = nm.translator.Nm2Api.get_common_device_info(devinfo)
 

--- a/tests/lib/nm/user_test.py
+++ b/tests/lib/nm/user_test.py
@@ -26,7 +26,7 @@ from libnmstate import nm
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.user.nmclient, "NM") as m:
+    with mock.patch.object(nm.user, "NM") as m:
         yield m
 
 

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -27,7 +27,7 @@ from libnmstate import schema
 
 @pytest.fixture
 def NM_mock():
-    with mock.patch.object(nm.wired.nmclient, "NM") as m:
+    with mock.patch.object(nm.wired, "NM") as m:
         yield m
 
 


### PR DESCRIPTION
Created `libnmstate.nm.NetworkManagerPlugin` to hold the `NM.Client`
and pass it to needed functions in `libnmstate.nm` folder:

 * The `libnmstate.nm.NetworkManagerPlugin.refresh_content()` is used
   to refresh the content on verification retry.

 * Changed the checkpoint to use the MainContext of `NM.Client` for
   refreshing the timeout. Because without Mainloop running after
   checkpoint rollback or destroy, we cannot ask Mainloop to release
   the reference of `NM.Client` used for refreshing timeout.

 * Created internal public function
   `libnmstate.nmstate.show_with_plugin()` allowing `apply()` function to
   query current status without creating new instance of
   `NetworkManagerPlugin`.

 * Created internal public function
   `libnmstate.nmstate.plugin_context()` allowing properly unload the
   plugin.

The design principle is move NM dedicate code to `NetworkManagerPlugin`
and shareable between plugins code should be in `libnmstate`.
Hence, remove the checkpoint `autodestroy` argument and contextmanager
code as these should be handled by `libnmstate` top level.