### PR TITLE
nm ethernet: Convert mac address from sysfs to upper case

### DIFF
--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -153,7 +153,7 @@ def _get_mac_address_from_sysfs(ifname):
     sysfs_path = f"/sys/class/net/{ifname}/address"
     try:
         with open(sysfs_path) as f:
-            mac = f.read().rstrip("\n")
+            mac = f.read().rstrip("\n").upper()
     except FileNotFoundError:
         pass
     return mac


### PR DESCRIPTION
Changing MAC address retrieved from sysfs to upper case, in order to be
consistent(using upper case) on MAC address.