### PR TITLE
[nmstate-0.3] state: Remove unmanaged interface before verifying

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -286,16 +286,16 @@ class Ifaces:
     def cur_ifaces(self):
         return self._cur_ifaces
 
-    def _remove_unmanaged_slaves(self):
+    def _remove_unknown_interface_type_slaves(self):
         """
-        When master containing unmanaged slaves, they should be removed from
-        master slave list.
+        When master containing slaves with unknown interface type, they should
+        be removed from master slave list before verifying.
         """
         for iface in self._ifaces.values():
             if iface.is_up and iface.is_master and iface.slaves:
                 for slave_name in iface.slaves:
                     slave_iface = self._ifaces[slave_name]
-                    if not slave_iface.is_up:
+                    if slave_iface.type == InterfaceType.UNKNOWN:
                         iface.remove_slave(slave_name)
 
     def verify(self, cur_iface_infos):
@@ -304,6 +304,7 @@ class Ifaces:
             cur_iface_infos=cur_iface_infos,
             save_to_disk=self._save_to_disk,
         )
+        cur_ifaces._remove_unknown_interface_type_slaves()
         for iface in self._ifaces.values():
             if iface.is_desired:
                 if iface.is_virtual and iface.original_dict.get(

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -637,7 +637,7 @@ def _mark_nm_external_subordinate_changed(context, net_state):
     that subordinate should be marked as changed for NM to take over.
     """
     for iface in net_state.ifaces.values():
-        if iface.type in MASTER_IFACE_TYPES:
+        if iface.is_desired or iface.is_changed and iface.is_master:
             for subordinate in iface.slaves:
                 nmdev = context.get_nm_dev(subordinate)
                 if nmdev:
@@ -647,5 +647,6 @@ def _mark_nm_external_subordinate_changed(context, net_state):
                         and NM.ActivationStateFlags.EXTERNAL
                         & nm_ac.get_state_flags()
                     ):
-                        subordinate_iface = net_state.ifaces[subordinate]
-                        subordinate_iface.mark_as_changed()
+                        subordinate_iface = net_state.ifaces.get(subordinate)
+                        if subordinate_iface:
+                            subordinate_iface.mark_as_changed()

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -166,6 +166,4 @@ def get_device_common_info(dev):
 
 def is_externally_managed(nmdev):
     nm_ac = nmdev.get_active_connection()
-    return (
-        nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()
-    )
+    return nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -23,6 +23,7 @@ from libnmstate.error import NmstateLibnmError
 
 from . import active_connection as ac
 from . import connection
+from .common import NM
 
 
 def activate(context, dev=None, connection_id=None):
@@ -161,3 +162,10 @@ def get_device_common_info(dev):
         "type_name": dev.get_type_description(),
         "state": dev.get_state(),
     }
+
+
+def is_externally_managed(nmdev):
+    nm_ac = nmdev.get_active_connection()
+    return (
+        nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()
+    )

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -53,6 +53,7 @@ from .testlib.env import is_ubuntu_kernel
 
 
 TEST_BRIDGE0 = "linux-br0"
+TEST_TAP0 = "tap0"
 
 
 BRIDGE_OPTIONS_YAML = """
@@ -699,3 +700,30 @@ def test_linux_bridge_replace_unmanaged_port(bridge_unmanaged_port, eth1_up):
         {LinuxBridge.Port.NAME: "eth1"}
     ]
     libnmstate.apply({Interface.KEY: [iface_state]})
+
+
+@pytest.fixture
+def bridge0_with_tap_port():
+    exec_cmd(f"ip tuntap add name {TEST_TAP0} mode tap".split(), check=True)
+    exec_cmd(f"ip link add {TEST_BRIDGE0} type bridge".split(), check=True)
+    exec_cmd(
+        f"ip link set {TEST_TAP0} master {TEST_BRIDGE0}".split(), check=True
+    )
+    exec_cmd(f"ip link set {TEST_TAP0} up".split(), check=True)
+    exec_cmd(f"ip link set {TEST_BRIDGE0} up".split(), check=True)
+    yield
+    exec_cmd(f"ip link del {TEST_TAP0}".split())
+    exec_cmd(f"ip link del {TEST_BRIDGE0}".split())
+    exec_cmd(f"nmcli c del {TEST_TAP0}".split())
+    exec_cmd(f"nmcli c del {TEST_BRIDGE0}".split())
+
+
+def test_ignore_unmanged_tap_as_bridge_port(bridge0_with_tap_port, port0_up):
+    """
+    The unknown interface should be still bridge port along with other ports
+    """
+    with _bridge0_with_port0(port0_up) as state:
+        state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+            LinuxBridge.PORT_SUBTREE
+        ].append({LinuxBridge.Port.NAME: TEST_TAP0})
+        assertlib.assert_state_match(state)


### PR DESCRIPTION
Since we remove unknown type interface before sending to apply, we should
also remove unknown type interface before verifying.