### PR TITLE
bond: Don't merge bond options when bond mode changed

### DIFF
--- a/libnmstate/metadata.py
+++ b/libnmstate/metadata.py
@@ -53,6 +53,7 @@ def generate_ifaces_metadata(desired_state, current_state):
     metadata is generated on interfaces, usable by the provider when
     configuring the interface.
     """
+    bond.generate_bond_mode_change_metadata(desired_state, current_state)
     _generate_link_master_metadata(
         desired_state.interfaces,
         current_state.interfaces,
@@ -91,6 +92,7 @@ def remove_ifaces_metadata(ifaces_state):
         iface_state.pop(MASTER, None)
         iface_state.pop(MASTER_TYPE, None)
         iface_state.pop(BRPORT_OPTIONS, None)
+        bond.remove_bond_mode_change_metadata(iface_state)
         iface_state.get(Interface.IPV4, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV6, {}).pop(ROUTES, None)
         iface_state.get(Interface.IPV4, {}).pop(DNS_METADATA, None)

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -392,6 +392,7 @@ class State:
         entries that appear only on one state are ignored.
         This is a reverse recursive update operation.
         """
+        origin_self_state = State(self.state)
         origin_other_state = other_state
         other_state = State(other_state.state)
         for name in self.interfaces.keys() & other_state.interfaces.keys():
@@ -402,6 +403,13 @@ class State:
             other_iface_state = origin_other_state.interfaces[name]
             if iface_state.get(Interface.TYPE) == LinuxBridge.TYPE:
                 merge_linux_bridge_ports(iface_state, other_iface_state)
+            elif iface_state.get(Interface.TYPE) == InterfaceType.BOND:
+                origin_self_iface_state = origin_self_state.interfaces.get(
+                    name
+                )
+                bond.discard_merged_data_on_mode_change(
+                    iface_state, origin_self_iface_state
+                )
 
     def complement_master_interfaces_removal(self, other_state):
         """

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -806,3 +806,36 @@ def test_bond_disable_arp_interval(bond99_with_2_slaves_and_arp_monitor):
     libnmstate.apply(state)
 
     assertlib.assert_state_match(state)
+
+
+@pytest.fixture
+def bond99_with_2_slaves_and_lacp_rate(eth1_up, eth2_up):
+    with bond_interface(
+        name=BOND99,
+        slaves=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.LACP,
+                Bond.OPTIONS_SUBTREE: {"lacp_rate": "fast"},
+            },
+        },
+    ) as state:
+        yield state
+
+
+def test_bond_switch_mode_with_conflict_option(
+    bond99_with_2_slaves_and_lacp_rate,
+):
+
+    state = bond99_with_2_slaves_and_lacp_rate
+    bond_config = state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
+    bond_config[Bond.MODE] = BondMode.ROUND_ROBIN
+    bond_config[Bond.OPTIONS_SUBTREE] = {"miimon": "140"}
+
+    libnmstate.apply(state)
+
+    assertlib.assert_state_match(state)
+    current_state = statelib.show_only((BOND99,))
+    current_bond_config = current_state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
+
+    assert "lacp_rate" not in current_bond_config[Bond.OPTIONS_SUBTREE]


### PR DESCRIPTION
When changing bond mode, user is required to provide all bond options
and no bond options will be merged from current state.

When changing bond mode, full deactivation is required in NetworkManager
do to bug https://bugzilla.redhat.com/show_bug.cgi?id=1819137

Procedure to fix this issue:
    * Generate a metadata if bond mode changed.
    * After merge, use desire bond option only if bond mode changed.
    * In NM profile modification, deactivate the interface before
      modification if bond mode changed.

Added integration test case and unit test cases.

