### PR TITLE
state: Remove unmanaged interface before verifying

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -286,16 +286,16 @@ class Ifaces:
     def cur_ifaces(self):
         return self._cur_ifaces
 
-    def _remove_unmanaged_slaves(self):
+    def _remove_unknown_interface_type_slaves(self):
         """
-        When master containing unmanaged slaves, they should be removed from
-        master slave list.
+        When master containing slaves with unknown interface type, they should
+        be removed from master slave list before verifying.
         """
         for iface in self._ifaces.values():
             if iface.is_up and iface.is_master and iface.slaves:
                 for slave_name in iface.slaves:
                     slave_iface = self._ifaces[slave_name]
-                    if not slave_iface.is_up:
+                    if slave_iface.type == InterfaceType.UNKNOWN:
                         iface.remove_slave(slave_name)
 
     def verify(self, cur_iface_infos):
@@ -304,6 +304,7 @@ class Ifaces:
             cur_iface_infos=cur_iface_infos,
             save_to_disk=self._save_to_disk,
         )
+        cur_ifaces._remove_unknown_interface_type_slaves()
         for iface in self._ifaces.values():
             if iface.is_desired:
                 if iface.is_virtual and iface.original_dict.get(

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -637,7 +637,7 @@ def _mark_nm_external_subordinate_changed(context, net_state):
     that subordinate should be marked as changed for NM to take over.
     """
     for iface in net_state.ifaces.values():
-        if iface.type in MASTER_IFACE_TYPES:
+        if iface.is_desired or iface.is_changed and iface.is_master:
             for subordinate in iface.slaves:
                 nmdev = context.get_nm_dev(subordinate)
                 if nmdev:
@@ -647,5 +647,6 @@ def _mark_nm_external_subordinate_changed(context, net_state):
                         and NM.ActivationStateFlags.EXTERNAL
                         & nm_ac.get_state_flags()
                     ):
-                        subordinate_iface = net_state.ifaces[subordinate]
-                        subordinate_iface.mark_as_changed()
+                        subordinate_iface = net_state.ifaces.get(subordinate)
+                        if subordinate_iface:
+                            subordinate_iface.mark_as_changed()

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -166,6 +166,4 @@ def get_device_common_info(dev):
 
 def is_externally_managed(nmdev):
     nm_ac = nmdev.get_active_connection()
-    return (
-        nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()
-    )
+    return nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -23,6 +23,7 @@ from libnmstate.error import NmstateLibnmError
 
 from . import active_connection as ac
 from . import connection
+from .common import NM
 
 
 def activate(context, dev=None, connection_id=None):
@@ -161,3 +162,10 @@ def get_device_common_info(dev):
         "type_name": dev.get_type_description(),
         "state": dev.get_state(),
     }
+
+
+def is_externally_managed(nmdev):
+    nm_ac = nmdev.get_active_connection()
+    return (
+        nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()
+    )


### PR DESCRIPTION
Since we remove unknown type interface before sending to apply, we should
also remove unknown type interface before verifying.