### PR TITLE
automation: Export pytest log when CI fails

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -27,7 +27,8 @@ PYTEST_OPTIONS="--verbose --verbose \
         --durations=5 \
         --cov /usr/lib/python*/site-packages/libnmstate \
         --cov /usr/lib/python*/site-packages/nmstatectl \
-        --cov-report=term"
+        --cov-report=term \
+        --log-file=pytest-run.log"
 
 NMSTATE_TEMPDIR=$(mktemp -d /tmp/nmstate-test-XXXX)
 
@@ -168,7 +169,8 @@ function collect_artifacts {
     container_exec "
       journalctl > "$CONT_EXPORT_DIR/journal.log" && \
       dmesg > "$CONT_EXPORT_DIR/dmesg.log" && \
-      cat /var/log/openvswitch/ovsdb-server.log > "$CONT_EXPORT_DIR/ovsdb-server.log" || true
+      cat /var/log/openvswitch/ovsdb-server.log > "$CONT_EXPORT_DIR/ovsdb-server.log" && \
+      mv "$CONTAINER_WORKSPACE/pytest-run.log" "$CONT_EXPORT_DIR/pytest-run.log" || true
     "
 }
 


### PR DESCRIPTION
Added pytest option to store the logfile, if the test fails it is also
saved in the directory that is uploaded to the log storage server.

Signed-off-by: Víctor Javier Díaz Garrido <vicdigar@hotmail.com>