### PR TITLE
nispor: Introduce nispor plugin

### DIFF
--- a/libnmstate/nispor/__init__.py
+++ b/libnmstate/nispor/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -1,0 +1,144 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import logging
+from operator import attrgetter
+
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIP
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+
+
+DEFAULT_MAC_ADDRESS = "00:00:00:00:00:00"
+
+
+class NisporPluginBaseIface:
+    def __init__(self, np_iface):
+        self._np_iface = np_iface
+
+    @property
+    def np_iface(self):
+        return self._np_iface
+
+    @property
+    def mac(self):
+        mac = self._np_iface.mac_address
+        if not mac:
+            mac = DEFAULT_MAC_ADDRESS
+        return mac
+
+    @property
+    def mtu(self):
+        return self._np_iface.mtu
+
+    @property
+    def type(self):
+        return InterfaceType.UNKNOWN
+
+    @property
+    def state(self):
+        np_state = self._np_iface.state
+        np_flags = self._np_iface.flags
+        if np_state == "Up" or "Up" in np_flags or "Running" in np_flags:
+            return InterfaceState.UP
+        elif np_state == "Down":
+            return InterfaceState.DOWN
+        else:
+            logging.debug(
+                f"Got unexpect nispor interface state {np_state} for "
+                f"{self._np_iface}"
+            )
+            return InterfaceState.DOWN
+
+    def ip_info(self):
+        return {
+            Interface.IPV4: NisporPlugintIpState(
+                Interface.IPV4, self.np_iface.ipv4
+            ).to_dict(),
+            Interface.IPV6: NisporPlugintIpState(
+                Interface.IPV6, self.np_iface.ipv6
+            ).to_dict(),
+        }
+
+    def to_dict(self):
+        iface_info = {
+            Interface.NAME: self.np_iface.name,
+            Interface.TYPE: self.type,
+            Interface.STATE: self.state,
+            Interface.MAC: self.mac,
+        }
+        if self.mtu:
+            iface_info[Interface.MTU] = self.mtu
+        ip_info = self.ip_info()
+        if ip_info:
+            iface_info.update(ip_info)
+
+        return iface_info
+
+
+class NisporPlugintIpState:
+    def __init__(self, family, np_ip_state):
+        self._family = family
+        self._np_ip_state = np_ip_state
+        self._addresses = []
+        if np_ip_state:
+            self._addresses = sorted(
+                np_ip_state.addresses, key=attrgetter("address")
+            )
+
+    @property
+    def _is_ipv6(self):
+        return self._family == Interface.IPV6
+
+    def _has_dhcp_address(self):
+        if self._is_ipv6:
+            return any(
+                addr.valid_lft != "forever" and addr.prefix_len == 128
+                for addr in self._addresses
+            )
+        else:
+            return any(addr.valid_lft != "forever" for addr in self._addresses)
+
+    def _has_autoconf_address(self):
+        return self._is_ipv6 and any(
+            addr.valid_lft != "forever" and addr.prefix_len == 64
+            for addr in self._addresses
+        )
+
+    def to_dict(self):
+        if not self._addresses or not self._np_ip_state:
+            return {InterfaceIP.ENABLED: False, InterfaceIP.ADDRESS: []}
+        else:
+            info = {
+                InterfaceIP.ENABLED: True,
+                InterfaceIP.ADDRESS: [
+                    {
+                        InterfaceIP.ADDRESS_IP: addr.address,
+                        InterfaceIP.ADDRESS_PREFIX_LENGTH: addr.prefix_len,
+                    }
+                    for addr in self._addresses
+                ],
+            }
+            if self._has_dhcp_address():
+                info[InterfaceIP.DHCP] = True
+            if self._has_autoconf_address():
+                info[InterfaceIPv6.AUTOCONF] = True
+            return info

--- a/libnmstate/nispor/bond.py
+++ b/libnmstate/nispor/bond.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginBondIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.BOND

--- a/libnmstate/nispor/bridge.py
+++ b/libnmstate/nispor/bridge.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginBridgeIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.LINUX_BRIDGE

