### PR TITLE
packaging: Support pre-release tag in RPM

### DIFF
--- a/packaging/get_version.sh
+++ b/packaging/get_version.sh
@@ -7,7 +7,10 @@ SRC_DIR="$(dirname "$0")/.."
 
 cd "$SRC_DIR"
 
-VERSION="$(cat libnmstate/VERSION)"
+VERSION_STR="$(cat libnmstate/VERSION)"
+VERSION=${VERSION_STR%-*}
+PRE_RELEASE=${VERSION_STR:$(( ${#VERSION} + 1 ))}
+: ${PRE_RELEASE:="alpha0"}
 DATE="$(date +%Y%m%d)"
 
 COMMIT_COUNT="$(git rev-list --count HEAD --)"
@@ -16,7 +19,7 @@ GIT_REVISION="$(git rev-parse --short HEAD)"
 TAR_VERSION="${VERSION}dev${COMMIT_COUNT}git${GIT_REVISION}"
 
 RPM_VERSION="${VERSION}"
-RPM_RELEASE="0.${DATE}.${COMMIT_COUNT}git${GIT_REVISION}"
+RPM_RELEASE="0.${PRE_RELEASE}.${DATE}.${COMMIT_COUNT}git${GIT_REVISION}"
 
 RPM_DATE="$(LC_TIME=C date +"%a %b %d %Y")"
 


### PR DESCRIPTION
When `libnmstate/VERSION` contains the pre-release tag(for example
0.2.10-rc1), the RPM generated by `packaging/make_rpm.sh` will contain
illegal string: `-`.

Convert the rpm name to `nmstate-0.2.10-0.rc1.20200419.1055gita6d5d57`
format and use `alpha0` if no pre-release tag found.