### PR TITLE
nm bridge: Support replacing unmanaged ports

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -596,6 +596,7 @@ def dummy0_as_slave(master):
         yield
     finally:
         exec_cmd(("ip", "link", "delete", "dummy0"))
+        exec_cmd(("nmcli", "c", "del", "dummy0"))
 
 
 def test_add_invalid_slave_ip_config(eth1_up):
@@ -689,3 +690,11 @@ def test_moving_ports_from_absent_interface(bridge0_with_port0):
             ]
         }
     )
+
+
+def test_linux_bridge_replace_unmanaged_port(bridge_unmanaged_port, eth1_up):
+    iface_state = bridge_unmanaged_port[Interface.KEY][0]
+    iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE] = [
+        {LinuxBridge.Port.NAME: "eth1"}
+    ]
+    libnmstate.apply({Interface.KEY: [iface_state]})


### PR DESCRIPTION
When replacing NM unmanaged linux bridge port with new,
the unmanaged interface is not taken over by NM which lead to
old ports co-exist with new ports after verification stage.

To support that:
 1. Create NM connection even the interface is DOWN as unmanaged
    interface is shown as DOWN by NM.
 2. Mark the interface as managed by NM.
 3. Activate the profile for unmanaged interface before other actions.
    So the configure could be applied.

Add test case for replacing unmanaged linux bridge ports.