### PR TITLE
code coverage: Remove coveralls

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -274,10 +274,6 @@ function upload_coverage {
     if [[ "$CI" == "true" ]] ;then
         container_exec "
             cd $CONTAINER_WORKSPACE &&
-            COVERALLS_PARALLEL=true COVERALLS_SERVICE_NAME=travis-ci coveralls
-        " || true
-        container_exec "
-            cd $CONTAINER_WORKSPACE &&
             bash <(curl -s https://codecov.io/bash)
         " || true
     fi
@@ -361,7 +357,6 @@ mkdir -p $EXPORT_DIR
 # The podman support wildcard when passing enviroments, but docker does not.
 CONTAINER_ID="$(${CONTAINER_CMD} run --privileged -d \
     -e CI \
-    -e COVERALLS_REPO_TOKEN \
     -e CODECOV_TOKEN \
     -e TRAVIS \
     -e TRAVIS_BRANCH \

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -25,7 +25,6 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    python3-pytest-cov \
                    python3-virtualenv \
                    python3-tox \
-                   python3-coveralls \
                    python3-requests \
                    python3-docopt \
                    && \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -21,7 +21,6 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    dnsmasq \
                    git \
                    iproute \
-                   python3-coveralls \
                    python3-tox \
                    python3-pytest \
                    python3-pytest-cov \


### PR DESCRIPTION
Currently, coveralls cannot make any comment in github pull request
regarding code coverage status even the data is uploaded to their
website correctly(showed in travis CI log).

Since the codecov.io is working well. Drop the use of coveralls.