### PR TITLE
nm.applier: team interfaces must be considered as master

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -26,6 +26,7 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge as LB
 from libnmstate.schema import OVSBridge as OvsB
+from libnmstate.schema import Team
 from libnmstate.appliers.bond import is_bond_mode_changed
 
 from . import bond
@@ -49,7 +50,7 @@ MAXIMUM_INTERFACE_LENGTH = 15
 
 MASTER_METADATA = "_master"
 MASTER_TYPE_METADATA = "_master_type"
-MASTER_IFACE_TYPES = ovs.BRIDGE_TYPE, bond.BOND_TYPE, LB.TYPE
+MASTER_IFACE_TYPES = ovs.BRIDGE_TYPE, bond.BOND_TYPE, LB.TYPE, Team.TYPE
 
 BRPORT_OPTIONS_METADATA = "_brport_options"
 


### PR DESCRIPTION
The team interface is a master interface so it must be activated in the
proper order. If not, nmstate could raise the following error:

```
libnmstate.error.NmstateLibnmError: Activate profile: eth1 failed:
reason=<enum NM_ACTIVE_CONNECTION_STATE_REASON_DEVICE_DISCONNECTED of type NM.ActiveConnectionStateReason>
<enum NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED of type NM.DeviceStateReason>
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>