### PR TITLE
tox: Fix pylint test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,10 @@ commands =
 
 [testenv:pylint]
 basepython = python3.6
-sitepackages = True
+sitepackages = true
 skip_install = true
 changedir = {toxinidir}
-deps = {[testenv]deps}
+deps =
     pylint==2.4.4
 commands =
     pylint \


### PR DESCRIPTION
The tox will try to compile pygobject which does not required for
pylint.

Remove the dependency install for pylint.