### PR TITLE
[Regression] nm: Only create ethernet section when desired

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -93,9 +93,9 @@ def apply_changes(context, net_state, save_to_disk):
                 )
         original_desired_iface_state = {}
         if net_state.ifaces.get(ifname):
-            original_desired_iface_state = net_state.ifaces[
-                ifname
-            ].original_dict
+            iface = net_state.ifaces[ifname]
+            if iface.is_desired:
+                original_desired_iface_state = iface.original_dict
             if (
                 set(original_desired_iface_state.keys())
                 <= set([Interface.STATE, Interface.NAME, Interface.TYPE])


### PR DESCRIPTION
The `iface.original_dict` is not original desire state when
`iface.is_desired == False` but the unmerged state when `BaseIface` is
created.

The case nm applier create the wire setting(especially MAC address) when
bond worker interface not included in desire state which then blocking
those worker interface been used in new mac restriced bond mode.

Integration test case created:
    * Create bond in mode 4(802.3ad/LACP), there both slave will hold the
      same MAC address.
    * Remove bond.
    * Create bond in mode 5(balance-tlb) where bond worker interface
      should not different.