### PR TITLE
[nmstate-0.3] nm: Fix converting memory-only profile to persistent

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -125,6 +125,7 @@ def apply_changes(context, net_state, save_to_disk):
                 and cur_con_profile
                 and cur_con_profile.profile
                 and not net_state.ifaces[ifname].is_changed
+                and cur_con_profile.is_memory_only != save_to_disk
             ):
                 # Don't create new profile if original desire does not ask
                 # anything besides state:up and not been marked as changed.

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -163,6 +163,16 @@ class ConnectionProfile:
         self._con_profile = con_profile
 
     @property
+    def is_memory_only(self):
+        if self._con_profile:
+            profile_flags = self._con_profile.get_flags()
+            return (
+                NM.SettingsConnectionFlags.UNSAVED & profile_flags
+                or NM.SettingsConnectionFlags.VOLATILE & profile_flags
+            )
+        return False
+
+    @property
     def devname(self):
         if self._con_profile:
             return self._con_profile.get_interface_name()

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -376,3 +376,12 @@ def test_linux_bridge_with_port_holding_two_profiles(eth1_with_two_profiles):
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.tier1
+def test_converting_memory_only_profile_to_persistent():
+    with dummy_interface(DUMMY0_IFNAME, save_to_disk=False) as dstate:
+        libnmstate.apply(dstate, save_to_disk=True)
+        assert _profile_exists(DUMMY_PROFILE_DIRECTORY + "dummy0.nmconnection")
+
+    assertlib.assert_absent(DUMMY0_IFNAME)


### PR DESCRIPTION
When converting memory-only profile to persistent using simple desire
state with `state: up` only, the memory only profile will not be
converted to persistent.

This is caused by `nm/applier.py` skip profile creation if desire state
is only `state: up`.

The fix is checking whether current profile's persistent state is equal
to desired.

Integration test case added.