### PR TITLE
test: Mark test_ovs_remove_port as xfail

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -17,8 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from subprocess import CalledProcessError
-
 import pytest
 
 import libnmstate
@@ -229,7 +227,16 @@ def test_ovs_service_missing():
     )
 
 
+class _OvsProfileStillExists(Exception):
+    pass
+
+
 @pytest.mark.tier1
+@pytest.mark.xfail(
+    reason="https://bugzilla.redhat.com/show_bug.cgi?id=1857123",
+    raises=_OvsProfileStillExists,
+    strict=False,
+)
 def test_ovs_remove_port(bridge_with_ports):
     for port_name in bridge_with_ports.ports_names:
         active_profiles = get_nm_active_profiles()
@@ -250,10 +257,12 @@ def test_ovs_remove_port(bridge_with_ports):
             }
         )
 
-        with pytest.raises(CalledProcessError):
-            cmdlib.exec_cmd(
-                f"nmcli connection show {proxy_port_profile}".split(" "),
-                check=True,
+        rc, output, _ = cmdlib.exec_cmd(
+            f"nmcli connection show {proxy_port_profile}".split(" "),
+        )
+        if rc == 0:
+            raise _OvsProfileStillExists(
+                f"{proxy_port_profile} still exists: {output}"
             )
 
 


### PR DESCRIPTION
Due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1857123 ,
nmcli might(1% chance) still show the deleted ovs port profile.