### PR TITLE
[nmstate-0.2] dns: support static DNS with dynamic IP

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -242,12 +242,8 @@ def _generate_dns_metadata(desired_state, current_state):
     if _dns_config_not_changed(desired_state, current_state):
         _preserve_current_dns_metadata(desired_state, current_state)
     else:
-        ifaces_routes = {
-            ifname: [r.to_dict() for r in routes]
-            for ifname, routes in desired_state.config_iface_routes.items()
-        }
         ipv4_iface, ipv6_iface = nm.dns.find_interfaces_for_name_servers(
-            ifaces_routes
+            desired_state
         )
         _save_dns_metadata(
             desired_state,

--- a/tests/lib/nm/dns_test.py
+++ b/tests/lib/nm/dns_test.py
@@ -23,14 +23,21 @@ import libnmstate.nm.connection as nm_connection
 import libnmstate.nm.dns as nm_dns
 import libnmstate.nm.ipv4 as nm_ipv4
 import libnmstate.nm.ipv6 as nm_ipv6
+from libnmstate.state import State
 from libnmstate.schema import DNS
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route
 
 
 TEST_IPV4_GATEWAY_IFACE = "eth1"
 TEST_IPV6_GATEWAY_IFACE = "eth2"
 TEST_STATIC_ROUTE_IFACE = "eth3"
+
+TEST_IFACE1 = "eth4"
 
 
 def _get_test_dns_v4():
@@ -135,72 +142,118 @@ def _assert_dns(setting_ip, dns_conf):
     assert setting_ip.props.dns_priority == priority
 
 
-def test_find_interfaces_for_dns_with_ipv6_and_ipv4_static_gateways():
-    iface_routes = _get_test_iface_routes()
-    assert (
-        TEST_IPV4_GATEWAY_IFACE,
-        TEST_IPV6_GATEWAY_IFACE,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
+parametrize_ip_ver = pytest.mark.parametrize(
+    "families",
+    [(Interface.IPV4,), (Interface.IPV6,), (Interface.IPV4, InterfaceIPv6)],
+    ids=["ipv4", "ipv6", "ipv4&ipv6"],
+)
 
 
-def test_find_interfaces_for_dns_with_ipv6_static_gateway_only():
-    iface_routes = {
-        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
-    }
-    assert (
-        None,
-        TEST_IPV6_GATEWAY_IFACE,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
-
-
-def test_find_interfaces_for_dns_with_ipv4_static_gateway_only():
-    iface_routes = {
-        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
-    }
-    assert (
-        TEST_IPV4_GATEWAY_IFACE,
-        None,
-    ) == nm_dns.find_interfaces_for_name_servers(iface_routes)
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_static_gateways(families):
+    state = _get_test_desired_state_static_gateway(families)
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IPV4_GATEWAY_IFACE
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IPV6_GATEWAY_IFACE
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(
+        State(state)
+    )
 
 
 def test_find_interfaces_for_dns_with_no_routes():
-    iface_routes = {}
-    assert (None, None) == nm_dns.find_interfaces_for_name_servers(
-        iface_routes
+    state = State(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_IPV4_GATEWAY_IFACE,
+                    Interface.STATE: InterfaceState.UP,
+                },
+                {
+                    Interface.NAME: TEST_IPV6_GATEWAY_IFACE,
+                    Interface.STATE: InterfaceState.UP,
+                },
+            ],
+        }
     )
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
 
 
 def test_find_interfaces_for_dns_with_no_gateway():
-    iface_routes = {TEST_STATIC_ROUTE_IFACE: _get_test_static_routes()}
-    assert (None, None) == nm_dns.find_interfaces_for_name_servers(
-        iface_routes
-    )
+    state = State(_get_test_desired_state_static_gateway(()))
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_dynamic_ip_but_no_auto_dns(families):
+    state = State(_get_test_desired_state_dynamic_ip_but_no_auto_dns(families))
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IFACE1
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IFACE1
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_with_dynamic_ip_and_auto_dns(families):
+    iface_state = {
+        Interface.NAME: TEST_IFACE1,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: {InterfaceIPv4.ENABLED: False},
+        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
+    }
+    if Interface.IPV4 in families:
+        iface_state[Interface.IPV4][InterfaceIPv4.ENABLED] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.DHCP] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.AUTO_DNS] = True
+
+    if Interface.IPV6 in families:
+        iface_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.DHCP] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTOCONF] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTO_DNS] = True
+    state = State({Interface.KEY: [iface_state]})
+    assert (None, None) == nm_dns.find_interfaces_for_name_servers(state)
+
+
+@parametrize_ip_ver
+def test_find_interfaces_for_dns_prefer_static_gateway(families):
+    state = _get_test_desired_state_static_gateway(families)
+    state2 = _get_test_desired_state_dynamic_ip_but_no_auto_dns(families)
+    state[Interface.KEY].extend(state2[Interface.KEY])
+    state = State(state)
+
+    expected_ifaces = [None, None]
+    if Interface.IPV4 in families:
+        expected_ifaces[0] = TEST_IPV4_GATEWAY_IFACE
+    if Interface.IPV6 in families:
+        expected_ifaces[1] = TEST_IPV6_GATEWAY_IFACE
+    expected_ifaces = tuple(expected_ifaces)
+    assert expected_ifaces == nm_dns.find_interfaces_for_name_servers(state)
 
 
 def _get_test_ipv4_gateway():
