### PR TITLE
dns: Enable support of 3+ unmixed DNS name server

### DIFF
--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -170,9 +170,18 @@ def validate_dns(state):
     dns_servers = (
         state.get(DNS.KEY, {}).get(DNS.CONFIG, {}).get(DNS.SERVER, [])
     )
-    if len(dns_servers) > 2:
+    if len(dns_servers) > 3:
+        logging.warning(
+            "The libc resolver may not support more than 3 nameservers."
+        )
+    if (
+        len(dns_servers) > 2
+        and any(is_ipv6_address(n) for n in dns_servers)
+        and any(not is_ipv6_address(n) for n in dns_servers)
+    ):
         raise NmstateNotImplementedError(
-            "Nmstate only support at most 2 DNS name servers"
+            "Three or more nameservers are only supported when using "
+            "either IPv4 or IPv6 nameservers but not both."
         )
 
 

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -31,7 +31,9 @@ from libnmstate.schema import Route
 
 
 IPV4_DNS_NAMESERVERS = ["8.8.8.8", "1.1.1.1"]
+EXTRA_IPV4_DNS_NAMESERVER = "9.9.9.9"
 IPV6_DNS_NAMESERVERS = ["2001:4860:4860::8888", "2606:4700:4700::1111"]
+EXTRA_IPV6_DNS_NAMESERVER = "2620:fe::9"
 EXAMPLE_SEARCHES = ["example.org", "example.com"]
 
 parametrize_ip_ver = pytest.mark.parametrize(
@@ -100,14 +102,27 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotImplementedError,
-    reason="https://nmstate.atlassian.net/browse/NMSTATE-220",
-    strict=True,
+@pytest.mark.parametrize(
+    "dns_servers",
+    [
+        (IPV4_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
+        (IPV6_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+        pytest.mark.xfail(
+            reason="Not supported",
+            raises=NmstateNotImplementedError,
+            strict=True,
+        )(IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+        pytest.mark.xfail(
+            reason="Not supported",
+            raises=NmstateNotImplementedError,
+            strict=True,
+        )(IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
+    ],
+    ids=["ipv4", "ipv6", "ipv4+ipv6", "ipv6+ipv4"],
 )
-def test_dns_edit_three_nameservers():
+def test_dns_edit_three_nameservers(dns_servers):
     dns_config = {
-        DNS.SERVER: IPV6_DNS_NAMESERVERS + [IPV4_DNS_NAMESERVERS[0]],
+        DNS.SERVER: dns_servers,
         DNS.SEARCH: [],
     }
     desired_state = {


### PR DESCRIPTION
Support 3 or more IPv4/IPv6 only DNS name servers.
Still not supported 3+ IPv4 and IPv6 mixed name servers.

A warning will be emitted when 4 or more DNS name severs defined.

Integration test cases added.