### PR TITLE
route: Use nispor for running routes

### DIFF
--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -20,6 +20,7 @@
 from nispor import NisporNetState
 
 from libnmstate.plugin import NmstatePlugin
+from libnmstate.schema import Route
 
 from .base_iface import NisporPluginBaseIface
 from .dummy import NisporPluginDummyIface
@@ -28,6 +29,7 @@ from .bond import NisporPluginBondIface
 from .vlan import NisporPluginVlanIface
 from .vxlan import NisporPluginVxlanIface
 from .bridge import NisporPluginBridgeIface
+from .route import nispor_route_state_to_nmstate
 
 
 class NisporPlugin(NmstatePlugin):
@@ -39,6 +41,7 @@ class NisporPlugin(NmstatePlugin):
     def plugin_capabilities(self):
         return [
             NmstatePlugin.PLUGIN_CAPABILITY_IFACE,
+            NmstatePlugin.PLUGIN_CAPABILITY_ROUTE,
         ]
 
     @property
@@ -76,3 +79,7 @@ class NisporPlugin(NmstatePlugin):
             else:
                 ifaces.append(NisporPluginBaseIface(np_iface).to_dict())
         return ifaces
+
+    def get_routes(self):
+        np_state = NisporNetState.retrieve()
+        return {Route.RUNNING: nispor_route_state_to_nmstate(np_state.routes)}

--- a/libnmstate/nispor/route.py
+++ b/libnmstate/nispor/route.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import Route
+
+
+IPV4_DEFAULT_GATEWAY_DESTINATION = "0.0.0.0/0"
+IPV6_DEFAULT_GATEWAY_DESTINATION = "::/0"
+
+
+def nispor_route_state_to_nmstate(np_routes):
+    return [
+        _nispor_route_to_nmstate(rt)
+        for rt in np_routes
+        if rt.scope == "Universe"
+    ]
+
+
+def _nispor_route_to_nmstate(np_rt):
+    if np_rt.dst:
+        destination = np_rt.dst
+    elif np_rt.gateway:
+        destination = (
+            IPV6_DEFAULT_GATEWAY_DESTINATION
+            if np_rt.address_family == "IPv6"
+            else IPV4_DEFAULT_GATEWAY_DESTINATION
+        )
+    else:
+        destination = ""
+
+    if np_rt.via:
+        next_hop = np_rt.via
+    elif np_rt.gateway:
+        next_hop = np_rt.gateway
+    else:
+        next_hop = ""
+
+    return {
+        Route.TABLE_ID: np_rt.table,
+        Route.DESTINATION: destination,
+        Route.NEXT_HOP_INTERFACE: np_rt.oif if np_rt.oif else "",
+        Route.NEXT_HOP_ADDRESS: next_hop,
+        Route.METRIC: np_rt.metric if np_rt.metric else 0,
+    }

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -141,22 +141,6 @@ def get_ip_profile(active_connection):
     return None
 
 
-def get_route_running(context):
-    return nm_route.get_running(_acs_and_ip_cfgs(context))
-
-
-def get_route_config(context):
-    return nm_route.get_config(acs_and_ip_profiles(context))
-
-
-def _acs_and_ip_cfgs(nm_client):
-    for ac in nm_client.get_active_connections():
-        ip_cfg = ac.get_ip4_config()
-        if not ip_cfg:
-            continue
-        yield ac, ip_cfg
-
-
 def acs_and_ip_profiles(nm_client):
     for ac in nm_client.get_active_connections():
         ip_profile = get_ip_profile(ac)

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -191,28 +191,6 @@ def get_ip_profile(active_connection):
     return None
 
 
-def get_route_running(nm_client):
-    return nm_route.get_running(_acs_and_ip_cfgs(nm_client))
-
-
-def get_route_config(nm_client):
-    routes = nm_route.get_config(acs_and_ip_profiles(nm_client))
-    for route in routes:
-        if route[Route.METRIC] == 0:
-            # Kernel will convert 0 to IPV6_DEFAULT_ROUTE_METRIC.
-            route[Route.METRIC] = IPV6_DEFAULT_ROUTE_METRIC
-
-    return routes
-
-
-def _acs_and_ip_cfgs(nm_client):
-    for ac in nm_client.get_active_connections():
-        ip_cfg = ac.get_ip6_config()
-        if not ip_cfg:
-            continue
-        yield ac, ip_cfg
-
-
 def acs_and_ip_profiles(nm_client):
     for ac in nm_client.get_active_connections():
         ip_profile = get_ip_profile(ac)

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -46,6 +46,7 @@ from .common import NM
 from .context import NmContext
 from .profile import get_all_applied_configs
 from .profile import NmProfiles
