### PR TITLE
nm/profile: Fix profile deletion on virtual interface

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -239,12 +239,7 @@ class NmProfile:
         elif ACTION_DEACTIVATE in self._actions_needed:
             device.deactivate(self._ctx, self.nmdev)
         elif ACTION_DELETE_DEV_PROFILES in self._actions_needed:
-            remote_connections = self.nmdev.get_available_connections()
-            for remote_con in remote_connections:
-                nm_profile = NmProfile(self._ctx, None)
-                nm_profile.nmdev = self.nmdev
-                nm_profile.remote_conn = remote_con
-                nm_profile.delete()
+            self.delete()
         elif ACTION_DELETE_DEV in self._actions_needed:
             device.delete_device(self._ctx, self.nmdev)
         self._next_action()


### PR DESCRIPTION
For virtual interface, after `ACTION_DEACTIVATE` finished,
the `self.nmdev` might be cache only which has will not return anything
regarding `self.nmdev.get_available_connections()`.

This is a race(with chance less than 1%) issue.

Instead of deleting all profile pointing to this device, try delete the
one imported/chose by `profile.store_config()`.

Test case included.