### PR TITLE
test: Properly delete connection profiles

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -248,13 +248,15 @@ def apply(args):
                 with open(statefile) as statefile:
                     statedata = statefile.read()
 
-            return apply_state(
+            ret = apply_state(
                 statedata,
                 args.verify,
                 args.commit,
                 args.timeout,
                 args.save_to_disk,
             )
+            if ret:
+                return ret
     elif not sys.stdin.isatty():
         statedata = sys.stdin.read()
         return apply_state(

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -163,6 +163,8 @@ def test_set_command_with_two_states():
     rc = ret[0]
 
     assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+    assertlib.assert_absent("linux-br0")
+
 
 
 def test_manual_confirmation(eth1_up):


### PR DESCRIPTION
As https://travis-ci.com/github/nmstate/nmstate/jobs/353095728
shows, the bridge created by `tests/integration/nm/linux_bridge_test.py`
is not correctly deleted.

This is caused by the delete action is not waiting profile's
deactivation.

Fixed all profile deletion calls in tests.