### PR TITLE
nm/checkpoint: trivial fixes.

### DIFF
--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -77,7 +77,6 @@ class CheckPoint:
             | common.NM.CheckpointCreateFlags.DISCONNECT_NEW_DEVICES
         )
 
-        self._ctx.register_async("Create checkpoint")
         try:
             self._ctx.client.checkpoint_create(
                 devs,
@@ -91,8 +90,9 @@ class CheckPoint:
             raise NMCheckPointCreationError(
                 "Failed to create checkpoint: " "{}".format(e)
             )
-        self._add_checkpoint_refresh_timeout()
+        self._ctx.register_async("Create checkpoint")
         self._ctx.wait_all_finish()
+        self._add_checkpoint_refresh_timeout()
 
     def _add_checkpoint_refresh_timeout(self):
         self._timeout_source = common.GLib.timeout_source_new(
@@ -123,7 +123,6 @@ class CheckPoint:
         if self._dbuspath:
             action = f"Destroy checkpoint {self._dbuspath}"
             userdata = action
-            self._ctx.register_async(action)
             try:
                 self._ctx.client.checkpoint_destroy(
                     self._dbuspath,
@@ -139,13 +138,13 @@ class CheckPoint:
             finally:
                 self._remove_checkpoint_refresh_timeout()
             logging.debug(f"Checkpoint {self._dbuspath} destroyed")
+            self._ctx.register_async(action)
             self._ctx.wait_all_finish()
 
     def rollback(self):
         if self._dbuspath:
             action = f"Rollback to checkpoint {self._dbuspath}"
             userdata = action
-            self._ctx.register_async(action)
             try:
                 self._ctx.client.checkpoint_rollback(
                     self._dbuspath,
@@ -162,6 +161,7 @@ class CheckPoint:
             finally:
                 self._remove_checkpoint_refresh_timeout()
             logging.debug(f"Checkpoint {self._dbuspath} rollback executed")
+            self._ctx.register_async(action)
             self._ctx.wait_all_finish()
 
     @property

--- a/libnmstate/nm/checkpoint.py
+++ b/libnmstate/nm/checkpoint.py
@@ -188,12 +188,10 @@ class CheckPoint:
                 self._ctx.fail(
                     NmstateLibnmError(f"Checkpoint create failed: {error_msg}")
                 )
-        except Exception as e:
-            if (
-                isinstance(e, common.GLib.GError)
-                # pylint: disable=no-member
-                and e.code == common.Gio.IOErrorEnum.PERMISSION_DENIED
-                # pylint: enable=no-member
+        except common.GLib.Error as e:
+            if e.matches(
+                common.NM.ManagerError.quark(),
+                common.NM.ManagerError.PERMISSIONDENIED,
             ):
                 self._ctx.fail(
                     NmstatePermissionError(
@@ -201,11 +199,9 @@ class CheckPoint:
                         " permission"
                     )
                 )
-            elif (
-                isinstance(e, common.GLib.GError)
-                # pylint: disable=no-member
-                and e.code == common.Gio.IOErrorEnum.NO_SPACE
-                # pylint: enable=no-member
+            elif e.matches(
+                common.NM.ManagerError.quark(),
+                common.NM.ManagerError.INVALIDARGUMENTS,
             ):
                 self._ctx.fail(
                     NmstateConflictError(
@@ -217,6 +213,10 @@ class CheckPoint:
                 self._ctx.fail(
                     NmstateLibnmError(f"Checkpoint create failed: error={e}")
                 )
+        except Exception as e:
+            self._ctx.fail(
+                NmstateLibnmError(f"Checkpoint create failed: error={e}")
+            )
 
     def _checkpoint_rollback_callback(self, client, result, data):
         action = data


### PR DESCRIPTION
Contain two patches:
 * Should not register async action when it might not started yet. And only start refreshing the checkpoint once creation succeeded.
 * Fix the incorrect use of `GLib.Error`.