### PR TITLE
[Plugin design] checkpoint: Move checkpoint functions to plugin level

### DIFF
--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -23,36 +23,35 @@ import pytest
 
 from libnmstate.nm.checkpoint import CheckPoint
 from libnmstate.nm.checkpoint import get_checkpoints
-from libnmstate.nm.checkpoint import NmstateConflictError
+from libnmstate.error import NmstateConflictError
+from libnmstate.error import NmstateValueError
 
 
 def test_creating_one_checkpoint(nm_context):
     """ I can create a checkpoint """
-    with CheckPoint(nm_context) as checkpoint:
-        pass
-
+    checkpoint = CheckPoint.create(nm_context)
     assert checkpoint is not None
+    checkpoint.destroy()
 
 
 def test_creating_two_checkpoints(nm_context):
     """ I cannot create a checkpoint when a checkpoint already exists. """
-    with CheckPoint(nm_context) as checkpoint:
-        with pytest.raises(NmstateConflictError):
-            with CheckPoint(nm_context):
-                pass
-
+    checkpoint = CheckPoint.create(nm_context)
+    with pytest.raises(NmstateConflictError):
+        CheckPoint.create(nm_context)
     assert checkpoint is not None
+    checkpoint.destroy()
 
 
 def test_checkpoint_timeout(nm_context):
     """ I can create a checkpoint that is removed after one second. """
-    with CheckPoint(nm_context, timeout=1, autodestroy=False) as checkpoint_a:
-        time.sleep(1)
-        with CheckPoint(nm_context) as checkpoint_b:
-            pass
+    checkpoint_a = CheckPoint.create(nm_context, timeout=1)
+    time.sleep(1)
+    checkpoint_b = CheckPoint.create(nm_context)
 
     assert checkpoint_b is not None
     assert checkpoint_a is not None
+    checkpoint_b.destroy()
 
 
 def test_getting_a_checkpoint(nm_context):
@@ -62,23 +61,77 @@ def test_getting_a_checkpoint(nm_context):
 
     assert len(checkpoints) == 0
 
-    with CheckPoint(nm_context) as checkpoint:
-        nm_context.refresh_content()
-        checkpoints = get_checkpoints(nm_context.client)
-        assert checkpoints[0] == checkpoint.dbuspath
-        assert len(checkpoints) == 1
+    checkpoint = CheckPoint.create(nm_context)
+
+    nm_context.refresh_content()
+    checkpoints = get_checkpoints(nm_context.client)
+
+    assert len(checkpoints) == 1
+    assert checkpoints[0] == str(checkpoint)
+    checkpoint.destroy()
 
 
 def test_creating_a_checkpoint_from_dbuspath(nm_context):
-    with CheckPoint(nm_context, autodestroy=False) as initial_checkpoint:
-        pass
-    new_checkpoint = CheckPoint(
-        nm_context, dbuspath=initial_checkpoint.dbuspath
-    )
+    initial_checkpoint = CheckPoint.create(nm_context)
+    new_checkpoint = CheckPoint(nm_context, dbuspath=str(initial_checkpoint))
     new_checkpoint.destroy()
     assert not get_checkpoints(nm_context.client)
 
 
 def test_repeat_create_destroy_checkpoint(nm_context):
     for _ in range(0, 1000):
-        CheckPoint(nm_context)
+        checkpoint = CheckPoint.create(nm_context)
+        checkpoint.destroy()
+
+
+def test_plugin_load_specific_checkpoint_not_exist(nm_plugin):
+    plugin = nm_plugin
+    plugin.create_checkpoint()
+
+    with pytest.raises(NmstateValueError):
+        plugin.rollback_checkpoint("checkpoint_not_exist")
+
+
+def test_plugin_load_default_checkpoint(nm_plugin):
+    plugin = nm_plugin
+    plugin.create_checkpoint()
+    plugin.rollback_checkpoint()
+
+    checkpoints = get_checkpoints(nm_plugin.context.client)
+
+    assert plugin.checkpoint is None
+    assert len(checkpoints) == 0
+
+
+def test_plugin_load_default_checkpoint_when_none_avaiable(nm_plugin):
+    plugin = nm_plugin
+    with pytest.raises(NmstateValueError):
+        plugin.rollback_checkpoint()
+
+
+def test_plugin_create_and_destroy_checkpoint(nm_plugin):
+    plugin = nm_plugin
+    plugin.create_checkpoint()
+    plugin.destroy_checkpoint()
+
+    checkpoints = get_checkpoints(nm_plugin.context.client)
+    assert len(checkpoints) == 0
+
+
+def test_plugin_create_and_rollback_checkpoint(nm_plugin):
+    plugin = nm_plugin
+    plugin.create_checkpoint()
+    plugin.rollback_checkpoint()
+
+    checkpoints = get_checkpoints(nm_plugin.context.client)
+    assert len(checkpoints) == 0
+
+
+def test_plugin_create_checkpoint_and_timeout(nm_plugin):
+    plugin = nm_plugin
+    plugin.create_checkpoint(timeout=1)
+    time.sleep(2)
+
+    nm_plugin.refresh_content()
+    checkpoints = get_checkpoints(nm_plugin.context.client)
+    assert len(checkpoints) == 0

--- a/tests/integration/nm/conftest.py
+++ b/tests/integration/nm/conftest.py
@@ -26,6 +26,12 @@ from libnmstate.nm.context import NmContext
 def nm_plugin():
     plugin = NetworkManagerPlugin()
     yield plugin
+    if plugin.checkpoint:
+        # Ignore failures as the checkpoint might already expired
+        try:
+            plugin.rollback_checkpoint()
+        except Exception:
+            pass
     plugin.unload()
 
 

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -35,12 +35,6 @@ BOND_TYPE = InterfaceType.BOND
 
 
 @pytest.fixture
-def netapplier_nm_mock():
-    with mock.patch.object(netapplier, "nm") as m:
-        yield m
-
-
-@pytest.fixture
 def show_with_plugin_mock():
     with mock.patch.object(netapplier, "show_with_plugin") as m:
         yield m
@@ -64,10 +58,7 @@ def net_state_mock():
 
 
 def test_iface_admin_state_change(
-    netapplier_nm_mock,
-    show_with_plugin_mock,
-    plugin_context_mock,
-    net_state_mock,
+    show_with_plugin_mock, plugin_context_mock, net_state_mock,
 ):
     current_config = {
         Interface.KEY: [
@@ -93,10 +84,7 @@ def test_iface_admin_state_change(
 
 
 def test_add_new_bond(
-    plugin_context_mock,
-    show_with_plugin_mock,
-    netapplier_nm_mock,
-    net_state_mock,
+    plugin_context_mock, show_with_plugin_mock, net_state_mock,
 ):
     show_with_plugin_mock.return_value = {}
 
@@ -126,10 +114,7 @@ def test_add_new_bond(
 
 
 def test_edit_existing_bond(
-    show_with_plugin_mock,
-    plugin_context_mock,
-    netapplier_nm_mock,
-    net_state_mock,
+    show_with_plugin_mock, plugin_context_mock, net_state_mock,
 ):
     current_config = {
         Interface.KEY: [


### PR DESCRIPTION
Moved checkpoint related functions to plugin level:
 * `create_checkpoint()`
 * `destroy_checkpoint()`
 * `rollback_checkpoint()`

Removed these NM specific exception as plugin should raise NmstateError
only:
 * `NMCheckPointError`
 * `NMCheckPointCreationError`
 * `NMCheckPointPermissionError`

To properly rollback when failures, context code moved to
`nmstate.py`.

