### PR TITLE
[Plugin design] validator: Remove the use of nm module

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -24,11 +24,7 @@ from . import connection
 from .common import NM
 
 
-BRIDGE_TYPE = "ovs-bridge"
-INTERNAL_INTERFACE_TYPE = "ovs-interface"
-PORT_TYPE = "ovs-port"
 PORT_PROFILE_PREFIX = "ovs-port-"
-CAPABILITY = "openvswitch"
 
 NM_OVS_VLAN_MODE_MAP = {
     "trunk": OB.Port.Vlan.Mode.TRUNK,

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -24,6 +24,7 @@ from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
+from libnmstate.plugin import NmstatePlugin
 
 from . import bond as nm_bond
 from . import bridge as nm_bridge
@@ -71,9 +72,9 @@ class NetworkManagerPlugin:
     def capabilities(self):
         capabilities = []
         if nm_ovs.has_ovs_capability(self.client) and is_ovs_running():
-            capabilities.append(nm_ovs.CAPABILITY)
+            capabilities.append(NmstatePlugin.OVS_CAPABILITY)
         if nm_team.has_team_capability(self.client):
-            capabilities.append(nm_team.CAPABILITY)
+            capabilities.append(NmstatePlugin.TEAM_CAPABILITY)
         return capabilities
 
     def get_interfaces(self):
@@ -102,7 +103,7 @@ class NetworkManagerPlugin:
             if nm_bond.is_bond_type_id(type_id):
                 bondinfo = nm_bond.get_bond_info(dev)
                 iface_info.update(_ifaceinfo_bond(bondinfo))
-            elif nm_ovs.CAPABILITY in self.capabilities:
+            elif NmstatePlugin.OVS_CAPABILITY in self.capabilities:
                 if nm_ovs.is_ovs_bridge_type_id(type_id):
                     iface_info["bridge"] = nm_ovs.get_ovs_info(
                         self.context, dev, devices_info

--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -25,7 +25,6 @@ from libnmstate.schema import Team
 
 from .common import NM
 
-CAPABILITY = "team"
 TEAMD_JSON_DEVICE = "device"
 TEAMD_JSON_PORTS = "ports"
 

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+class NmstatePlugin:
+    OVS_CAPABILITY = "openvswitch"
+    TEAM_CAPABILITY = "team"

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -27,8 +27,8 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.error import NmstateDependencyError
 
-from . import nm
 from . import schema
+from .plugin import NmstatePlugin
 
 MAX_SUPPORTED_INTERFACES = 1000
 
@@ -48,13 +48,13 @@ def validate_capabilities(state, capabilities):
 
 def validate_interface_capabilities(ifaces_state, capabilities):
     ifaces_types = [iface_state.get("type") for iface_state in ifaces_state]
-    has_ovs_capability = nm.ovs.CAPABILITY in capabilities
-    has_team_capability = nm.team.CAPABILITY in capabilities
+    has_ovs_capability = NmstatePlugin.OVS_CAPABILITY in capabilities
+    has_team_capability = NmstatePlugin.TEAM_CAPABILITY in capabilities
     for iface_type in ifaces_types:
         is_ovs_type = iface_type in (
-            nm.ovs.BRIDGE_TYPE,
-            nm.ovs.PORT_TYPE,
-            nm.ovs.INTERNAL_INTERFACE_TYPE,
+            InterfaceType.OVS_BRIDGE,
+            InterfaceType.OVS_INTERFACE,
+            InterfaceType.OVS_PORT,
         )
         if is_ovs_type and not has_ovs_capability:
             if not is_ovs_running():

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -24,6 +24,7 @@ import pytest
 from libnmstate import nm
 from libnmstate.nm.common import NM
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge as OB
 
 from .testlib import main_context
@@ -256,7 +257,7 @@ def _create_bridge_iface(ctx, iface_bridge_settings):
 def _create_iface_settings(iface_con_profile, port_master_name):
     iface_con_setting = nm.connection.ConnectionSetting()
     iface_con_setting.import_by_profile(iface_con_profile)
-    iface_con_setting.set_master(port_master_name, nm.ovs.PORT_TYPE)
+    iface_con_setting.set_master(port_master_name, InterfaceType.OVS_PORT)
     return (iface_con_setting.setting,)
 
 
@@ -265,9 +266,9 @@ def _create_port_setting(port_state, port_profile_name):
     iface_con_setting.create(
         con_name=port_profile_name,
         iface_name=port_profile_name,
-        iface_type=nm.ovs.PORT_TYPE,
+        iface_type=InterfaceType.OVS_PORT,
     )
-    iface_con_setting.set_master(BRIDGE0, nm.ovs.BRIDGE_TYPE)
+    iface_con_setting.set_master(BRIDGE0, InterfaceType.OVS_BRIDGE)
     bridge_port_setting = nm.ovs.create_port_setting(port_state)
     return iface_con_setting.setting, bridge_port_setting
 
@@ -277,9 +278,9 @@ def _create_internal_iface_setting(iface_name, master_name):
     iface_con_setting.create(
         con_name=iface_name,
         iface_name=iface_name,
-        iface_type=nm.ovs.INTERNAL_INTERFACE_TYPE,
+        iface_type=InterfaceType.OVS_INTERFACE,
     )
-    iface_con_setting.set_master(master_name, nm.ovs.PORT_TYPE)
+    iface_con_setting.set_master(master_name, InterfaceType.OVS_PORT)
     bridge_internal_iface_setting = nm.ovs.create_interface_setting()
     ipv4_setting = nm.ipv4.create_setting({}, None)
     ipv6_setting = nm.ipv6.create_setting({}, None)


### PR DESCRIPTION
The nmstate top level codes should only use NetworkManagerPlugin.

This patch remove the use of `nm` internal variables in `validator.py`:

 * Replace `nm.ovs.BRIDGE_TYPE` with `InterfaceType.OVS_BRIDGE`
 * Replace `nm.ovs.PORT_TYPE` with `InterfaceType.OVS_PORT`
 * Replace `nm.ovs.INTERNAL_INTERFACE_TYPE` with
      `InterfaceType.OVS_INTERFACE`
 * Replace `nm.ovs.CAPABILITY` with `NmstatePlugin.OVS_CAPABILITY`
 * Replace `nm.team.CAPABILITY` with `NmstatePlugin.TEAM_CAPABILITY`

The newly added file `libnmstate/plugin.py` will hold the data only
used by nmstate plugin.
