### PR TITLE
nm: Change NetworkManager plugin as optional

### DIFF
--- a/libnmstate/nm/common.py
+++ b/libnmstate/nm/common.py
@@ -19,15 +19,15 @@
 
 import gi
 
-try:
-    gi.require_version("NM", "1.0")  # NOQA: F402
-    from gi.repository import NM  # pylint: disable=no-name-in-module
-except ValueError:
-    NM = None
+gi.require_version("NM", "1.0")
 
-from gi.repository import GLib
-from gi.repository import GObject
-from gi.repository import Gio
+# It is required to state the NM version before importing it
+# But this break the flak8 rule: https://www.flake8rules.com/rules/E402.html
+# Use NOQA: E402 to suppress it.
+from gi.repository import NM  # NOQA: E402
+from gi.repository import GLib  # NOQA: E402
+from gi.repository import GObject  # NOQA: E402
+from gi.repository import Gio  # NOQA: E402
 
 
 # To suppress the "import not used" error

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -20,6 +20,7 @@ from distutils.version import StrictVersion
 import logging
 from operator import itemgetter
 
+from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateValueError
 from libnmstate.ifaces.ovs import is_ovs_running
 from libnmstate.schema import DNS
@@ -226,7 +227,10 @@ class NetworkManagerPlugin(NmstatePlugin):
         nm_utils_version = _nm_utils_decode_version()
 
         if nm_client_version is None:
-            logging.warning("NetworkManager is not running")
+            raise NmstateDependencyError(
+                "NetworkManager daemon is not running which is required for "
+                "NetworkManager plugin"
+            )
         elif StrictVersion(nm_client_version) != StrictVersion(
             nm_utils_version
         ):


### PR DESCRIPTION
Previously, if NetworkManager plugin is not properly loaded, we raise
exception of it. This stop user from using their own backend.

Changed the NetworkManager plugin as optional by only log a warning
indicating plugin is not loaded with reason.

Integration test case included.