### PR TITLE
base_iface: rename iface_type property to type

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -152,7 +152,7 @@ class BaseIface:
         return self._name
 
     @property
-    def iface_type(self):
+    def type(self):
         return self._info.get(Interface.TYPE, InterfaceType.UNKNOWN)
 
     @property
@@ -285,7 +285,7 @@ class BaseIface:
         if self.is_master and not self.is_absent:
             for slave_name in self.slaves:
                 slave_iface = ifaces[slave_name]
-                slave_iface.set_master(self.name, self.iface_type)
+                slave_iface.set_master(self.name, self.type)
 
     def update(self, info):
         self._info.update(info)

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -74,7 +74,7 @@ class Ifaces:
 
                 if iface_info.get(Interface.TYPE) is None:
                     if cur_iface:
-                        iface_info[Interface.TYPE] = cur_iface.iface_type
+                        iface_info[Interface.TYPE] = cur_iface.type
                     elif iface.is_up:
                         raise NmstateValueError(
                             f"Interface {iface.name} has no type defined "
@@ -82,7 +82,7 @@ class Ifaces:
                         )
                 iface = _to_specific_iface_obj(iface_info, save_to_disk)
                 if (
-                    iface.iface_type == InterfaceType.UNKNOWN
+                    iface.type == InterfaceType.UNKNOWN
                     # Allowing deletion of down profiles
                     and not iface.is_absent
                 ):
@@ -147,7 +147,7 @@ class Ifaces:
         When OVS patch peer does not exist or is down, raise an error.
         """
         for iface in self._ifaces.values():
-            if iface.iface_type == InterfaceType.OVS_INTERFACE and iface.is_up:
+            if iface.type == InterfaceType.OVS_INTERFACE and iface.is_up:
                 if iface.peer:
                     peer_iface = self._ifaces.get(iface.peer)
                     if not peer_iface or not peer_iface.is_up:
@@ -156,8 +156,7 @@ class Ifaces:
                             "be up"
                         )
                     elif (
-                        not peer_iface.iface_type
-                        == InterfaceType.OVS_INTERFACE
+                        not peer_iface.type == InterfaceType.OVS_INTERFACE
                         or not peer_iface.is_patch_port
                     ):
                         raise NmstateValueError(

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -84,7 +84,7 @@ class OvsBridgeIface(BridgeIface):
             slave_iface.update(
                 {BridgeIface.BRPORT_OPTIONS_METADATA: port_config}
             )
-            if slave_iface.iface_type == InterfaceType.OVS_INTERFACE:
+            if slave_iface.type == InterfaceType.OVS_INTERFACE:
                 slave_iface.parent = self.name
         super().gen_metadata(ifaces)
 
@@ -101,7 +101,7 @@ class OvsBridgeIface(BridgeIface):
             }
         )
         slave_iface.mark_as_changed()
-        slave_iface.set_master(self.name, self.iface_type)
+        slave_iface.set_master(self.name, self.type)
         slave_iface.parent = self.name
         return slave_iface
 

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -168,9 +168,9 @@ class NmstateOvsdbPlugin(NmstatePlugin):
                 continue
             if not iface.is_up:
                 continue
-            if iface.iface_type == OVSBridge.TYPE:
+            if iface.type == OVSBridge.TYPE:
                 table_name = "Bridge"
-            elif iface.iface_type == OVSInterface.TYPE:
+            elif iface.type == OVSInterface.TYPE:
                 table_name = "Interface"
             else:
                 continue

--- a/tests/lib/ifaces/ovs_iface_test.py
+++ b/tests/lib/ifaces/ovs_iface_test.py
@@ -183,7 +183,7 @@ class TestOvsBrigeIface:
         )
 
         ovs_iface = ifaces[OVS_IFACE_NAME]
-        assert ovs_iface.iface_type == InterfaceType.OVS_INTERFACE
+        assert ovs_iface.type == InterfaceType.OVS_INTERFACE
         assert ovs_iface.parent == OVS_BRIDGE_IFACE_NAME
         assert ovs_iface.is_virtual
         assert ovs_iface.master == OVS_BRIDGE_IFACE_NAME


### PR DESCRIPTION
In order to follow the property naming, it makes sense to rename
"iface_type" property to "type".

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>