### PR TITLE
nm dns: Use applied config for running config

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -56,6 +56,7 @@ class NetworkManagerPlugin(NmstatePlugin):
         self._ctx = NmContext()
         self._checkpoint = None
         self._check_version_mismatch()
+        self.__applied_configs = None
 
     @property
     def priority(self):
@@ -69,6 +70,12 @@ class NetworkManagerPlugin(NmstatePlugin):
         if self._ctx:
             self._ctx.clean_up()
             self._ctx = None
+
+    @property
+    def _applied_configs(self):
+        if self.__applied_configs is None:
+            self.__applied_configs = get_all_applied_configs(self.context)
+        return self.__applied_configs
 
     @property
     def checkpoint(self):
@@ -104,7 +111,7 @@ class NetworkManagerPlugin(NmstatePlugin):
         info = []
         capabilities = self.capabilities
 
-        applied_configs = get_all_applied_configs(self.context)
+        applied_configs = self._applied_configs
 
         devices_info = [
             (dev, nm_device.get_device_common_info(dev))
@@ -180,13 +187,11 @@ class NetworkManagerPlugin(NmstatePlugin):
     def get_dns_client_config(self):
         return {
             DNS.RUNNING: nm_dns.get_running(self.client),
-            DNS.CONFIG: nm_dns.get_config(
-                nm_ipv4.acs_and_ip_profiles(self.client),
-                nm_ipv6.acs_and_ip_profiles(self.client),
-            ),
+            DNS.CONFIG: nm_dns.get_running_config(self._applied_configs),
         }
 
     def refresh_content(self):
+        self.__applied_configs = None
         self._ctx.refresh_content()
 
     def apply_changes(self, net_state, save_to_disk):

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -170,8 +170,7 @@ def test_remove_dns_config(empty_dns_config):
         {Interface.KEY: [], DNS.KEY: {DNS.CONFIG: empty_dns_config}}
     )
     current_state = libnmstate.show()
-    dns_config = {DNS.SERVER: [], DNS.SEARCH: []}
-    assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
+    assert {} == current_state[DNS.KEY][DNS.CONFIG]
 
 
 @pytest.fixture

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -109,10 +109,7 @@ def test_dns_edit(eth1_up):
         assertlib.assert_state(desired_state)
 
     current_state = netinfo.show()
-    assert current_state.get(DNS.KEY, {}).get(DNS.CONFIG, {}) == {
-        DNS.SERVER: [],
-        DNS.SEARCH: [],
-    }
+    assert current_state.get(DNS.KEY, {}).get(DNS.CONFIG, {}) == {}
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
Use the applied config for querying running DNS client configuration.