### PR TITLE
state: support `state:ignore`

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -262,6 +262,10 @@ class BaseIface:
         return self.state == InterfaceState.UP
 
     @property
+    def is_ignore(self):
+        return self.state == InterfaceState.IGNORE
+
+    @property
     def is_down(self):
         return self.state == InterfaceState.DOWN
 

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -86,7 +86,7 @@ class NmProfiles:
         self._profiles = [
             NmProfile(self._ctx, save_to_disk, iface)
             for iface in net_state.ifaces.values()
-            if iface.is_changed or iface.is_desired
+            if (iface.is_changed or iface.is_desired) and not iface.is_ignore
         ]
 
         for profile in self._profiles:
@@ -604,12 +604,12 @@ def get_all_applied_configs(context):
 
 def _preapply_dns_fix_for_profiles(context, net_state):
     """
-     * When DNS configuration does not changed and old interface hold DNS
-       configuration is not included in `ifaces_desired_state`, preserve
-       the old DNS configure by removing DNS metadata from
-       `ifaces_desired_state`.
-     * When DNS configuration changed, include old interface which is holding
-       DNS configuration, so it's DNS configure could be removed.
+    * When DNS configuration does not changed and old interface hold DNS
+      configuration is not included in `ifaces_desired_state`, preserve
+      the old DNS configure by removing DNS metadata from
+      `ifaces_desired_state`.
+    * When DNS configuration changed, include old interface which is holding
+      DNS configuration, so it's DNS configure could be removed.
     """
     cur_dns_iface_names = nm_dns.get_dns_config_iface_names(
         ipv4.acs_and_ip_profiles(context.client),

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -93,6 +93,7 @@ class InterfaceState:
     DOWN = "down"
     UP = "up"
     ABSENT = "absent"
+    IGNORE = "ignore"
 
 
 class InterfaceType:

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -91,6 +91,7 @@ definitions:
             - absent
             - up
             - down
+            - ignore
         mac-address:
           $ref: "#/definitions/types/mac-address"
         mtu:


### PR DESCRIPTION
Introducing `InterfaceState.IGNORE` for:
    * The ignored interface will not be changed when applying desire state.
    * The state verification will not be impacted by ignored interface.

Test cases added.