### PR TITLE
state: Need explicit `InterfaceState.UP`

### DIFF
--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -95,8 +95,22 @@ def validate_interface_capabilities(ifaces_state, capabilities):
 
 
 def validate_interfaces_state(original_desired_state, current_state):
+    _validate_new_interface_state(original_desired_state, current_state)
     validate_link_aggregation_state(original_desired_state, current_state)
     _validate_linux_bond(original_desired_state, current_state)
+
+
+def _validate_new_interface_state(original_desired_state, current_state):
+    """
+    New interface should explictly specify the Interface.STATE
+    """
+    for iface_name, iface_state in original_desired_state.interfaces.items():
+        cur_iface_state = current_state.interfaces.get(iface_name)
+        if not cur_iface_state and not iface_state.get(Interface.STATE):
+            raise NmstateValueError(
+                "Interface.STATE is required but undefined for interface "
+                f"{iface_name}"
+            )
 
 
 def validate_link_aggregation_state(desired_state, current_state):

--- a/tests/lib/validator_test.py
+++ b/tests/lib/validator_test.py
@@ -662,3 +662,36 @@ class TestLinuxBondValidator:
                 Bond.OPTIONS_SUBTREE: {},
             },
         }
+
+
+def test_new_interface_with_no_state():
+    current_state = state.State({})
+    desired_state = state.State(
+        {
+            Interface.KEY: [
+                {Interface.NAME: "foo", Interface.TYPE: InterfaceType.UNKNOWN}
+            ]
+        }
+    )
+    with pytest.raises(NmstateValueError):
+        libnmstate.validator.validate_interfaces_state(
+            desired_state, current_state
+        )
+
+
+def test_existing_interface_with_no_state():
+    current_state = state.State(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "foo",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.TYPE: InterfaceType.UNKNOWN,
+                }
+            ]
+        }
+    )
+    desired_state = state.State({Interface.KEY: [{Interface.NAME: "foo",}]})
+    libnmstate.validator.validate_interfaces_state(
+        desired_state, current_state
+    )


### PR DESCRIPTION
Add validation check to make sure interface has Interface.STATE
either merge from current state or defined in desire state.
If not raise `NmstateValueError` exception.

Unit test cases added to cover both cases.