+from .route import get_running_config as get_route_running_config
 
 
 class NetworkManagerPlugin(NmstatePlugin):
@@ -159,16 +160,7 @@ class NetworkManagerPlugin(NmstatePlugin):
         return info
 
     def get_routes(self):
-        return {
-            Route.RUNNING: (
-                nm_ipv4.get_route_running(self.client)
-                + nm_ipv6.get_route_running(self.client)
-            ),
-            Route.CONFIG: (
-                nm_ipv4.get_route_config(self.client)
-                + nm_ipv6.get_route_config(self.client)
-            ),
-        }
+        return {Route.CONFIG: get_route_running_config(self._applied_configs)}
 
     def get_route_rules(self):
         return {

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -70,11 +70,7 @@ def show_with_plugins(plugins, include_status_data=None):
 
     report[Interface.KEY] = _get_interface_info_from_plugins(plugins)
 
-    route_plugin = _find_plugin_for_capability(
-        plugins, NmstatePlugin.PLUGIN_CAPABILITY_ROUTE
-    )
-    if route_plugin:
-        report[Route.KEY] = route_plugin.get_routes()
+    report[Route.KEY] = _get_routes_from_plugins(plugins)
 
     route_rule_plugin = _find_plugin_for_capability(
         plugins, NmstatePlugin.PLUGIN_CAPABILITY_ROUTE_RULE
@@ -238,3 +234,13 @@ def _parse_checkpoints(checkpoints):
     checkpoint_index = {}
     for plugin_name, checkpoint in zip(parsed[0::2], parsed[1::2]):
         checkpoint_index[plugin_name] = checkpoint
+
+
+def _get_routes_from_plugins(plugins):
+    ret = {Route.RUNNING: [], Route.CONFIG: []}
+    for plugin in plugins:
+        if NmstatePlugin.PLUGIN_CAPABILITY_ROUTE in plugin.plugin_capabilities:
+            plugin_routes = plugin.get_routes()
+            ret[Route.RUNNING].extend(plugin_routes.get(Route.RUNNING, []))
+            ret[Route.CONFIG].extend(plugin_routes.get(Route.CONFIG, []))
+    return ret

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PyGObject
 PyYAML
 setuptools
 varlink
-nispor>=0.5.0
+nispor>=0.5.1

--- a/tests/integration/plugin_test.py
+++ b/tests/integration/plugin_test.py
@@ -61,16 +61,16 @@ BAR_IFACE_STATES = [
     },
 ]
 
+TEST_ROUTE_ENTRY = {
+    Route.DESTINATION: "198.51.100.0/24",
+    Route.METRIC: 103,
+    Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+    Route.NEXT_HOP_INTERFACE: FOO_IFACE_NAME,
+    Route.TABLE_ID: 100,
+}
+
 TEST_ROUTE_STATE = {
-    Route.RUNNING: [
-        {
-            Route.DESTINATION: "198.51.100.0/24",
-            Route.METRIC: 103,
-            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
-            Route.NEXT_HOP_INTERFACE: FOO_IFACE_NAME,
-            Route.TABLE_ID: 100,
-        }
-    ],
+    Route.RUNNING: [TEST_ROUTE_ENTRY],
     Route.CONFIG: [],
 }
 
@@ -272,7 +272,7 @@ def test_two_plugins_with_merged_iface_by_priority(with_multiple_plugins):
 
 def test_load_external_route_plugin(with_route_plugin):
     state = libnmstate.show()
-    assert state[Route.KEY] == TEST_ROUTE_STATE
+    assert TEST_ROUTE_ENTRY in state[Route.KEY][Route.RUNNING]
 
 
 def test_load_external_route_rule_plugin(with_route_rule_plugin):


### PR DESCRIPTION
Change the plugin design on route allowing plugin to append routes into
results of `libnmstate.show()` so that nispor plugin could provide kernel
running routes and NetworkManager plugin could provide running
configured static routes.

The nispor plugin will shows global(`RT_SCOPE_UNIVERSE`) routes of kernel.

The niposr 0.5.1 is required for this change.