### PR TITLE
python: Instruct black to use python 3.6 style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 79
+target-version = ["py36"]


### PR DESCRIPTION
Use `--target-version=[py36]` argument in black command.