### PR TITLE
CHANGELOG: New release 0.2.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # Changelog
-## [0.2.10-rc1] - 2020-04-15
+## [0.2.10] - 2020-04-21
 ### New features
  - Support Linux bridge VLAN filtering
 


### PR DESCRIPTION
 - Support Linux bridge VLAN filtering

 - bond: Don't merge bond options when bond mode changed
   https://bugzilla.redhat.com/1812737
 - Fix the race between OVS bridge config querying and OVS interface deletion