### PR TITLE
test: Fix flake8 error: ambiguous variable name 'l'

### DIFF
--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -86,7 +86,9 @@ def get_non_up_events(result, dev):
     :return: List of non UP events
     """
     return [
-        l for l in result.out.split("\n") if "state UP" not in l and dev in l
+        line
+        for line in result.out.split("\n")
+        if "state UP" not in line and dev in line
     ]
 
 

--- a/tests/integration/testlib/nmplugin.py
+++ b/tests/integration/testlib/nmplugin.py
@@ -32,7 +32,9 @@ def disable_nm_plugin(plugin):
     except CalledProcessError:
         yield
     else:
-        lib_path = [l for l in rpm_output.split() if l.endswith(".so")][0]
+        lib_path = [lib for lib in rpm_output.split() if lib.endswith(".so")][
+            0
+        ]
         with mount_devnull_to_path(lib_path):
             yield
 


### PR DESCRIPTION
The flake8 3.8.1+ will raise error when using variables named 'l', 'O',
or 'I'.

Fixed by changing variable name.