### PR TITLE
[nmstate-0.3] pretty state: Dumping state in the sorted order with priority

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -25,6 +25,7 @@ import yaml
 
 import libnmstate
 from libnmstate.error import NmstateVerificationError
+from libnmstate.prettystate import PrettyState
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
@@ -70,6 +71,22 @@ BRIDGE_PORT_YAML = """
 stp-hairpin-mode: false
 stp-path-cost: 100
 stp-priority: 32
+"""
+
+VLAN_FILTER_PORT_YAML = """
+    port:
+    - name: eth1
+      stp-hairpin-mode: false
+      stp-path-cost: 100
+      stp-priority: 32
+      vlan:
+        enable-native: true
+        mode: trunk
+        tag: 300
+        trunk-tags:
+        - id: 100
+        - id: 101
+        - id: 102
 """
 
 
@@ -540,6 +557,13 @@ class TestVlanFiltering:
             TEST_BRIDGE0, bridge_config_subtree
         ) as desired_state:
             assertlib.assert_state_match(desired_state)
+
+    def test_pretty_state_port_name_first(
+        self, bridge_with_trunk_port_and_native_config
+    ):
+        current_state = show_only((TEST_BRIDGE0,))
+        pretty_state = PrettyState(current_state)
+        assert VLAN_FILTER_PORT_YAML in pretty_state.yaml
 
 
 @pytest.fixture

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -69,7 +69,6 @@ ETH1_YAML_CONFIG = b"""interfaces:
 - name: eth1
   state: up
   type: ethernet
-  mtu: 1500
   ipv4:
     address:
     - ip: 192.0.2.250
@@ -77,6 +76,7 @@ ETH1_YAML_CONFIG = b"""interfaces:
     enabled: true
   ipv6:
     enabled: false
+  mtu: 1500
 """
 
 EXAMPLES = find_examples_dir()

--- a/tests/lib/pretty_state.py
+++ b/tests/lib/pretty_state.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.prettystate import PrettyState
+
+TEST_STATE = {
+    "0": "a",
+    "type": "unknown",
+    "name": "foo",
+    "ipv4": {"abc": 1, "enabled": "false"},
+    "slaves": [{"a": 1, "name": "bar1"}, {"a": 2, "name": "bar2"}],
+    "state": "up",
+}
+
+TEST_YAML_STATE = """---
+name: foo
+type: unknown
+state: up
+'0': a
+ipv4:
+  enabled: 'false'
+  abc: 1
+slaves:
+- name: bar1
+  a: 1
+- name: bar2
+  a: 2
+"""
+
+TEST_JSON_STATE = """{
+    "name": "foo",
+    "type": "unknown",
+    "state": "up",
+    "0": "a",
+    "ipv4": {
+        "enabled": "false",
+        "abc": 1
+    },
+    "slaves": [
+        {
+            "name": "bar1",
+            "a": 1
+        },
+        {
+            "name": "bar2",
+            "a": 2
+        }
+    ]
+}"""
+
+
+def test_pretty_state_order_with_priority():
+    state = PrettyState(TEST_STATE)
+    assert state.yaml == TEST_YAML_STATE
+
+
+def test_json_ovs_bond_name_list_first():
+    state = PrettyState(TEST_STATE)
+    assert state.json == TEST_JSON_STATE


### PR DESCRIPTION
For OVS bond port, we would like the `name` been shown before other
properties.

To achieve that, we sort the dict keys and honoring the priority list which
means keys in `PRIORITY_LIST` will be shown before others.

Currently the `PRIORITY_LIST` is:
`("name", "type", "state", "enabled", "dns", "route-rules", "routes",
  "interfaces")`

Test cases added.