--- a/libnmstate/nispor/dummy.py
+++ b/libnmstate/nispor/dummy.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginDummyIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.DUMMY

--- a/libnmstate/nispor/ethernet.py
+++ b/libnmstate/nispor/ethernet.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginEthernetIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.ETHERNET

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import nispor
+
+from libnmstate.plugin import NmstatePlugin
+
+from .base_iface import NisporPluginBaseIface
+from .dummy import NisporPluginDummyIface
+from .ethernet import NisporPluginEthernetIface
+from .bond import NisporPluginBondIface
+from .vlan import NisporPluginVlanIface
+from .vxlan import NisporPluginVxlanIface
+from .bridge import NisporPluginBridgeIface
+
+
+class NisporPlugin(NmstatePlugin):
+    @property
+    def name(self):
+        return "nispor"
+
+    @property
+    def plugin_capabilities(self):
+        return [
+            NmstatePlugin.PLUGIN_CAPABILITY_IFACE,
+        ]
+
+    @property
+    def priority(self):
+        # Let NetworkManagerPlugin take priority as nispor might be wrong on
+        # DHCP status and currently nispor does not support all interface types
+        # yet.
+        return NmstatePlugin.DEFAULT_PRIORITY - 1
+
+    def get_interfaces(self):
+        np_state = nispor.get_state()
+        ifaces = []
+        for np_iface in np_state.ifaces.values():
+            iface_type = np_iface.type
+            if iface_type == "Dummy":
+                ifaces.append(NisporPluginDummyIface(np_iface).to_dict())
+            elif iface_type == "Veth":
+                ifaces.append(NisporPluginEthernetIface(np_iface).to_dict())
+            elif iface_type == "Ethernet":
+                ifaces.append(NisporPluginEthernetIface(np_iface).to_dict())
+            elif iface_type == "Bond":
+                ifaces.append(NisporPluginBondIface(np_iface).to_dict())
+            elif iface_type == "Vlan":
+                ifaces.append(NisporPluginVlanIface(np_iface).to_dict())
+            elif iface_type == "Vxlan":
+                ifaces.append(NisporPluginVxlanIface(np_iface).to_dict())
+            elif iface_type == "Bridge":
+                ifaces.append(NisporPluginBridgeIface(np_iface).to_dict())
+            else:
+                ifaces.append(NisporPluginBaseIface(np_iface).to_dict())
+        return ifaces

--- a/libnmstate/nispor/vlan.py
+++ b/libnmstate/nispor/vlan.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginVlanIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.VLAN

--- a/libnmstate/nispor/vxlan.py
+++ b/libnmstate/nispor/vxlan.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginVxlanIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.VXLAN

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -58,6 +58,10 @@ class NetworkManagerPlugin(NmstatePlugin):
         self._check_version_mismatch()
 
     @property
+    def priority(self):
+        return NmstatePlugin.DEFAULT_PRIORITY
+
+    @property
     def name(self):
         return "NetworkManager"
 
@@ -108,6 +112,9 @@ class NetworkManagerPlugin(NmstatePlugin):
         ]
 
         for dev, devinfo in devices_info:
+            if not dev.get_managed():
+                # Skip unmanaged interface
+                continue
             type_id = devinfo["type_id"]
 
             iface_info = nm_translator.Nm2Api.get_common_device_info(devinfo)

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -29,9 +29,10 @@ from .device import list_devices
 def get_all_applied_configs(context):
     applied_configs = {}
     for nm_dev in list_devices(context.client):
