### PR TITLE
state: Support remove all slaves

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -144,6 +144,8 @@ def _apply_ifaces_state(
             with _setup_providers():
                 state2edit = state.State(desired_state.state)
                 state2edit.merge_interfaces(current_state)
+                state2edit.complement_master_slave_list_change(current_state)
+                state2edit.merge_interfaces(current_state)
                 nm.applier.apply_changes(
                     list(state2edit.interfaces.values()),
                     original_desired_state,

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -251,20 +251,16 @@ def test_add_slave_to_bond_without_slaves(eth1_up):
         assert bond_cur_state[Bond.CONFIG_SUBTREE][Bond.SLAVES] == [slave_name]
 
 
-@pytest.mark.xfail(
-    strict=True, reason="https://github.com/nmstate/nmstate/issues/932"
-)
-def test_remove_all_slaves_from_bond(eth1_up):
-    slave_name = (eth1_up[Interface.KEY][0][Interface.NAME],)
-    with bond_interface(name=BOND99, slaves=[slave_name]) as state:
-        state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.SLAVES] = []
+def test_remove_all_slaves_from_bond(bond99_with_2_slaves):
+    state = bond99_with_2_slaves
+    state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.SLAVES] = []
 
-        libnmstate.apply(state)
+    libnmstate.apply(state)
 
-        current_state = statelib.show_only((BOND99,))
-        bond_cur_state = current_state[Interface.KEY][0]
+    current_state = statelib.show_only((BOND99,))
+    bond_cur_state = current_state[Interface.KEY][0]
 
-        assert bond_cur_state[Bond.CONFIG_SUBTREE][Bond.SLAVES] == []
+    assert bond_cur_state[Bond.CONFIG_SUBTREE][Bond.SLAVES] == []
 
 
 @pytest.mark.tier1

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -584,3 +584,12 @@ def _create_bridge_subtree_config(port_names):
         add_port_to_bridge(bridge_state, port, port_state)
 
     return bridge_state
+
+
+@pytest.mark.tier1
+def test_bridge_remove_all_slaves(bridge0_with_port0):
+    state = bridge0_with_port0
+    bridge_config = state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE]
+    bridge_config[LinuxBridge.PORT_SUBTREE] = []
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -293,3 +293,19 @@ def test_ovs_vlan_access_tag():
 
     assertlib.assert_absent(BRIDGE1)
     assertlib.assert_absent(PORT1)
+
+
+def test_ovs_bridge_remove_all_slaves(bridge_with_ports):
+    state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: BRIDGE1,
+                OVSBridge.CONFIG_SUBTREE: {OVSBridge.PORT_SUBTREE: []},
+            },
+            # OVS internal Interface is need to remove explicitly when master
+            # remove it # from slave list
+            {Interface.NAME: PORT1, Interface.STATE: InterfaceState.ABSENT},
+        ]
+    }
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -136,3 +136,16 @@ def test_team_change_port_order(eth1_up, eth2_up):
             Team.PORT_SUBTREE
         ].reverse()
         libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def team_with_two_slaves(eth1_up, eth2_up):
+    with team_interface(TEAM0, [PORT1, PORT2]) as desired_state:
+        yield desired_state
+
+
+def test_team_remove_all_slaves(team_with_two_slaves):
+    state = team_with_two_slaves
+    state[Interface.KEY][0][Team.CONFIG_SUBTREE][Team.PORT_SUBTREE] = []
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)


### PR DESCRIPTION
When changing slaves list of bond/bridge/ovs_bridge/team, slave interface
need to be included in desire state explicitly. Or a verification
failure will triggered.

This patch will include changed slave interface in desire state
automatically.

Integration test cases added.