### PR TITLE
nm/active_connection: Fix timeout in deactivation

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -116,6 +116,9 @@ class ActiveConnection:
                     "Connection is not active on {}, no need to "
                     "deactivate".format(self.devname)
                 )
+                if self._act_con:
+                    self._act_con.handler_disconnect(handler_id)
+                self._ctx.finish_async(action)
             else:
                 if self._act_con:
                     self._act_con.handler_disconnect(handler_id)

--- a/tests/integration/timeout_test.py
+++ b/tests/integration/timeout_test.py
@@ -17,8 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-import time
-
 import pytest
 
 import libnmstate
@@ -54,6 +52,9 @@ def test_lot_of_vlans_with_bridges(eth1_up):
                 },
             ]
         )
-    checkpoint = libnmstate.apply({Interface.KEY: interfaces}, commit=False)
-    libnmstate.rollback(checkpoint=checkpoint)
-    time.sleep(5)
+    try:
+        libnmstate.apply({Interface.KEY: interfaces})
+    finally:
+        for iface in interfaces:
+            iface[Interface.STATE] = InterfaceState.ABSENT
+        libnmstate.apply({Interface.KEY: interfaces})


### PR DESCRIPTION
When deactivating a activate connection which is already
deactivated(e.g. VLAN interface will be auto deactivated when base
interface is down), nmstate will timeout on waiting deactivation.

The root cause of it is we never mark the deactivation as done when
above case happens.

Expanded the `test_lot_of_vlans_with_bridges` test case to remove
created vlans and bridges using `state: absent`.