### PR TITLE
tests: fix error on test_ovs_remove_port

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -18,6 +18,7 @@
 #
 
 from subprocess import CalledProcessError
+import time
 
 import pytest
 
@@ -249,6 +250,7 @@ def test_ovs_remove_port(bridge_with_ports):
                 ]
             }
         )
+        time.sleep(1)
 
         with pytest.raises(CalledProcessError):
             cmdlib.exec_cmd(


### PR DESCRIPTION
In the ovs_remove_port test we are using nmcli directly using cmdlib.
nmcli need a second to refresh the information if not, it will be
outdated and then the test will not raise the exception.

This was not happening before because Nmstate was waiting 5 seconds
after applying the state.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>