### PR TITLE
README.release: trivial fixes.

### DIFF
--- a/.github/ISSUE_TEMPLATE/creating-a-new-release.md
+++ b/.github/ISSUE_TEMPLATE/creating-a-new-release.md
@@ -11,7 +11,7 @@ assignees: ''
 ## Changelog
 
 - [ ] First, update the CHANGELOG file in the project root directory. Use the command
-`git log  --oneline --since v0.1.2` to get the changes since the last tag. Add
+`git log  --oneline v0.3.0..HEAD` to get the changes since the last tag. Add
 an entry like the following:
 
 ```

--- a/.github/ISSUE_TEMPLATE/creating-a-new-release.md
+++ b/.github/ISSUE_TEMPLATE/creating-a-new-release.md
@@ -56,7 +56,8 @@ git push --delete upstream <tag_name>
 git clean -x -d -n
 # before running the next command check, that it is ok to remove the files
 git clean -x -d -f
-python3 setup.py sdist
+# Please remove python3-setuptools_scm, or it will all git files into tarbal.
+env --unset=PYTHONPATH python3 setup.py sdist
 gpg2 --armor --detach-sign dist/nmstate-<version>.tar.gz
 ```
 

--- a/packaging/README.release.md
+++ b/packaging/README.release.md
@@ -1,2 +1,1 @@
-# Please use the Issue Template found [here](../.github/ISSUE_TEMPLATE/creating-a-new-release.md).
-## Also available when creating a new issue.
+../.github/ISSUE_TEMPLATE/creating-a-new-release.md


### PR DESCRIPTION
 * Create soft link from `.github/ISSUE_TEMPLATE/creating-a-new-release.md` to `packaging/README.release.md`.
 * Fix the git command for showing changes since certain version.
 * Add notes for creating release tarball.