### PR TITLE
linux bridge: Add linux bridge options required by oVirt

### DIFF
--- a/libnmstate/ifaces/bridge.py
+++ b/libnmstate/ifaces/bridge.py
@@ -22,9 +22,15 @@
 from operator import itemgetter
 
 from libnmstate.schema import Bridge
+from libnmstate.schema import LinuxBridge
 
 from ..state import merge_dict
 from .base_iface import BaseIface
+
+READ_ONLY_OPTIONS = [
+    LinuxBridge.Options.HELLO_TIMER,
+    LinuxBridge.Options.GC_TIMER,
+]
 
 
 class BridgeIface(BaseIface):
@@ -93,6 +99,7 @@ class BridgeIface(BaseIface):
 
     def state_for_verify(self):
         self._normalize_linux_bridge_port_vlan()
+        self._remove_read_only_bridge_options()
         state = super().state_for_verify()
         return state
 
@@ -113,6 +120,12 @@ class BridgeIface(BaseIface):
         for port_config in self.port_configs:
             if not port_config.get(Bridge.Port.VLAN_SUBTREE):
                 port_config[Bridge.Port.VLAN_SUBTREE] = {}
+
+    def _remove_read_only_bridge_options(self):
+        for key in READ_ONLY_OPTIONS:
+            self._bridge_config.get(LinuxBridge.OPTIONS_SUBTREE, {}).pop(
+                key, None
+            )
 
 
 def _index_port_configs(port_configs):

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -493,7 +493,9 @@ def _build_connection_profile(
 
         if bridge_options or bridge_ports:
             linux_bridge_setting = bridge.create_setting(
-                iface_desired_state, base_profile
+                iface_desired_state,
+                base_profile,
+                original_desired_iface_state,
             )
             settings.append(linux_bridge_setting)
     elif iface_type == InterfaceType.OVS_BRIDGE:

--- a/libnmstate/nm/common.py
+++ b/libnmstate/nm/common.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from distutils.version import StrictVersion
+
 import gi
 
 try:
@@ -28,6 +30,12 @@ except ValueError:
 from gi.repository import GLib
 from gi.repository import GObject
 from gi.repository import Gio
+
+
+def nm_version_bigger_or_equal_to(version):
+    return StrictVersion(
+        f"{NM.MAJOR_VERSION}.{NM.MINOR_VERSION}.{NM.MICRO_VERSION}"
+    ) >= StrictVersion(version)
 
 
 # To suppress the "import not used" error

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -192,11 +192,32 @@ class Bridge:
 class LinuxBridge(Bridge):
     TYPE = "linux-bridge"
     STP_SUBTREE = "stp"
+    MULTICAST_SUBTREE = "multicast"
 
     class Options:
         GROUP_FORWARD_MASK = "group-forward-mask"
         MAC_AGEING_TIME = "mac-ageing-time"
         MULTICAST_SNOOPING = "multicast-snooping"
+        GROUP_ADDR = "group-addr"
+        GROUP_FWD_MASK = "group-fwd-mask"
+        HASH_ELASTICITY = "hash-elasticity"
+        HASH_MAX = "hash-max"
+        MULTICAST_ROUTER = "multicast-router"
+        MULTICAST_LAST_MEMBER_COUNT = "multicast-last-member-count"
+        MULTICAST_LAST_MEMBER_INTERVAL = "multicast-last-member-interval"
+        MULTICAST_MEMBERSHIP_INTERVAL = "multicast-membership-interval"
+        MULTICAST_QUERIER = "multicast-querier"
+        MULTICAST_QUERIER_INTERVAL = "multicast-querier-interval"
+        MULTICAST_QUERY_USE_IFADDR = "multicast-query-use-ifaddr"
+        MULTICAST_QUERY_INTERVAL = "multicast-query-interval"
+        MULTICAST_QUERY_RESPONSE_INTERVAL = "multicast-query-response-interval"
+        MULTICAST_STARTUP_QUERY_COUNT = "multicast-startup-query-count"
+        MULTICAST_STARTUP_QUERY_INTERVAL = "multicast-startup-query-interval"
+
+        # Read only properties begin
+        HELLO_TIMER = "hello-timer"
+        GC_TIMER = "gc-timer"
+        # Read only properties end
 
     class Port(Bridge.Port):
         STP_HAIRPIN_MODE = "stp-hairpin-mode"

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -21,7 +21,7 @@ properties:
             - "$ref": "#/definitions/interface-unknown/rw"
             - "$ref": "#/definitions/interface-ethernet/rw"
             - "$ref": "#/definitions/interface-bond/rw"
-            - "$ref": "#/definitions/interface-linux-bridge/rw"
+            - "$ref": "#/definitions/interface-linux-bridge/all"
             - "$ref": "#/definitions/interface-ovs-bridge/all"
             - "$ref": "#/definitions/interface-ovs-interface/rw"
             - "$ref": "#/definitions/interface-dummy/rw"
@@ -261,6 +261,22 @@ definitions:
             options:
               type: object
   interface-linux-bridge:
+    all:
+      allOf:
+        - $ref: "#/definitions/interface-linux-bridge/rw"
+        - $ref: "#/definitions/interface-linux-bridge/ro"
+    ro:
+      properties:
+        bridge:
+          type: object
+          properties:
+            options:
+              type: object
+              properties:
+                gc-timer:
+                  type: integer
+                hello-timer:
+                  type: integer
     rw:
       properties:
         type:
@@ -306,8 +322,36 @@ definitions:
                   type: integer
                 group-forward-mask:
                   type: integer
+                group-addr:
+                  $ref: "#/definitions/types/mac-address"
+                hash-max:
+                  type: integer
                 multicast-snooping:
                   type: boolean
+                multicast-router:
+                  type: integer
+                multicast-last-member-count:
+                  type: integer
+                multicast-last-member-interval:
+                  type: integer
+                multicast-membership-interval:
+                  type: integer
+                multicast-querier:
+                  type: boolean
+                multicast-querier-interval:
+                  type: integer
+                multicast-query-use-ifaddr:
+                  type: boolean
+                multicast-query-interval:
+                  type: integer
+                multicast-query-response-interval:
+                  type: integer
+                multicast-router:
+                  type: integer
+                multicast-startup-query-count:
+                  type: integer
+                multicast-startup-query-interval:
+                  type: integer
                 stp:
                   type: object
                   properties:

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -17,8 +17,20 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from distutils.version import StrictVersion
 import os
+import re
+
+from .cmdlib import exec_cmd
 
 
 def is_fedora():
     return os.path.exists("/etc/fedora-release")
+
+
+def is_nm_older_than_1_25_2():
+    _, output, _ = exec_cmd(["nmcli", "-v"], check=True)
+    match = re.compile("version ([0-9.]+)").search(output)
+    assert match
+
+    return StrictVersion(match.group(1)) < StrictVersion("1.25.2")


### PR DESCRIPTION
Adding linux bridge options required by oVirt:

https://www.ovirt.org/documentation/admin-guide/appe-Custom_Network_Properties.html

New read only bridge options:
 * `LinuxBridge.Options.HELLO_TIMER`
 * `LinuxBridge.Options.GC_TIMER`

New read-writable bridge options:
 * `LinuxBridge.Options.GROUP_ADDR`
 * `LinuxBridge.Options.HASH_MAX`
 * `LinuxBridge.Options.MULTICAST_LAST_MEMBER_COUNT`
 * `LinuxBridge.Options.MULTICAST_LAST_MEMBER_INTERVAL`
 * `LinuxBridge.Options.MULTICAST_MEMBERSHIP_INTERVAL`
 * `LinuxBridge.Options.MULTICAST_QUERIER`
 * `LinuxBridge.Options.MULTICAST_QUERIER_INTERVAL`
 * `LinuxBridge.Options.MULTICAST_QUERY_USE_IFADDR`
 * `LinuxBridge.Options.MULTICAST_QUERY_INTERVAL`
 * `LinuxBridge.Options.MULTICAST_QUERY_RESPONSE_INTERVAL`
 * `LinuxBridge.Options.MULTICAST_STARTUP_QUERY_COUNT`
 * `LinuxBridge.Options.MULTICAST_STARTUP_QUERY_INTERVAL`

In order to allowing adding slave to bridge without bridge link change,
`nm/bridge.py` now only update bridge options to disk defined in desire
state.

NetworkManager does not support querying run time bridge options, hence
use sysfs folder to query all above bridge options.


Due to bug of NetworkManager, nm plugin does not support editing
`LB.Options.MULTICAST_ROUTER` yet:
https://bugzilla.redhat.com/show_bug.cgi?id=1845608

Test cases added.