### PR TITLE
vrf: Add support of Virtual Routing and Forwarding

### DIFF
--- a/examples/vrf0_absent.yml
+++ b/examples/vrf0_absent.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+  - name: vrf0
+    type: vrf
+    state: absent

--- a/examples/vrf0_with_eth1.yml
+++ b/examples/vrf0_with_eth1.yml
@@ -1,0 +1,9 @@
+---
+interfaces:
+  - name: vrf0
+    type: vrf
+    state: up
+    vrf:
+      port:
+        - eth1
+      route-table-id: 100

--- a/libnmstate/ifaces/vrf.py
+++ b/libnmstate/ifaces/vrf.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import VRF
+
+from .base_iface import BaseIface
+
+
+class VrfIface(BaseIface):
+    def sort_port(self):
+        if self.port:
+            self.raw[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].sort()
+
+    @property
+    def route_table_id(self):
+        return self.raw.get(VRF.CONFIG_SUBTREE, {}).get(VRF.ROUTE_TABLE_ID)
+
+    @property
+    def port(self):
+        return self.raw.get(VRF.CONFIG_SUBTREE, {}).get(VRF.PORT_SUBTREE, [])
+
+    @property
+    def is_controller(self):
+        return True
+
+    @property
+    def is_virtual(self):
+        return True
+
+    def pre_edit_validation_and_cleanup(self):
+        super().pre_edit_validation_and_cleanup()
+        if self.is_up:
+            self._validate_route_table_id()
+
+    def _validate_route_table_id(self):
+        """
+        The route table ID is manadatory
+        """
+        if not self.raw.get(VRF.CONFIG_SUBTREE, {}).get(VRF.ROUTE_TABLE_ID):
+            raise NmstateValueError(
+                f"Invalid route table ID for VRF interface {self.name}"
+            )
+
+    def remove_port(self, port_name):
+        self.raw[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [
+            s for s in self.port if s != port_name
+        ]
+        self.sort_port()

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -30,6 +30,7 @@ from .vlan import NisporPluginVlanIface
 from .vxlan import NisporPluginVxlanIface
 from .bridge import NisporPluginBridgeIface
 from .route import nispor_route_state_to_nmstate
+from .vrf import NisporPluginVrfIface
 
 
 class NisporPlugin(NmstatePlugin):
@@ -76,6 +77,8 @@ class NisporPlugin(NmstatePlugin):
                 ifaces.append(
                     NisporPluginBridgeIface(np_iface, np_ports).to_dict()
                 )
+            elif iface_type == "Vrf":
+                ifaces.append(NisporPluginVrfIface(np_iface).to_dict())
             else:
                 ifaces.append(NisporPluginBaseIface(np_iface).to_dict())
         return ifaces

--- a/libnmstate/nispor/vrf.py
+++ b/libnmstate/nispor/vrf.py
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import VRF
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginVrfIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.VRF
+
+    def to_dict(self):
+        info = super().to_dict()
+        info[VRF.CONFIG_SUBTREE] = {
+            VRF.PORT_SUBTREE: self._np_iface.subordinates,
+            VRF.ROUTE_TABLE_ID: self._np_iface.table_id,
+        }
+        return info

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -32,6 +32,7 @@ from libnmstate.schema import LinuxBridge as LB
 from libnmstate.schema import OVSBridge as OvsB
 from libnmstate.schema import OVSInterface
 from libnmstate.schema import Team
+from libnmstate.schema import VRF
 from libnmstate.ifaces.base_iface import BaseIface
 from libnmstate.ifaces.bond import BondIface
 from libnmstate.ifaces.bridge import BridgeIface
@@ -58,6 +59,7 @@ from .common import NM
 from .device import mark_device_as_managed
 from .device import list_devices
 from .device import is_externally_managed
+from .vrf import create_vrf_setting
 
 
 ACTION_DEACTIVATE_BEFOREHAND = "deactivate-beforehand"
@@ -487,6 +489,11 @@ class NmProfile:
         team_setting = team.create_setting(self.iface_info, self._remote_conn)
         if team_setting:
             settings.append(team_setting)
+
+        if VRF.CONFIG_SUBTREE in self.iface_info:
+            settings.append(
+                create_vrf_setting(self.iface_info[VRF.CONFIG_SUBTREE])
+            )
 
         return settings
 

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -47,6 +47,7 @@ class Api2Nm:
                 InterfaceType.VLAN: NM.SETTING_VLAN_SETTING_NAME,
                 InterfaceType.VXLAN: NM.SETTING_VXLAN_SETTING_NAME,
                 InterfaceType.LINUX_BRIDGE: NM.SETTING_BRIDGE_SETTING_NAME,
+                InterfaceType.VRF: NM.SETTING_VRF_SETTING_NAME,
             }
             try:
                 ovs_types = {

--- a/libnmstate/nm/vrf.py
+++ b/libnmstate/nm/vrf.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2018-2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import VRF
+from .common import NM
+
+
+def create_vrf_setting(vrf_config):
+    vrf_setting = NM.SettingVrf.new()
+    vrf_setting.props.table = vrf_config[VRF.ROUTE_TABLE_ID]
+    return vrf_setting

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -112,6 +112,7 @@ class InterfaceType:
     VLAN = "vlan"
     VXLAN = "vxlan"
     TEAM = "team"
+    VRF = "vrf"
     OTHER = "other"
 
     VIRT_TYPES = (
@@ -392,3 +393,9 @@ class LLDP:
         TLV_TYPE = "type"
         TLV_SUBTYPE = "subtype"
         ORGANIZATION_CODE = "oui"
+
+
+class VRF:
+    CONFIG_SUBTREE = "vrf"
+    PORT_SUBTREE = "port"
+    ROUTE_TABLE_ID = "route-table-id"

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -29,6 +29,7 @@ properties:
             - "$ref": "#/definitions/interface-vlan/rw"
             - "$ref": "#/definitions/interface-vxlan/rw"
             - "$ref": "#/definitions/interface-team/rw"
+            - "$ref": "#/definitions/interface-vrf/rw"
             - "$ref": "#/definitions/interface-other/rw"
   routes:
     type: object
@@ -623,6 +624,22 @@ definitions:
               properties:
                 name:
                   type: string
+  interface-vrf:
+    rw:
+      properties:
+        type:
+          type: string
+          enum:
+            - vrf
+        vrf:
+          type: object
+          properties:
+            ports:
+              type: array
+              items:
+                type: string
+            route-table-id:
+              type: integer
 
   interface-other:
     rw:

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -169,3 +169,12 @@ def test_add_ovs_patch_and_remove():
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent("patch0")
+
+
+def test_add_remove_vrf(eth1_up):
+    with example_state(
+        "vrf0_with_eth1.yml", cleanup="vrf0_absent.yml"
+    ) as desired_state:
+        assertlib.assert_state_match(desired_state)
+
+    assertlib.assert_absent("vrf0")

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -1,0 +1,166 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+import libnmstate
+
+from libnmstate.error import NmstateNotSupportedError
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import VRF
+
+from .testlib import assertlib
+
+TEST_VRF0 = "test-vrf0"
+TEST_VRF1 = "test-vrf1"
+TEST_VRF_PORT0 = "eth1"
+TEST_VRF_PORT1 = "eth2"
+TEST_ROUTE_TABLE_ID0 = 100
+TEST_ROUTE_TABLE_ID1 = 101
+
+
+@pytest.fixture
+def vrf0_with_port0(port1_up):
+    vrf_iface_info = {
+        Interface.NAME: TEST_VRF0,
+        Interface.TYPE: InterfaceType.VRF,
+        VRF.CONFIG_SUBTREE: {
+            VRF.PORT_SUBTREE: [TEST_VRF_PORT0],
+            VRF.ROUTE_TABLE_ID: TEST_ROUTE_TABLE_ID0,
+        },
+    }
+    libnmstate.apply({Interface.KEY: [vrf_iface_info]})
+    yield vrf_iface_info
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_VRF0,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    assertlib.assert_absent(TEST_VRF0)
+
+
+@pytest.fixture
+def vrf1_with_port1(port1_up):
+    vrf_iface_info = {
+        Interface.NAME: TEST_VRF1,
+        Interface.TYPE: InterfaceType.VRF,
+        VRF.CONFIG_SUBTREE: {
+            VRF.PORT_SUBTREE: [TEST_VRF_PORT1],
+            VRF.ROUTE_TABLE_ID: TEST_ROUTE_TABLE_ID1,
+        },
+    }
+    libnmstate.apply({Interface.KEY: [vrf_iface_info]})
+    yield vrf_iface_info
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_VRF1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    assertlib.assert_absent(TEST_VRF1)
+
+
+class TestVrf:
+    def test_create_and_remove(self, vrf0_with_port0):
+        pass
+
+    def test_change_route_table_id(self, vrf0_with_port0):
+        iface_info = vrf0_with_port0
+        iface_info[VRF.CONFIG_SUBTREE][VRF.ROUTE_TABLE_ID] += 1
+        desired_state = {Interface.KEY: [iface_info]}
+        with pytest.raises(NmstateNotSupportedError):
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+
+    def test_create_with_empty_ports(self):
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_VRF0,
+                    Interface.TYPE: InterfaceType.VRF,
+                    VRF.CONFIG_SUBTREE: {
+                        VRF.PORT_SUBTREE: [],
+                        VRF.ROUTE_TABLE_ID: TEST_ROUTE_TABLE_ID0,
+                    },
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_add_and_remove_port(self, vrf0_with_port0, port1_up):
+        iface_info = vrf0_with_port0
+        iface_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].append(TEST_VRF_PORT1)
+        desired_state = {Interface.KEY: [iface_info]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+        iface_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].remove(TEST_VRF_PORT1)
+        desired_state = {Interface.KEY: [iface_info]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_remove_port(self, vrf0_with_port0):
+        iface_info = vrf0_with_port0
+        iface_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = []
+        desired_state = {Interface.KEY: [iface_info]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_remove_all_ports(self, vrf0_with_port0):
+        iface_info = vrf0_with_port0
+        iface_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = []
+        desired_state = {Interface.KEY: [iface_info]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_moving_port_from_other_vrf(
+        self, vrf0_with_port0, vrf1_with_port1
+    ):
+        vrf0_iface = vrf0_with_port0
+        vrf1_iface = vrf1_with_port1
+        vrf0_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = []
+        vrf1_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [
+            TEST_VRF_PORT0,
+            TEST_VRF_PORT1,
+        ]
+
+        desired_state = {Interface.KEY: [vrf0_iface, vrf1_iface]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_swaping_port(self, vrf0_with_port0, vrf1_with_port1):
+        vrf0_iface = vrf0_with_port0
+        vrf1_iface = vrf1_with_port1
+        vrf0_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [TEST_VRF_PORT1]
+        vrf1_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [TEST_VRF_PORT0]
+        desired_state = {Interface.KEY: [vrf0_iface, vrf1_iface]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)

--- a/tests/lib/ifaces/vrf_iface_test.py
+++ b/tests/lib/ifaces/vrf_iface_test.py
@@ -1,0 +1,71 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import VRF
+from libnmstate.schema import InterfaceType
+
+from libnmstate.ifaces.vrf import VrfIface
+
+from ..testlib.ifacelib import gen_foo_iface_info
+
+PORT1_IFACE_NAME = "port1"
+PORT2_IFACE_NAME = "port2"
+
+
+class TestVrfIface:
+    def _gen_iface_info(self):
+        iface_info = gen_foo_iface_info(iface_type=InterfaceType.TEAM)
+        iface_info[VRF.CONFIG_SUBTREE] = {
+            VRF.PORT_SUBTREE: [PORT1_IFACE_NAME, PORT2_IFACE_NAME],
+            VRF.ROUTE_TABLE_ID: 100,
+        }
+        return iface_info
+
+    def test_vrf_is_virtual(self):
+        assert VrfIface(self._gen_iface_info()).is_virtual
+
+    def test_vrf_is_controller(self):
+        assert VrfIface(self._gen_iface_info()).is_controller
+
+    def test_vrf_sort_ports(self):
+        iface1_info = self._gen_iface_info()
+        iface2_info = self._gen_iface_info()
+        iface2_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].reverse()
+
+        iface1 = VrfIface(iface1_info)
+        iface2 = VrfIface(iface2_info)
+
+        assert iface1.state_for_verify() == iface2.state_for_verify()
+
+    def test_vrf_remove_port(self):
+        iface_info = self._gen_iface_info()
+        iface_info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].pop()
+
+        iface = VrfIface(iface_info)
+        assert iface.port == [PORT1_IFACE_NAME]
+
+    def test_validate_missing_table_id(self):
+        iface_info = self._gen_iface_info()
+        iface_info[VRF.CONFIG_SUBTREE].pop(VRF.ROUTE_TABLE_ID)
+        iface = VrfIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()

--- a/tests/lib/nm/translator_test.py
+++ b/tests/lib/nm/translator_test.py
@@ -58,6 +58,7 @@ def test_api2nm_iface_type_map(NM_mock):
         InterfaceType.VLAN: NM_mock.SETTING_VLAN_SETTING_NAME,
         InterfaceType.LINUX_BRIDGE: NM_mock.SETTING_BRIDGE_SETTING_NAME,
         InterfaceType.VXLAN: NM_mock.SETTING_VXLAN_SETTING_NAME,
+        InterfaceType.VRF: NM_mock.SETTING_VRF_SETTING_NAME,
     }
 
     assert map == expected_map

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -35,6 +35,7 @@ from libnmstate.schema import OVSInterface
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 from libnmstate.schema import Team
+from libnmstate.schema import VRF
 from libnmstate.schema import VXLAN
 
 
@@ -794,3 +795,20 @@ class TestOVSInterface:
         )
 
         libnmstate.validator.schema_validate(default_data)
+
+
+class TestIfaceTypeVrf:
+    def _gen_base_vrf_iface_info(self):
+        return {
+            Interface.NAME: "vrf0",
+            Interface.TYPE: InterfaceType.VRF,
+            VRF.CONFIG_SUBTREE: {
+                VRF.PORT_SUBTREE: ["foo1", "foo2"],
+                VRF.ROUTE_TABLE_ID: 100,
+            },
+        }
+
+    def test_valid_vrf_interface_with_ports(self):
+        libnmstate.validator.schema_validate(
+            {Interface.KEY: [self._gen_base_vrf_iface_info()]}
+        )


### PR DESCRIPTION
Example of desire state for VRF:

```yml
interfaces:
- name: vrf0
  type: vrf
  vrf:
    route-table-id: 100
    port:
      - eth1
      - eth2
```

Example yaml files(`vrf0_with_eth1.yml` and `vrf0_absent.yml`) included.

Due to limitation of NetworkManager, `NmstateNotSupportedError` will be
raised when changing route table ID of existing interface.

Test cases included.
