### PR TITLE
Codeowners: Remove tyll

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 # Default reviewers for everything
-* @cathay4t @EdDev @ffmancera @tyll
+* @cathay4t @EdDev @ffmancera


### PR DESCRIPTION
Since I don't have time to review everything anymore, remove myself from the codeowners.

Signed-off-by: Till Maas <opensource@till.name>