### PR TITLE
CI container: Use tox from EPEL8 repo

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -25,10 +25,10 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    python3-pytest \
                    python3-pytest-cov \
                    python3-virtualenv \
+                   python3-tox \
                    && \
-    pip3 install python-coveralls tox==3.5.3 --user && \
+    pip3 install python-coveralls --user && \
     alternatives --set python /usr/bin/python3 && \
-    ln -s /root/.local/bin/tox /usr/bin/tox && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \
     dnf clean all && \
     systemctl enable openvswitch && \


### PR DESCRIPTION
Use `python3-tox` from EPEL8 repo instead of pip.