### PR TITLE
nm.team: Fixed 'hwaddr' should be not included in team option

### DIFF
--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -28,6 +28,7 @@ from libnmstate.schema import Team
 CAPABILITY = "team"
 TEAMD_JSON_DEVICE = "device"
 TEAMD_JSON_PORTS = "ports"
+TEAMD_JSON_HWADDR = "hwaddr"
 
 
 def has_team_capability():
@@ -100,6 +101,7 @@ def get_info(device):
 
 def _convert_teamd_config_to_nmstate_config(teamd_config, slave_names):
     teamd_config.pop(TEAMD_JSON_DEVICE, None)
+    teamd_config.pop(TEAMD_JSON_HWADDR, None)
     port_config = teamd_config.get(TEAMD_JSON_PORTS, {})
     team_port = _merge_port_config_with_slaves_info(port_config, slave_names)
 

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -35,6 +35,7 @@ from .testlib import assertlib
 from .testlib.cmdlib import exec_cmd
 from .testlib.cmdlib import RC_SUCCESS
 from .testlib.nmplugin import disable_nm_plugin
+from .testlib.statelib import show_only
 
 
 TEAM0 = "team0"
@@ -96,6 +97,14 @@ def test_nm_team_plugin_missing():
                     ]
                 }
             )
+
+
+def test_hwaddr_team_show(eth1_up, eth2_up):
+    with team_interface(TEAM0, [PORT1, PORT2]):
+        state = show_only((TEAM0,))
+        assert (
+            state[Interface.KEY][0][Team.CONFIG_SUBTREE].get("hwaddr") is None
+        )
 
 
 @contextmanager


### PR DESCRIPTION
Modified team.py to pop the hardware address from the Json.
Also made an integration test to test the changes in team_test.py.
Ref: https://bugzilla.redhat.com/1808990

Signed-off-by: Víctor Javier Díaz Garrido <vicdigar@hotmail.com>