### PR TITLE
dns: fix remove dns config

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -181,9 +181,11 @@ class DnsState:
 
     def verify(self, cur_dns_state):
         cur_dns = DnsState(des_dns_state=None, cur_dns_state=cur_dns_state,)
-        if self.config.get(DNS.SERVER) != cur_dns.config.get(
-            DNS.SERVER
-        ) or self.config.get(DNS.SEARCH) != cur_dns.config.get(DNS.SEARCH):
+        if self.config.get(DNS.SERVER, []) != cur_dns.config.get(
+            DNS.SERVER, []
+        ) or self.config.get(DNS.SEARCH, []) != cur_dns.config.get(
+            DNS.SEARCH, []
+        ):
             raise NmstateVerificationError(
                 format_desired_current_state_diff(
                     {DNS.KEY: self.config}, {DNS.KEY: cur_dns.config},

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -166,7 +166,9 @@ def test_remove_dns_config(empty_dns_config):
     }
     libnmstate.apply(desired_state)
 
-    libnmstate.apply({Interface.KEY: [], DNS.KEY: {DNS.CONFIG: {}}})
+    libnmstate.apply(
+        {Interface.KEY: [], DNS.KEY: {DNS.CONFIG: empty_dns_config}}
+    )
     current_state = libnmstate.show()
     dns_config = {DNS.SERVER: [], DNS.SEARCH: []}
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]


### PR DESCRIPTION
This patch is fixing the support of removing the dns config. In
addition, is fixing the `test_remove_dns_config` test by using the
parametrize variable.

Ref: https://bugzilla.redhat.com/1850698

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>