### PR TITLE
nm ip: Use running config for DHCP status

### DIFF
--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -99,7 +99,7 @@ def _add_addresses(setting_ipv4, addresses):
         setting_ipv4.add_address(naddr)
 
 
-def get_info(active_connection):
+def get_info(active_connection, applied_config):
     """
     Provides the current active values for an active connection.
     It includes not only the configured values, but the consequences of the
@@ -110,7 +110,9 @@ def get_info(active_connection):
     if active_connection is None:
         return info
 
-    ip_profile = get_ip_profile(active_connection)
+    ip_profile = (
+        applied_config.get_setting_ip4_config() if applied_config else None
+    )
     if ip_profile:
         info[InterfaceIPv4.DHCP] = ip_profile.get_method() == (
             NM.SETTING_IP4_CONFIG_METHOD_AUTO

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -34,7 +34,7 @@ IPV6_DEFAULT_ROUTE_METRIC = 1024
 INT32_MAX = 2 ** 31 - 1
 
 
-def get_info(active_connection):
+def get_info(active_connection, applied_config):
     info = {InterfaceIPv6.ENABLED: False}
     if active_connection is None:
         return info
@@ -43,7 +43,9 @@ def get_info(active_connection):
     info[InterfaceIPv6.AUTOCONF] = False
 
     is_link_local_method = False
-    ip_profile = get_ip_profile(active_connection)
+    ip_profile = (
+        applied_config.get_setting_ip6_config() if applied_config else None
+    )
     if ip_profile:
         method = ip_profile.get_method()
         if method == NM.SETTING_IP6_CONFIG_METHOD_AUTO:

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -48,6 +48,7 @@ from .checkpoint import CheckPoint
 from .checkpoint import get_checkpoints
 from .common import NM
 from .context import NmContext
+from .profile import get_all_applied_configs
 
 
 class NetworkManagerPlugin(NmstatePlugin):
@@ -99,6 +100,8 @@ class NetworkManagerPlugin(NmstatePlugin):
         info = []
         capabilities = self.capabilities
 
+        applied_configs = get_all_applied_configs(self.context)
+
         devices_info = [
             (dev, nm_device.get_device_common_info(dev))
             for dev in nm_device.list_devices(self.client)
@@ -108,10 +111,15 @@ class NetworkManagerPlugin(NmstatePlugin):
             type_id = devinfo["type_id"]
 
             iface_info = nm_translator.Nm2Api.get_common_device_info(devinfo)
+            applied_config = applied_configs.get(iface_info[Interface.NAME])
 
             act_con = nm_connection.get_device_active_connection(dev)
-            iface_info[Interface.IPV4] = nm_ipv4.get_info(act_con)
-            iface_info[Interface.IPV6] = nm_ipv6.get_info(act_con)
+            iface_info[Interface.IPV4] = nm_ipv4.get_info(
+                act_con, applied_config
+            )
+            iface_info[Interface.IPV6] = nm_ipv6.get_info(
+                act_con, applied_config
+            )
             iface_info.update(nm_wired.get_info(dev))
             iface_info.update(nm_user.get_info(self.context, dev))
             iface_info.update(nm_lldp.get_info(self.client, dev))

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+# This file is targeting:
+#   * NM.RemoteConnection, NM.SimpleConnection releated
+
+import logging
+
+from .common import NM
+from .device import list_devices
+
+
+def get_all_applied_configs(context):
+    applied_configs = {}
+    for nm_dev in list_devices(context.client):
+        if nm_dev.get_state() in (
+            NM.DeviceState.ACTIVATED,
+            NM.DeviceState.IP_CONFIG,
+        ):
+            iface_name = nm_dev.get_iface()
+            if iface_name:
+                action = f"Retrieve applied config: {iface_name}"
+                context.register_async(action, fast=True)
+                nm_dev.get_applied_connection_async(
+                    flags=0,
+                    cancellable=context.cancellable,
+                    callback=_get_applied_config_callback,
+                    user_data=(iface_name, action, applied_configs, context),
+                )
+    context.wait_all_finish()
+    return applied_configs
+
+
+def _get_applied_config_callback(nm_dev, result, user_data):
+    iface_name, action, applied_configs, context = user_data
+    context.finish_async(action)
+    try:
+        remote_conn, _ = nm_dev.get_applied_connection_finish(result)
+        applied_configs[nm_dev.get_iface()] = remote_conn
+    except Exception as e:
+        logging.warning(
+            "Failed to retrieve applied config for device "
+            f"{iface_name}: {e}"
+        )

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -109,7 +109,7 @@ def test_create_setting_with_static_addresses(NM_mock):
 
 
 def test_get_info_with_no_connection():
-    info = nm.ipv4.get_info(active_connection=None)
+    info = nm.ipv4.get_info(active_connection=None, applied_config=None)
 
     assert info == {InterfaceIPv4.ENABLED: False}
 
@@ -119,7 +119,7 @@ def test_get_info_with_no_ipv4_config():
     con_mock.get_ip4_config.return_value = None
     con_mock.get_connection.return_value = None
 
-    info = nm.ipv4.get_info(active_connection=con_mock)
+    info = nm.ipv4.get_info(active_connection=con_mock, applied_config=None)
 
     assert info == {InterfaceIPv4.ENABLED: False}
 
@@ -140,7 +140,9 @@ def test_get_info_with_ipv4_config(NM_mock):
     set_ip_conf.props.ignore_auto_dns = False
     set_ip_conf.props.ignore_auto_routes = False
 
-    info = nm.ipv4.get_info(active_connection=act_con_mock)
+    info = nm.ipv4.get_info(
+        active_connection=act_con_mock, applied_config=None
+    )
 
     assert info == {
         InterfaceIPv4.ENABLED: True,

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -121,7 +121,7 @@ def test_create_setting_with_static_addresses(NM_mock):
 
 
 def test_get_info_with_no_connection():
-    info = nm.ipv6.get_info(active_connection=None)
+    info = nm.ipv6.get_info(active_connection=None, applied_config=None)
 
     assert info == {InterfaceIPv6.ENABLED: False}
 
@@ -131,7 +131,7 @@ def test_get_info_with_no_ipv6_config():
     con_mock.get_ip6_config.return_value = None
     con_mock.get_connection.return_value = None
 
-    info = nm.ipv6.get_info(active_connection=con_mock)
+    info = nm.ipv6.get_info(active_connection=con_mock, applied_config=None)
 
     assert info == {InterfaceIPv6.ENABLED: False}
 
@@ -152,7 +152,9 @@ def test_get_info_with_ipv6_config(NM_mock):
     set_ip_conf.props.ignore_auto_dns = False
     set_ip_conf.props.ignore_auto_routes = False
 
-    info = nm.ipv6.get_info(active_connection=act_con_mock)
+    info = nm.ipv6.get_info(
+        active_connection=act_con_mock, applied_config=None
+    )
 
     assert info == {
         InterfaceIPv6.ENABLED: True,


### PR DESCRIPTION
Previously we are using start up config(config saved to disk) for DHCP
status, this patch we changed to use running/effective config.

The applied profile are retrieved from
`NM.Device.get_applied_connection_async()` asynchronously.

The new file `libnmstate/nm/profile.py` will provides
`get_all_applied_configs()` in the sync/blocked way.

The running config are refreshed on every `get_interfaces()` call.

Integration test case added.
