### PR TITLE
InfiniBand: Add support of IP over InfiniBand

### DIFF
--- a/examples/infiniband_pkey_ipoib_create.yml
+++ b/examples/infiniband_pkey_ipoib_create.yml
@@ -1,0 +1,9 @@
+---
+interfaces:
+  - name: mlx5_ib0.80ff
+    type: infiniband
+    state: up
+    infiniband:
+      base-iface: mlx5_ib0
+      mode: datagram
+      pkey: '0x80ff'

--- a/examples/infiniband_pkey_ipoib_delete.yml
+++ b/examples/infiniband_pkey_ipoib_delete.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+  - name: mlx5_ib0.80ff
+    type: infiniband
+    state: absent

--- a/libnmstate/ifaces/infiniband.py
+++ b/libnmstate/ifaces/infiniband.py
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import InfiniBand
+from libnmstate.schema import Interface
+
+from .base_iface import BaseIface
+
+
+class InfiniBandIface(BaseIface):
+    @property
+    def parent(self):
+        return self._ib_config.get(InfiniBand.BASE_IFACE)
+
+    @property
+    def _pkey(self):
+        return self._ib_config.get(InfiniBand.PKEY)
+
+    @property
+    def need_parent(self):
+        if not self._pkey or str(self._pkey) == str(InfiniBand.DEFAULT_PKEY):
+            return False
+        return True
+
+    @property
+    def _ib_config(self):
+        return self.raw.get(InfiniBand.CONFIG_SUBTREE, {})
+
+    def pre_edit_validation_and_cleanup(self):
+        _cannonicalize_pkey(self.raw)
+        self._validate_mandatory_properties()
+        self._validate_interface_name_format_for_pkey_nic()
+        super().pre_edit_validation_and_cleanup()
+
+    def _validate_mandatory_properties(self):
+        if self.is_up:
+            if InfiniBand.MODE not in self._ib_config:
+                raise NmstateValueError(
+                    f"InfiniBand interface {self.name} has missing "
+                    f"mandatory property: {InfiniBand.MODE}"
+                )
+
+    def state_for_verify(self):
+        state = super().state_for_verify()
+        _cannonicalize_pkey(state)
+        return state
+
+    def _validate_interface_name_format_for_pkey_nic(self):
+        if self.need_parent:
+            pkey_str = f"{self._pkey:x}"
+            expected_name = f"{self.parent}.{pkey_str}"
+            if self.name != expected_name:
+                raise NmstateValueError(
+                    f"InfiniBand interface name {self.name} is invalid "
+                    f"for specified pkey, should be {expected_name}"
+                )
+
+
+def _cannonicalize_pkey(iface_info):
+    """
+     * Set as 0xffff if pkey not defined
+     * Convert pkey string to integer
+     * Raise NmstateValueError when out of range(16 bites)
+    """
+    iface_name = iface_info[Interface.NAME]
+    ib_config = iface_info.get(InfiniBand.CONFIG_SUBTREE, {})
+    original_pkey = ib_config.get(InfiniBand.PKEY)
+    is_invalid = False
+    if original_pkey is None:
+        ib_config[InfiniBand.PKEY] = 0xFFFF
+    elif isinstance(original_pkey, str):
+        if original_pkey.startswith("0x"):
+            try:
+                ib_config[InfiniBand.PKEY] = int(original_pkey, 16)
+            except ValueError:
+                is_invalid = True
+        else:
+            try:
+                ib_config[InfiniBand.PKEY] = int(original_pkey, 10)
+            except ValueError:
+                is_invalid = True
+
+    if (
+        is_invalid
+        or ib_config[InfiniBand.PKEY] > 0xFFFF
+        or ib_config[InfiniBand.PKEY] <= 0
+    ):
+        raise NmstateValueError(
+            f"Invalid infiniband pkey for interface {iface_name}: "
+            f"{original_pkey}, should be integer or hex string in the range of"
+            "1 - 0xffff"
+        )

