### PR TITLE
automation: export /var/log/openvswitch/ovsdb-server.log

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -167,7 +167,8 @@ function run_tests {
 function collect_artifacts {
     container_exec "
       journalctl > "$CONT_EXPORT_DIR/journal.log" && \
-      dmesg > "$CONT_EXPORT_DIR/dmesg.log" || true
+      dmesg > "$CONT_EXPORT_DIR/dmesg.log" && \
+      cat /var/log/openvswitch/ovsdb-server.log > "$CONT_EXPORT_DIR/ovsdb-server.log" || true
     "
 }
 


### PR DESCRIPTION
The OVS logs from /var/log/openvswitch/ovsdb-server.log could be useful
for debugging OVS issues.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>