### PR TITLE
test: Enable IPv6 in container globally

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -79,6 +79,8 @@ function container_pre_test_setup {
     container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
         /proc/sys/kernel/core_pattern"
     container_exec "ulimit -c unlimited"
+    # Enable IPv6 in container globally
+    container_exec "sysctl -w net.ipv6.conf.all.disable_ipv6=0"
 }
 
 function copy_workspace_container {

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -643,12 +643,6 @@ def _setup_dhcp_nics():
 
     cmdlib.exec_cmd(
         f"ip netns exec {DHCP_SRV_NS} "
-        f"sysctl -w net.ipv6.conf.{DHCP_SRV_NIC}.disable_ipv6=0".split(),
-        check=True,
-    )
-
-    cmdlib.exec_cmd(
-        f"ip netns exec {DHCP_SRV_NS} "
         f"ip addr add {DHCP_SRV_IP6}/64 dev {DHCP_SRV_NIC}".split(),
         check=True,
     )


### PR DESCRIPTION
The docker by default disabled the IPv6 in container which is
not how we test nmstate in real world.