### PR TITLE
sriov: raise proper exception when SR-IOV parameter is not supported

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -316,6 +316,15 @@ class ConnectionProfile:
             )
             ac.remove_handlers()
             self._mainloop.execute_next_action()
+        elif (
+            not ac.is_activating
+            and self._is_sriov_parameter_not_supported_by_driver()
+        ):
+            ac.remove_handlers()
+            self._mainloop.quit(
+                f"The device={self.devname} does not support one or more "
+                "of the SR-IOV parameters set."
+            )
         elif not ac.is_activating:
             ac.remove_handlers()
             self._mainloop.quit(
@@ -323,6 +332,12 @@ class ConnectionProfile:
                     ac.devname, ac.reason
                 )
             )
+
+    def _is_sriov_parameter_not_supported_by_driver(self):
+        return (
+            self._nmdevice.props.state_reason
+            == NM.DeviceStateReason.SRIOV_CONFIGURATION_FAILED
+        )
 
     def _add_connection2_callback(self, src_object, result, _user_data):
         try:


### PR DESCRIPTION
Some SR-IOV parameters could be not supported by the device driver.
Nmstate must return a proper error message instead of a generic one.

```
2020-05-03 12:35:19,728 root         ERROR    NM main-loop aborted:
The device=eno1 does not support one or more of the SR-IOV parameters
set.
```

Ref: https://bugzilla.redhat.com/1819588

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>