### PR TITLE
dns: Fix remove dns config

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -33,14 +33,16 @@ class DnsState:
 
     def __init__(self, des_dns_state, cur_dns_state):
         self._config_changed = False
-        if des_dns_state:
+        if des_dns_state is None or des_dns_state.get(DNS.CONFIG) is None:
+            # Use current config if DNS.KEY not defined or DNS.CONFIG not
+            # defined.
+            self._dns_state = cur_dns_state or {}
+        else:
             self._dns_state = des_dns_state
             self._validate()
             self._config_changed = _is_dns_config_changed(
                 des_dns_state, cur_dns_state
             )
-        else:
-            self._dns_state = cur_dns_state or {}
         self._cur_dns_state = deepcopy(cur_dns_state) if cur_dns_state else {}
 
     @property
@@ -179,7 +181,9 @@ class DnsState:
 
     def verify(self, cur_dns_state):
         cur_dns = DnsState(des_dns_state=None, cur_dns_state=cur_dns_state,)
-        if self.config != cur_dns.config:
+        if self.config.get(DNS.SERVER) != cur_dns.config.get(
+            DNS.SERVER
+        ) or self.config.get(DNS.SEARCH) != cur_dns.config.get(DNS.SEARCH):
             raise NmstateVerificationError(
                 format_desired_current_state_diff(
                     {DNS.KEY: self.config}, {DNS.KEY: cur_dns.config},

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -144,7 +144,17 @@ def test_dns_edit_three_nameservers(dns_servers):
 
 
 @pytest.mark.tier1
-def test_remove_dns_config():
+@pytest.mark.parametrize(
+    "empty_dns_config",
+    [{DNS.SERVER: []}, {DNS.SEARCH: []}, {DNS.SERVER: [], DNS.SEARCH: []}, {}],
+    ids=[
+        "empty_server",
+        "empty_search",
+        "empty_server_and_search",
+        "empty_dict",
+    ],
+)
+def test_remove_dns_config(empty_dns_config):
     dns_config = {
         DNS.SERVER: [IPV6_DNS_NAMESERVERS[0], IPV4_DNS_NAMESERVERS[0]],
         DNS.SEARCH: [],

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -50,7 +50,7 @@ IPV6_DNS_SERVER2 = "2001:db8:a::2"
 IPV6_DNS_SERVER3 = "2001:db8:a::3"
 
 DNS_SEARCHES_1 = ["example.com", "example.org"]
-DNS_SEARCHES_2 = (["example.info", "example.net"],)
+DNS_SEARCHES_2 = ["example.info", "example.net"]
 
 DNS_CONFIG1 = {
     DNS.SERVER: [IPV4_DNS_SERVER1, IPV6_DNS_SERVER1],


### PR DESCRIPTION
Current code raise NmstateVerificationError when user not providing
the full state:

        `{DNS.SERVER: [], DNS.SEARCH: []}`

Now supporting remove static DNS config via:
  * `{}`
 * `{DNS.SERVER: []}`
 * `{DNS.SEARCH: []}`
 * `{DNS.SERVER: [], DNS.SEARCH: []}`

Test case updated for this.