### PR TITLE
ovs: Fix bug when adding bond to existing bridge

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -217,7 +217,8 @@ class Ifaces:
                     self._ifaces[iface_name].mark_as_changed()
             if cur_iface:
                 for slave_name in iface.config_changed_slaves(cur_iface):
-                    self._ifaces[slave_name].mark_as_changed()
+                    if slave_name in self._ifaces:
+                        self._ifaces[slave_name].mark_as_changed()
 
     def _match_child_iface_state_with_parent(self):
         """

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -327,6 +327,16 @@ class TestOvsLinkAggregation:
             pretty_state = PrettyState(current_state)
             assert OVS_BOND_YAML_STATE in pretty_state.yaml
 
+    @pytest.mark.tier1
+    def test_add_ovs_lag_to_existing_ovs_bridge(self, port0_up, port1_up):
+        with Bridge(BRIDGE1).create():
+            port0_name = port0_up[Interface.KEY][0][Interface.NAME]
+            port1_name = port1_up[Interface.KEY][0][Interface.NAME]
+            bridge = Bridge(BRIDGE1)
+            bridge.add_link_aggregation_port(BOND1, (port1_name, port0_name))
+            libnmstate.apply(bridge.state)
+            assertlib.assert_state_match(bridge.state)
+
 
 @pytest.mark.tier1
 def test_ovs_vlan_access_tag():


### PR DESCRIPTION
When adding OVS bond/link aggregation interface to existing OVS bridge,
nmstate will fail with error:

    > self._ifaces[slave_name].mark_as_changed()
    E KeyError: 'bond1'

This is because ovs bond interface does not require a interface entry in
desire state.

Fixed by check before adding dict.

Integration test case added.