### PR TITLE
automation: extend --customize argument for no container support

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -263,6 +263,13 @@ function upgrade_nm_from_copr {
     exec_cmd "systemctl restart NetworkManager"
 }
 
+function run_customize_command {
+    if [[ -n "$customize_cmd" ]];then
+        clean_dnf_cache
+        exec_cmd "${customize_cmd}"
+    fi
+}
+
 options=$(getopt --options "" \
     --long customize:,pytest-args:,help,debug-shell,test-type:,el8,copr:,artifacts-dir:,test-vdsm,machine,use-installed-nmstate\
     -- "${@}")
@@ -339,11 +346,13 @@ done
 
 modprobe_ovs
 
-if [ -z ${RUN_BAREMETAL} ];then
-    container_pre_test_setup
-else
+if [ -n "${RUN_BAREMETAL}" ];then
     CONTAINER_WORKSPACE="."
+    run_customize_command
     start_machine_services
+else
+    container_pre_test_setup
+    run_customize_command
 fi
 
 if [[ -v copr_repo ]];then

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -78,10 +78,6 @@ function container_pre_test_setup {
     fi
 
     create_container
-    if [[ -n "$customize_cmd" ]];then
-        clean_dnf_cache
-        container_exec "${customize_cmd}"
-    fi
 
     container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
         /proc/sys/kernel/core_pattern"


### PR DESCRIPTION
Some CI gating platforms need to install dependencies using pip3.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>