### PR TITLE
test, integ: clean auto_dns and auto_routes before tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,6 +25,8 @@ import pytest
 
 import libnmstate
 from libnmstate.schema import DNS
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
@@ -84,6 +86,15 @@ def _empty_net_state():
         Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}]
     }
     desired_state[RouteRule.KEY] = {RouteRule.CONFIG: []}
+
+    for iface_state in desired_state[Interface.KEY]:
+        if iface_state[Interface.IPV4][InterfaceIP.ENABLED]:
+            iface_state[Interface.IPV4][InterfaceIP.AUTO_DNS] = False
+            iface_state[Interface.IPV4][InterfaceIP.AUTO_ROUTES] = False
+        if iface_state[Interface.IPV6][InterfaceIP.ENABLED]:
+            iface_state[Interface.IPV6][InterfaceIP.AUTO_DNS] = False
+            iface_state[Interface.IPV6][InterfaceIP.AUTO_ROUTES] = False
+
     libnmstate.apply(desired_state)
 
 


### PR DESCRIPTION
If the tests are being run out of the container it is possible to
contain interfaces with dynamic DNS configured. When that happens, the
test fails because the current state contains the dns configuration from
that interface.

In order to fix this, the test is checking the current configuration
contains the desired DNS configuration.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>