--- a/libnmstate/nm/infiniband.py
+++ b/libnmstate/nm/infiniband.py
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import logging
+
+from libnmstate.schema import InfiniBand
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from .common import NM
+
+_NM_IB_MODE_DATAGRAM = "datagram"
+_NM_IB_MODE_CONNECTED = "connected"
+
+
+def get_info(applied_config):
+    if applied_config:
+        ib_setting = applied_config.get_setting_infiniband()
+        if ib_setting:
+            mode = _nm_ib_mode_to_nmstate(ib_setting.get_transport_mode())
+            if not mode:
+                logging.warning(
+                    "Unknown InfiniBand transport mode "
+                    f"{ib_setting.get_transport_mode()} for interface "
+                    f"{applied_config.get_interface_name()}"
+                )
+                return {}
+
+            pkey = ib_setting.get_p_key()
+            if pkey == -1:
+                pkey = str(InfiniBand.DEFAULT_PKEY)
+            else:
+                pkey = hex(pkey)
+
+            base_iface = ib_setting.get_parent()
+            if base_iface is None:
+                base_iface = ""
+
+            return {
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.PKEY: pkey,
+                    InfiniBand.MODE: mode,
+                    InfiniBand.BASE_IFACE: base_iface,
+                },
+            }
+    return {}
+
+
+def _nm_ib_mode_to_nmstate(nm_ib_mode):
+    if nm_ib_mode == _NM_IB_MODE_DATAGRAM:
+        return InfiniBand.Mode.DATAGRAM
+    elif nm_ib_mode == _NM_IB_MODE_CONNECTED:
+        return InfiniBand.Mode.CONNECTED
+    else:
+        return None
+
+
+def create_setting(iface_info, base_con_profile, original_iface_info):
+    ib_config = iface_info.get(InfiniBand.CONFIG_SUBTREE)
+    if not ib_config:
+        return None
+
+    ib_setting = None
+    if base_con_profile:
+        ib_setting = base_con_profile.get_setting_infiniband()
+        if ib_setting:
+            ib_setting = ib_setting.duplicate()
+
+    if not ib_setting:
+        ib_setting = NM.SettingInfiniband.new()
+
+    if Interface.MTU in original_iface_info:
+        ib_setting.props.mtu = original_iface_info[Interface.MTU]
+    if Interface.MAC in original_iface_info:
+        ib_setting.props.mac_address = original_iface_info[Interface.MAC]
+
+    if ib_config[InfiniBand.PKEY] == InfiniBand.DEFAULT_PKEY:
+        ib_setting.props.p_key = -1
+    else:
+        ib_setting.props.p_key = ib_config[InfiniBand.PKEY]
+    ib_setting.props.transport_mode = ib_config[InfiniBand.MODE]
+
+    if InfiniBand.BASE_IFACE in ib_config:
+        if ib_config[InfiniBand.BASE_IFACE]:
+            ib_setting.props.parent = ib_config[InfiniBand.BASE_IFACE]
+        else:
+            ib_setting.props.parent = None
+
+    return ib_setting

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -48,6 +48,7 @@ from .context import NmContext
 from .profile import get_all_applied_configs
 from .profile import NmProfiles
 from .route import get_running_config as get_route_running_config
+from .infiniband import get_info as get_infiniband_info
 
 
 class NetworkManagerPlugin(NmstatePlugin):
@@ -137,6 +138,7 @@ class NetworkManagerPlugin(NmstatePlugin):
             iface_info.update(nm_user.get_info(self.context, dev))
             iface_info.update(nm_lldp.get_info(self.client, dev))
             iface_info.update(nm_team.get_info(dev))
+            iface_info.update(get_infiniband_info(applied_config))
 
             if nm_bond.is_bond_type_id(type_id):
                 bondinfo = nm_bond.get_bond_info(dev)

--- a/libnmstate/nm/translator.py
+++ b/libnmstate/nm/translator.py
@@ -48,6 +48,7 @@ class Api2Nm:
                 InterfaceType.VXLAN: NM.SETTING_VXLAN_SETTING_NAME,
                 InterfaceType.LINUX_BRIDGE: NM.SETTING_BRIDGE_SETTING_NAME,
                 InterfaceType.VRF: NM.SETTING_VRF_SETTING_NAME,
