### PR TITLE
Switch to podman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 language: generic
 env:
     global:
-        - CONTAINER_CMD=docker
+        - CONTAINER_CMD=podman
         - customize=""
     matrix:
         - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
@@ -50,15 +50,20 @@ matrix:
 
 addons:
     apt:
+        sources:
+        # Add podman repo suggested by
+        #   https://podman.io/getting-started/installation.html
+        - sourceline: 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /'
+          key_url: 'https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_18.04/Release.key'
+
         packages:
             - git
             - gnupg2
             - openssh-client
             - python-tox
             - xz-utils
-
-services:
-    - docker
+            - podman
+            - containernetworking-plugins   # Need for podman as root user
 
 script:
     - sudo modprobe openvswitch

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ changedir = {toxinidir}
 deps =
     yamllint==1.23.0
 commands =
-    yamllint .
+    yamllint libnmstate/schemas/ examples/
 
 [pytest]
 addopts = -rxs


### PR DESCRIPTION
The docker does not allows sysfs modification on linux bridge option
like `multicast_startup_query_interval`, hence we should switch to
podman.

Using the podman upstream ubuntu repo for installing.

The URL in .travis.yml is long and will fail yamllint, hence changed the
yamllint to check on `examples/` and `libnmstate/schemas/` folder only.
