### PR TITLE
[nmstate-0.3] test: Isolate veth peer into separate net namespace

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -36,6 +36,8 @@ PYTEST_OPTIONS="--verbose --verbose \
 
 NMSTATE_TEMPDIR=$(mktemp -d /tmp/nmstate-test-XXXX)
 
+VETH_PEER_NS="nmstate_test"
+
 : ${CONTAINER_CMD:=podman}
 
 test -t 1 && USE_TTY="-t"
@@ -221,14 +223,18 @@ function check_iface_exist {
 
 function prepare_network_environment {
     set +e
+    exec_cmd "ip netns add ${VETH_PEER_NS}"
     for device in $INTERFACES;
     do
         peer="${device}peer"
         check_iface_exist $device
         if [ $? -eq 1 ]; then
             CREATED_INTERFACES="${CREATED_INTERFACES} ${device}"
-            exec_cmd "ip link add ${device} type veth peer name ${peer} && ip link set ${peer} up"
-	    exec_cmd "nmcli device set ${device} managed yes"
+            exec_cmd "ip link add ${device} type veth peer name ${peer}"
+            exec_cmd "ip link set ${peer} netns ${VETH_PEER_NS}"
+            exec_cmd "ip netns exec ${VETH_PEER_NS} ip link set ${peer} up"
+            exec_cmd "ip link set ${device} up"
+            exec_cmd "nmcli device set ${device} managed yes"
         fi
     done
     set -e
@@ -239,6 +245,7 @@ function teardown_network_environment {
     do
         exec_cmd "ip link del ${device}"
     done
+    exec_cmd "ip netns del ${VETH_PEER_NS}"
 }
 
 function upgrade_nm_from_copr {

--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from contextlib import contextmanager
+import os
 import time
 import yaml
 
@@ -317,11 +318,12 @@ def lldp_enabled(ifstate):
 
 
 def _send_lldp_packet():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
     cmdlib.exec_cmd(
         (
             "tcpreplay",
-            "--intf1=lldptestpeer",
-            f"tests/integration/test_captures/lldp.pcap",
+            "--intf1=eth1peer",
+            f"{test_dir}/test_captures/lldp.pcap",
         ),
         check=True,
     )

--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -31,9 +31,14 @@ from .testlib import assertlib
 from .testlib import cmdlib
 from .testlib import ifacelib
 from .testlib import statelib
+from .testlib.veth import create_veth_pair
+from .testlib.veth import remove_veth_pair
 
 
 LLDPTEST = "lldptest"
+LLDPTEST_PEER = "lldptest.peer"
+
+LLDP_TEST_NS = "nmstate_lldp_test"
 
 LLDP_SYSTEM_DESC = (
     "Summit300-48 - Version 7.4e.1 (Build 5) by Release_Master "
@@ -118,10 +123,10 @@ LLDP_TEST_SYSTEM_NAME = "Summit300-48"
 @pytest.fixture(scope="module")
 def lldpiface_env():
     try:
-        _create_veth_pair()
+        create_veth_pair(LLDPTEST, LLDPTEST_PEER, LLDP_TEST_NS)
         yield
     finally:
-        _remove_veth_pair()
+        remove_veth_pair(LLDPTEST, LLDP_TEST_NS)
 
 
 @pytest.fixture
@@ -140,8 +145,8 @@ def test_lldp_yaml(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
-
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
         assert test_neighbor == yaml.safe_load(EXPECTED_LLDP_NEIGHBOR)
 
 
@@ -150,7 +155,8 @@ def test_lldp_system(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         seen = set()
         for tlv in test_neighbor:
@@ -169,7 +175,8 @@ def test_lldp_chassis(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -186,7 +193,8 @@ def test_lldp_management_addresses(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -206,7 +214,8 @@ def test_lldp_macphy(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -227,7 +236,8 @@ def test_lldp_port(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -245,7 +255,8 @@ def test_lldp_port_vlan(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -264,7 +275,8 @@ def test_lldp_vlan(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -284,7 +296,8 @@ def test_lldp_mfs(lldptest_up):
         _send_lldp_packet()
         dstate = statelib.show_only((LLDPTEST,))
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
-        test_neighbor = _get_lldp_test(lldp_config[LLDP.NEIGHBORS_SUBTREE])
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
 
         tlvs = list(
             filter(
@@ -320,48 +333,9 @@ def lldp_enabled(ifstate):
 def _send_lldp_packet():
     test_dir = os.path.dirname(os.path.realpath(__file__))
     cmdlib.exec_cmd(
-        (
-            "tcpreplay",
-            "--intf1=eth1peer",
-            f"{test_dir}/test_captures/lldp.pcap",
-        ),
+        f"ip netns exec {LLDP_TEST_NS} "
+        f"tcpreplay --intf1={LLDPTEST_PEER} "
+        f"{test_dir}/test_captures/lldp.pcap".split(),
         check=True,
     )
     time.sleep(1)
-
-
-def _get_lldp_test(neighbors):
-    for neighbor in neighbors:
-        tlvs = list(
-            filter(
-                lambda tlv: tlv[LLDP.Neighbors.TLV_TYPE] == 5
-                and tlv[SYSTEM_NAME] == LLDP_TEST_SYSTEM_NAME,
-                neighbor,
-            )
-        )
-        if len(tlvs) == 1:
-            return neighbor
-
-    return None
-
-
-def _create_veth_pair():
-    cmdlib.exec_cmd(
-        (
-            "ip",
-            "link",
-            "add",
-            LLDPTEST,
-            "type",
-            "veth",
-            "peer",
-            "name",
-            LLDPTEST + "peer",
-        ),
-        check=True,
-    )
-    cmdlib.exec_cmd(("ip", "link", "set", LLDPTEST + "peer", "up"), check=True)
-
-
-def _remove_veth_pair():
-    cmdlib.exec_cmd(("ip", "link", "del", "dev", LLDPTEST), check=True)

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+
+from .cmdlib import exec_cmd
+
+
+def create_veth_pair(nic, nic_peer, peer_ns):
+    """
+    Create a veth pair and place the {peer} into {peer_ns} namespace.
+    The {nic} will be marked as managed by NetworkManager
+    """
+    exec_cmd(
+        f"ip link add {nic} type veth peer name {nic_peer}".split(),
+        check=True,
+    )
+    exec_cmd(f"ip netns add {peer_ns}".split(), check=True)
+    exec_cmd(f"ip link set {nic_peer} netns {peer_ns}".split(), check=True)
+    exec_cmd(f"ip link set {nic} up".split(), check=True)
+    exec_cmd(
+        f"ip netns exec {peer_ns} ip link set {nic_peer} up".split(),
+        check=True,
+    )
+    exec_cmd(f"nmcli device set {nic} managed yes".split(), check=True)
+
+
+def remove_veth_pair(nic, peer_ns):
+    exec_cmd(f"ip link del {nic}".split())
+    exec_cmd(f"ip netns del {peer_ns}".split())


### PR DESCRIPTION
Put the veth peer into separate net namespace, to NetworkManager will not
impact test results by trying to managing the veth peer.