### PR TITLE
ovsdb: Allowing remove all ports from OVS bridge

### DIFF
--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -222,19 +222,11 @@ class NmstateOvsdbPlugin(NmstatePlugin):
     def _db_write(self, changes):
         changes_index = {change.row_name: change for change in changes}
         changed_tables = set(change.table_name for change in changes)
-        updated_names = []
         for changed_table in changed_tables:
             for row in self._idl.tables[changed_table].rows.values():
                 if row.name in changes_index:
                     change = changes_index[row.name]
                     setattr(row, change.column_name, change.column_value)
-                    updated_names.append(change.row_name)
-        new_rows = set(changes_index.keys()) - set(updated_names)
-        if new_rows:
-            raise NmstatePluginError(
-                f"BUG: row {new_rows} does not exists in OVS DB "
-                "and currently we don't create new row"
-            )
 
     def _start_transaction(self):
         self._transaction = Transaction(self._idl)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -616,3 +616,17 @@ def test_create_memory_only_ovs_bridge_not_supported():
 
     with pytest.raises(NmstateNotSupportedError):
         libnmstate.apply(bridge.state, save_to_disk=False)
+
+
+def test_remove_all_ovs_ports(bridge_with_ports):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BRIDGE1,
+                    OVSBridge.CONFIG_SUBTREE: {OVSBridge.PORT_SUBTREE: []},
+                }
+            ]
+        }
+    )
+    assertlib.assert_absent(PORT1)


### PR DESCRIPTION
When removing all ports from OVS bridge, the OVSDB will have no
information regarding this bridge, which cause OVSDB failed to find
the correct row.

Silently ignore row not found failure and let verification stage do the
work.
