### PR TITLE
[nmstate-0.3] tests: update outdated xfails

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -581,7 +581,7 @@ def test_slave_ipaddr_learned_via_dhcp_added_as_static_to_linux_bridge(
         assertlib.assert_state_match(state)
 
 
-@pytest.mark.xfail(raises=NmstateNotImplementedError)
+@pytest.mark.xfail(raises=NmstateNotImplementedError, strict=True)
 def test_ipv6_autoconf_only(dhcpcli_up):
     desired_state = dhcpcli_up
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]

--- a/tests/integration/iface_admin_state_test.py
+++ b/tests/integration/iface_admin_state_test.py
@@ -45,7 +45,9 @@ def test_set_a_down_iface_down(eth1_up):
     assertlib.assert_state(desired_state)
 
 
-@pytest.mark.xfail(reason="Some ifaces cannot be removed", strict=True)
+@pytest.mark.xfail(
+    raises=AssertionError, reason="Some ifaces cannot be removed", strict=True,
+)
 def test_removing_a_non_removable_iface(eth1_up):
     desired_state = {
         Interface.KEY: [

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -134,7 +134,9 @@ def test_add_route_without_table_id(eth1_up):
 
 
 @pytest.mark.xfail(
-    raises=NmstateNotImplementedError, reason="Red Hat Bug 1707396"
+    raises=NmstateNotImplementedError,
+    reason="https://bugzilla.redhat.com/1707396",
+    strict=True,
 )
 def test_multiple_gateway(eth1_up):
     libnmstate.apply(

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -95,9 +95,6 @@ def test_set_vxlan_iface_down(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
-@pytest.mark.xfail(
-    reason="https://bugzilla.redhat.com/show_bug.cgi?id=1772382", strict=False
-)
 def test_add_new_bond_iface_with_vxlan(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     bond_name = "bond1"

--- a/tests/lib/nm/route_test.py
+++ b/tests/lib/nm/route_test.py
@@ -212,7 +212,7 @@ def test_change_gateway(nm_ip, routes, gateways):
 @pytest.mark.xfail(
     raises=NmstateNotImplementedError,
     strict=True,
-    reason="Network Manager Bug: " "https://bugzilla.redhat.com/1707396",
+    reason="Network Manager Bug: https://bugzilla.redhat.com/1707396",
 )
 @parametrize_ip_ver_routes_gw
 def test_add_two_gateway(nm_ip, routes, gateways):
@@ -228,7 +228,7 @@ def test_add_two_gateway(nm_ip, routes, gateways):
 @pytest.mark.xfail(
     raises=NmstateNotImplementedError,
     strict=True,
-    reason="Network Manager Bug: " "https://bugzilla.redhat.com/1707396",
+    reason="Network Manager Bug: https://bugzilla.redhat.com/1707396",
 )
 @parametrize_ip_ver_routes_gw
 def test_add_duplicate_gateways(nm_ip, routes, gateways):


### PR DESCRIPTION
This patch is updating xfails, adding `strict=True` and wrong reasons.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>