### PR TITLE
iface: Allowing moving subordinate from absent interface

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -413,10 +413,12 @@ class Ifaces:
             for slave_name in iface.slaves:
                 cur_master = slave_master_map.get(slave_name)
                 if cur_master:
-                    raise NmstateValueError(
-                        f"Interface {iface.name} slave {slave_name} is "
-                        f"already enslaved by interface {cur_master}"
-                    )
+                    cur_master_iface = self._ifaces.get(cur_master)
+                    if cur_master_iface and not cur_master_iface.is_absent:
+                        raise NmstateValueError(
+                            f"Interface {iface.name} slave {slave_name} is "
+                            f"already enslaved by interface {cur_master}"
+                        )
                 else:
                     slave_master_map[slave_name] = iface.name
 

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -657,3 +657,35 @@ def test_linux_bridge_option_integer_rounded_on_ubuntu_kernel(
 
     with pytest.raises(NmstateKernelIntegerRoundedError):
         libnmstate.apply(desired_state)
+
+
+@pytest.mark.tier1
+def test_moving_ports_from_absent_interface(bridge0_with_port0):
+    iface_state = bridge0_with_port0[Interface.KEY][0]
+    iface_state[Interface.NAME] = "linux-br1"
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                iface_state,
+                {
+                    Interface.NAME: TEST_BRIDGE0,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
+
+    assertlib.assert_state_match({Interface.KEY: [iface_state]})
+    assertlib.assert_absent(TEST_BRIDGE0)
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "linux-br1",
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )


### PR DESCRIPTION
Current code will raise NmstateValueError on overbooks subordinate even
the old main interface is marked as absent.