### PR TITLE
inclusive language: deprecate "slaves" from the API

### DIFF
--- a/examples/bond_linuxbridge_vlan_up.yml
+++ b/examples/bond_linuxbridge_vlan_up.yml
@@ -25,7 +25,7 @@ interfaces:
     state: up
     link-aggregation:
       mode: active-backup
-      slaves:
+      port:
         - eth1
         - eth2
   - name: eth1

--- a/examples/ovsbridge_bond_create.yml
+++ b/examples/ovsbridge_bond_create.yml
@@ -10,6 +10,6 @@ interfaces:
         - name: ovs-bond1
           link-aggregation:
             mode: balance-slb
-            slaves:
+            port:
               - name: eth1
               - name: eth2

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -68,7 +68,7 @@ def get_bond_info(nm_device):
     slaves = get_slaves(nm_device)
     options = _get_options(nm_device)
     if slaves or options:
-        return {"slaves": slaves, "options": options}
+        return {Bond.PORT: slaves, Bond.OPTIONS_SUBTREE: options}
     else:
         return {}
 

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -252,12 +252,12 @@ def _get_lag_info(port_name, port_setting, port_slave_names):
     port_info[OB.Port.NAME] = port_name
     port_info[OB.Port.LINK_AGGREGATION_SUBTREE] = {
         OB.Port.LinkAggregation.MODE: mode,
-        OB.Port.LinkAggregation.SLAVES_SUBTREE: sorted(
+        OB.Port.LinkAggregation.PORT_SUBTREE: sorted(
             [
-                {OB.Port.LinkAggregation.Slave.NAME: iface_name}
+                {OB.Port.LinkAggregation.Port.NAME: iface_name}
                 for iface_name in port_slave_names
             ],
-            key=itemgetter(OB.Port.LinkAggregation.Slave.NAME),
+            key=itemgetter(OB.Port.LinkAggregation.Port.NAME),
         ),
     }
     return port_info

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -95,14 +95,14 @@ class Nm2Api:
         bond_options = copy.deepcopy(bondinfo.get(Bond.OPTIONS_SUBTREE))
         if not bond_options:
             return {}
-        bond_slaves = bondinfo[Bond.SLAVES]
+        bond_slaves = bondinfo[Bond.PORT]
 
         bond_mode = bond_options[Bond.MODE]
         del bond_options[Bond.MODE]
         return {
             Bond.CONFIG_SUBTREE: {
                 Bond.MODE: bond_mode,
-                Bond.SLAVES: [slave.props.interface for slave in bond_slaves],
+                Bond.PORT: [slave.props.interface for slave in bond_slaves],
                 Bond.OPTIONS_SUBTREE: bond_options,
             }
         }

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import warnings
+
 import pkgutil
 import yaml
 
@@ -145,12 +147,53 @@ class InterfaceIPv6(InterfaceIP):
     AUTOCONF = "autoconf"
 
 
-class Bond:
+OVS_BRIDGE = "OVSBridge.Port.LinkAggregation"
+
+
+DEPRECATED_CONSTANTS = {
+    "Bond.SLAVES": "Bond.PORT",
+    f"LinkAggregation.SLAVES_SUBTREE": f"{OVS_BRIDGE}.PORT_SUBTREE",
+    f"LinkAggregation.Slave": f"{OVS_BRIDGE}.Port",
+}
+
+
+class _DeprecatorType(type):
+    def __getattribute__(cls, attribute):
+        try:
+            return super().__getattribute__(attribute)
+        except AttributeError:
+            deprecated_class = cls
+            deprecated_classname = deprecated_class.__name__
+            deprecated_name = attribute
+
+            oldconstant = f"{deprecated_classname}.{deprecated_name}"
+            newconstant = DEPRECATED_CONSTANTS.get(oldconstant)
+
+            if newconstant:
+                warnings.warn(
+                    f"Using '{oldconstant}' is deprecated, "
+                    f"use '{newconstant}' instead.",
+                    FutureWarning,
+                    stacklevel=3,
+                )
+
+                attributes = newconstant.split(".")
+                new_classname = attributes.pop(0)
+                new_value = globals()[new_classname]
+                while attributes:
+                    new_value = getattr(new_value, attributes.pop(0))
+
+                return new_value
+
+            raise
+
+
+class Bond(metaclass=_DeprecatorType):
     KEY = InterfaceType.BOND
     CONFIG_SUBTREE = "link-aggregation"
 
     MODE = "mode"
-    SLAVES = "slaves"
+    PORT = "port"
     OPTIONS_SUBTREE = "options"
 
 
@@ -304,11 +347,11 @@ class OVSBridge(Bridge, OvsDB):
     class Port(Bridge.Port):
         LINK_AGGREGATION_SUBTREE = "link-aggregation"
 
-        class LinkAggregation:
+        class LinkAggregation(metaclass=_DeprecatorType):
             MODE = "mode"
-            SLAVES_SUBTREE = "slaves"
+            PORT_SUBTREE = "port"
 
-            class Slave:
+            class Port:
                 NAME = "name"
 
             class Options:

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -263,6 +263,10 @@ definitions:
               type: array
               items:
                 type: string
+            port:
+              type: array
+              items:
+                type: string
             options:
               type: object
   interface-linux-bridge:
@@ -413,6 +417,13 @@ definitions:
                       mode:
                         type: string
                       slaves:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      port:
                         type: array
                         items:
                           type: object

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -46,7 +46,7 @@ def test_create_and_remove_bond(eth1_up, nm_plugin):
         )
 
         bond_desired_state = {
-            schema.Bond.SLAVES: [],
+            schema.Bond.PORT: [],
             schema.Bond.OPTIONS_SUBTREE: bond_options,
         }
         assert bond_current_state == bond_desired_state
