### PR TITLE
nm/checkpoint: Only assign dbus path after creation succeeded

### DIFF
--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -171,13 +171,13 @@ class CheckPoint:
     def _checkpoint_create_callback(self, client, result, data):
         try:
             cp = client.checkpoint_create_finish(result)
-            self._dbuspath = cp.get_path()
             if cp:
                 logging.debug(
                     "Checkpoint {} created for all devices".format(
                         self._dbuspath
                     )
                 )
+                self._dbuspath = cp.get_path()
                 self._ctx.finish_async("Create checkpoint")
             else:
                 error_msg = (

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -197,7 +197,7 @@ class CheckPoint:
             ):
                 self._ctx.fail(
                     NmstatePermissionError(
-                        f"Checkpoint create failed due to insufficient"
+                        "Checkpoint create failed due to insufficient"
                         " permission"
                     )
                 )
@@ -209,7 +209,7 @@ class CheckPoint:
             ):
                 self._ctx.fail(
                     NmstateConflictError(
-                        f"Checkpoint create failed due to a"
+                        "Checkpoint create failed due to a"
                         " conflict with an existing checkpoint"
                     )
                 )


### PR DESCRIPTION
Should only assign dbus path to CheckPoint object after checked the
newly created checkpoint is not-No