### PR TITLE
schema: fix flake8 warning on unnecessary f-string

### DIFF
--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -152,8 +152,8 @@ OVS_BRIDGE = "OVSBridge.Port.LinkAggregation"
 
 DEPRECATED_CONSTANTS = {
     "Bond.SLAVES": "Bond.PORT",
-    f"LinkAggregation.SLAVES_SUBTREE": f"{OVS_BRIDGE}.PORT_SUBTREE",
-    f"LinkAggregation.Slave": f"{OVS_BRIDGE}.Port",
+    "LinkAggregation.SLAVES_SUBTREE": f"{OVS_BRIDGE}.PORT_SUBTREE",
+    "LinkAggregation.Slave": f"{OVS_BRIDGE}.Port",
 }
 
 


### PR DESCRIPTION
```
libnmstate/schema.py:156:5: F541 f-string is missing placeholders
    f"LinkAggregation.SLAVES_SUBTREE": f"{OVS_BRIDGE}.PORT_SUBTREE",
    ^
libnmstate/schema.py:157:5: F541 f-string is missing placeholders
    f"LinkAggregation.Slave": f"{OVS_BRIDGE}.Port",
    ^
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>