### PR TITLE
ovs: Eliminate the repeat call of is_ovs_running()

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -97,6 +97,7 @@ class NetworkManagerPlugin(NmstatePlugin):
 
     def get_interfaces(self):
         info = []
+        capabilities = self.capabilities
 
         devices_info = [
             (dev, nm_device.get_device_common_info(dev))
@@ -122,7 +123,7 @@ class NetworkManagerPlugin(NmstatePlugin):
             if nm_bond.is_bond_type_id(type_id):
                 bondinfo = nm_bond.get_bond_info(dev)
                 iface_info.update(_ifaceinfo_bond(bondinfo))
-            elif NmstatePlugin.OVS_CAPABILITY in self.capabilities:
+            elif NmstatePlugin.OVS_CAPABILITY in capabilities:
                 if nm_ovs.is_ovs_bridge_type_id(type_id):
                     iface_info["bridge"] = nm_ovs.get_ovs_info(
                         self.context, dev, devices_info

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -47,9 +47,10 @@ def validate_capabilities(state, capabilities):
 
 
 def validate_interface_capabilities(ifaces_state, capabilities):
-    ifaces_types = [iface_state.get("type") for iface_state in ifaces_state]
+    ifaces_types = {iface_state.get("type") for iface_state in ifaces_state}
     has_ovs_capability = NmstatePlugin.OVS_CAPABILITY in capabilities
     has_team_capability = NmstatePlugin.TEAM_CAPABILITY in capabilities
+    ovs_is_running = is_ovs_running()
     for iface_type in ifaces_types:
         is_ovs_type = iface_type in (
             InterfaceType.OVS_BRIDGE,
@@ -57,7 +58,7 @@ def validate_interface_capabilities(ifaces_state, capabilities):
             InterfaceType.OVS_PORT,
         )
         if is_ovs_type and not has_ovs_capability:
-            if not is_ovs_running():
+            if not ovs_is_running:
                 raise NmstateDependencyError(
                     "openvswitch service is not started."
                 )


### PR DESCRIPTION
The `validate_interface_capabilities()` is invoking `is_ovs_running()`
on every interface. Fixed by using `set()` for interface types for
duplicate types and also caching ovs daemon status.

The `NetworkManagerPlugin.get_interfaces()` is invoking
`is_ovs_running()` on every interface. Fixed by caching ovs daemon
status.