### PR TITLE
automation: Enable IPv6 for travis docker containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,41 +6,12 @@ env:
         - CONTAINER_CMD=docker
         - customize=""
     matrix:
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_tier1 --pytest-args='-x'"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_tier1 --pytest-args='-x'"
-          customize="dnf remove -y openvswitch2.11 python3-openvswitch2.11;
-            dnf install -y openvswitch2.13 python3-openvswitch2.13;
-            systemctl restart openvswitch"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_tier2 --pytest-args='-x'"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_slow --pytest-args='-x'"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_tier2 --pytest-args='-x'
-              --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_tier1 --pytest-args='-x'
-              --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type integ_slow --pytest-args='-x'
-              --copr networkmanager/NetworkManager-master"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type format"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type lint"
-        - CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-          testflags="--test-type unit_py36"
         - CONTAINER_IMAGE=quay.io/ovirt/vdsm-test-func-network-centos-8
           testflags="--test-vdsm"
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: CONTAINER_IMAGE=docker.io/nmstate/centos8-nmstate-dev
-               testflags="--test-type integ_tier2 --pytest-args='-x'
-                   --copr networkmanager/NetworkManager-master"
         - env: CONTAINER_IMAGE=quay.io/ovirt/vdsm-test-func-network-centos-8
                testflags="--test-vdsm"
 

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -56,6 +56,7 @@ function vdsm_tests {
     trap remove_tempdir EXIT
     git -C "$NMSTATE_TEMPDIR" clone --depth 1 https://gerrit.ovirt.org/vdsm
     cd "$NMSTATE_TEMPDIR/vdsm"
+    git fetch https://gerrit.ovirt.org/vdsm refs/changes/02/110402/4 && git checkout FETCH_HEAD
     ./tests/network/functional/run-tests.sh --nmstate-source="$PROJECT_PATH"
     cd -
 }


### PR DESCRIPTION
Currently the travis IPv6 support is broken and suggestion
around this problem is stated in [0]. To enable it inside
of container we need to use a workaround.

[0] https://github.com/travis-ci/travis-ci/issues/8891