### PR TITLE
test lldp: Allowing running test from any folder

### DIFF
--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from contextlib import contextmanager
+import os
 import time
 import yaml
 
@@ -299,11 +300,12 @@ def lldp_enabled(ifstate):
 
 
 def _send_lldp_packet():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
     cmdlib.exec_cmd(
         (
             "tcpreplay",
             "--intf1=eth1peer",
-            "tests/integration/test_captures/lldp.pcap",
+            f"{test_dir}/test_captures/lldp.pcap",
         ),
         check=True,
     )


### PR DESCRIPTION
Got failure when running pytest in 'tests/integration' folder stating
`tests/integration/test_captures/lldp.pcap` not found.

Use absolute path for the LLDP capture file will fix this problem.