### PR TITLE
tests: fix bad variable names in loops

### DIFF
--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -36,7 +36,7 @@ from .base_iface import BaseIface
 
 
 SYSTEMCTL_TIMEOUT_SECONDS = 5
-DEPRECATED_SLAVES = "port"
+DEPRECATED_SLAVES = "slaves"
 
 
 class OvsBridgeIface(BridgeIface):

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -197,10 +197,10 @@ def _attach_port_to_bridge(ctx, port_state):
 
     _create_proxy_port(ctx, port_profile_name, port_state)
     if lag_state:
-        port = [
+        ports = [
             port for port in lag_state[OB.Port.LinkAggregation.PORT_SUBTREE]
         ]
-        for port in port:
+        for port in ports:
             _connect_interface(ctx, port_profile_name, port)
     elif _is_internal_interface(ctx, port_name):
         iface_name = port_name

--- a/tests/integration/team_test.py
+++ b/tests/integration/team_test.py
@@ -95,13 +95,13 @@ def test_add_invalid_port_ip_config(eth1_up):
     desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.ENABLED] = True
     desired_state[Interface.KEY][0][Interface.IPV4][InterfaceIP.DHCP] = True
     with pytest.raises(NmstateValueError):
-        with team_interface(TEAM0, port=("eth1",)) as state:
+        with team_interface(TEAM0, ports=("eth1",)) as state:
             desired_state[Interface.KEY].append(state[Interface.KEY][0])
             libnmstate.apply(desired_state)
 
 
 @contextmanager
-def team_interface(ifname, port=None):
+def team_interface(ifname, ports=None):
     desired_state = {
         Interface.KEY: [
             {
@@ -111,10 +111,10 @@ def team_interface(ifname, port=None):
             }
         ]
     }
-    if port:
+    if ports:
         team_state = {Team.PORT_SUBTREE: []}
         desired_state[Interface.KEY][0][Team.CONFIG_SUBTREE] = team_state
-        for port in port:
+        for port in ports:
             team_state[Team.PORT_SUBTREE].append({Team.Port.NAME: port})
     libnmstate.apply(desired_state)
     try:


### PR DESCRIPTION
After replacing variables names in order to use inclusive language, some
of them were not done in a good way. This patch is fixing the
deprecation of "slaves" in OVSBridge, as it was broken after the
internal code replacement.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>