+                InterfaceType.INFINIBAND: NM.SETTING_INFINIBAND_SETTING_NAME,
             }
             try:
                 ovs_types = {

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -113,6 +113,7 @@ class InterfaceType:
     VXLAN = "vxlan"
     TEAM = "team"
     VRF = "vrf"
+    INFINIBAND = "infiniband"
     OTHER = "other"
 
     VIRT_TYPES = (
@@ -399,3 +400,15 @@ class VRF:
     CONFIG_SUBTREE = "vrf"
     PORT_SUBTREE = "port"
     ROUTE_TABLE_ID = "route-table-id"
+
+
+class InfiniBand:
+    CONFIG_SUBTREE = "infiniband"
+    PKEY = "pkey"
+    MODE = "mode"
+    BASE_IFACE = "base-iface"
+    DEFAULT_PKEY = 0xFFFF
+
+    class Mode:
+        DATAGRAM = "datagram"
+        CONNECTED = "connected"

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -30,6 +30,7 @@ properties:
             - "$ref": "#/definitions/interface-vxlan/rw"
             - "$ref": "#/definitions/interface-team/rw"
             - "$ref": "#/definitions/interface-vrf/rw"
+            - "$ref": "#/definitions/interface-infiniband/rw"
             - "$ref": "#/definitions/interface-other/rw"
   routes:
     type: object
@@ -710,3 +711,24 @@ definitions:
       properties:
         enabled:
           type: boolean
+  interface-infiniband:
+    rw:
+      properties:
+        type:
+          type: string
+          enum:
+            - infiniband
+        infiniband:
+          type: object
+          properties:
+            base-iface:
+              type: string
+            pkey:
+              type:
+                - string
+                - integer
+            mode:
+              type: string
+              enum:
+                - datagram
+                - connected

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -178,3 +178,19 @@ def test_add_remove_vrf(eth1_up):
         assertlib.assert_state_match(desired_state)
 
     assertlib.assert_absent("vrf0")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for infiniband test",
+)
+def test_add_ib_pkey_nic_and_remove():
+    test_nic = os.environ["TEST_REAL_NIC"]
+    with example_state(
+        "infiniband_pkey_ipoib_create.yml",
+        cleanup="infiniband_pkey_ipoib_delete.yml",
+        substitute=("mlx5_ib0", test_nic),
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    assertlib.assert_absent(f"{test_nic}.80ff")

--- a/tests/integration/infiniband_test.py
+++ b/tests/integration/infiniband_test.py
@@ -1,0 +1,342 @@
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+
+import pytest
+
+import libnmstate
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import Bond
+from libnmstate.schema import BondMode
+from libnmstate.schema import InfiniBand
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import LinuxBridge
+
+from .testlib import assertlib
+from .testlib import statelib
+from .testlib.bondlib import bond_interface
+from .testlib.bridgelib import linux_bridge
+from .testlib.bridgelib import add_port_to_bridge
+
+
+TEST_BRIDGE0 = "linux-br0"
+TEST_BOND99 = "bond99"
+TEST_PKEY1 = "0x80fe"
+TEST_PKEY2 = "0x80ff"
+
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV6_ADDRESS1 = "2001:db8:1::1"
+
+TEST_STATIC_IPV4_CONFIG = {
+    InterfaceIPv4.ENABLED: True,
+    InterfaceIPv4.DHCP: False,
+    InterfaceIPv4.ADDRESS: [
+        {
+            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+        }
+    ],
+}
+
+TEST_STATIC_IPV6_CONFIG = {
+    InterfaceIPv6.ENABLED: True,
+    InterfaceIPv6.DHCP: False,
+    InterfaceIPv6.AUTOCONF: False,
+    InterfaceIPv6.ADDRESS: [
+        {
+            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        }
+    ],
+}
+
+
+def _test_nic_name():
+    return os.environ.get("TEST_REAL_NIC")
+
+
+def _test_ib_mode():
+    return (
+        InfiniBand.Mode.CONNECTED
+        if os.environ.get("TEST_IB_CONNECTED_MODE")
+        else InfiniBand.Mode.DATAGRAM
+    )
+
+
+def _gen_ib_iface_info(
+    base_iface, pkey=InfiniBand.DEFAULT_PKEY, mode=InfiniBand.Mode.DATAGRAM,
+):
+    if pkey == InfiniBand.DEFAULT_PKEY:
+        iface_name = base_iface
+        base_iface = ""
+    else:
+        iface_name = f"{base_iface}.{pkey[2:]}"
+
+    return {
+        Interface.NAME: iface_name,
+        Interface.TYPE: InterfaceType.INFINIBAND,
+        InfiniBand.CONFIG_SUBTREE: {
+            InfiniBand.PKEY: pkey,
+            InfiniBand.MODE: mode,
+            InfiniBand.BASE_IFACE: base_iface,
+        },
+    }
+
+
+@pytest.fixture
+def ib_base_nic():
+    iface_info = _gen_ib_iface_info(_test_nic_name(), mode=_test_ib_mode())
+    libnmstate.apply({Interface.KEY: [iface_info]})
+    yield iface_info
+    iface_info[Interface.STATE] = InterfaceState.ABSENT
+    libnmstate.apply(
+        {Interface.KEY: [iface_info]}, verify_change=False,
+    )
+
+
+@pytest.fixture
+def ib_pkey_nic1(ib_base_nic):
+    iface_info = _gen_ib_iface_info(
+        _test_nic_name(), TEST_PKEY1, _test_ib_mode()
+    )
+    libnmstate.apply({Interface.KEY: [iface_info]})
+    yield iface_info
+    iface_info[Interface.STATE] = InterfaceState.ABSENT
+    libnmstate.apply(
+        {Interface.KEY: [iface_info]}, verify_change=False,
+    )
+
+
+@pytest.fixture
+def ib_pkey_nic2(ib_base_nic):
+    iface_info = _gen_ib_iface_info(
+        _test_nic_name(), TEST_PKEY2, _test_ib_mode()
+    )
+    libnmstate.apply({Interface.KEY: [iface_info]})
+    yield iface_info
+    iface_info[Interface.STATE] = InterfaceState.ABSENT
+    libnmstate.apply(
+        {Interface.KEY: [iface_info]}, verify_change=False,
+    )
+
+
+@pytest.fixture
+def empty_test_bridge():
+    bridge_config = {}
+    with linux_bridge(TEST_BRIDGE0, bridge_config) as state:
+        yield state
+
+
+@pytest.fixture
+def empty_test_bond():
+    with bond_interface(TEST_BOND99, []) as state:
+        yield state
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC(TEST_IB_CONNECTED_MODE optionally) "
+    "for infiniband test",
+)
+class TestInfiniBand:
+    def test_create_and_remove_pkey_nic(self, ib_base_nic):
+        desired_state = {
+            Interface.KEY: [
+                _gen_ib_iface_info(
+                    _test_nic_name(), TEST_PKEY1, _test_ib_mode()
+                )
+            ]
+        }
+        try:
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+        finally:
+            desired_state[Interface.KEY][0][
+                Interface.STATE
+            ] = InterfaceState.ABSENT
+            libnmstate.apply(desired_state)
+
+    def test_change_mtu_of_base_nic(self, ib_base_nic):
+        desired_state = {
+            Interface.KEY: [
+                {Interface.NAME: _test_nic_name(), Interface.MTU: 1280}
+            ]
+        }
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_change_mtu_of_pkey_nic(self, ib_pkey_nic1):
+        iface_info = ib_pkey_nic1
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: iface_info[Interface.NAME],
+                        Interface.MTU: 1280,
+                    }
+                ]
+            }
+        )
+
+        iface_info[Interface.MTU] = 1280
+        desired_state = {Interface.KEY: [iface_info]}
+        assertlib.assert_state_match(desired_state)
+
+    def test_remove_base_nic_got_pkey_nics_removed_automatically(
+        self, ib_pkey_nic1
+    ):
+        pkey_iface_name = ib_pkey_nic1[Interface.NAME]
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: _test_nic_name(),
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
+        )
+        current_state = statelib.show_only((pkey_iface_name,))
+        if len(current_state[Interface.KEY]):
+            # The interface might be deleted after base interface
+            cur_pkey_iface_info = current_state[Interface.KEY][0]
+            assert cur_pkey_iface_info[Interface.STATE] == InterfaceState.DOWN
+
+    def test_change_ip_of_base_nic(self, ib_base_nic):
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: _test_nic_name(),
+                    Interface.IPV4: TEST_STATIC_IPV4_CONFIG,
+                    Interface.IPV6: TEST_STATIC_IPV6_CONFIG,
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_change_ip_of_pkey_nic(self, ib_pkey_nic1):
+        iface_name = ib_pkey_nic1[Interface.NAME]
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: iface_name,
+                    Interface.IPV4: TEST_STATIC_IPV4_CONFIG,
+                    Interface.IPV6: TEST_STATIC_IPV6_CONFIG,
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_add_base_nic_to_linux_bridge(
+        self, empty_test_bridge, ib_base_nic
+    ):
+        """
+        The InfiniBand is IP over IB, hence there is ethernet layer for
+        IPoIB NIC, so there is no way for adding a IPoIB NIC to bridge
+        """
+        bridge_iface_info = empty_test_bridge[Interface.KEY][0]
+        bridge_iface_info[LinuxBridge.CONFIG_SUBTREE] = {}
+        add_port_to_bridge(
+            bridge_iface_info[LinuxBridge.CONFIG_SUBTREE], _test_nic_name()
+        )
+        desired_state = {Interface.KEY: [bridge_iface_info]}
+
+        with pytest.raises(NmstateValueError):
+            libnmstate.apply(desired_state)
+
+    def test_add_pkey_nic_to_linux_bridge(
+        self, empty_test_bridge, ib_pkey_nic1
+    ):
+        pkey_iface_name = ib_pkey_nic1[Interface.NAME]
+        bridge_iface_info = empty_test_bridge[Interface.KEY][0]
+        bridge_iface_info[LinuxBridge.CONFIG_SUBTREE] = {}
+        add_port_to_bridge(
+            bridge_iface_info[LinuxBridge.CONFIG_SUBTREE], pkey_iface_name
+        )
+        desired_state = {Interface.KEY: [bridge_iface_info]}
+
+        with pytest.raises(NmstateValueError):
+            libnmstate.apply(desired_state)
+
+    def test_add_base_nic_to_active_backup_bond(
+        self, empty_test_bond, ib_base_nic
+    ):
+        with bond_interface(
+            TEST_BOND99, [_test_nic_name()], create=False
+        ) as desired_state:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.MODE
+            ] = BondMode.ACTIVE_BACKUP
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+
+    def test_add_pkey_nic_to_active_backup_bond(
+        self, empty_test_bond, ib_pkey_nic1, ib_pkey_nic2,
+    ):
+        port1_name = ib_pkey_nic1[Interface.NAME]
+        port2_name = ib_pkey_nic2[Interface.NAME]
+        with bond_interface(
+            TEST_BOND99, [port1_name, port2_name], create=False
+        ) as desired_state:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.MODE
+            ] = BondMode.ACTIVE_BACKUP
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+
+    def test_expect_exception_when_adding_base_nic_to_round_robin_bond(
+        self, empty_test_bond, ib_base_nic
+    ):
+        """
+        IP over InfiniBand interface is only allowd to be port of active-backup
+        bond.
+        """
+        with bond_interface(
+            TEST_BOND99, [_test_nic_name()], create=False
+        ) as desired_state:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.MODE
+            ] = BondMode.ROUND_ROBIN
+            with pytest.raises(NmstateValueError):
+                libnmstate.apply(desired_state)
+
+    def test_expect_exception_when_adding_pkey_nic_to_round_robin_bond(
+        self, empty_test_bond, ib_pkey_nic1, ib_pkey_nic2,
+    ):
+        """
+        IP over InfiniBand interface is only allowd to be port of active-backup
+        bond.
+        """
+        port1_name = ib_pkey_nic1[Interface.NAME]
+        port2_name = ib_pkey_nic2[Interface.NAME]
+        with bond_interface(
+            TEST_BOND99, [port1_name, port2_name], create=False
+        ) as desired_state:
+            desired_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+                Bond.MODE
+            ] = BondMode.ROUND_ROBIN
+            with pytest.raises(NmstateValueError):
+                libnmstate.apply(desired_state)

