### PR TITLE
sriov: normalize vf mac address before verification

### DIFF
--- a/libnmstate/appliers/sriov.py
+++ b/libnmstate/appliers/sriov.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import Ethernet
+
+
+def capitalize_vf_mac(ifstate):
+    vfs = (
+        ifstate.get(Ethernet.CONFIG_SUBTREE, {})
+        .get(Ethernet.SRIOV_SUBTREE, {})
+        .get(Ethernet.SRIOV.VFS_SUBTREE, [])
+    )
+    for vf in vfs:
+        vf_mac = vf.get(Ethernet.SRIOV.VFS.MAC_ADDRESS)
+        if vf_mac:
+            vf[Ethernet.SRIOV.VFS.MAC_ADDRESS] = vf_mac.upper()

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -193,7 +193,7 @@ def _parse_ip_link_output_options_for_vf(vf):
         match_expr = expr.search(vf)
         if match_expr:
             if option == Ethernet.SRIOV.VFS.MAC_ADDRESS:
-                value = match_expr.group(0)
+                value = match_expr.group(0).upper()
             else:
                 value = match_expr.group(1)
 

--- a/libnmstate/state.py
+++ b/libnmstate/state.py
@@ -32,6 +32,7 @@ from libnmstate import metadata
 from libnmstate.appliers import bond
 from libnmstate.appliers import linux_bridge
 from libnmstate.appliers import ovs_bridge
+from libnmstate.appliers import sriov
 from libnmstate.appliers import team
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
@@ -746,10 +747,17 @@ class State:
                 )
 
     def _capitalize_mac(self):
+        """
+        The MAC address is upper case but case insensitive. This is
+        capitalizing the MAC address. In addition, this is unifying the output
+        format MAC for SR-IOV VFs.
+        """
         for ifstate in self.interfaces.values():
             mac = ifstate.get(Interface.MAC)
             if mac:
                 ifstate[Interface.MAC] = mac.upper()
+            if ifstate[Interface.TYPE] == InterfaceType.ETHERNET:
+                sriov.capitalize_vf_mac(ifstate)
 
     def _remove_empty_description(self):
         for ifstate in self.interfaces.values():

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -109,6 +109,17 @@ def test_sriov_remove_vf_config(sriov_iface_vf):
     assertlib.assert_state(sriov_interface)
 
 
+@pytest.mark.xfail(
+    raises=NmstateNotSupportedError,
+    reason="The device does not support SR-IOV.",
+)
+def test_sriov_vf_mac_mixed_case(sriov_iface_vf):
+    eth_config = sriov_iface_vf[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    vf0 = eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE][0]
+    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = "FF:EE:dd:CC:BB:aa"
+    libnmstate.apply(sriov_interface)
+
+
 @pytest.fixture
 def sriov_interface(eth1_up):
     eth1_up[Interface.KEY][0][Ethernet.CONFIG_SUBTREE] = SRIOV_CONFIG


### PR DESCRIPTION
The VF mac address is being read from the sysfs, it is always in
lowercase. In order to avoid verification failures, nmstate is setting
the VF mac to lowercase in the desired state before verifying.

Ref: https://bugzilla.redhat.com/1818750

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>