### PR TITLE
Validate vlan mtu not greater than base iface

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -298,6 +298,10 @@ class BaseIface:
     def mtu(self):
         return self._info.get(Interface.MTU)
 
+    @mtu.setter
+    def mtu(self, value):
+        self._info[Interface.MTU] = value
+
     def _capitalize_mac(self):
         if self.mac:
             self._info[Interface.MAC] = self.mac.upper()

--- a/tests/lib/ifaces/vxlan_iface_test.py
+++ b/tests/lib/ifaces/vxlan_iface_test.py
@@ -20,7 +20,9 @@
 import pytest
 
 from libnmstate.error import NmstateValueError
+from libnmstate.ifaces import Ifaces
 from libnmstate.schema import VXLAN
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
 from libnmstate.ifaces.vxlan import VxlanIface
@@ -32,6 +34,13 @@ BASE_IFACE_NAME = "base1"
 
 
 class TestVxlanIface:
+    def _gen_base_iface_info(self):
+        iface_info = gen_foo_iface_info(iface_type=InterfaceType.ETHERNET)
+        iface_info[Interface.NAME] = BASE_IFACE_NAME
+        iface_info[Interface.MTU] = 1500
+
+        return iface_info
+
     def _gen_iface_info(self):
         iface_info = gen_foo_iface_info(iface_type=InterfaceType.VXLAN)
         iface_info[VXLAN.CONFIG_SUBTREE] = {
@@ -63,3 +72,29 @@ class TestVxlanIface:
         iface = VxlanIface(iface_info)
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
+
+    def test_add_vxlan_with_mtu_greater_than_base(self):
+        base_iface_info = self._gen_base_iface_info()
+        vxlan_iface_info = self._gen_iface_info()
+        vxlan_iface_info[Interface.MTU] = base_iface_info[Interface.MTU] + 1
+
+        with pytest.raises(NmstateValueError):
+            Ifaces(
+                des_iface_infos=[base_iface_info, vxlan_iface_info],
+                cur_iface_infos=[],
+            )
+
+    def test_add_vxlan_with_base_mtu_undefined(self):
+        base_iface_info = self._gen_base_iface_info()
+        base_iface_info[Interface.MTU] = None
+        vxlan_iface_info = self._gen_iface_info()
+        vxlan_iface_info[Interface.MTU] = 1501
+
+        ifaces = Ifaces(
+            des_iface_infos=[base_iface_info, vxlan_iface_info],
+            cur_iface_infos=[],
+        )
+
+        base_iface = ifaces.get(base_iface_info.get(Interface.NAME))
+
+        assert base_iface.mtu == vxlan_iface_info[Interface.MTU]


### PR DESCRIPTION
fixes #1047 
A new validator is added that verifies that the
MTU of VLAN is less than or equal to MTU of base iface

Signed-off-by: Adwait Thattey <coderdude1999@gmail.com>