### PR TITLE
[nmstate-0.3] state: Don't merge state:down if not defined in desire state

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -220,6 +220,12 @@ class BaseIface:
 
     def merge(self, other):
         merge_dict(self._info, other._info)
+        # If down state is not from orignal state, set it as UP.
+        if (
+            Interface.STATE not in self._origin_info
+            and self.state == InterfaceState.DOWN
+        ):
+            self._info[Interface.STATE] = InterfaceState.UP
 
     def _validate_slave_ip(self):
         for family in (Interface.IPV4, Interface.IPV6):

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -24,6 +24,7 @@ import pytest
 from libnmstate.error import NmstateInternalError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
 
 from libnmstate.ifaces.base_iface import BaseIface
 from ..testlib.constants import MAC_ADDRESS1
@@ -71,6 +72,19 @@ class TestBaseIface:
         assert des_info == ori_des_info
         assert cur_iface.to_dict() == ori_cur_info
         assert des_iface.to_dict() == expected_info
+
+    def test_do_not_merge_down_state_from_current(self):
+        iface_info = gen_foo_iface_info()
+        cur_iface_info = gen_foo_iface_info()
+        iface_info.pop(Interface.STATE)
+        cur_iface_info[Interface.STATE] = InterfaceState.DOWN
+
+        iface = BaseIface(iface_info)
+        cur_iface = BaseIface(cur_iface_info)
+
+        iface.merge(cur_iface)
+
+        assert iface.is_up
 
     def test_capitalize_mac(self):
         iface_info = gen_foo_iface_info()


### PR DESCRIPTION
When user include only interface name in desire state, we should
treat it as state:up instead of merging from current state:down.

Test case added.