### PR TITLE
nmstate.gpg: Use new URL for GPG public key

### DIFF
--- a/README.install.md
+++ b/README.install.md
@@ -70,9 +70,7 @@ method.
 
 Download the tarball and the signature file. Then, verify the signature:
 ```bash
-curl --silent \
-    https://raw.githubusercontent.com/nmstate/nmstate/master/nmstate.gpg \
-    | gpg2 --import
+curl --silent https://www.nmstate.io/nmstate.gpg | gpg2 --import
 gpg2 --verify nmstate-<version>.tar.gz.asc nmstate-<version>.tar.gz
 ```
 

--- a/packaging/README.release.md
+++ b/packaging/README.release.md
@@ -64,9 +64,7 @@ gpg2 --armor --detach-sign dist/nmstate-<version>.tar.gz
 * Download the tarball and the signature.
 * Check if the signature is correct.
 ```bash
-curl --silent \
-    https://raw.githubusercontent.com/nmstate/nmstate/master/nmstate.gpg \
-    | gpg2 --import
+curl --silent https://www.nmstate.io/nmstate.gpg | gpg2 --import
 gpg2 --verify nmstate-<version>.tar.gz.asc nmstate-<version>.tar.gz
 ```
 * Check in a clean Fedora/centOS container if the package build and install correctly.


### PR DESCRIPTION
The GPG public keys of maintainers are stored at

https://www.nmstate.io/nmstate.gpg

Updated README files to use this new URL.