### PR TITLE
Revert "Packaging: adjust dependecy requirements #1203"

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -41,7 +41,7 @@ Summary:        nmstate plugin for OVS database manipulation
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 # The python-openvswitch rpm pacakge is not in the same repo with nmstate,
 # hence state it as Recommends, no requires.
-Requires:     python3dist(ovs)
+Recommends:     python3dist(ovs)
 
 %description -n python3-%{libname}
 This package contains the Python 3 library for Nmstate.


### PR DESCRIPTION
This reverts commit 97d1cbada4b7b600f85484055f31862d1a42c737.

OVS on RHEL is in a different repo than nmstate, thus Recommends
should be used.

Signed-off-by: Antonio Cardace <acardace@redhat.com>