@@ -61,7 +61,7 @@ def test_bond_with_a_slave(eth1_up, nm_plugin):
         nic_name = eth1_up[Interface.KEY][0][Interface.NAME]
         _attach_slave_to_bond(nm_plugin.context, BOND0, nic_name)
         bond_desired_state = {
-            schema.Bond.SLAVES: [nic_name],
+            schema.Bond.PORT: [nic_name],
             schema.Bond.OPTIONS_SUBTREE: bond_options,
         }
 
@@ -164,9 +164,7 @@ def _create_connection_setting(bond, port_con_profile):
 
 def _convert_slaves_devices_to_iface_names(info):
     if info:
-        info[Bond.SLAVES] = [
-            slave.props.interface for slave in info[Bond.SLAVES]
-        ]
+        info[Bond.PORT] = [slave.props.interface for slave in info[Bond.PORT]]
     return info
 
 

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -68,7 +68,7 @@ def test_external_managed_subordnates(bond99_with_dummy_slaves_by_iproute):
                     Bond.CONFIG_SUBTREE: {
                         # Change the bond mode to force a reactivate
                         Bond.MODE: BondMode.ACTIVE_BACKUP,
-                        Bond.SLAVES: [DUMMY1, DUMMY2],
+                        Bond.PORT: [DUMMY1, DUMMY2],
                     },
                 }
             ]

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -126,9 +126,9 @@ def test_bridge_with_bond_and_two_slaves(
         OB.Port.NAME: port_name,
         OB.Port.LINK_AGGREGATION_SUBTREE: {
             LAG.MODE: mode,
-            LAG.SLAVES_SUBTREE: [
-                {LAG.Slave.NAME: slave0_name},
-                {LAG.Slave.NAME: slave1_name},
+            LAG.PORT_SUBTREE: [
+                {LAG.Port.NAME: slave0_name},
+                {LAG.Port.NAME: slave1_name},
             ],
         },
     }
@@ -198,8 +198,7 @@ def _attach_port_to_bridge(ctx, port_state):
     _create_proxy_port(ctx, port_profile_name, port_state)
     if lag_state:
         slaves = [
-            slave
-            for slave in lag_state[OB.Port.LinkAggregation.SLAVES_SUBTREE]
+            slave for slave in lag_state[OB.Port.LinkAggregation.PORT_SUBTREE]
         ]
         for slave in slaves:
             _connect_interface(ctx, port_profile_name, slave)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -63,7 +63,7 @@ OVS_BOND_YAML_STATE = f"""
     - name: {BOND1}
       link-aggregation:
         mode: active-backup
-        slaves:
+        port:
         - name: {ETH1}
         - name: {ETH2}
 """

--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -36,7 +36,7 @@ def bond_interface(name, slaves, extra_iface_state=None, create=True):
                 Interface.STATE: InterfaceState.UP,
                 Bond.CONFIG_SUBTREE: {
                     Bond.MODE: BondMode.ROUND_ROBIN,
-                    Bond.SLAVES: slaves,
+                    Bond.PORT: slaves,
                 },
             }
         ]
