### PR TITLE
packaging: make varlink as hard requirement

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -43,19 +43,11 @@ Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 # hence state it as Recommends, no requires.
 Requires:     python3dist(ovs)
 
-%package -n nmstate-varlink
-Summary:        Varlink support for libnmstate
-Requires:       python3dist(varlink)
-
-
 %description -n python3-%{libname}
 This package contains the Python 3 library for Nmstate.
 
 %description -n nmstate-plugin-ovsdb
 This package contains the nmstate plugin for OVS database manipulation.
-
-%description -n nmstate-varlink
-This package provides varlink support for libnmstate.
 
 %prep
 %setup -q
@@ -86,14 +78,11 @@ mkdir -p %{buildroot}%{_unitdir} && cp -a %{buildroot}%{python3_sitelib}/nmstate
 %{python3_sitelib}/%{libname}
 %exclude %{python3_sitelib}/%{libname}/plugins/nmstate_plugin_*
 %exclude %{python3_sitelib}/%{libname}/plugins/__pycache__/nmstate_plugin_*
+%{_unitdir}/nmstate-varlink.service
 
 %files -n nmstate-plugin-ovsdb
 %{python3_sitelib}/%{libname}/plugins/nmstate_plugin_ovsdb*
 %{python3_sitelib}/%{libname}/plugins/__pycache__/nmstate_plugin_ovsdb*
-
-%files -n nmstate-varlink
-%{_unitdir}/nmstate-varlink.service
-
 
 %changelog
 @CHANGELOG@

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ jsonschema
 PyGObject
 PyYAML
 setuptools
+varlink


### PR DESCRIPTION
Varlink is only used for varlink support so it should not be imported
when doing other operations using nmstatectl.

```
File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 40, in <module>
  from nmstatectl.nmstate_varlink import start_varlink_server
File "/usr/lib/python3.6/site-packages/nmstatectl/nmstate_varlink.py", line 31, in <module>
  raise libnmError.NmstateDependencyError("python3 varlink module not found")
libnmstate.error.NmstateDependencyError: python3 varlink module not found
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>