### PR TITLE
test: Create a empty network state before test starts

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,9 @@ import warnings
 import pytest
 
 import libnmstate
+from libnmstate.schema import DNS
+from libnmstate.schema import Route
+from libnmstate.schema import RouteRule
 
 from .testlib import ifacelib
 
@@ -51,15 +54,37 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def logging_setup():
+def test_env_setup():
+    _logging_setup()
+    old_state = libnmstate.show()
+    _empty_net_state()
+    _ethx_init()
+    yield
+    libnmstate.apply(old_state, verify_change=False)
+    _diff_initial_state(old_state)
+
+
+def _empty_net_state():
+    """
+    Remove existing DNS, routes, route rules in case it interference tests.
+    """
+    desired_state = libnmstate.show()
+    desired_state[DNS.KEY] = {DNS.CONFIG: {}}
+    desired_state[Route.KEY] = {
+        Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}]
+    }
+    desired_state[RouteRule.KEY] = {RouteRule.CONFIG: []}
+    libnmstate.apply(desired_state)
+
+
+def _logging_setup():
     logging.basicConfig(
         format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
         level=logging.DEBUG,
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def ethx_init(diff_initial_state):
+def _ethx_init():
     """ Remove any existing definitions on the ethX interfaces. """
     ifacelib.ifaces_init("eth1", "eth2")
 
@@ -80,10 +105,7 @@ port0_up = eth1_up
 port1_up = eth2_up
 
 
-@pytest.fixture(scope="session", autouse=True)
-def diff_initial_state():
-    old_state = libnmstate.show()
-    yield
+def _diff_initial_state(old_state):
     new_state = libnmstate.show()
 
     if old_state != new_state:


### PR DESCRIPTION
Some test case like DNS/DHCP/Route tests might got impacted by host's
original network state(for example, the initial removal of eth1/eth2
configure will fail when host is configured as static DNS with dynamic
IP as libnmstate.apply() will try to preserve the DNS information).

To fix that, create a empty network state before test starts using
session level autouse fixture `test_env_setup` to:
 * Setup log level
 * Remove all static route
 * Remove all DNS configuration
 * Remove all route rule configuration
 * Restore host's network states after test ended.
 * Show left over network interfaces created by test cases.