### PR TITLE
[nmstate-0.3] nm profile: Remove inactivate profile of desired interface

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -105,6 +105,15 @@ def apply_changes(context, net_state, save_to_disk):
                 cur_con_profile = connection.ConnectionProfile(
                     context, profile=con_profile
                 )
+
+        if save_to_disk:
+            # TODO: Need handle save_to_disk=False
+            connection.delete_iface_profiles_except(
+                context,
+                ifname,
+                cur_con_profile.profile if cur_con_profile else None,
+            )
+
         original_desired_iface_state = {}
         if net_state.ifaces.get(ifname):
             iface = net_state.ifaces[ifname]
@@ -137,7 +146,6 @@ def apply_changes(context, net_state, save_to_disk):
             con_profiles.append(new_con_profile)
         else:
             # Missing connection, attempting to create a new one.
-            connection.delete_iface_inactive_connections(context, ifname)
             new_con_profile.add(save_to_disk)
             con_profiles.append(new_con_profile)
     context.wait_all_finish()

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -496,9 +496,14 @@ def get_device_active_connection(nm_device):
     return active_conn
 
 
-def delete_iface_inactive_connections(context, ifname):
+def delete_iface_profiles_except(context, ifname, excluded_profile):
     for con in list_connections_by_ifname(context, ifname):
-        con.delete()
+        if (
+            not excluded_profile
+            or not con.profile
+            or con.profile.get_uuid() != excluded_profile.get_uuid()
+        ):
+            con.delete()
 
 
 def list_connections_by_ifname(context, ifname):


### PR DESCRIPTION
For changed/desired interface, NM should remove all its inactive
profiles so that it could update and activate the same one.

Integration test case included.