### PR TITLE
[Regression] nm bridge: Don't reset bridge options for empty bridge options

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -430,7 +430,7 @@ class NmProfile:
         if bond_opts:
             settings.append(bond.create_setting(bond_opts, wired_setting))
         elif nm_iface_type == bridge.BRIDGE_TYPE:
-            bridge_config = self.original_iface_info.get(LB.CONFIG_SUBTREE, {})
+            bridge_config = self.iface_info.get(LB.CONFIG_SUBTREE, {})
             bridge_options = bridge_config.get(LB.OPTIONS_SUBTREE)
             bridge_ports = bridge_config.get(LB.PORT_SUBTREE)
             if bridge_options or bridge_ports:

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -756,3 +756,9 @@ def test_change_multicast_snooping_from_false_to_true(port0_up, port1_up):
             LinuxBridge.Options.MULTICAST_SNOOPING
         ] = True
         libnmstate.apply(lb_state)
+
+
+def test_empty_state_does_not_change_bridge_options(bridge0_with_port0):
+    original_state = show_only((TEST_BRIDGE0,))
+    libnmstate.apply({Interface.KEY: [{Interface.NAME: TEST_BRIDGE0}]})
+    assertlib.assert_state_match(original_state)

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -97,6 +97,8 @@ def _prepare_state_for_verify(desired_state_data):
     _remove_iface_state_for_verify(current_state)
     _expand_vlan_filter_range(current_state)
     _expand_vlan_filter_range(full_desired_state)
+    _remove_linux_bridge_read_only_options(current_state)
+    _remove_linux_bridge_read_only_options(full_desired_state)
 
     return full_desired_state, current_state
 
@@ -181,3 +183,13 @@ def _expand_vlan_filter_range(state):
             port_config[LB.Port.VLAN_SUBTREE][
                 LB.Port.Vlan.TRUNK_TAGS
             ] = new_trunk_tags
+
+
+def _remove_linux_bridge_read_only_options(state):
+    for iface_state in state.state[Interface.KEY]:
+        bridge_options = iface_state.get(LB.CONFIG_SUBTREE, {}).get(
+            LB.OPTIONS_SUBTREE, {}
+        )
+        if bridge_options:
+            for key in (LB.Options.HELLO_TIMER, LB.Options.GC_TIMER):
+                bridge_options.pop(key, None)


### PR DESCRIPTION
When desire state don't have bridge options, the linux bridge
configuration will be reset back to default.

The root cause is we check on `original_iface_info` instead of merged
one for creating linux bridge settings.

Fixed by use the old code -- using merge state for bridge options.

Test case included to make sure this never happens again.