--- a/tests/lib/ifaces/infiniband_test.py
+++ b/tests/lib/ifaces/infiniband_test.py
@@ -1,0 +1,226 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import Bond
+from libnmstate.schema import BondMode
+from libnmstate.ifaces import Ifaces
+from libnmstate.schema import InfiniBand
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import LinuxBridge
+from libnmstate.schema import OVSBridge
+
+from libnmstate.ifaces.infiniband import InfiniBandIface
+
+from ..testlib.ifacelib import gen_foo_iface_info
+from ..testlib.bridgelib import gen_bridge_iface_info
+from ..testlib.ovslib import gen_ovs_bridge_info
+
+BASE_IFACE_NAME = "ib0"
+TEST_PKEY = "0x8001"
+PKEY_IFACE_NAME = f"{BASE_IFACE_NAME}.{TEST_PKEY[2:]}"
+
+
+class TestInfiniBandIface:
+    def _gen_base_iface_info(self):
+        iface_info = gen_foo_iface_info(iface_type=InterfaceType.INFINIBAND)
+        iface_info[Interface.NAME] = BASE_IFACE_NAME
+        iface_info[Interface.MTU] = 1500
+        iface_info[InfiniBand.CONFIG_SUBTREE] = {
+            InfiniBand.PKEY: InfiniBand.DEFAULT_PKEY,
+            InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+        }
+
+        return iface_info
+
+    def _gen_iface_info(self):
+        iface_info = gen_foo_iface_info(iface_type=InterfaceType.INFINIBAND)
+        iface_info[Interface.NAME] = PKEY_IFACE_NAME
+        iface_info[InfiniBand.CONFIG_SUBTREE] = {
+            InfiniBand.PKEY: TEST_PKEY,
+            InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+            InfiniBand.BASE_IFACE: BASE_IFACE_NAME,
+        }
+        return iface_info
+
+    def test_get_parent(self):
+        assert (
+            InfiniBandIface(self._gen_iface_info()).parent == BASE_IFACE_NAME
+        )
+
+    def test_need_parent(self):
+        assert InfiniBandIface(self._gen_iface_info()).need_parent
+
+    def test_base_iface_not_need_parent(self):
+        assert not InfiniBandIface(self._gen_base_iface_info()).need_parent
+
+    def test_is_not_virtual(self):
+        assert not InfiniBandIface(self._gen_iface_info()).is_virtual
+
+    def test_cannot_have_ip_as_port(self):
+        assert not InfiniBandIface(self._gen_iface_info()).can_have_ip_as_port
+
+    def test_validate_base_iface_missing(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE].pop(InfiniBand.BASE_IFACE)
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_validate_mode_missing(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE].pop(InfiniBand.MODE)
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_cannonicalize_undefined_pkey(self):
+        iface_info = self._gen_base_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE].pop(InfiniBand.PKEY)
+
+        iface = InfiniBandIface(iface_info)
+        iface.pre_edit_validation_and_cleanup()
+        assert (
+            iface.to_dict()[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY]
+            == InfiniBand.DEFAULT_PKEY
+        )
+
+    def test_cannonicalize_hex_string_pkey_to_numer(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY] = TEST_PKEY
+
+        iface = InfiniBandIface(iface_info)
+        iface.pre_edit_validation_and_cleanup()
+        assert iface.to_dict()[InfiniBand.CONFIG_SUBTREE][
+            InfiniBand.PKEY
+        ] == int(TEST_PKEY, 16)
+
+    def test_cannonicalize_string_pkey_to_numer(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][
+            InfiniBand.PKEY
+        ] = f"{int(TEST_PKEY, 16)}"
+
+        iface = InfiniBandIface(iface_info)
+        iface.pre_edit_validation_and_cleanup()
+        assert iface.to_dict()[InfiniBand.CONFIG_SUBTREE][
+            InfiniBand.PKEY
+        ] == int(TEST_PKEY, 16)
+
+    def test_cannonicalize_invalid_string_pkey(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY] = "invalid_pkey"
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_cannonicalize_pkey_bigger_than_maximum(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY] = 0xFFFF + 1
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_cannonicalize_pkey_smaller_than_minimum(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY] = 0
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_validate_invalid_iface_name(self):
+        iface_info = self._gen_iface_info()
+        iface_info[Interface.NAME] = "invalid_pkey"
+
+        iface = InfiniBandIface(iface_info)
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_verify_string_pkey(self):
+        iface_info = self._gen_iface_info()
+        iface_info[InfiniBand.CONFIG_SUBTREE][InfiniBand.PKEY] = int(
+            TEST_PKEY, 16
+        )
+
+        iface = InfiniBandIface(iface_info)
+        current_iface = InfiniBandIface(self._gen_iface_info())
+        iface.match(current_iface)
+
+    def test_remove_base_iface_got_child_marked_as_absent(self):
+        base_iface_info = self._gen_base_iface_info()
+        base_iface_info[Interface.STATE] = InterfaceState.ABSENT
+        ifaces = Ifaces([base_iface_info, self._gen_iface_info()], [])
+        ifaces[PKEY_IFACE_NAME].state = InterfaceState.ABSENT
+        ifaces[BASE_IFACE_NAME].state = InterfaceState.ABSENT
+
+    def test_expect_exception_for_adding_ib_to_linux_bridge(self):
+        base_iface_info = self._gen_base_iface_info()
+        ib_iface_info = self._gen_iface_info()
+        bridge_iface_info = gen_bridge_iface_info()
+        bridge_config = bridge_iface_info[LinuxBridge.CONFIG_SUBTREE]
+        bridge_config[LinuxBridge.PORT_SUBTREE] = [
+            {LinuxBridge.Port.NAME: PKEY_IFACE_NAME}
+        ]
+        with pytest.raises(NmstateValueError):
+            Ifaces([base_iface_info, ib_iface_info, bridge_iface_info], [])
+
+    def test_expect_exception_for_adding_ib_to_ovs_bridge(self):
+        base_iface_info = self._gen_base_iface_info()
+        ib_iface_info = self._gen_iface_info()
+        bridge_iface_info = gen_ovs_bridge_info()
+        bridge_config = bridge_iface_info[OVSBridge.CONFIG_SUBTREE]
+        bridge_config[OVSBridge.PORT_SUBTREE] = [
+            {OVSBridge.Port.NAME: PKEY_IFACE_NAME}
+        ]
+        with pytest.raises(NmstateValueError):
+            Ifaces([base_iface_info, ib_iface_info, bridge_iface_info], [])
+
+    def test_add_ib_to_bond_not_in_active_backup_mode(self):
+        base_iface_info = self._gen_base_iface_info()
+        ib_iface_info = self._gen_iface_info()
+        bond_iface_info = gen_foo_iface_info(iface_type=InterfaceType.BOND)
+        bond_iface_info[Bond.CONFIG_SUBTREE] = {
+            Bond.MODE: BondMode.ROUND_ROBIN,
+            Bond.PORT: [PKEY_IFACE_NAME],
+            Bond.OPTIONS_SUBTREE: {},
+        }
+
+        with pytest.raises(NmstateValueError):
+            Ifaces([base_iface_info, ib_iface_info, bond_iface_info], [])
+
+    def test_add_ib_to_bond_in_active_backup_mode(self):
+        base_iface_info = self._gen_base_iface_info()
+        ib_iface_info = self._gen_iface_info()
+        bond_iface_info = gen_foo_iface_info(iface_type=InterfaceType.BOND)
+        bond_iface_info[Bond.CONFIG_SUBTREE] = {
+            Bond.MODE: BondMode.ACTIVE_BACKUP,
+            Bond.PORT: [PKEY_IFACE_NAME],
+            Bond.OPTIONS_SUBTREE: {},
+        }
+
+        Ifaces([base_iface_info, ib_iface_info, bond_iface_info], [])

