### PR TITLE
[nmstate-0.3] ip: canonicalize IP address

### DIFF
--- a/libnmstate/iplib.py
+++ b/libnmstate/iplib.py
@@ -52,3 +52,17 @@ def ip_address_full_to_tuple(addr):
         raise NmstateValueError(f"Invalid IP address, error: {err}")
 
     return f"{net.network_address}", net.prefixlen
+
+
+def canonicalize_ip_network(address):
+    try:
+        return ipaddress.ip_network(address, strict=False).with_prefixlen
+    except ValueError as e:
+        raise NmstateValueError(f"Invalid IP network address: {e}")
+
+
+def canonicalize_ip_address(address):
+    try:
+        return ipaddress.ip_address(address).compressed
+    except ValueError as e:
+        raise NmstateValueError(f"Invalid IP address: {e}")

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -22,6 +22,8 @@ from collections import defaultdict
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.iplib import is_ipv6_address
+from libnmstate.iplib import canonicalize_ip_network
+from libnmstate.iplib import canonicalize_ip_address
 from libnmstate.prettystate import format_desired_current_state_diff
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
@@ -44,6 +46,7 @@ class RouteEntry(StateEntry):
         # TODO: Convert IPv6 full address to abbreviated address
         self.complement_defaults()
         self._invalid_reason = None
+        self._canonicalize_ip_address()
 
     @property
     def is_ipv6(self):
@@ -147,6 +150,15 @@ class RouteEntry(StateEntry):
                 )
                 return False
         return True
+
+    def _canonicalize_ip_address(self):
+        if not self.absent:
+            if self.destination:
+                self.destination = canonicalize_ip_network(self.destination)
+            if self.next_hop_address:
+                self.next_hop_address = canonicalize_ip_address(
+                    self.next_hop_address
+                )
 
 
 class RouteState:

--- a/libnmstate/route_rule.py
+++ b/libnmstate/route_rule.py
@@ -6,7 +6,7 @@ from libnmstate.error import NmstateVerificationError
 from libnmstate.error import NmstateValueError
 from libnmstate.iplib import KERNEL_MAIN_ROUTE_TABLE_ID
 from libnmstate.iplib import is_ipv6_address
-from libnmstate.iplib import to_ip_address_full
+from libnmstate.iplib import canonicalize_ip_network
 from libnmstate.prettystate import format_desired_current_state_diff
 from libnmstate.schema import Interface
 from libnmstate.schema import RouteRule
@@ -23,7 +23,7 @@ class RouteRuleEntry(StateEntry):
         self.priority = route_rule.get(RouteRule.PRIORITY)
         self.route_table = route_rule.get(RouteRule.ROUTE_TABLE)
         self._complement_defaults()
-        self._append_prefix_length_for_host_only_ip()
+        self._canonicalize_ip_network()
 
     def _complement_defaults(self):
         if self.ip_from is None:
@@ -38,11 +38,11 @@ class RouteRuleEntry(StateEntry):
         ):
             self.route_table = KERNEL_MAIN_ROUTE_TABLE_ID
 
-    def _append_prefix_length_for_host_only_ip(self):
-        if self.ip_from and "/" not in self.ip_from:
-            self.ip_from = to_ip_address_full(self.ip_from)
-        if self.ip_to and "/" not in self.ip_to:
-            self.ip_to = to_ip_address_full(self.ip_to)
+    def _canonicalize_ip_network(self):
+        if self.ip_from:
+            self.ip_from = canonicalize_ip_network(self.ip_from)
+        if self.ip_to:
+            self.ip_to = canonicalize_ip_network(self.ip_to)
 
     def _keys(self):
         return (self.ip_from, self.ip_to, self.priority, self.route_table)


### PR DESCRIPTION
Canonicalize these IP addresses:
    * `InterfaceIP.ADDRESS_IP`
    * `Route.DESTINATION`
    * `Route.NEXT_HOP_ADDRESS`
    * `RouteRule.IP_FROM`
    * `RouteRule.IP_TO`

Introduced two functions to `libnmstate/iplib.py`:
    * `canonicalize_ip_network()` returns address with prefix
    * `canonicalize_ip_address()` returns address without prefix

Unit test cases added.