### PR TITLE
vlan/vxlan: Check VLAN base interface MTU

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -303,6 +303,10 @@ class BaseIface:
     def mtu(self):
         return self._info.get(Interface.MTU)
 
+    @mtu.setter
+    def mtu(self, value):
+        self._info[Interface.MTU] = value
+
     def _capitalize_mac(self):
         if self.mac:
             self._info[Interface.MAC] = self.mac.upper()

--- a/tests/lib/ifaces/vxlan_iface_test.py
+++ b/tests/lib/ifaces/vxlan_iface_test.py
@@ -21,8 +21,10 @@ import pytest
 
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import VXLAN
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
+from libnmstate.ifaces.ifaces import Ifaces
 from libnmstate.ifaces.vxlan import VxlanIface
 
 from ..testlib.constants import IPV4_ADDRESS1
@@ -63,3 +65,29 @@ class TestVxlanIface:
         iface = VxlanIface(iface_info)
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
+
+    def test_validate_vxlan_mtu_bigger_than_parent(self):
+        vxlan_iface_info = self._gen_iface_info()
+        base_iface_info = gen_foo_iface_info()
+        base_iface_info[Interface.NAME] = BASE_IFACE_NAME
+        base_iface_info[Interface.MTU] = 1500
+        vxlan_iface_info[Interface.MTU] = 1501
+        with pytest.raises(NmstateValueError):
+            Ifaces(
+                des_iface_infos=[base_iface_info, vxlan_iface_info],
+                cur_iface_infos=[],
+            )
+
+    def test_validate_vxlan_mtu_when_parent_mtu_not_defined(self):
+        vxlan_iface_info = self._gen_iface_info()
+        base_iface_info = gen_foo_iface_info()
+        base_iface_info[Interface.NAME] = BASE_IFACE_NAME
+        vxlan_iface_info[Interface.MTU] = 1501
+
+        ifaces = Ifaces(
+            des_iface_infos=[base_iface_info, vxlan_iface_info],
+            cur_iface_infos=[],
+        )
+        new_base_iface = ifaces[BASE_IFACE_NAME]
+
+        assert new_base_iface.mtu == 1501


### PR DESCRIPTION
Raises NmstateValueError when VLAN/VxLAN interface's MTU is bigger than
base interface.

If base interface has no MTU defined, use VLAN/VxLAN interface's.

Unit test cases added.