### PR TITLE
nm vxlan: Remove unused code nm_version()

### DIFF
--- a/libnmstate/nm/nmclient.py
+++ b/libnmstate/nm/nmclient.py
@@ -45,10 +45,6 @@ NM_MANAGER_ERROR_DOMAIN = "nm-manager-error-quark"
 _NMCLIENT_CLEANUP_TIMEOUT = 5
 
 
-def nm_version():
-    return NM.Client.get_version(client())
-
-
 def _delete_client():
     global _nmclient
     if _nmclient:

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -17,10 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from distutils.version import StrictVersion
-
-from libnmstate import nm
-from libnmstate.nm import connection
 from libnmstate.nm import nmclient
 from libnmstate.schema import VXLAN
 
@@ -83,13 +79,4 @@ def _get_destination_port(device):
 
     [1] https://bugzilla.redhat.com/show_bug.cgi?id=1768388
     """
-    if nm.nmclient.nm_version() >= StrictVersion("1.20.6"):
-        return device.get_dst_port()
-    else:
-        con = connection.ConnectionProfile()
-        con.import_by_device(device)
-        if con.profile:
-            vxlan_settings = con.profile.get_setting_vxlan()
-            if vxlan_settings:
-                return vxlan_settings.get_destination_port()
-    return 0
+    return device.get_dst_port()

--- a/tests/integration/nm/vxlan_test.py
+++ b/tests/integration/nm/vxlan_test.py
@@ -19,10 +19,6 @@
 
 from contextlib import contextmanager
 
-import pytest
-
-from distutils.version import StrictVersion
-
 from libnmstate import nm
 from libnmstate.nm.nmclient import nmclient_context
 from libnmstate.schema import Interface
@@ -41,12 +37,6 @@ def test_create_and_remove_vxlan(eth1_up):
     assert not _get_vxlan_current_state(vxlan_name)
 
 
-@pytest.mark.xfail(
-    condition=StrictVersion(nm.nmclient.nm_version())
-    < StrictVersion("1.20.6"),
-    strict=True,
-    reason="https://bugzilla.redhat.com/show_bug.cgi?id=1768388",
-)
 def test_read_destination_port_from_libnm(eth1_up):
     vxlan_desired_state = _create_vxlan_state(eth1_up)
     with _vxlan_interface(vxlan_desired_state):


### PR DESCRIPTION
As nmstate minimum supported NM version is 1.22.10, there is no need to
check for version 1.20.6 in `nm/vxlan.py`.

Unused code removed.