### PR TITLE
packaging: use a 'Recommends' dep for OVS if building for RHEL

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -39,9 +39,13 @@ Requires:       python3-nispor
 %package -n nmstate-plugin-ovsdb
 Summary:        nmstate plugin for OVS database manipulation
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
+%if 0%{?rhel}
 # The python-openvswitch rpm pacakge is not in the same repo with nmstate,
 # hence state it as Recommends, no requires.
-Requires:     python3dist(ovs)
+Recommends:     python3dist(ovs)
+%else
+Requires:       python3dist(ovs)
+%endif
 
 %description -n python3-%{libname}
 This package contains the Python 3 library for Nmstate.


### PR DESCRIPTION
Keep using a Requires for fedora.

This fixes an issue when building the package for ELN.
https://docs.fedoraproject.org/en-US/eln/

Signed-off-by: Antonio Cardace <acardace@redhat.com>