### PR TITLE
nm ovs: Remove unused function get_bridge_info()

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -128,14 +128,6 @@ def get_port_by_slave(nmdev):
     return None
 
 
-def get_bridge_info(bridge_device, devices_info):
-    info = get_ovs_info(bridge_device, devices_info)
-    if info:
-        return {OB.CONFIG_SUBTREE: info}
-    else:
-        return {}
-
-
 def get_ovs_info(bridge_device, devices_info):
     port_profiles = _get_slave_profiles(bridge_device, devices_info)
     ports = _get_bridge_ports_info(port_profiles, devices_info)

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -160,7 +160,9 @@ def _get_bridge_current_state():
             (dev, nm.device.get_device_common_info(dev))
             for dev in nm.device.list_devices()
         ]
-        state = nm.ovs.get_bridge_info(nmdev, devices_info)
+        ovs_info = nm.ovs.get_ovs_info(nmdev, devices_info)
+        if ovs_info:
+            state[OB.CONFIG_SUBTREE] = ovs_info
     return state
 
 


### PR DESCRIPTION
The `get_bridge_info()` in `nm/ovs.py` is not used in production code,
but test only.

Removed.