-    return [
-        {
-            Route.DESTINATION: "0.0.0.0/0",
-            Route.METRIC: 200,
-            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
-            Route.NEXT_HOP_INTERFACE: TEST_IPV4_GATEWAY_IFACE,
-            Route.TABLE_ID: 54,
-        }
-    ]
+    return {
+        Route.DESTINATION: "0.0.0.0/0",
+        Route.METRIC: 200,
+        Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        Route.NEXT_HOP_INTERFACE: TEST_IPV4_GATEWAY_IFACE,
+        Route.TABLE_ID: 54,
+    }
 
 
 def _get_test_ipv6_gateway():
-    return [
-        {
-            Route.DESTINATION: "::/0",
-            Route.METRIC: 201,
-            Route.NEXT_HOP_ADDRESS: "2001:db8:2::f",
-            Route.NEXT_HOP_INTERFACE: TEST_IPV6_GATEWAY_IFACE,
-            Route.TABLE_ID: 54,
-        }
-    ]
+    return {
+        Route.DESTINATION: "::/0",
+        Route.METRIC: 201,
+        Route.NEXT_HOP_ADDRESS: "2001:db8:2::f",
+        Route.NEXT_HOP_INTERFACE: TEST_IPV6_GATEWAY_IFACE,
+        Route.TABLE_ID: 54,
+    }
 
 
 def _get_test_static_routes():
@@ -222,9 +275,47 @@ def _get_test_static_routes():
     ]
 
 
-def _get_test_iface_routes():
-    return {
-        TEST_IPV4_GATEWAY_IFACE: _get_test_ipv4_gateway(),
-        TEST_IPV6_GATEWAY_IFACE: _get_test_ipv6_gateway(),
-        TEST_STATIC_ROUTE_IFACE: _get_test_static_routes(),
+def _get_test_desired_state_static_gateway(families):
+    state = {
+        Route.KEY: {Route.CONFIG: _get_test_static_routes()},
+        Interface.KEY: [
+            {
+                Interface.NAME: TEST_IPV4_GATEWAY_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+            {
+                Interface.NAME: TEST_IPV6_GATEWAY_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+            {
+                Interface.NAME: TEST_STATIC_ROUTE_IFACE,
+                Interface.STATE: InterfaceState.UP,
+            },
+        ],
     }
+    if Interface.IPV4 in families:
+        state[Route.KEY][Route.CONFIG].append(_get_test_ipv4_gateway())
+    if Interface.IPV6 in families:
+        state[Route.KEY][Route.CONFIG].append(_get_test_ipv6_gateway())
+    return state
+
+
+def _get_test_desired_state_dynamic_ip_but_no_auto_dns(families):
+    iface_state = {
+        Interface.NAME: TEST_IFACE1,
+        Interface.STATE: InterfaceState.UP,
+        Interface.IPV4: {InterfaceIPv4.ENABLED: False},
+        Interface.IPV6: {InterfaceIPv6.ENABLED: False},
+    }
+    if Interface.IPV4 in families:
+        iface_state[Interface.IPV4][InterfaceIPv4.ENABLED] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.DHCP] = True
+        iface_state[Interface.IPV4][InterfaceIPv4.AUTO_DNS] = False
+
+    if Interface.IPV6 in families:
+        iface_state[Interface.IPV6][InterfaceIPv6.ENABLED] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.DHCP] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTOCONF] = True
+        iface_state[Interface.IPV6][InterfaceIPv6.AUTO_DNS] = False
+
+    return {Interface.KEY: [iface_state]}


### PR DESCRIPTION
Added the support of static DNS configuration with dynamic IP interface as
long as specified interface has `InterfaceIP.AUTO_DNS` set to False.

When choosing interface to storing DNS configuration, the interface with
static address and gateway is preferred over dynamic interface with
`InterfaceIP.AUTO_DNS` set to False.

Added Unit test cases and integration test cases.

Also included the patch `test: Create a empty network state before test starts`.