### PR TITLE
[nmstate-0.2] travis: specify registry for container images in vdsm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ env:
           testflags="--test-type lint"
         - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev:nmstate-0.2
           testflags="--test-type unit_py36"
-        - testflags="--test-vdsm"
+        - CONTAINER_IMAGE=quay.io/ovirt/vdsm-test-func-network-centos-8
+          testflags="--test-vdsm"
 
 matrix:
     fast_finish: true
@@ -35,7 +36,8 @@ matrix:
         - env: CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev:nmstate-0.2
                testflags="--test-type integ --pytest-args='-x'
                    --copr networkmanager/NetworkManager-master"
-        - env: testflags="--test-vdsm"
+        - env: CONTAINER_IMAGE=quay.io/ovirt/vdsm-test-func-network-centos-8
+               testflags="--test-vdsm"
 
 addons:
     apt:


### PR DESCRIPTION
As Travis CI is now using docker, we must specify the registry for the
container image in the vdsm CI tests. Docker is trying to get the
container image from a private registry in dockerhub first.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>