### PR TITLE
nm bond: Fix the bond default option getter

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -35,6 +35,8 @@ NM_SUPPORTED_BOND_OPTIONS = nmclient.NM.SettingBond.get_valid_options(
     nmclient.NM.SettingBond.new()
 )
 
+SYSFS_BOND_OPTION_FOLDER_FMT = "/sys/class/net/{ifname}/bonding"
+
 
 def create_setting(options, wired_setting):
     bond_setting = nmclient.NM.SettingBond.new()
@@ -70,7 +72,6 @@ def get_bond_info(nm_device):
 
 def _get_options(nm_device):
     ifname = nm_device.get_iface()
-    bond_setting = nmclient.NM.SettingBond.new()
     bond_option_names_in_profile = get_bond_option_names_in_profile(nm_device)
     if (
         "miimon" in bond_option_names_in_profile
@@ -79,14 +80,23 @@ def _get_options(nm_device):
         bond_option_names_in_profile.add("arp_interval")
         bond_option_names_in_profile.add("miimon")
 
-    options = {}
-    for sysfs_file in glob.iglob(f"/sys/class/net/{ifname}/bonding/*"):
+    # Mode is required
+    sysfs_folder = SYSFS_BOND_OPTION_FOLDER_FMT.format(ifname=ifname)
+    mode = _read_sysfs_file(f"{sysfs_folder}/mode")
+
+    bond_setting = nmclient.NM.SettingBond.new()
+    bond_setting.add_option("mode", mode)
+
+    options = {"mode": mode}
+    for sysfs_file in glob.iglob(f"{sysfs_folder}/*"):
         option = os.path.basename(sysfs_file)
         if option in NM_SUPPORTED_BOND_OPTIONS:
             value = _read_sysfs_file(sysfs_file)
+            # When default_value is None, it means this option is invalid
+            # under this bond mode
+            default_value = bond_setting.get_option_default(option)
             if (
-                option == "mode"
-                or value != bond_setting.get_option_default(option)
+                (default_value and value != default_value)
                 # Always include bond options which are explicitly defined in
                 # on-disk profile.
                 or option in bond_option_names_in_profile

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -824,6 +824,7 @@ def bond99_with_2_slaves_and_lacp_rate(eth1_up, eth2_up):
         yield state
 
 
+@pytest.mark.tier1
 def test_bond_switch_mode_with_conflict_option(
     bond99_with_2_slaves_and_lacp_rate,
 ):


### PR DESCRIPTION
The `test_bond_switch_mode_with_conflict_option` test case will
fail in NM 1.23.2 as `lacp_rate` is still showing in incompatible bond
mode as the `NM.SettingBond.get_option_default()` is return None.

Since NM 1.23.2, the `NM.SettingBond.get_option_default()` supports
provide bond mode specific default options.
When certain option is not valid in specific bond mode, the
`get_option_default()` will return None.

The fix is query out the bond mode first, then set the bond mode in
`NM.SettingBond` which could provide default bond options of this bond
mode.