### PR TITLE
nm.applier: set the profile name as the interface name

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -384,14 +384,13 @@ def _build_connection_profile(
     ]
 
     con_setting = connection.ConnectionSetting()
+    iface_name = iface_desired_state[Interface.NAME]
     if base_profile:
         con_setting.import_by_profile(base_con_profile)
+        con_setting.set_profile_name(iface_name)
     else:
-        iface_name = iface_desired_state[Interface.NAME]
         con_setting.create(
-            con_name=iface_desired_state[Interface.NAME],
-            iface_name=iface_name,
-            iface_type=iface_type,
+            con_name=iface_name, iface_name=iface_name, iface_type=iface_type,
         )
     master = iface_desired_state.get(MASTER_METADATA)
     _translate_master_type(iface_desired_state)

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -488,6 +488,9 @@ class ConnectionSetting:
             self._setting.props.master = master
             self._setting.props.slave_type = slave_type
 
+    def set_profile_name(self, con_name):
+        self._setting.props.id = con_name
+
     @property
     def setting(self):
         return self._setting


### PR DESCRIPTION
We are renaming the profile names to our standard which is the interface
name. If an interface has an existing profile with a non-standard
profile name, when importing the profile we should not import the
profile name because it is causing the following error:

```
2020-05-25 06:55:34,581 root         DEBUG    Async action: Create checkpoint started
2020-05-25 06:55:34,587 root         DEBUG    Checkpoint None created for all devices
2020-05-25 06:55:34,587 root         DEBUG    Async action: Create checkpoint finished
2020-05-25 06:55:34,590 root         DEBUG    Async action: Update profile: testeth0 started
2020-05-25 06:55:34,604 root         DEBUG    Async action: Update profile: testeth0 finished
2020-05-25 06:55:34,604 root         DEBUG    Async action: Reapply device config: eth0 started
2020-05-25 06:55:34,607 root         DEBUG    Device reapply failed on eth0:
error=nm-device-error-quark: Can't reapply changes to '802-3-ethernet.cloned-mac-address' setting (3)
Fallback to device activation
2020-05-25 06:55:34,609 root         DEBUG    Async action: Activate profile: eth0 started
2020-05-25 06:55:34,629 root         DEBUG    Connection activation initiated:
dev=None, con-state=<enum NM_ACTIVE_CONNECTION_STATE_ACTIVATING of type NM.ActiveConnectionState>
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/libnmstate/nm/connection.py", line 218, in _active_connection_callback
    self._nm_dev = self._ctx.get_nm_dev(devname)
  File "/usr/lib/python3.6/site-packages/libnmstate/nm/context.py", line 220, in get_nm_dev
    return self.client.get_device_by_iface(iface_name)
TypeError: Argument 1 does not allow None as a value
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>