-        if nm_dev.get_state() in (
-            NM.DeviceState.ACTIVATED,
-            NM.DeviceState.IP_CONFIG,
+        if (
+            nm_dev.get_state()
+            in (NM.DeviceState.ACTIVATED, NM.DeviceState.IP_CONFIG,)
+            and nm_dev.get_managed()
         ):
             iface_name = nm_dev.get_iface()
             if iface_name:

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -123,20 +123,6 @@ def get_info(device):
     info = {}
 
     iface = device.get_iface()
-    try:
-        mtu = int(device.get_mtu())
-        if mtu:
-            info[Interface.MTU] = mtu
-    except AttributeError:
-        pass
-
-    mac = device.get_hw_address()
-    if not mac:
-        mac = _get_mac_address_from_sysfs(iface)
-
-    # A device may not have a MAC or it may not yet be "realized" (zeroed mac).
-    if mac and mac != ZEROED_MAC:
-        info[Interface.MAC] = mac
 
     if device.get_device_type() == NM.DeviceType.ETHERNET:
         ethernet = _get_ethernet_info(device, iface)
@@ -144,21 +130,6 @@ def get_info(device):
             info[Ethernet.CONFIG_SUBTREE] = ethernet
 
     return info
-
-
-def _get_mac_address_from_sysfs(ifname):
-    """
-    Fetch the mac address of an interface from sysfs.
-    This is a workaround for https://bugzilla.redhat.com/1786937.
-    """
-    mac = None
-    sysfs_path = f"/sys/class/net/{ifname}/address"
-    try:
-        with open(sysfs_path) as f:
-            mac = f.read().rstrip("\n").upper()
-    except FileNotFoundError:
-        pass
-    return mac
 
 
 def _get_ethernet_info(device, iface):

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -34,6 +34,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
+from .nispor.plugin import NisporPlugin
 from .plugin import NmstatePlugin
 from .state import merge_dict
 
@@ -99,7 +100,7 @@ def plugins_capabilities(plugins):
 
 
 def _load_plugins():
-    plugins = [NetworkManagerPlugin()]
+    plugins = [NetworkManagerPlugin(), NisporPlugin()]
     plugins.extend(_load_external_py_plugins())
     return plugins
 

--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -5,6 +5,7 @@ RUN dnf install -y centos-release-stream && \
     dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools && \
     dnf copr enable nmstate/ovs-el8 -y && \
+    dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
@@ -30,6 +31,7 @@ RUN dnf install -y centos-release-stream && \
                    python3-coveralls \
                    python3-requests \
                    python3-docopt \
+                   python3-nispor \
                    tcpreplay \
                    && \
     alternatives --set python /usr/bin/python3 && \

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -4,6 +4,7 @@ RUN dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled PowerTools && \
     dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable networkmanager/NetworkManager-1.26 -y && \
+    dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
@@ -29,6 +30,7 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    python3-coveralls \
                    python3-requests \
                    python3-docopt \
+                   python3-nispor \
                    tcpreplay \
                    && \
     alternatives --set python /usr/bin/python3 && \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -2,6 +2,7 @@ FROM docker.io/library/fedora:32
 
 RUN dnf -y install dnf-plugins-core && \
     dnf copr enable networkmanager/NetworkManager-1.26 -y && \
+    dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \
                    NetworkManager-ovs \
@@ -38,6 +39,7 @@ RUN dnf -y install dnf-plugins-core && \
                    glib2-devel \
                    gobject-introspection-devel \
                    python3-devel \
+                   python3-nispor \
                    make && \
                    \
     dnf clean all && \

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -33,6 +33,7 @@ Recommends:     NetworkManager-config-server
 # required for OVS and team support
 Suggests:       NetworkManager-ovs
 Suggests:       NetworkManager-team
+Requires:       python3-nispor
 
 %package -n nmstate-plugin-ovsdb
 Summary:        nmstate plugin for OVS database manipulation

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -25,6 +25,7 @@ import yaml
 
 import libnmstate
 from libnmstate.error import NmstateKernelIntegerRoundedError
+from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.prettystate import PrettyState
@@ -694,6 +695,12 @@ def test_moving_ports_from_absent_interface(bridge0_with_port0):
     )
 
 
