### PR TITLE
[nmstate-0.3] nm.wired: do not report MTU if it is 0

### DIFF
--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -124,7 +124,9 @@ def get_info(device):
 
     iface = device.get_iface()
     try:
-        info[Interface.MTU] = int(device.get_mtu())
+        mtu = int(device.get_mtu())
+        if mtu:
+            info[Interface.MTU] = mtu
     except AttributeError:
         pass
 


### PR DESCRIPTION
If an interface contains an MTU with value 0, Nmstate should not report
it because it is an special interface like OVS patch port interfaces.

Added a test case for this.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>