@@ -45,7 +45,7 @@ def bond_interface(name, slaves, extra_iface_state=None, create=True):
         desired_state[Interface.KEY][0].update(extra_iface_state)
         if slaves:
             desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
-                Bond.SLAVES
+                Bond.PORT
             ] = slaves
 
     if create:

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -58,8 +58,8 @@ class Bridge:
         self._add_port(name)
         port = self._get_port(name)
         port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE] = {
-            OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: [
-                {OVSBridge.Port.LinkAggregation.Slave.NAME: slave}
+            OVSBridge.Port.LinkAggregation.PORT_SUBTREE: [
+                {OVSBridge.Port.LinkAggregation.Port.NAME: slave}
                 for slave in slaves
             ]
         }

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -150,7 +150,7 @@ class State:
 
     def _sort_iface_lag_slaves(self):
         for ifstate in self._state[Interface.KEY]:
-            ifstate.get(Bond.CONFIG_SUBTREE, {}).get(Bond.SLAVES, []).sort()
+            ifstate.get(Bond.CONFIG_SUBTREE, {}).get(Bond.PORT, []).sort()
 
     def _sort_iface_bridge_ports(self):
         for ifstate in self._state[Interface.KEY]:
@@ -253,8 +253,8 @@ class State:
             ).get(OVSBridge.PORT_SUBTREE, []):
                 port_config.get(
                     OVSBridge.Port.LINK_AGGREGATION_SUBTREE, {}
-                ).get(OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE, []).sort(
-                    key=itemgetter(OVSBridge.Port.LinkAggregation.Slave.NAME)
+                ).get(OVSBridge.Port.LinkAggregation.PORT_SUBTREE, []).sort(
+                    key=itemgetter(OVSBridge.Port.LinkAggregation.Port.NAME)
                 )
 
 

--- a/tests/lib/ifaces/bond_iface_test.py
+++ b/tests/lib/ifaces/bond_iface_test.py
@@ -62,7 +62,7 @@ class TestBondIface:
         iface_info = gen_foo_iface_info(iface_type=InterfaceType.BOND)
         iface_info[Bond.CONFIG_SUBTREE] = {
             Bond.MODE: TEST_BOND_MODE,
-            Bond.SLAVES: deepcopy(TEST_SLAVES),
+            Bond.PORT: deepcopy(TEST_SLAVES),
             Bond.OPTIONS_SUBTREE: {},
         }
         return iface_info
@@ -90,7 +90,7 @@ class TestBondIface:
     def test_bond_sort_slaves(self):
         iface_info1 = self._gen_iface_info()
         iface_info2 = self._gen_iface_info()
