### PR TITLE
[nmstate-0.2] state: allow missing arp_ip_target when ARP monitoring disabled

### DIFF
--- a/libnmstate/appliers/bond.py
+++ b/libnmstate/appliers/bond.py
@@ -113,3 +113,16 @@ def get_bond_named_option_value_by_id(option_name, option_id_value):
         with contextlib.suppress(ValueError, IndexError):
             return option_value[int(option_id_value)]
     return option_id_value
+
+
+def fix_bond_option_arp_monitor(cur_iface_state):
+    """
+    Fix the current iface_state by
+    adding 'arp_ip_target=""' when ARP monitor is disabled by `arp_interval=0`
+    """
+    bond_options = cur_iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
+    if (
+        bond_options.get("arp_interval") in ("0", 0)
+        and "arp_ip_target" not in bond_options
+    ):
+        bond_options["arp_ip_target"] = ""

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -321,6 +321,7 @@ class State:
 
         metadata.remove_ifaces_metadata(self)
         other_state.sanitize_dynamic_ip()
+        other_state._pre_verification_fix()
 
         self.merge_interfaces(other_state)
 
@@ -328,6 +329,15 @@ class State:
         other_state.normalize_for_verification()
 
         self._assert_interfaces_equal(other_state)
+
+    def _pre_verification_fix(self):
+        """
+        Invoking iface specific fixes.
+        Supposed to only run againt current state.
+        """
+        for iface_state in self.interfaces.values():
+            if iface_state.get(Interface.TYPE) == InterfaceType.BOND:
+                bond.fix_bond_option_arp_monitor(iface_state)
 
     def verify_routes(self, other_state):
         for iface_name, routes in self.config_iface_routes.items():

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -53,6 +53,8 @@ ETH2 = "eth2"
 MAC0 = "02:FF:FF:FF:FF:00"
 MAC1 = "02:FF:FF:FF:FF:01"
 
+IPV4_ADDRESS1 = "192.0.2.251"
+
 BOND99_YAML_BASE = """
 interfaces:
 - name: bond99
@@ -185,7 +187,7 @@ def test_add_bond_with_slaves_and_ipv4(eth1_up, eth2_up, setup_remove_bond99):
 
     libnmstate.apply(desired_bond_state)
 
-    assertlib.assert_state(desired_bond_state)
+    assertlib.assert_state_match(desired_bond_state)
 
 
 def test_rollback_for_bond(eth1_up, eth2_up):
@@ -305,7 +307,7 @@ def test_swap_slaves_between_bonds(bond88_with_slave, bond99_with_eth2):
     state.update(bond99_with_eth2)
     libnmstate.apply(state)
 
-    assertlib.assert_state(state)
+    assertlib.assert_state_match(state)
 
 
 def test_set_bond_mac_address(eth1_up):
@@ -459,7 +461,7 @@ def test_preserve_bond_after_bridge_removal(bond99_with_eth2):
     bridge_state = add_port_to_bridge(create_bridge_subtree_state(), BOND99)
     with linux_bridge(bridge_name, bridge_state) as desired_state:
         assertlib.assert_state_match(desired_state)
-    assertlib.assert_state(bond99_with_eth2)
+    assertlib.assert_state_match(bond99_with_eth2)
 
 
 def test_create_vlan_over_a_bond(bond99_with_eth2):
@@ -479,7 +481,7 @@ def test_change_bond_option_miimon(bond99_with_2_slaves):
     bond_options = iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
     bond_options["miimon"] = 200
     libnmstate.apply(desired_state)
-    assertlib.assert_state(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
 def test_change_bond_option_with_an_id_value(bond99_with_eth2):
@@ -677,3 +679,32 @@ def test_new_bond_uses_mac_of_first_slave_by_name(eth1_eth2_with_no_profile):
         assert get_mac_address(BOND99) == eth1_mac
         _nmcli_simulate_boot(BOND99)
         assert get_mac_address(BOND99) == eth1_mac
+
+
+@pytest.fixture
+def bond99_with_2_slaves_and_arp_monitor(eth1_up, eth2_up):
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+                Bond.OPTIONS_SUBTREE: {
+                    "arp_interval": 60,
+                    "arp_ip_target": IPV4_ADDRESS1,
+                },
+            },
+        },
+    ) as state:
+        yield state
+
+
+def test_bond_disable_arp_interval(bond99_with_2_slaves_and_arp_monitor):
+    state = bond99_with_2_slaves_and_arp_monitor
+    bond_config = state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
+    bond_config[Bond.OPTIONS_SUBTREE]["arp_interval"] = 0
+    bond_config[Bond.OPTIONS_SUBTREE]["arp_ip_target"] = ""
+
+    libnmstate.apply(state)
+
+    assertlib.assert_state_match(state)

--- a/tests/integration/mem_leak_test.py
+++ b/tests/integration/mem_leak_test.py
@@ -48,7 +48,7 @@ def test_libnmstate_show_fd_leak(disable_logging):
     original_fd = get_current_open_fd()
     for x in range(0, 100):
         libnmstate.show()
-    assert get_current_open_fd() == original_fd
+    assert get_current_open_fd() <= original_fd
 
 
 @pytest.mark.tier1
@@ -57,4 +57,4 @@ def test_libnmstate_apply_fd_leak(disable_logging):
     for x in range(0, 10):
         with ifacelib.iface_up("eth1"):
             pass
-    assert get_current_open_fd() == original_fd
+    assert get_current_open_fd() <= original_fd


### PR DESCRIPTION
Got verification failure when disabling `arp_interval` of existing bond
regarding `arp_ip_target: ''` not included in new state.

This is because NetworkManager does not store `arp_ip_target: ''` in
on-disk profile when `arp_interval` is zero/disabled.

The fix is allowing backend to skip `arp_ip_target` when ARP monitoring
is disabled(`arp_interval==0`) by fix the bond option before
verification.

Added function `libnmstate.applier.bond.iface_state_pre_verify_fix()`.

Introduced `self._pre_verification_fix()` to `State.verify_interfaces()`
allowing `state.py` to delegating state modification to interface
specific function without knowing the detail.

Integration test case added.

Signed-off-by: Gris Ge <fge@redhat.com>