### PR TITLE
[nmstate-0.2] tests, integ: fix TypeError on dns tests

### DIFF
--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -106,16 +106,22 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
     [
         (IPV4_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
-        pytest.mark.xfail(
-            reason="Not supported",
-            raises=NmstateNotImplementedError,
-            strict=True,
-        )(IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
-        pytest.mark.xfail(
-            reason="Not supported",
-            raises=NmstateNotImplementedError,
-            strict=True,
-        )(IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
+        pytest.param(
+            (IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+            marks=pytest.mark.xfail(
+                reason="Not supported",
+                raises=NmstateNotImplementedError,
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            (IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
+            marks=pytest.mark.xfail(
+                reason="Not supported",
+                raises=NmstateNotImplementedError,
+                strict=True,
+            ),
+        ),
     ],
     ids=["ipv4", "ipv6", "ipv4+ipv6", "ipv6+ipv4"],
 )


### PR DESCRIPTION
On some platforms NMCI is getting the following error:

```
state = {'dns-resolver': {'config': {'search': [], 'server':
MarkDecorator(mark=Mark(name='xfail', args=(['2001:4860:4860::888...:
'eth1'}, {'destination': '::/0', 'metric': 201, 'next-hop-address':
'2001:db8:2::f', 'next-hop-interface': 'eth1'}]}}

    def validate_dns(state):
        """
        Only support at most 2 name servers now:
        https://nmstate.atlassian.net/browse/NMSTATE-220
        """
        dns_servers = (
            state.get(DNS.KEY, {}).get(DNS.CONFIG, {}).get(DNS.SERVER, [])
        )
>       if len(dns_servers) > 3:
E       TypeError: object of type 'MarkDecorator' has no len()
```

In order to fix this, this patch is splitting the supported and not
supported 3+ nameserver edit tests.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>