### PR TITLE
nm/connection: Use uuid of profile as action ID for profile deletion

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -105,7 +105,10 @@ class ConnectionProfile:
             if not self.profile:
                 self.import_by_device()
         if self.profile:
-            action = f"Delete profile: {self.profile.get_id()}"
+            action = (
+                f"Delete profile: id:{self.profile.get_id()}, "
+                f"uuid:{self.profile.get_uuid()}"
+            )
             user_data = action
             self._ctx.register_async(action, fast=True)
             self.profile.delete_async(

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -95,6 +95,7 @@ def _delete_vlan(ctx, devname):
     nmdev = ctx.get_nm_dev(devname)
     with main_context(ctx):
         nm.device.deactivate(ctx, nmdev)
+        ctx.wait_all_finish()
         nm.device.delete(ctx, nmdev)
 
 


### PR DESCRIPTION
The `nm.device.delete()` will delete all profiles found for certain
NM.Device. The async action ID is using device name for all of them.
When multiple profiles found, the async action ID will conflict with
existing one, then raise exception:

    raise NmstateInternalError(
        f"BUG: An existing actions {action} is already registered"
    )

Changed to use both interface name and UUID of profile will fix this issue.