-        iface_info2[Bond.CONFIG_SUBTREE][Bond.SLAVES].reverse()
+        iface_info2[Bond.CONFIG_SUBTREE][Bond.PORT].reverse()
 
         assert iface_info2 != iface_info1
         assert (
@@ -339,7 +339,7 @@ class TestBondIface:
     def test_remove_slave(self):
         iface = BondIface(self._gen_iface_info())
         expected_iface_info = self._gen_iface_info()
-        expected_iface_info[Bond.CONFIG_SUBTREE][Bond.SLAVES] = [
+        expected_iface_info[Bond.CONFIG_SUBTREE][Bond.PORT] = [
             SLAVE2_IFACE_NAME
         ]
 

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -289,7 +289,7 @@ class TestIfaces:
         cur_iface_infos.append(child_iface_info)
 
         des_ovs_bridge_info = gen_ovs_bridge_info()
-        ovs_bridge_iface = OvsBridgeIface(des_ovs_bridge_info)
+        ovs_bridge_iface = OvsBridgeIface(des_ovs_bridge_info, True)
         ovs_bridge_iface.remove_slave(OVS_IFACE_NAME)
         des_iface_info = ovs_bridge_iface.to_dict()
 

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -96,7 +96,7 @@ def test_add_new_bond(
                 Interface.STATE: InterfaceState.UP,
                 Bond.CONFIG_SUBTREE: {
                     Bond.MODE: BondMode.ROUND_ROBIN,
-                    Bond.SLAVES: [],
+                    Bond.PORT: [],
                     Bond.OPTIONS_SUBTREE: {"miimon": 200},
                 },
                 Interface.IPV4: {},
@@ -125,7 +125,7 @@ def test_edit_existing_bond(
                 Interface.STATE: InterfaceState.UP,
                 Bond.CONFIG_SUBTREE: {
                     Bond.MODE: BondMode.ROUND_ROBIN,
-                    Bond.SLAVES: [],
+                    Bond.PORT: [],
                     Bond.OPTIONS_SUBTREE: {"miimon": "100"},
                 },
                 Interface.IPV4: {InterfaceIPv4.ENABLED: False},

--- a/tests/lib/nm/translator_test.py
+++ b/tests/lib/nm/translator_test.py
@@ -109,7 +109,7 @@ def test_nm2api_common_device_info(NM_mock):
 def test_nm2api_bond_info():
     slaves_mock = [mock.MagicMock(), mock.MagicMock()]
     bondinfo = {
-        Bond.SLAVES: slaves_mock,
+        Bond.PORT: slaves_mock,
         Bond.OPTIONS_SUBTREE: {Bond.MODE: BondMode.ROUND_ROBIN, "miimon": 120},
     }
     info = nm.translator.Nm2Api.get_bond_info(bondinfo)
@@ -117,7 +117,7 @@ def test_nm2api_bond_info():
     expected_info = {
         Bond.CONFIG_SUBTREE: {
             Bond.MODE: BondMode.ROUND_ROBIN,
-            Bond.SLAVES: [
+            Bond.PORT: [
                 slaves_mock[0].props.interface,
                 slaves_mock[1].props.interface,
             ],

--- a/tests/lib/schema_deprecation_test.py
+++ b/tests/lib/schema_deprecation_test.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate.schema import Bond
+from libnmstate.schema import OVSBridge
+
+
+def test_bond_deprecated_constants():
+    with pytest.warns(FutureWarning) as record:
+        deprecated_value = getattr(Bond, "SLAVES")
+
+    assert len(record) == 1
+    assert "SLAVES" in record[0].message.args[0]
+    assert deprecated_value == "port"
+
+
+def test_ovsbridge_slaves_subtree_deprecated_constants():
+    with pytest.warns(FutureWarning) as record:
+        deprecated_value = getattr(
+            OVSBridge.Port.LinkAggregation, "SLAVES_SUBTREE"
+        )
+
+    assert len(record) == 1
+    assert "SLAVES_SUBTREE" in record[0].message.args[0]
+    assert deprecated_value == "port"
+
+
+def test_ovsbridge_port_subtree_deprecated_constants():
+    with pytest.warns(FutureWarning) as record:
+        # pylint: disable=E1101
+        deprecated_value = getattr(
+            OVSBridge.Port.LinkAggregation.Slave, "NAME"
+        )
+        # pylint: enable=E1101
+
+    assert len(record) == 1
+    assert "Port" in record[0].message.args[0]
+    assert deprecated_value == "name"

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -716,9 +716,9 @@ class TestOVSBridgeLinkAggregation:
             OVSBridge.Port.NAME: "bond",
             OVSBridge.Port.LINK_AGGREGATION_SUBTREE: {
                 OVSBridge.Port.LinkAggregation.MODE: "bond-mode",
-                OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE: [
-                    {OVSBridge.Port.LinkAggregation.Slave.NAME: "iface1"},
-                    {OVSBridge.Port.LinkAggregation.Slave.NAME: "iface2"},
+                OVSBridge.Port.LinkAggregation.PORT_SUBTREE: [
+                    {OVSBridge.Port.LinkAggregation.Port.NAME: "iface1"},
+                    {OVSBridge.Port.LinkAggregation.Port.NAME: "iface2"},
                 ],
             },
         }


### PR DESCRIPTION
* Bond.SLAVES is now deprecated by Bond.PORT

* OVSBridge.Port.LinkAggregation.SLAVES_SUBTREE is now deprecated by
  OVSBridge.Port.LinkAggregation.PORT_SUBTREE

* OVSBridge.Port.LinkAggregation.Slave.NAME is now deprecated by
  OVSBridge.Port.LinkAggregation.Port.NAME

* Team.PORT_SUBTREE is now "port" instead of "ports"

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>