### PR TITLE
[nmstate-0.3] Backport run tests out of containers

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -259,6 +259,13 @@ function upgrade_nm_from_copr {
     exec_cmd "systemctl restart NetworkManager"
 }
 
+function run_customize_command {
+    if [[ -n "$customize_cmd" ]];then
+        clean_dnf_cache
+        exec_cmd "${customize_cmd}"
+    fi
+}
+
 options=$(getopt --options "" \
     --long customize:,pytest-args:,help,debug-shell,test-type:,el8,copr:,artifacts-dir:,test-vdsm,machine,use-installed-nmstate\
     -- "${@}")
@@ -335,11 +342,13 @@ done
 
 modprobe_ovs
 
-if [ -z ${RUN_BAREMETAL} ];then
-    container_pre_test_setup
-else
+if [ -n "${RUN_BAREMETAL}" ];then
     CONTAINER_WORKSPACE="."
+    run_customize_command
     start_machine_services
+else
+    container_pre_test_setup
+    run_customize_command
 fi
 
 if [[ -v copr_repo ]];then

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -20,6 +20,9 @@ TEST_TYPE_INTEG_SLOW="integ_slow"
 FEDORA_IMAGE_DEV="docker.io/nmstate/fedora-nmstate-dev"
 CENTOS_IMAGE_DEV="docker.io/nmstate/centos8-nmstate-dev"
 
+CREATED_INTERFACES=""
+INTERFACES="eth1 eth2"
+
 PYTEST_OPTIONS="--verbose --verbose \
         --log-level=DEBUG \
         --log-date-format='%Y-%m-%d %H:%M:%S' \
@@ -36,39 +39,26 @@ NMSTATE_TEMPDIR=$(mktemp -d /tmp/nmstate-test-XXXX)
 : ${CONTAINER_CMD:=podman}
 
 test -t 1 && USE_TTY="-t"
-
-function remove_container {
-    res=$?
-    [ "$res" -ne 0 ] && echo "*** ERROR: $res"
-    container_exec 'rm -rf $CONTAINER_WORKSPACE/*nmstate*.rpm' || true
-    ${CONTAINER_CMD} rm -f $CONTAINER_ID
-}
+source automation/tests-container-utils.sh
+source automation/tests-machine-utils.sh
 
 function pyclean {
+    exec_cmd '
         find . -type f -name "*.py[co]" -delete
         find . -type d -name "__pycache__" -delete
-}
-
-function container_exec {
-    ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
-        /bin/bash -c "cd $CONTAINER_WORKSPACE && $1"
-}
-
-function add_extra_networks {
-    container_exec '
-      ip link add eth1 type veth peer eth1peer && \
-      ip link add eth2 type veth peer eth2peer && \
-      ip link set eth1peer up && \
-      ip link set eth2peer up
-      # Due to https://nmstate.atlassian.net/browse/NMSTATE-279
-      # Mandually set test NICs as managed by NetworkManager.
-      nmcli device set eth1 managed yes
-      nmcli device set eth2 managed yes
     '
 }
 
