### PR TITLE
Route rule: support host without prefix length

### DIFF
--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -640,6 +640,30 @@ def test_route_rule_add_without_route_table(route_rule_test_env):
     _check_ip_rules(rules)
 
 
+def test_route_rule_add_from_to_single_host(route_rule_test_env):
+    """
+    When route table is not define in route rule, the main route table will
+    be used.
+    """
+    state = route_rule_test_env
+    rules = [
+        {
+            RouteRule.IP_FROM: "2001:db8:a::",
+            RouteRule.IP_TO: "2001:db8:f::/64",
+        },
+        {
+            RouteRule.IP_FROM: "2001:db8:a::/64",
+            RouteRule.IP_TO: "2001:db8:f::",
+        },
+        {RouteRule.IP_FROM: "203.0.113.1", RouteRule.IP_TO: "192.0.2.0/24"},
+        {RouteRule.IP_FROM: "203.0.113.0/24", RouteRule.IP_TO: "192.0.2.1"},
+    ]
+    state[RouteRule.KEY] = {RouteRule.CONFIG: rules}
+
+    libnmstate.apply(state)
+    _check_ip_rules(rules)
+
+
 def _check_ip_rules(rules):
     for rule in rules:
         iprule.ip_rule_exist_in_os(

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -32,6 +32,10 @@ def ip_rule_exist_in_os(ip_from, ip_to, priority, table):
         ip_to and iplib.is_ipv6_address(ip_to)
     ):
         cmds.append("-6")
+    if ip_from and "/" not in ip_from:
+        ip_from = iplib.to_ip_address_full(ip_from)
+    if ip_to and "/" not in ip_to:
+        ip_to = iplib.to_ip_address_full(ip_to)
     result = cmdlib.exec_cmd(cmds + ["--json", "rule"])
     logging.debug(f"Current ip rules in OS: {result[1]}")
     assert result[0] == 0


### PR DESCRIPTION
Got verification failure when specified `RouteRule.IP_FROM` or
`RouteRule.IP_TO` using host without prefix length.

Appending `/32` or `/128` before verification would fix this.

Integration test added.