### PR TITLE
nm.translator: use constants from the schema

### DIFF
--- a/tests/lib/nm/translator_test.py
+++ b/tests/lib/nm/translator_test.py
@@ -135,4 +135,4 @@ def test_iface_admin_state(NM_mock):
         NM_mock.DeviceState.IP_CHECK
     )
 
-    assert nm.translator.ApiIfaceAdminState.UP == admin_state
+    assert InterfaceState.UP == admin_state


### PR DESCRIPTION
Use the constants from the schema instead of hardcoded strings.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>