### PR TITLE
[nmstate-0.2] dns: Enable support of 3+ unmixed DNS name server

### DIFF
--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -166,9 +166,18 @@ def validate_dns(state):
     dns_servers = (
         state.get(DNS.KEY, {}).get(DNS.CONFIG, {}).get(DNS.SERVER, [])
     )
-    if len(dns_servers) > 2:
+    if len(dns_servers) > 3:
+        logging.warning(
+            "The libc resolver may not support more than 3 nameservers."
+        )
+    if (
+        len(dns_servers) > 2
+        and any(is_ipv6_address(n) for n in dns_servers)
+        and any(not is_ipv6_address(n) for n in dns_servers)
+    ):
         raise NmstateNotImplementedError(
-            "Nmstate only support at most 2 DNS name servers"
+            "Three or more nameservers are only supported when using "
+            "either IPv4 or IPv6 nameservers but not both."
         )
 
 


### PR DESCRIPTION
Support 3 or more IPv4/IPv6 only DNS name servers.
Still not supported 3+ IPv4 and IPv6 mixed name servers.

A warning will be emitted when 4 or more DNS name severs defined.

Integration test cases added.