### PR TITLE
WIP: Travis CI: Switch to Ubuntu 20.04 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 ---
-dist: bionic
+dist: focal
 language: generic
 env:
     global:
-        - CONTAINER_CMD=docker
+        - CONTAINER_CMD=podman
         - customize=""
     matrix:
         - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
@@ -56,9 +56,7 @@ addons:
             - openssh-client
             - python-tox
             - xz-utils
-
-services:
-    - docker
+            - podman
 
 script:
     - sudo modprobe openvswitch


### PR DESCRIPTION
The Ubuntu 20.04 ships the podman in official repo, change from docker
to podman.