### PR TITLE
nm.active_connection: fix incorrect use of GLib.Error

### DIFF
--- a/tests/lib/nm/active_connection_test.py
+++ b/tests/lib/nm/active_connection_test.py
@@ -18,11 +18,10 @@
 #
 
 from libnmstate.nm.common import NM
-from libnmstate.nm.active_connection import NM_MANAGER_ERROR_DOMAIN
 from libnmstate.nm.common import GLib
 
 
 def test_nm_manager_error_domain_str():
-    assert NM_MANAGER_ERROR_DOMAIN == GLib.quark_to_string(
+    assert "nm-manager-error-quark" == GLib.quark_to_string(
         NM.ManagerError.quark()
     )


### PR DESCRIPTION
The exception raise by libnm on activation is GLib.Error and
its code is NM.ManagerError as its error domain `nm-manager-error`.

Use `GLib.Error.matches()` to check on error types.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>