+function exec_cmd {
+    if [ -z ${RUN_BAREMETAL} ];then
+        container_exec "$1"
+    else
+        bash -c "$1"
+    fi
+}
+
 function dump_network_info {
-    container_exec '
+    exec_cmd '
       nmcli dev; \
       # Use empty PAGER variable to stop nmcli send output to less which hang \
       # the CI. \
@@ -81,20 +71,22 @@ function dump_network_info {
 }
 
 function install_nmstate {
-    container_exec '
-      rpm -ivh `./packaging/make_rpm.sh|tail -1 || exit 1`
-    '
+    if [ $INSTALL_NMSTATE == "true" ];then
+        exec_cmd '
+          rpm -ivh `./packaging/make_rpm.sh|tail -1 || exit 1`
+        '
+    fi
 }
 
 function run_tests {
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_FORMAT ];then
-        container_exec "tox -e black"
+        exec_cmd "tox -e black"
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_LINT ];then
-        container_exec "tox -e flake8,pylint"
+        exec_cmd "tox -e flake8,pylint"
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
@@ -103,10 +95,10 @@ function run_tests {
             # Due to https://github.com/pypa/virtualenv/issues/1009
             # Instruct virtualenv not to upgrade to the latest versions of pip,
             # setuptools, wheel and etc
-            container_exec 'env VIRTUALENV_NO_DOWNLOAD=1 \
+            exec_cmd 'env VIRTUALENV_NO_DOWNLOAD=1 \
                             tox --sitepackages -e py36'
         else
-            container_exec 'tox -e py36'
+            exec_cmd "tox -e py36"
         fi
     fi
 
@@ -116,15 +108,15 @@ function run_tests {
             echo "Running unit test in $CONTAINER_IMAGE container is not " \
                  "support yet"
         else
-            container_exec 'tox -e py38'
+            exec_cmd "tox -e py38"
         fi
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_INTEG ];then
-        container_exec "
-          cd $CONTAINER_WORKSPACE &&
-          pytest \
+        exec_cmd "cd $CONTAINER_WORKSPACE"
+        exec_cmd "
+            pytest \
             $PYTEST_OPTIONS \
             --cov-report=html:htmlcov-integ \
             tests/integration \
@@ -132,8 +124,8 @@ function run_tests {
     fi
 
     if  [ $TEST_TYPE == $TEST_TYPE_INTEG_TIER1 ];then
-        container_exec "
-          cd $CONTAINER_WORKSPACE &&
+        exec_cmd "cd $CONTAINER_WORKSPACE"
+        exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
             --cov-report=html:htmlcov-integ_tier1 \
@@ -143,8 +135,8 @@ function run_tests {
     fi
 
     if  [ $TEST_TYPE == $TEST_TYPE_INTEG_TIER2 ];then
-        container_exec "
-          cd $CONTAINER_WORKSPACE &&
+        exec_cmd "cd $CONTAINER_WORKSPACE"
+        exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
             --cov-report=html:htmlcov-integ_tier2 \
@@ -155,8 +147,8 @@ function run_tests {
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_INTEG_SLOW ];then
-        container_exec "
-          cd $CONTAINER_WORKSPACE &&
+        exec_cmd "cd $CONTAINER_WORKSPACE"
+        exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
             --cov-report=html:htmlcov-integ_slow \
@@ -164,15 +156,6 @@ function run_tests {
             tests/integration \
             ${nmstate_pytest_extra_args}"
     fi
-}
-
-function collect_artifacts {
-    container_exec "
-      journalctl > "$CONT_EXPORT_DIR/journal.log" && \
-      dmesg > "$CONT_EXPORT_DIR/dmesg.log" && \
-      cat /var/log/openvswitch/ovsdb-server.log > "$CONT_EXPORT_DIR/ovsdb-server.log" && \
-      mv "$CONTAINER_WORKSPACE/pytest-run.log" "$CONT_EXPORT_DIR/pytest-run.log" || true
-    "
 }
 
 function write_separator {
@@ -195,79 +178,28 @@ function write_separator {
 function run_exit {
     write_separator "TEARDOWN"
     dump_network_info
-    collect_artifacts
-    remove_container
-    remove_tempdir
-}
-
-function open_shell {
-    res=$?
-    [ "$res" -ne 0 ] && echo "*** ERROR: $res"
-    set +o errexit
-    container_exec 'echo "pytest tests/integration --pdb" >> ~/.bash_history'
-    container_exec 'exec /bin/bash'
-    run_exit
-}
-
-# Return 0 if file is changed else 1
-function is_file_changed {
-    git remote add upstream https://github.com/nmstate/nmstate.git
-    git fetch upstream
-    if [ -n "$TRAVIS_BRANCH" ]; then
-        git diff --exit-code --name-only upstream/$TRAVIS_BRANCH -- $1
+    if [ -z ${RUN_BAREMETAL} ];then
+        collect_artifacts
+        remove_container
+        remove_tempdir
     else
-        git diff -exit-code --name-only upstream/master -- $1
+        teardown_network_environment
     fi
-
-    if [ $? -eq 0 ];then
-        return 1
-    else
-        return 0
-    fi
-}
-
-function rebuild_container_images {
-    if is_file_changed "$PROJECT_PATH/packaging"; then
-        if [ $CONTAINER_IMAGE == $CENTOS_IMAGE_DEV ];then
-            ${PROJECT_PATH}/packaging/build-container.sh centos8-nmstate-dev
-        elif [ $CONTAINER_IMAGE == $FEDORA_IMAGE_DEV ];then
-            ${PROJECT_PATH}/packaging/build-container.sh fedora-nmstate-dev
-        fi
-    fi
-}
-
-function upgrade_nm_from_copr {
-    local copr_repo=$1
-    # The repoid for a Copr repo is the name with the slash replaces by a colon
-    local copr_repo_id="copr:copr.fedorainfracloud.org:${copr_repo/\//:}"
-    # Workaround for dnf failure:
-    # [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
-    if [[ "$CI" == "true" ]];then
-        container_exec "rm -fv /var/cache/dnf/metadata_lock.pid"
-        container_exec "dnf clean all"
-        container_exec "dnf makecache || :"
-    fi
-    container_exec "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
-    container_exec "yum copr enable --assumeyes ${copr_repo}"
-    # Update only from Copr to limit the changes in the environment
-    container_exec "yum update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
-    container_exec "systemctl restart NetworkManager"
 }
 
 function modprobe_ovs {
     lsmod | grep -q ^openvswitch || modprobe openvswitch || { echo 1>&2 "Please run 'modprobe openvswitch' as root"; exit 1; }
 }
 
-function remove_tempdir {
-    rm -rf "$NMSTATE_TEMPDIR"
-}
-
-function vdsm_tests {
-    trap remove_tempdir EXIT
-    git -C "$NMSTATE_TEMPDIR" clone --depth 1 https://gerrit.ovirt.org/vdsm
-    cd "$NMSTATE_TEMPDIR/vdsm"
-    ./tests/network/functional/run-tests.sh --nmstate-source="$PROJECT_PATH"
-    cd -
+function check_services {
+    exec_cmd 'while ! systemctl is-active dbus; do sleep 1; done'
+    exec_cmd 'systemctl start systemd-udevd
+                 while ! systemctl is-active systemd-udevd; do sleep 1; done
+    '
+    exec_cmd '
+        systemctl restart NetworkManager
+        while ! systemctl is-active NetworkManager; do sleep 1; done
+    '
 }
 
 function upload_coverage {
@@ -283,8 +215,52 @@ function upload_coverage {
     fi
 }
 
+function check_iface_exist {
+    exec_cmd "ip link | grep -q $1"
+}
+
+function prepare_network_environment {
+    set +e
+    for device in $INTERFACES;
+    do
+        peer="${device}peer"
+        check_iface_exist $device
+        if [ $? -eq 1 ]; then
+            CREATED_INTERFACES="${CREATED_INTERFACES} ${device}"
+            exec_cmd "ip link add ${device} type veth peer name ${peer} && ip link set ${peer} up"
+	    exec_cmd "nmcli device set ${device} managed yes"
+        fi
+    done
+    set -e
+}
+
+function teardown_network_environment {
+    for device in $CREATED_INTERFACES;
+    do
+        exec_cmd "ip link del ${device}"
+    done
+}
+
+function upgrade_nm_from_copr {
+    local copr_repo=$1
+    # The repoid for a Copr repo is the name with the slash replaces by a colon
+    local copr_repo_id="copr:copr.fedorainfracloud.org:${copr_repo/\//:}"
+    # Workaround for dnf failure:
+    # [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
+    if [[ "$CI" == "true" ]];then
+        exec_cmd "rm -fv /var/cache/dnf/metadata_lock.pid"
+        exec_cmd "dnf clean all"
+        exec_cmd "dnf makecache || :"
+    fi
+    exec_cmd "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
+    exec_cmd "yum copr enable --assumeyes ${copr_repo}"
+    # Update only from Copr to limit the changes in the environment
+    exec_cmd "yum update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
+    exec_cmd "systemctl restart NetworkManager"
+}
+
 options=$(getopt --options "" \
-    --long customize:,pytest-args:,help,debug-shell,test-type:,el8,copr:,artifacts-dir:,test-vdsm\
+    --long customize:,pytest-args:,help,debug-shell,test-type:,el8,copr:,artifacts-dir:,test-vdsm,machine,use-installed-nmstate\
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -319,11 +295,17 @@ while true; do
         vdsm_tests
         exit
         ;;
+    --machine)
+        RUN_BAREMETAL="true"
+        ;;
+    --use-installed-nmstate)
+        INSTALL_NMSTATE="false"
+        ;;
     --help)
         set +x
         echo -n "$0 [--copr=...] [--customize=...] [--debug-shell] [--el8] "
-        echo -n "[--help] [--pytest-args=...] "
-        echo "[--test-type=<TEST_TYPE>] [--test-vdsm]"
+        echo -n "[--help] [--pytest-args=...] [--machine] "
+        echo "[--use-installed-nmstate] [--test-type=<TEST_TYPE>] [--test-vdsm]"
         echo "    Valid TEST_TYPE are:"
         echo "     * $TEST_TYPE_ALL (default)"
         echo "     * $TEST_TYPE_FORMAT"
@@ -348,72 +330,38 @@ done
 
 : ${TEST_TYPE:=$TEST_TYPE_ALL}
 : ${CONTAINER_IMAGE:=$FEDORA_IMAGE_DEV}
-
-${CONTAINER_CMD} --version && cat /etc/resolv.conf
+: ${INSTALL_NMSTATE:="true"}
+: ${INSTALL_DEPS:="false"}
 
 modprobe_ovs
 
-if [[ "$CI" == "true" ]];then
-    rebuild_container_images
+if [ -z ${RUN_BAREMETAL} ];then
+    container_pre_test_setup
+else
+    CONTAINER_WORKSPACE="."
+    start_machine_services
 fi
-
-mkdir -p $EXPORT_DIR
-# The podman support wildcard when passing enviroments, but docker does not.
-CONTAINER_ID="$(${CONTAINER_CMD} run --privileged -d \
-    -e CI \
-    -e COVERALLS_REPO_TOKEN \
-    -e CODECOV_TOKEN \
-    -e TRAVIS \
-    -e TRAVIS_BRANCH \
-    -e TRAVIS_COMMIT \
-    -e TRAVIS_JOB_NUMBER \
-    -e TRAVIS_PULL_REQUEST \
-    -e TRAVIS_JOB_ID \
-    -e TRAVIS_REPO_SLUG \
-    -e TRAVIS_TAG \
-    -e TRAVIS_OS_NAME \
-    -e SHIPPABLE \
-    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-    -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
-    -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
-[ -n "$debug_exit_shell" ] && trap open_shell EXIT || trap run_exit EXIT
 
 if [[ -v copr_repo ]];then
     upgrade_nm_from_copr "${copr_repo}"
 fi
 
-if [[ -v customize_cmd ]];then
-    container_exec "${customize_cmd}"
+check_services
+prepare_network_environment
+
+if [ -n "$RUN_BAREMETAL" ];then
+    trap run_exit ERR EXIT
 fi
 
-container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
-    /proc/sys/kernel/core_pattern"
-container_exec "ulimit -c unlimited"
-
-container_exec 'while ! systemctl is-active dbus; do sleep 1; done'
-container_exec 'systemctl start systemd-udevd
-             while ! systemctl is-active systemd-udevd; do sleep 1; done
-'
-container_exec '
-    systemctl restart NetworkManager
-    while ! systemctl is-active NetworkManager; do sleep 1; done
-'
-add_extra_networks
-
-container_exec '(source /etc/os-release; echo $PRETTY_NAME); rpm -q NetworkManager'
+exec_cmd '(source /etc/os-release; echo $PRETTY_NAME); rpm -q NetworkManager'
 
 dump_network_info
 
 pyclean
-if [[ "$CI" != "true" ]];then
-    if $CONTAINER_CMD --version | grep -qv podman; then
-      container_exec "cp -rf $CONTAINER_WORKSPACE /root/nmstate-workspace || true"
-    else
-      container_exec "cp -rf $CONTAINER_WORKSPACE /root/nmstate-workspace"
-    fi
-    # Change workspace to keep the original one clean
-    CONTAINER_WORKSPACE="/root/nmstate-workspace"
+if [ -z ${RUN_BAREMETAL} ];then
+    copy_workspace_container
 fi
+
 install_nmstate
 run_tests
 upload_coverage

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -ex
+
+function remove_container {
+    res=$?
+    [ "$res" -ne 0 ] && echo "*** ERROR: $res"
+    container_exec 'rm -rf $CONTAINER_WORKSPACE/*nmstate*.rpm' || true
+    ${CONTAINER_CMD} rm -f $CONTAINER_ID
+}
+
+function container_exec {
+    ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
+        /bin/bash -c "cd $CONTAINER_WORKSPACE && $1"
+}
+
+function open_shell {
+    res=$?
+    [ "$res" -ne 0 ] && echo "*** ERROR: $res"
+    set +o errexit
+    container_exec 'echo "pytest tests/integration --pdb" >> ~/.bash_history'
+    container_exec 'exec /bin/bash'
+    run_exit
+}
+
+# Return 0 if file is changed else 1
+function is_file_changed {
+    git remote add upstream https://github.com/nmstate/nmstate.git
+    git fetch upstream
+    if [ -n "$TRAVIS_BRANCH" ]; then
+        git diff --exit-code --name-only upstream/$TRAVIS_BRANCH -- $1
+    else
+        git diff -exit-code --name-only upstream/master -- $1
+    fi
+
+    if [ $? -eq 0 ];then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function rebuild_container_images {
+    set +x
+    if is_file_changed "$PROJECT_PATH/packaging"; then
+        if [ $CONTAINER_IMAGE == $CENTOS_IMAGE_DEV ];then
+            ${PROJECT_PATH}/packaging/build-container.sh centos8-nmstate-dev
+        elif [ $CONTAINER_IMAGE == $FEDORA_IMAGE_DEV ];then
+            ${PROJECT_PATH}/packaging/build-container.sh fedora-nmstate-dev
+        fi
+    fi
+}
+
+function remove_tempdir {
+    rm -rf "$NMSTATE_TEMPDIR"
+}
+
+function vdsm_tests {
+    trap remove_tempdir EXIT
+    git -C "$NMSTATE_TEMPDIR" clone --depth 1 https://gerrit.ovirt.org/vdsm
+    cd "$NMSTATE_TEMPDIR/vdsm"
+    ./tests/network/functional/run-tests.sh --nmstate-source="$PROJECT_PATH"
+    cd -
+}
+
+function collect_artifacts {
+    container_exec "
+      journalctl > "$CONT_EXPORT_DIR/journal.log" && \
+      dmesg > "$CONT_EXPORT_DIR/dmesg.log" && \
+      cat /var/log/openvswitch/ovsdb-server.log > "$CONT_EXPORT_DIR/ovsdb-server.log" && \
+      mv "$CONTAINER_WORKSPACE/pytest-run.log" "$CONT_EXPORT_DIR/pytest-run.log" || true
+    "
+}
+
+function container_pre_test_setup {
+    ${CONTAINER_CMD} --version && cat /etc/resolv.conf
+
+    if [[ "$CI" == "true" ]];then
+        rebuild_container_images
+    fi
+
+    create_container
+    if [[ -v customize_cmd ]];then
+        container_exec "${customize_cmd}"
+    fi
+
+    container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
+        /proc/sys/kernel/core_pattern"
+    container_exec "ulimit -c unlimited"
+}
+
+function copy_workspace_container {
+    if [[ "$CI" != "true" ]];then
+        if $CONTAINER_CMD --version | grep -qv podman; then
+          container_exec "cp -rf $CONTAINER_WORKSPACE /root/nmstate-workspace || true"
+        else
+          container_exec "cp -rf $CONTAINER_WORKSPACE /root/nmstate-workspace"
+        fi
+        # Change workspace to keep the original one clean
+        CONTAINER_WORKSPACE="/root/nmstate-workspace"
+    fi
+}
+
+function create_container {
+  mkdir -p $EXPORT_DIR
+  # The podman support wildcard when passing enviroments, but docker does not.
+  CONTAINER_ID="$(${CONTAINER_CMD} run --privileged -d \
+      -e CI \
+      -e COVERALLS_REPO_TOKEN \
+      -e CODECOV_TOKEN \
+      -e TRAVIS \
+      -e TRAVIS_BRANCH \
+      -e TRAVIS_COMMIT \
+      -e TRAVIS_JOB_NUMBER \
+      -e TRAVIS_PULL_REQUEST \
+      -e TRAVIS_JOB_ID \
+      -e TRAVIS_REPO_SLUG \
+      -e TRAVIS_TAG \
+      -e TRAVIS_OS_NAME \
+      -e SHIPPABLE \
+      -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+      -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
+      -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
+  [[ -v "$debug_exit_shell" ]] && trap open_shell EXIT || trap run_exit EXIT
+}

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -119,5 +119,5 @@ function create_container {
       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
       -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
       -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
-  [[ -v "$debug_exit_shell" ]] && trap open_shell EXIT || trap run_exit EXIT
+  [ -n "$debug_exit_shell" ] && trap open_shell EXIT || trap run_exit EXIT
 }

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -78,9 +78,6 @@ function container_pre_test_setup {
     fi
 
     create_container
-    if [[ -v customize_cmd ]];then
-        container_exec "${customize_cmd}"
-    fi
 
     container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
         /proc/sys/kernel/core_pattern"

--- a/automation/tests-machine-utils.sh
+++ b/automation/tests-machine-utils.sh
@@ -1,0 +1,4 @@
+function start_machine_services {
+    systemctl start openvswitch
+    systemctl restart NetworkManager
+}


### PR DESCRIPTION
This backport is needed in order to enable CI gating for Fedora packages.