### PR TITLE
nm.ipv4, nm.ipv6: add auto-route-table-id support for IPv4 and IPv6

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -66,6 +66,10 @@ def create_setting(config, base_con_profile):
             setting_ipv4.props.ignore_auto_dns = not config.get(
                 InterfaceIPv4.AUTO_DNS, True
             )
+            setting_ipv4.props.route_table = config.get(
+                InterfaceIPv4.AUTO_ROUTE_TABLE_ID,
+                Route.USE_DEFAULT_ROUTE_TABLE,
+            )
             # NetworkManager will remove the virtual interfaces like bridges
             # when the DHCP timeout expired, set it to the maximum value to
             # make this unlikely.
@@ -118,6 +122,7 @@ def get_info(active_connection):
             info[InterfaceIPv4.AUTO_DNS] = not props.ignore_auto_dns
             info[InterfaceIPv4.ENABLED] = True
             info[InterfaceIPv4.ADDRESS] = []
+            info[InterfaceIPv4.AUTO_ROUTE_TABLE_ID] = props.route_table
     else:
         info[InterfaceIPv4.DHCP] = False
 

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -62,6 +62,7 @@ def get_info(active_connection):
             info[InterfaceIPv6.AUTO_ROUTES] = not props.ignore_auto_routes
             info[InterfaceIPv6.AUTO_GATEWAY] = not props.never_default
             info[InterfaceIPv6.AUTO_DNS] = not props.ignore_auto_dns
+            info[InterfaceIPv6.AUTO_ROUTE_TABLE_ID] = props.route_table
 
     ipconfig = active_connection.get_ip6_config()
     if ipconfig is None:
@@ -144,6 +145,10 @@ def create_setting(config, base_con_profile):
         setting_ip.props.ignore_auto_dns = not config.get(
             InterfaceIPv6.AUTO_DNS, True
         )
+        route_table = config.get(InterfaceIPv6.AUTO_ROUTE_TABLE_ID)
+        if route_table:
+            setting_ip.props.route_table = route_table
+
     elif ip_addresses:
         _set_static(setting_ip, ip_addresses)
     else:

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -133,6 +133,7 @@ class InterfaceIP:
     AUTO_DNS = "auto-dns"
     AUTO_GATEWAY = "auto-gateway"
     AUTO_ROUTES = "auto-routes"
+    AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -482,6 +482,8 @@ definitions:
               type: boolean
             auto-dns:
               type: boolean
+            auto-route-table-id:
+              type: integer
             address:
               type: array
               items:
@@ -519,6 +521,8 @@ definitions:
               type: boolean
             auto-dns:
               type: boolean
+            auto-route-table-id:
+              type: integer
             address:
               type: array
               items:

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -86,6 +86,7 @@ def test_enable_dhcp_with_no_server(eth1_up, nm_plugin):
         InterfaceIPv4.AUTO_DNS: True,
         InterfaceIPv4.AUTO_GATEWAY: True,
         InterfaceIPv4.AUTO_ROUTES: True,
+        InterfaceIPv4.AUTO_ROUTE_TABLE_ID: 0,
     }
     assert retry_till_true_or_timeout(
         RETRY_TIMEOUT, _ip_state_is_expected, nm_plugin, expected_ipv4_state


### PR DESCRIPTION
This patch is adding support for `table_id` on IPv4 and IPv6. `table_id`
is setting `NM.SettingIPConfig.route-table` which decides in which table
the route will be configured.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>