### PR TITLE
[nmstate-0.2] nm.ovs: check slave profile exists before adding it

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -245,5 +245,6 @@ def _get_slave_profiles(master_device, devices_info):
         if active_con:
             master = active_con.props.master
             if master and (master.get_iface() == master_device.get_iface()):
-                slave_profiles.append(active_con.props.connection)
+                if active_con.props.connection:
+                    slave_profiles.append(active_con.props.connection)
     return slave_profiles


### PR DESCRIPTION
In openstack `test_ovs_remove_port` is failing with the following error:

```
_____________________________ test_ovs_remove_port _____________________________

bridge_with_ports = <integration.testlib.ovslib.Bridge object at 0x7f3598880080>

    @pytest.mark.xfail(
        raises=NmstateLibnmError, reason="https://bugzilla.redhat.com/1724901"
    )
    def test_ovs_remove_port(bridge_with_ports):
        for port_name in bridge_with_ports.ports_names:
            nm_port_profile_name = nmlib.get_ovs_port_by_slave(port_name)
            assert nmlib.list_profiles_by_iface_name(nm_port_profile_name)
            libnmstate.apply(
                {
                    Interface.KEY: [
                        {
                            Interface.NAME: port_name,
>                           Interface.STATE: InterfaceState.ABSENT,
                        }
                    ]
                }
            )

tests/integration/ovs_test.py:203:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3.6/site-packages/libnmstate/deprecation.py:40: in wrapper
    return func(*args, **kwargs)
/usr/lib/python3.6/site-packages/libnmstate/nm/nmclient.py:96: in wrapped
    ret = func(*args, **kwargs)
/usr/lib/python3.6/site-packages/libnmstate/netapplier.py:73: in apply
    state.State(desired_state), verify_change, commit, rollback_timeout
/usr/lib/python3.6/site-packages/libnmstate/netapplier.py:169: in _apply_ifaces_state
    _verify_change(desired_state)
/usr/lib/python3.6/site-packages/libnmstate/netapplier.py:219: in _verify_change
    current_state = state.State(netinfo.show())
/usr/lib/python3.6/site-packages/libnmstate/deprecation.py:40: in wrapper
    return func(*args, **kwargs)
/usr/lib/python3.6/site-packages/libnmstate/nm/nmclient.py:96: in wrapped
    ret = func(*args, **kwargs)
/usr/lib/python3.6/site-packages/libnmstate/netinfo.py:46: in show
    report = {Constants.INTERFACES: _interfaces()}
/usr/lib/python3.6/site-packages/libnmstate/netinfo.py:118: in _interfaces
    iface_info["bridge"] = nm.ovs.get_ovs_info(dev, devices_info)
/usr/lib/python3.6/site-packages/libnmstate/nm/ovs.py:141: in get_ovs_info
    ports = _get_bridge_ports_info(port_profiles, devices_info)
/usr/lib/python3.6/site-packages/libnmstate/nm/ovs.py:157: in _get_bridge_ports_info
    port_info = _get_bridge_port_info(p, devices_info)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

port_profile = None
devices_info = [(<NM.DeviceGeneric object at 0x7f3596f3db40
(NMDeviceGeneric at 0x559c8cbb02e0)>, {'name': 'lo', 'state': <enum
NM_DE...type NM.DeviceState>, 'type_id': <enum NM_DEVICE_TYPE_IP_TUNNEL
of type NM.DeviceType>, 'type_name': 'iptunnel'}), ...]

    def _get_bridge_port_info(port_profile, devices_info):
        """
        Report port information.
        Note: The current implementation supports only system OVS ports and
        access vlan-mode (trunks are not supported).
        """
        port_info = {}

>       port_setting = port_profile.get_setting(nmclient.NM.SettingOvsPort)
E       AttributeError: 'NoneType' object has no attribute 'get_setting'

/usr/lib/python3.6/site-packages/libnmstate/nm/ovs.py:171: AttributeError
```
After deleting the ovs-interface, we are retrieving the current state.
When getting the ovs-bridge interface state we are getting the slave
profiles. Here is the problem. When getting the slaves devices and
checking they have an active connection and is a slave of ovs-bridge,
then we are getting the profile and adding it to the list.

That is incorrect. When deleting an interface, the profile disappears
right away but the currently NM.ActiveConnection and NM.Device may
take some time to go down. It depends on the system, this is why we
are only seeing this on openstack VM. We SHOULD never assume that
NM.ActiveConnection.props.connection is always != None at that point.

Checking if the profile is not None before adding it to the slave list
fix this problem.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>