--- a/tests/lib/nm/translator_test.py
+++ b/tests/lib/nm/translator_test.py
@@ -59,6 +59,7 @@ def test_api2nm_iface_type_map(NM_mock):
         InterfaceType.LINUX_BRIDGE: NM_mock.SETTING_BRIDGE_SETTING_NAME,
         InterfaceType.VXLAN: NM_mock.SETTING_VXLAN_SETTING_NAME,
         InterfaceType.VRF: NM_mock.SETTING_VRF_SETTING_NAME,
+        InterfaceType.INFINIBAND: NM_mock.SETTING_INFINIBAND_SETTING_NAME,
     }
 
     assert map == expected_map

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -26,6 +26,7 @@ import libnmstate
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Ethernet
+from libnmstate.schema import InfiniBand
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
@@ -812,3 +813,74 @@ class TestIfaceTypeVrf:
         libnmstate.validator.schema_validate(
             {Interface.KEY: [self._gen_base_vrf_iface_info()]}
         )
+
+
+class TestInfiniBand:
+    def test_valid_base_interface_full_info(self, default_data):
+        default_data[Interface.KEY].append(
+            {
+                Interface.NAME: "ib0",
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+                    InfiniBand.PKEY: InfiniBand.DEFAULT_PKEY,
+                    InfiniBand.BASE_IFACE: "",
+                },
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_valid_base_interface_minimum_info(self, default_data):
+        default_data[Interface.KEY].append(
+            {
+                Interface.NAME: "ib0",
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+                },
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_valid_pkey_interface_using_integer_pkey(self, default_data):
+        default_data[Interface.KEY].append(
+            {
+                Interface.NAME: "ib0.80ff",
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+                    InfiniBand.PKEY: 0x80FF,
+                    InfiniBand.BASE_IFACE: "ib0",
+                },
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_valid_pkey_interface_using_string_pkey(self, default_data):
+        default_data[Interface.KEY].append(
+            {
+                Interface.NAME: "ib0.80ff",
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+                    InfiniBand.PKEY: "0x80FF",
+                    InfiniBand.BASE_IFACE: "ib0",
+                },
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_valid_pkey_interface_using_invalid_mode(self, default_data):
+        default_data[Interface.KEY].append(
+            {
+                Interface.NAME: "ib0.80ff",
+                Interface.TYPE: InterfaceType.INFINIBAND,
+                InfiniBand.CONFIG_SUBTREE: {
+                    InfiniBand.MODE: "invalid",
+                    InfiniBand.PKEY: "0x80FF",
+                    InfiniBand.BASE_IFACE: "ib0",
+                },
+            }
+        )
+        with pytest.raises(js.ValidationError):
+            libnmstate.validator.schema_validate(default_data)


### PR DESCRIPTION
Supporting IP over InfiniBand via:

```yml
- name: mlx5_ib1.8013
  type: infiniband
  state: up
  infiniband:
    base-iface: mlx5_ib1
    mode: datagram
    pkey: '0x8013'
```

Limitations:
 * Will raise NmstateValueError when setting IP over InfiniBand interface
   as bridge port. This is because they don't have ethernet layer.
   Please use RDMA over Converged Ethernet (RoCE).

 * Will raise NmstateValueError when setting IP over InfiniBand
   interface as bond port which is not in "active-backup" bond mode.
   This is Linux kernel limitation. Please use RDMA over Converged
   Ethernet for other bond modes.

To run the integration test case on real hardware of infiniband, please
use this command:

    sudo env TEST_REAL_NIC=mlx5_ib0 pytest-3 -vv  ./infiniband_test.py

Test cases are included.
