### PR TITLE
test, integ: clean auto_routes and auto_dns only in the needed tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,8 +25,6 @@ import pytest
 
 import libnmstate
 from libnmstate.schema import DNS
-from libnmstate.schema import Interface
-from libnmstate.schema import InterfaceIP
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
@@ -86,14 +84,6 @@ def _empty_net_state():
         Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}]
     }
     desired_state[RouteRule.KEY] = {RouteRule.CONFIG: []}
-
-    for iface_state in desired_state[Interface.KEY]:
-        if iface_state[Interface.IPV4][InterfaceIP.ENABLED]:
-            iface_state[Interface.IPV4][InterfaceIP.AUTO_DNS] = False
-            iface_state[Interface.IPV4][InterfaceIP.AUTO_ROUTES] = False
-        if iface_state[Interface.IPV6][InterfaceIP.ENABLED]:
-            iface_state[Interface.IPV6][InterfaceIP.AUTO_DNS] = False
-            iface_state[Interface.IPV6][InterfaceIP.AUTO_ROUTES] = False
 
     libnmstate.apply(desired_state)
 


### PR DESCRIPTION
In some platforms it is not possible to lose the connectivity during a
long time. In order to fix this, we are only cleaning auto_dns and
auto_routes in the tests when necessary.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>