### PR TITLE
linux bridge: Workaround for 250 HZ kernel

### DIFF
--- a/libnmstate/error.py
+++ b/libnmstate/error.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2020 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -74,6 +74,17 @@ class NmstateVerificationError(NmstateError):
     """
     After applied desired state, current state does not match desired state for
     unknown reason.
+    """
+
+    pass
+
+
+class NmstateKernelIntegerRoundedError(NmstateVerificationError):
+    """
+    After applied desired state, current state does not match desire state
+    due to integer been rounded by kernel.
+    For example, with HZ configured as 250 in kernel, the linux bridge option
+    multicast_startup_query_interval, 3125 will be rounded to 3124.
     """
 
     pass

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -19,6 +19,7 @@
 
 import logging
 
+from libnmstate.error import NmstateKernelIntegerRoundedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.prettystate import format_desired_current_state_diff
@@ -302,6 +303,21 @@ class Ifaces:
                             )
                         )
                     elif not iface.match(cur_iface):
+                        if iface.type == InterfaceType.LINUX_BRIDGE:
+                            (
+                                key,
+                                value,
+                                cur_value,
+                            ) = LinuxBridgeIface.is_integer_rounded(
+                                iface, cur_iface
+                            )
+                            if key:
+                                raise NmstateKernelIntegerRoundedError(
+                                    "Linux kernel configured with 250 HZ "
+                                    "will round up/down the integer in linux "
+                                    f"bridge {iface.name} option '{key}' "
+                                    f"from {value} to {cur_value}."
+                                )
                         raise NmstateVerificationError(
                             format_desired_current_state_diff(
                                 iface.state_for_verify(),

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -129,7 +129,7 @@ def _create_bridge_config(ports):
                 LB.Options.MULTICAST_QUERY_INTERVAL: 12500,
                 LB.Options.MULTICAST_QUERY_RESPONSE_INTERVAL: 1000,
                 LB.Options.MULTICAST_STARTUP_QUERY_COUNT: 2,
-                LB.Options.MULTICAST_STARTUP_QUERY_INTERVAL: 3125,
+                LB.Options.MULTICAST_STARTUP_QUERY_INTERVAL: 3000,
             }
         )
     return bridge_config

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -28,6 +28,10 @@ def is_fedora():
     return os.path.exists("/etc/fedora-release")
 
 
+def is_ubuntu_kernel():
+    return "Ubuntu" in os.uname().version
+
+
 def is_nm_older_than_1_25_2():
     _, output, _ = exec_cmd(["nmcli", "-v"], check=True)
     match = re.compile("version ([0-9.]+)").search(output)


### PR DESCRIPTION
The linux kernel bridge option use `clock_t_to_jiffies()` and
`clock_t_to_jiffies()` when showing/setting to/from user input value.

Above two functions will lose precision when kernel HZ is configured as
250(Ubuntu 18.04/20.04 is), which lead to `NmstateVerificationError` when
trying to set `multicast_startup_query_interval` of linux bridge to
3125 which been rounded to 3124 by kernel.

Will raise `NmstateKernelIntergerRounded` at verification stage when
integer is rounded for linux bridge option.

Changed old test case to get it pass on Travis CI(Ubuntu host).
Added new test case for this use case.