### PR TITLE
CI: Remove NM copr repo from CentOS stream image

### DIFF
--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -5,7 +5,6 @@ RUN dnf install -y centos-release-stream && \
     dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools && \
     dnf copr enable nmstate/ovs-el8 -y && \
-    dnf copr enable networkmanager/NetworkManager-1.26 -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \


### PR DESCRIPTION
The CentOS stream is shipping NM 1.26 now, no need to use
NM 1.26 copr repo any more.