### PR TITLE
nm ovs: Raise NmstateNotSupportedError for save_to_disk=False

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -30,6 +30,7 @@ from libnmstate.schema import OVSBridge
 from libnmstate.schema import OvsDB
 from libnmstate.schema import OVSInterface
 from libnmstate.error import NmstateDependencyError
+from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateValueError
 
 from .testlib import assertlib
@@ -533,3 +534,10 @@ def test_create_ovs_with_internal_ports_in_reverse_order():
     assertlib.assert_absent(BRIDGE1)
     assertlib.assert_absent(PORT1)
     assertlib.assert_absent(PORT2)
+
+
+def test_create_memory_only_ovs_bridge_not_supported():
+    bridge = Bridge(BRIDGE1)
+
+    with pytest.raises(NmstateNotSupportedError):
+        libnmstate.apply(bridge.state, save_to_disk=False)


### PR DESCRIPTION
Due to limitation of NetworkManager 1.26, nmstate cannot support
`save_to_disk=False`(ask, memory only) state for OVS interfaces.

Raise NmstateNotSupportedError if NetworkManager version is older than
1.28 and has OVS interface in desire state with `save_to_disk=False`.

Integration test case included.