### PR TITLE
[nmstate-0.2] nm bond: Fix the bond default option getter

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -725,6 +725,7 @@ def bond99_with_2_slaves_and_lacp_rate(eth1_up, eth2_up):
         yield state
 
 
+@pytest.mark.tier1
 def test_bond_switch_mode_with_conflict_option(
     bond99_with_2_slaves_and_lacp_rate,
 ):


### PR DESCRIPTION
The `test_bond_switch_mode_with_conflict_option` test case will
fail in NM 1.23.2 as `lacp_rate` is still showing in incompatible bond
mode as the `NM.SettingBond.get_option_default()` is return None.

Since NM 1.23.2, the `NM.SettingBond.get_option_default()` supports
provide bond mode specific default options.
When certain option is not valid in specific bond mode, the
`get_option_default()` will return None.

The fix is query out the bond mode first, then set the bond mode in
`NM.SettingBond` which could provide default bond options of this bond
mode.

Also promoting `test_bond_switch_mode_with_conflict_option` as tier1
test case.