### PR TITLE
nispor: Introduce nispor plugin

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -320,6 +320,7 @@ class BaseIface:
             * Explicitly set state as UP if not defined.
             * Remove IPv6 link local addresses.
             * Remove empty description.
+            * Ignore the down state for non-virtual interface
         """
         self._capitalize_mac()
         self.sort_slaves()
@@ -335,6 +336,8 @@ class BaseIface:
             state[Interface.STATE] = InterfaceState.UP
         if self.is_absent and not self._save_to_disk:
             state[Interface.STATE] = InterfaceState.DOWN
+        if not self.is_virtual and self.is_down:
+            state.pop(Interface.STATE)
 
         return state
 

--- a/libnmstate/nispor/__init__.py
+++ b/libnmstate/nispor/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -1,0 +1,146 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from operator import itemgetter
+
+from libnmstate.error import NmstateInternalError
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+
+
+class NisporBaseIface:
+    def __init__(self, np_info):
+        self._np_info = np_info
+
+    @property
+    def np_info(self):
+        return self._np_info
+
+    @property
+    def mac(self):
+        return self._np_info.get("mac_address", "00:00:00:00:00:00")
+
+    @property
+    def mtu(self):
+        return self._np_info["mtu"]
+
+    @property
+    def state(self):
+        np_info = self._np_info["state"]
+        # Subordinate port like bridge port might in down link state at certain
+        # point(e.g. bridge STP)
+        if np_info == "Up" or self._is_subordinate:
+            return InterfaceState.UP
+        elif np_info == "Down":
+            return InterfaceState.DOWN
+        else:
+            raise NmstateInternalError(
+                f"Got unexpect nispor interface state {np_info} for "
+                f"{self._np_info}"
+            )
+
+    @property
+    def _is_subordinate(self):
+        return "bridge_port" in self.np_info or "bond_slave" in self.np_info
+
+    @property
+    def ip_info(self):
+        return {
+            Interface.IPV4: NisportIpState(
+                Interface.IPV4, self.np_info.get("ipv4")
+            ).to_dict(),
+            Interface.IPV6: NisportIpState(
+                Interface.IPV6, self.np_info.get("ipv6")
+            ).to_dict(),
+        }
+
+    def to_dict(self):
+        iface_info = {
+            Interface.NAME: self.np_info["name"],
+            Interface.STATE: self.state,
+            Interface.MAC: self.mac,
+            Interface.MTU: self.mtu,
+        }
+        if self.state == InterfaceState.UP:
+            iface_info.update(self.ip_info)
+
+        return iface_info
+
+
+class NisportIpState:
+    def __init__(self, family, np_info):
+        self._family = family
+        self._np_info = np_info
+        self._addresses = []
+        if np_info:
+            self._addresses = sorted(np_info.get("addresses", []),
+                    key=itemgetter("address"))
+
+    @property
+    def _is_ipv6(self):
+        return self._family == Interface.IPV6
+
+    def _has_dhcp_address(self):
+        if self._is_ipv6:
+            return any(
+                addr["valid_lft"] != "forever" and addr["prefix_len"] == 128
+                for addr in self._addresses
+            )
+        else:
+            return any(
+                addr["valid_lft"] != "forever" for addr in self._addresses
+            )
+
+    def _has_autoconf_address(self):
+        return self._is_ipv6 and any(
+            addr["valid_lft"] != "forever" and addr["prefix_len"] == 64
+            for addr in self._addresses
+        )
+
+    def to_dict(self):
+        if not self._addresses or not self._np_info:
+            if self._is_ipv6:
+                # IPv6 is considered as disabled if there is no even
+                # IPv6 link local address
+                return {
+                    InterfaceIP.ENABLED: False,
+                }
+            else:
+                # When there is not IPv4 address, we don't know whether
+                # interface is disabled or not just waiting DHCP,
+                # let other plugin discover the enable status
+                return {}
+        else:
+            info = {
+                InterfaceIP.ENABLED: True,
+                InterfaceIP.ADDRESS: [
+                    {
+                        InterfaceIP.ADDRESS_IP: addr["address"],
+                        InterfaceIP.ADDRESS_PREFIX_LENGTH: addr["prefix_len"],
+                    }
+                    for addr in self._addresses
+                ],
+            }
+            if self._has_dhcp_address():
+                info[InterfaceIP.DHCP] = True
+            if self._has_autoconf_address():
+                info[InterfaceIPv6.AUTOCONF] = True
+            return info

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import json
+
+import nispor
+
+from libnmstate.plugin import NmstatePlugin
+
+from .base_iface import NisporBaseIface
+
+
+class NisporPlugin(NmstatePlugin):
+    @property
+    def name(self):
+        return "nispor"
+
+    @property
+    def plugin_capabilities(self):
+        return [
+            NmstatePlugin.PLUGIN_CAPABILITY_IFACE,
+        ]
+
+    def get_interfaces(self):
+        np_state = json.loads(nispor.get_state())
+        ifaces = []
+        for np_iface in np_state.get("ifaces", {}).values():
+            np_iface_type = np_iface["iface_type"]
+            if np_iface["state"] != "Unknown":
+                if np_iface_type in ["Unknown", "Veth"]:
+                    ifaces.append(NisporBaseIface(np_iface).to_dict())
+        return ifaces

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -58,6 +58,11 @@ class NetworkManagerPlugin(NmstatePlugin):
         self._check_version_mismatch()
 
     @property
+    def priority(self):
+        # Let nispor plugin take priority
+        return NmstatePlugin.DEFAULT_PRIORITY - 1
+
+    @property
     def name(self):
         return "NetworkManager"
 

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -34,6 +34,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
+from .nispor.plugin import NisporPlugin
 from .plugin import NmstatePlugin
 from .state import merge_dict
 
@@ -99,7 +100,7 @@ def plugins_capabilities(plugins):
 
 
 def _load_plugins():
-    plugins = [NetworkManagerPlugin()]
+    plugins = [NetworkManagerPlugin(), NisporPlugin()]
     plugins.extend(_load_external_py_plugins())
     return plugins
 

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -3,6 +3,7 @@ FROM docker.io/library/centos:8
 RUN dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools && \
     dnf copr enable nmstate/ovs-el8 -y && \
+    dnf copr enable cathay4t/nispor -y && \
     dnf copr enable networkmanager/NetworkManager-1.22 -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
@@ -29,6 +30,7 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    python3-coveralls \
                    python3-requests \
                    python3-docopt \
+                   python3-nispor \
                    tcpreplay \
                    && \
     alternatives --set python /usr/bin/python3 && \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -1,6 +1,8 @@
 FROM docker.io/library/fedora:32
 
-RUN dnf -y install --setopt=install_weak_deps=False \
+RUN dnf -y install dnf-plugins-core && \
+    dnf copr enable cathay4t/nispor -y && \
+    dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
                    NetworkManager-team \
@@ -36,6 +38,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
                    glib2-devel \
                    gobject-introspection-devel \
                    python3-devel \
+                   python3-nispor \
                    make && \
                    \
     dnf clean all && \

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -19,6 +19,7 @@
 from contextlib import contextmanager
 from copy import deepcopy
 import logging
+from operator import itemgetter
 import os
 import time
 
@@ -28,6 +29,7 @@ import libnmstate
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
@@ -572,6 +574,10 @@ def test_dhcp_on_bridge0(dhcpcli_up_with_dynamic_ip):
 
     origin_ipv4_state = origin_port_state[Interface.KEY][0][Interface.IPV4]
     origin_ipv6_state = origin_port_state[Interface.KEY][0][Interface.IPV6]
+    _sort_ip_addresses(origin_ipv4_state[InterfaceIP.ADDRESS])
+    _sort_ip_addresses(origin_ipv6_state[InterfaceIP.ADDRESS])
+    _sort_ip_addresses(new_ipv4_state[InterfaceIP.ADDRESS])
+    _sort_ip_addresses(new_ipv6_state[InterfaceIP.ADDRESS])
     assert origin_ipv4_state == new_ipv4_state
     assert origin_ipv6_state == new_ipv6_state
 
@@ -1247,3 +1253,7 @@ def clean_state():
         yield
     finally:
         libnmstate.apply(current_state)
+
+
+def _sort_ip_addresses(addresses):
+    addresses.sort(key=itemgetter(InterfaceIP.ADDRESS_IP))

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -90,6 +90,8 @@ def _prepare_state_for_verify(desired_state_data):
     full_desired_state.normalize()
     _fix_bond_state(current_state)
     _fix_ovsdb_external_ids(full_desired_state)
+    _remove_iface_state_for_verify(full_desired_state)
+    _remove_iface_state_for_verify(current_state)
 
     return full_desired_state, current_state
 
@@ -131,3 +133,7 @@ def _fix_ovsdb_external_ids(state):
         )
         for key, value in external_ids.items():
             external_ids[key] = str(value)
+
+def _remove_iface_state_for_verify(state):
+    for iface_state in state.state[Interface.KEY]:
+        iface_state.pop(Interface.STATE, None)

--- a/tests/integration/testlib/ifacelib.py
+++ b/tests/integration/testlib/ifacelib.py
@@ -41,19 +41,13 @@ def iface_up(ifname):
 
 
 def _set_eth_admin_state(ifname, state):
-    current_state = statelib.show_only((ifname,))
-    (current_ifstate,) = current_state[schema.Interface.KEY]
-    iface_current_admin_state = current_ifstate[schema.Interface.STATE]
-    if (
-        iface_current_admin_state != state
-        or state == schema.InterfaceState.ABSENT
-    ):
-        desired_state = {
+    libnmstate.apply(
+        {
             schema.Interface.KEY: [
                 {schema.Interface.NAME: ifname, schema.Interface.STATE: state}
             ]
         }
-        libnmstate.apply(desired_state)
+    )
 
 
 def get_mac_address(ifname):


### PR DESCRIPTION
Introduce `NisporPlugin` for querying on these informations using
python3-nispor package:
 * MTU, MAC, state, IP address.
 * DHCP/AUTOCONF status:
    * Mark DHCP/AUTOCONF as true when found IP address with valid_lft not
      forever and correct prefix length.

As nispor might be wrong on DHCP status and interface type comparing to
NetworkManager, so NetworkManager plugin take priority over nispor
plugin and override conflict data.

Removed the code in NetworkManager plugin for querying above information
except the DHCP/Autoconf and IP stack enable status.

Integration test case added.

