### PR TITLE
CI: Fix the rpmdb error when running in travis CI

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -241,13 +241,11 @@ function upgrade_nm_from_copr {
     # [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
     if [[ "$CI" == "true" ]];then
         container_exec "rm -fv /var/cache/dnf/metadata_lock.pid"
-        container_exec "dnf clean all"
-        container_exec "dnf makecache || :"
     fi
-    container_exec "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
-    container_exec "yum copr enable --assumeyes ${copr_repo}"
+    container_exec "dnf install --assumeyes 'dnf-command(copr)'"
+    container_exec "dnf copr enable --assumeyes ${copr_repo}"
     # Update only from Copr to limit the changes in the environment
-    container_exec "yum update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
+    container_exec "dnf update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
     container_exec "systemctl restart NetworkManager"
 }
 

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -2,6 +2,7 @@ FROM docker.io/library/centos:8
 
 RUN dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools && \
+    dnf -y install dnf-plugin-ovl && \
     dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable networkmanager/NetworkManager-1.22 -y && \
     dnf -y install --setopt=install_weak_deps=False \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -1,6 +1,7 @@
 FROM docker.io/library/fedora:32
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install dnf-plugin-ovl &&
+    dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
                    NetworkManager-team \


### PR DESCRIPTION
Due to bug of rpm and overlay2:
    https://bugzilla.redhat.com/show_bug.cgi?id=1680124

In travis CI, the might fail with:

```
error: db5 error(2) from dbenv->open: No such file or directory
error: cannot open Packages index using db5 - No such file or directory (2)
error: cannot open Packages database in /var/lib/rpm
Error: Error: rpmdb open failed
```

https://travis-ci.com/github/nmstate/nmstate/jobs/302357321#L619

To fix this issue, installing `dnf-plugin-ovl` would solve this problem
as suggested in https://bugzilla.redhat.com/1213602 .
