### PR TITLE
[nmstate-0.3] ifaces: ignore unknown type ifaces from current and desired state

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import logging
+
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.prettystate import format_desired_current_state_diff
@@ -129,6 +131,7 @@ class Ifaces:
         self._mark_orphen_as_absent()
         self._bring_slave_up_if_not_in_desire()
         self._validate_ovs_patch_peers()
+        self._remove_unknown_type_interfaces()
 
     def _bring_slave_up_if_not_in_desire(self):
         """
@@ -348,6 +351,18 @@ class Ifaces:
                 raise NmstateValueError(
                     f"Interface {iface.name} has unknown parent: "
                     f"{iface.parent}"
+                )
+
+    def _remove_unknown_type_interfaces(self):
+        """
+        Remove unknown type interfaces that are set as up.
+        """
+        for iface in list(self._ifaces.values()):
+            if iface.type == InterfaceType.UNKNOWN and iface.is_up:
+                self._ifaces.pop(iface.name, None)
+                logging.debug(
+                    f"Interface {iface.name} is type {iface.type} and "
+                    "will be ignored during the activation"
                 )
 
     def _validate_over_booked_slaves(self):

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -143,6 +143,17 @@ class TestIfaces:
         with pytest.raises(NmstateValueError):
             Ifaces([des_iface_info1, des_iface_info2], cur_iface_infos)
 
+    def test_remove_unknown_interfaces(self):
+        des_iface_infos = self._gen_iface_infos()
+        cur_iface_info = {
+            Interface.NAME: FOO3_IFACE_NAME,
+            Interface.TYPE: InterfaceType.UNKNOWN,
+            Interface.STATE: InterfaceState.UP,
+        }
+
+        ifaces = Ifaces(des_iface_infos, [cur_iface_info])
+        assert cur_iface_info not in ifaces.values()
+
     def test_mark_slave_as_changed_if_master_marked_as_absent(self):
         cur_iface_infos = self._gen_iface_infos()
         cur_iface_infos[0][Interface.NAME] = SLAVE1_IFACE_NAME


### PR DESCRIPTION
 After merging the desired and current state Nmstate will
 ignore unknown type interfaces that are up.
    
 This issue was generating the following error:
    
```
    Traceback (most recent call last):
      File "/usr/local/bin/nmstatectl", line 11, in <module>
        load_entry_point('nmstate==0.4.0', 'console_scripts', 'nmstatectl')()
      File "/usr/local/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 67, in main
        return args.func(args)
      File "/usr/local/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 225, in edit
        new_state, verify_change=args.verify, save_to_disk=args.save_to_disk
      File "/usr/local/lib/python3.6/site-packages/libnmstate/netapplier.py", line 71, in apply
        _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk)
      File "/usr/local/lib/python3.6/site-packages/libnmstate/netapplier.py", line 104, in _apply_ifaces_state
        plugin.apply_changes(net_state, save_to_disk)
      File "/usr/local/lib/python3.6/site-packages/libnmstate/nm/plugin.py", line 177, in apply_changes
        nm_applier.apply_changes(self.context, net_state, save_to_disk)
      File "/usr/local/lib/python3.6/site-packages/libnmstate/nm/applier.py", line 129, in apply_changes
        context.wait_all_finish()
      File "/usr/local/lib/python3.6/site-packages/libnmstate/nm/context.py", line 216, in wait_all_finish
        raise tmp_error
    libnmstate.error.NmstateLibnmError: Add profile: virbr0-nic failed with error:
    nm-connection-error-quark: connection.type: connection type 'unknown' is not valid (7)
```