+@pytest.mark.xfail(
+    reason="https://bugzilla.redhat.com/1869063 and "
+    "https://bugzilla.redhat.com/1869079",
+    raises=(NmstateLibnmError, NmstateVerificationError),
+    strict=True,
+)
 def test_linux_bridge_replace_unmanaged_port(bridge_unmanaged_port, eth1_up):
     iface_state = bridge_unmanaged_port[Interface.KEY][0]
     iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE] = [

--- a/tests/integration/nm/ipv4_test.py
+++ b/tests/integration/nm/ipv4_test.py
@@ -40,10 +40,19 @@ IPV4_ADDRESS1 = "192.0.2.251"
 RETRY_TIMEOUT = 5
 
 
+def _dict_is_subset(superset, subset):
+    """
+    Code copied from Ignacio Vazquez-Abrams in
+    https://stackoverflow.com/questions/9323749
+    License is CC BY-SA 3.0
+    """
+    return all(item in superset.items() for item in subset.items())
+
+
 def _ip_state_is_expected(nm_plugin, expected_state):
     nm_plugin.refresh_content()
     ipv4_current_state = _get_ipv4_current_state(nm_plugin.context, TEST_IFACE)
-    return ipv4_current_state == expected_state
+    return _dict_is_subset(expected_state, ipv4_current_state)
 
 
 @iproutelib.ip_monitor_assert_stable_link_up(TEST_IFACE)

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -19,7 +19,6 @@
 
 from contextlib import contextmanager
 from operator import itemgetter
-import time
 
 import pytest
 
@@ -33,9 +32,9 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import LinuxBridge as LB
 from libnmstate.nm.common import NM
 
-from ..testlib import cmdlib
 from ..testlib import iproutelib
 from ..testlib.bridgelib import linux_bridge
+from ..testlib.dummy import nm_unmanaged_dummy
 from .testlib import main_context
 
 
@@ -268,26 +267,8 @@ def _remove_read_only_properties(bridge_state):
 
 @pytest.fixture
 def nm_unmanaged_dummy1():
-    cmdlib.exec_cmd(
-        f"ip link add name {DUMMY1} type dummy".split(" "), check=True
-    )
-    cmdlib.exec_cmd(f"ip link set {DUMMY1} up".split(" "), check=True)
-    cmdlib.exec_cmd(
-        f"nmcli dev set {DUMMY1} managed yes".split(" "), check=True
-    )
-    time.sleep(1)  # Wait device became managed
-    yield
-    libnmstate.apply(
-        {
-            Interface.KEY: [
-                {
-                    Interface.NAME: DUMMY1,
-                    Interface.STATE: InterfaceState.ABSENT,
-                }
-            ]
-        },
-        verify_change=False,
-    )
+    with nm_unmanaged_dummy(DUMMY1):
+        yield
 
 
 @pytest.mark.tier1

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -28,6 +28,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge as OB
 
 from .testlib import main_context
+from ..testlib import statelib
 
 
 BRIDGE0 = "brtest0"
@@ -98,7 +99,7 @@ def test_bridge_with_internal_interface(bridge_default_config, nm_plugin):
     with _bridge_interface(nm_plugin.context, bridge_desired_state):
         bridge_current_state = _get_bridge_current_state(nm_plugin)
         assert bridge_desired_state == bridge_current_state
-        _assert_mac_exists(nm_plugin.context, port_name)
+        _assert_mac_exists(port_name)
 
     assert not _get_bridge_current_state(nm_plugin)
 
@@ -322,9 +323,6 @@ def _get_iface_bridge_settings(bridge_options):
     return bridge_con_setting.setting, bridge_setting
 
 
-def _assert_mac_exists(ctx, ifname):
-    state = {}
-    nmdev = ctx.get_nm_dev(ifname)
-    if nmdev:
-        state = nm.wired.get_info(nmdev)
-    assert state.get(Interface.MAC)
+def _assert_mac_exists(ifname):
+    iface_state = statelib.show_only((ifname,))[Interface.KEY][0]
+    assert iface_state.get(Interface.MAC)

--- a/tests/integration/nm/wired_test.py
+++ b/tests/integration/nm/wired_test.py
@@ -21,6 +21,7 @@ from libnmstate import nm
 from libnmstate import schema
 
 from .testlib import main_context
+from ..testlib import statelib
 
 
 ETH1 = "eth1"
@@ -30,12 +31,12 @@ MTU0 = 1200
 
 
 def test_interface_mtu_change(eth1_up, nm_plugin):
-    wired_base_state = _get_wired_current_state(nm_plugin, ETH1)
+    wired_base_state = _get_wired_current_state(ETH1)
     _modify_interface(
         nm_plugin.context, wired_state={schema.Interface.MTU: MTU0}
     )
 
-    wired_current_state = _get_wired_current_state(nm_plugin, ETH1)
+    wired_current_state = _get_wired_current_state(ETH1)
 
     assert wired_current_state == {
         schema.Interface.MAC: wired_base_state[schema.Interface.MAC],
@@ -44,12 +45,12 @@ def test_interface_mtu_change(eth1_up, nm_plugin):
 
 
 def test_interface_mac_change_with_modify(eth1_up, nm_plugin):
-    wired_base_state = _get_wired_current_state(nm_plugin, ETH1)
+    wired_base_state = _get_wired_current_state(ETH1)
     _modify_interface(
         nm_plugin.context, wired_state={schema.Interface.MAC: MAC0}
     )
 
-    wired_current_state = _get_wired_current_state(nm_plugin, ETH1)
+    wired_current_state = _get_wired_current_state(ETH1)
 
     assert wired_current_state == {
         schema.Interface.MAC: MAC0,
@@ -70,10 +71,12 @@ def _modify_interface(ctx, wired_state):
         nm.device.modify(ctx, nmdev, new_conn.profile)
 
 
-def _get_wired_current_state(plugin, ifname):
-    plugin.refresh_content()
-    nmdev = plugin.context.get_nm_dev(ifname)
-    return nm.wired.get_info(nmdev) if nmdev else {}
+def _get_wired_current_state(ifname):
+    iface_state = statelib.show_only((ifname,))[schema.Interface.KEY][0]
+    return {
+        schema.Interface.MTU: iface_state[schema.Interface.MTU],
+        schema.Interface.MAC: iface_state[schema.Interface.MAC],
+    }
 
 
 def _create_iface_settings(wired_state, con_profile):

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -21,7 +21,6 @@ import json
 import os
 import time
 
-
 from libnmstate import __version__
 from libnmstate.error import NmstateConflictError
 from libnmstate.schema import Constants
@@ -41,28 +40,43 @@ ROLLBACK_CMD = ["nmstatectl", "rollback"]
 LOOPBACK_JSON_CONFIG = """        {
             "name": "lo",
             "type": "unknown",
-            "state": "down",
+            "state": "up",
             "ipv4": {
-                "enabled": false
+                "enabled": true,
+                "address": [
+                    {
+                        "ip": "127.0.0.1",
+                        "prefix-length": 8
+                    }
+                ]
             },
             "ipv6": {
-                "enabled": false
+                "enabled": true,
+                "address": [
+                    {
+                        "ip": "::1",
+                        "prefix-length": 128
+                    }
+                ]
             },
-            "lldp": {
-                "enabled": false
-            },
+            "mac-address": "00:00:00:00:00:00",
             "mtu": 65536
         }"""
 
 LOOPBACK_YAML_CONFIG = """- name: lo
   type: unknown
-  state: down
+  state: up
   ipv4:
-    enabled: false
+    enabled: true
+    address:
+    - ip: 127.0.0.1
+      prefix-length: 8
   ipv6:
-    enabled: false
-  lldp:
-    enabled: false
+    enabled: true
+    address:
+    - ip: ::1
+      prefix-length: 128
+  mac-address: 00:00:00:00:00:00
   mtu: 65536"""
 
 ETH1_YAML_CONFIG = b"""interfaces:

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -20,6 +20,7 @@
 import pytest
 
 import libnmstate
+from libnmstate.iplib import is_ipv6_link_local_addr
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -27,7 +28,9 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 
 from .testlib import assertlib
+from .testlib import cmdlib
 from .testlib import statelib
+from .testlib.dummy import nm_unmanaged_dummy
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 
 # TEST-NET addresses: https://tools.ietf.org/html/rfc5737#section-3
@@ -41,6 +44,8 @@ IPV6_ADDRESS1 = "2001:db8:1::1"
 IPV6_ADDRESS2 = "2001:db8:2::1"
 IPV6_LINK_LOCAL_ADDRESS1 = "fe80::1"
 IPV6_LINK_LOCAL_ADDRESS2 = "fe80::2"
+
+DUMMY1 = "dummy1"
 
 
 @pytest.fixture
@@ -585,3 +590,45 @@ def test_modify_ipv6_with_reapply(setup_eth1_ipv6):
     libnmstate.apply(setup_eth1_ipv6)
 
     assertlib.assert_state(setup_eth1_ipv6)
+
+
+@pytest.mark.tier1
+def test_get_ip_address_from_unmanaged_dummy():
+    with nm_unmanaged_dummy(DUMMY1):
+        cmdlib.exec_cmd(
+            f"ip addr add {IPV4_ADDRESS1}/24 dev {DUMMY1}".split(), check=True
+        )
+        cmdlib.exec_cmd(
+            f"ip -6 addr add {IPV6_ADDRESS2}/64 dev {DUMMY1}".split(),
+            check=True,
+        )
+        iface_state = statelib.show_only((DUMMY1,))[Interface.KEY][0]
+        # Remove IPv6 link local address
+        iface_state[Interface.IPV6][InterfaceIPv6.ADDRESS] = [
+            addr
+            for addr in iface_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
+            if not is_ipv6_link_local_addr(
+                addr[InterfaceIPv6.ADDRESS_IP],
+                addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
+            )
+        ]
+
+        assert iface_state[Interface.IPV4] == {
+            InterfaceIPv4.ENABLED: True,
+            InterfaceIPv4.ADDRESS: [
+                {
+                    InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                }
+            ],
+        }
+
+        assert iface_state[Interface.IPV6] == {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                }
+            ],
+        }

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -90,6 +90,8 @@ def _prepare_state_for_verify(desired_state_data):
     full_desired_state.normalize()
     _fix_bond_state(current_state)
     _fix_ovsdb_external_ids(full_desired_state)
+    _remove_iface_state_for_verify(full_desired_state)
+    _remove_iface_state_for_verify(current_state)
 
     return full_desired_state, current_state
 
@@ -131,3 +133,8 @@ def _fix_ovsdb_external_ids(state):
         )
         for key, value in external_ids.items():
             external_ids[key] = str(value)
+
+
+def _remove_iface_state_for_verify(state):
+    for iface_state in state.state[Interface.KEY]:
+        iface_state.pop(Interface.STATE, None)

--- a/tests/integration/testlib/dummy.py
+++ b/tests/integration/testlib/dummy.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+
+from . import cmdlib
+
+
+@contextmanager
+def nm_unmanaged_dummy(name):
+    cmdlib.exec_cmd(f"ip link add name {name} type dummy".split(), check=True)
+    cmdlib.exec_cmd(f"ip link set {name} up".split(), check=True)
+    cmdlib.exec_cmd(f"nmcli d set {name} managed false".split(), check=True)
+    try:
+        yield
+    finally:
+        try:
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: name,
+                            Interface.STATE: InterfaceState.ABSENT,
+                        }
+                    ]
+                },
+                verify_change=False,
+            )
+        except Exception:
+            # dummy1 might not became managed by NM, hence removal might fail
+            cmdlib.exec_cmd(f"ip link del {name}".split())

--- a/tests/integration/testlib/ifacelib.py
+++ b/tests/integration/testlib/ifacelib.py
@@ -41,19 +41,13 @@ def iface_up(ifname):
 
 
 def _set_eth_admin_state(ifname, state):
-    current_state = statelib.show_only((ifname,))
-    (current_ifstate,) = current_state[schema.Interface.KEY]
-    iface_current_admin_state = current_ifstate[schema.Interface.STATE]
-    if (
-        iface_current_admin_state != state
-        or state == schema.InterfaceState.ABSENT
-    ):
-        desired_state = {
+    libnmstate.apply(
+        {
             schema.Interface.KEY: [
                 {schema.Interface.NAME: ifname, schema.Interface.STATE: state}
             ]
         }
-        libnmstate.apply(desired_state)
+    )
 
 
 def get_mac_address(ifname):

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -111,52 +111,48 @@ def test_create_setting_with_static_addresses(NM_mock):
 def test_get_info_with_no_connection():
     info = nm.ipv4.get_info(active_connection=None, applied_config=None)
 
-    assert info == {InterfaceIPv4.ENABLED: False}
+    assert info == {}
 
 
-def test_get_info_with_no_ipv4_config():
+def test_get_info_with_no_applied_config():
     con_mock = mock.MagicMock()
-    con_mock.get_ip4_config.return_value = None
-    con_mock.get_connection.return_value = None
 
     info = nm.ipv4.get_info(active_connection=con_mock, applied_config=None)
 
-    assert info == {InterfaceIPv4.ENABLED: False}
+    assert info == {}
 
 
-def test_get_info_with_ipv4_config(NM_mock):
-    act_con_mock = mock.MagicMock()
-    config_mock = act_con_mock.get_ip4_config.return_value
-    address_mock = mock.MagicMock()
-    config_mock.get_addresses.return_value = [address_mock]
-    remote_conn_mock = mock.MagicMock()
-    act_con_mock.get_connection.return_value = remote_conn_mock
-    set_ip_conf = mock.MagicMock()
-    remote_conn_mock.get_setting_ip4_config.return_value = set_ip_conf
-    set_ip_conf.get_method.return_value = (
-        NM_mock.SETTING_IP4_CONFIG_METHOD_MANUAL
-    )
-    set_ip_conf.props.never_default = False
-    set_ip_conf.props.ignore_auto_dns = False
-    set_ip_conf.props.ignore_auto_routes = False
+def test_get_info_with_no_ip_profile():
+    con_mock = mock.MagicMock()
+    applied_config_mock = mock.MagicMock()
+    applied_config_mock.get_setting_ip4_config.return_value = None
 
     info = nm.ipv4.get_info(
-        active_connection=act_con_mock, applied_config=None
+        active_connection=con_mock, applied_config=applied_config_mock
+    )
+
+    assert info == {InterfaceIPv4.ENABLED: False, InterfaceIPv4.DHCP: False}
+
+
+def test_get_info_with_ip_profile(NM_mock):
+    act_con_mock = mock.MagicMock()
+    applied_config_mock = mock.MagicMock()
+    ip_profile = mock.MagicMock()
+    applied_config_mock.get_setting_ip4_config.return_value = ip_profile
+    ip_profile.get_method.return_value = (
+        NM_mock.SETTING_IP4_CONFIG_METHOD_MANUAL
+    )
+    ip_profile.props.never_default = False
+    ip_profile.props.ignore_auto_dns = False
+    ip_profile.props.ignore_auto_routes = False
+
+    info = nm.ipv4.get_info(
+        active_connection=act_con_mock, applied_config=applied_config_mock
     )
 
     assert info == {
         InterfaceIPv4.ENABLED: True,
         InterfaceIPv4.DHCP: False,
-        InterfaceIPv4.ADDRESS: [
-            {
-                InterfaceIPv4.ADDRESS_IP: (
-                    address_mock.get_address.return_value
-                ),
-                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: int(
-                    address_mock.get_prefix.return_value
-                ),
-            }
-        ],
     }
 
 

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -123,53 +123,53 @@ def test_create_setting_with_static_addresses(NM_mock):
 def test_get_info_with_no_connection():
     info = nm.ipv6.get_info(active_connection=None, applied_config=None)
 
-    assert info == {InterfaceIPv6.ENABLED: False}
+    assert info == {}
 
 
-def test_get_info_with_no_ipv6_config():
+def test_get_info_with_no_applied_config():
     con_mock = mock.MagicMock()
-    con_mock.get_ip6_config.return_value = None
-    con_mock.get_connection.return_value = None
 
     info = nm.ipv6.get_info(active_connection=con_mock, applied_config=None)
 
-    assert info == {InterfaceIPv6.ENABLED: False}
+    assert info == {}
 
 
-def test_get_info_with_ipv6_config(NM_mock):
-    act_con_mock = mock.MagicMock()
-    config_mock = act_con_mock.get_ip6_config.return_value
-    address_mock = mock.MagicMock()
-    config_mock.get_addresses.return_value = [address_mock]
-    remote_conn_mock = mock.MagicMock()
-    act_con_mock.get_connection.return_value = remote_conn_mock
-    set_ip_conf = mock.MagicMock()
-    remote_conn_mock.get_setting_ip6_config.return_value = set_ip_conf
-    set_ip_conf.get_method.return_value = (
-        NM_mock.SETTING_IP6_CONFIG_METHOD_MANUAL
-    )
-    set_ip_conf.props.never_default = False
-    set_ip_conf.props.ignore_auto_dns = False
-    set_ip_conf.props.ignore_auto_routes = False
+def test_get_info_with_no_ip_profile():
+    con_mock = mock.MagicMock()
+    applied_config_mock = mock.MagicMock()
+    applied_config_mock.get_setting_ip6_config.return_value = None
 
     info = nm.ipv6.get_info(
-        active_connection=act_con_mock, applied_config=None
+        active_connection=con_mock, applied_config=applied_config_mock
+    )
+
+    assert info == {
+        InterfaceIPv6.ENABLED: False,
+        InterfaceIPv6.DHCP: False,
+        InterfaceIPv6.AUTOCONF: False,
+    }
+
+
+def test_get_info_with_ip_profile(NM_mock):
+    act_con_mock = mock.MagicMock()
+    applied_config_mock = mock.MagicMock()
+    ip_profile = mock.MagicMock()
+    applied_config_mock.get_setting_ip6_config.return_value = ip_profile
+    ip_profile.get_method.return_value = (
+        NM_mock.SETTING_IP6_CONFIG_METHOD_MANUAL
+    )
+    ip_profile.props.never_default = False
+    ip_profile.props.ignore_auto_dns = False
+    ip_profile.props.ignore_auto_routes = False
+
+    info = nm.ipv6.get_info(
+        active_connection=act_con_mock, applied_config=applied_config_mock
     )
 
     assert info == {
         InterfaceIPv6.ENABLED: True,
-        InterfaceIPv6.AUTOCONF: False,
         InterfaceIPv6.DHCP: False,
-        InterfaceIPv6.ADDRESS: [
-            {
-                InterfaceIPv6.ADDRESS_IP: (
-                    address_mock.get_address.return_value
-                ),
-                InterfaceIPv6.ADDRESS_PREFIX_LENGTH: int(
-                    address_mock.get_prefix.return_value
-                ),
-            }
-        ],
+        InterfaceIPv6.AUTOCONF: False,
     }
 
 

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -154,10 +154,7 @@ def test_get_info_with_invalid_duplex(ethtool_mock, NM_mock):
 
     info = nm.wired.get_info(dev_mock)
 
-    assert info == {
-        schema.Interface.MAC: dev_mock.get_hw_address.return_value,
-        schema.Interface.MTU: dev_mock.get_mtu.return_value,
-    }
+    assert info == {}
 
 
 class TestWiredSetting:


### PR DESCRIPTION
Introduce `NisporPlugin` for querying on these informations using
python3-nispor package:
 * MTU, MAC, state, IP address.
 * DHCP/AUTOCONF status:
    * Mark DHCP/AUTOCONF as true when found IP address with valid_lft not
      forever and correct prefix length.

As nispor might be wrong on DHCP status and interface type comparing to
NetworkManager, so NetworkManager plugin take priority over nispor
plugin and override conflict data.

Removed the code in NetworkManager plugin for querying above information
except the DHCP/Autoconf and IP stack enable status.

Integration test case added.

Signed-off-by: Gris Ge <fge@redhat.com>