### PR TITLE
test: Register pytest marker

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,10 @@ nmstate: {nmstate_version}
 """
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow tier1 tier2")
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"


### PR DESCRIPTION
The pytest-4.6.9 will complain unregister markers:

```
  /usr/lib/python3.7/site-packages/_pytest/mark/structures.py:335:
  PytestUnknownMarkWarning: Unknown pytest.mark.tier1 - is this a typo?
  You can register custom marks to avoid this warning - for details, see
  https://docs.pytest.org/en/latest/mark.html
```

To suppress that warning message, use `pytest_configure()` to register
the markers.