### PR TITLE
nm.active_connection: wait until NM.ActiveConnection is deleted

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -245,6 +245,5 @@ def _get_slave_profiles(master_device, devices_info):
         if active_con:
             master = active_con.props.master
             if master and (master.get_iface() == master_device.get_iface()):
-                if active_con.props.connection:
-                    slave_profiles.append(active_con.props.connection)
+                slave_profiles.append(active_con.props.connection)
     return slave_profiles


### PR DESCRIPTION
If any interface is marked as absent, then nmstate should wait until the
NM.ActiveConnection is deleted. This allow nmstate to do not check if
the profile exists when getting the current state eliminating all the
race conditions at that point.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>