### PR TITLE
[nmstate-0.2] Packit: Add packit configuration

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,15 @@
+---
+specfile_path: nmstate.spec
+upstream_package_name: nmstate
+upstream_project_url: http://nmstate.io
+create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
+current_version_command: ["python3", "setup.py", "--version"]
+actions:
+  post-upstream-clone: "bash -c './packaging/make_spec.sh > nmstate.spec'"
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - centos-stream-x86_64
+        - epel-8-x86_64


### PR DESCRIPTION
Add configuration for packit-as-a-service to enable automatic Copr
builds for pull requests.

Signed-off-by: Till Maas <opensource@till.name>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>