### PR TITLE
travis: switch to docker as podman 1.9.0 is broken in Ubuntu 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: generic
 env:
     global:
         - use_coveralls=true
+        - CONTAINER_CMD=docker
     matrix:
         - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
           testflags="--test-type integ_tier1 --pytest-args='-x'
@@ -39,20 +40,15 @@ matrix:
 
 addons:
     apt:
-        sources:
-        # Add podman repo suggested by
-        #   https://podman.io/getting-started/installation.html
-        - sourceline: 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /'
-          key_url: 'https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_18.04/Release.key'
-
         packages:
             - git
             - gnupg2
             - openssh-client
             - python-tox
             - xz-utils
-            - podman
-            - containernetworking-plugins   # Need for podman as root user
+
+services:
+    - docker
 
 script:
     - sudo modprobe openvswitch


### PR DESCRIPTION
We are installing podman from the opensuse repository [1], 16th April
they have updated the podman package from podman 1.8.2 to podman 1.9.0
which is broken. As the repository does not contain podman
1.8.2 anymore, we are switching to docker again temporarily.

[1] http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>