### PR TITLE
 [nmstate-0.3] nm, ovs: Fix report crash when OVS has dup iface names

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -140,7 +140,12 @@ def get_port_by_slave(nmdev):
 
 
 def get_ovs_info(context, bridge_device, devices_info):
-    port_profiles = _get_slave_profiles(bridge_device, devices_info)
+    ovs_ports_info = (
+        info
+        for info in devices_info
+        if is_ovs_port_type_id(info[1]["type_id"])
+    )
+    port_profiles = _get_slave_profiles(bridge_device, ovs_ports_info)
     ports = _get_bridge_ports_info(context, port_profiles, devices_info)
     options = _get_bridge_options(context, bridge_device)
 
@@ -203,8 +208,21 @@ def _get_bridge_port_info(context, port_profile, devices_info):
     vlan_mode = port_setting.props.vlan_mode
 
     port_name = port_profile.get_interface_name()
-    port_device = context.get_nm_dev(port_name)
-    port_slave_profiles = _get_slave_profiles(port_device, devices_info)
+    port_device = next(
+        dev
+        for dev, devinfo in devices_info
+        if devinfo["name"] == port_name
+        and is_ovs_port_type_id(devinfo["type_id"])
+    )
+    devices_info_excluding_bridges_and_ports = (
+        info
+        for info in devices_info
+        if not is_ovs_bridge_type_id(info[1]["type_id"])
+        and not is_ovs_port_type_id(info[1]["type_id"])
+    )
+    port_slave_profiles = _get_slave_profiles(
+        port_device, devices_info_excluding_bridges_and_ports
+    )
     port_slave_names = [c.get_interface_name() for c in port_slave_profiles]
 
     if port_slave_names:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import time
+
 import pytest
 
 import libnmstate
@@ -630,3 +632,81 @@ def test_remove_all_ovs_ports(bridge_with_ports):
         }
     )
     assertlib.assert_absent(PORT1)
+
+
+@pytest.fixture
+def ovs_bridge_with_internal_interface_and_identical_names():
+    device_name = "obridge0"
+
+    cmdlib.exec_cmd(
+        [
+            "nmcli",
+            "connection",
+            "add",
+            "type",
+            "ovs-bridge",
+            "conn.interface",
+            device_name,
+        ],
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        [
+            "nmcli",
+            "connection",
+            "add",
+            "type",
+            "ovs-port",
+            "conn.interface",
+            device_name,
+            "master",
+            device_name,
+        ],
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        [
+            "nmcli",
+            "connection",
+            "add",
+            "type",
+            "ovs-interface",
+            "slave-type",
+            "ovs-port",
+            "conn.interface",
+            device_name,
+            "master",
+            device_name,
+        ],
+        check=True,
+    )
+
+    try:
+        yield device_name
+    finally:
+        _, con_names, _ = cmdlib.exec_cmd(
+            ["nmcli", "-f", "NAME", "connection"], check=True,
+        )
+        con_to_delete = [
+            con_name.strip()
+            for con_name in con_names.splitlines()
+            if device_name in con_name
+        ]
+        cmdlib.exec_cmd(
+            ["nmcli", "connection", "delete"] + con_to_delete, check=True,
+        )
+        # Wait for command to take affect.
+        time.sleep(1)
+
+        assertlib.assert_absent(device_name)
+
+
+def test_ovs_report_with_identical_inteface_names(
+    ovs_bridge_with_internal_interface_and_identical_names,
+):
+    name = ovs_bridge_with_internal_interface_and_identical_names
+    state = statelib.show_only((name,))
+
+    assert state
+    # The plugin infra only supports a single iface to be reported.
+    assert len(state[Interface.KEY]) == 1

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -61,7 +61,7 @@ def test_get_ovs_info_without_ports(context_mock, nm_connection_mock, NM_mock):
     bridge_device = mock.MagicMock()
     _mock_port_profile(nm_connection_mock)
 
-    device_info = [(bridge_device, None)]
+    device_info = [(bridge_device, {"type_id": NM_mock.DeviceType.OVS_BRIDGE})]
     info = nm.ovs.get_ovs_info(context_mock, bridge_device, device_info)
 
     expected_info = {
@@ -77,15 +77,25 @@ def test_get_ovs_info_without_ports(context_mock, nm_connection_mock, NM_mock):
 
 
 def test_get_ovs_info_with_ports_without_interfaces(
-    nm_connection_mock, NM_mock, context_mock
+    nm_connection_mock, NM_mock
 ):
     bridge_device = mock.MagicMock()
     port_device = mock.MagicMock()
     _mock_port_profile(nm_connection_mock)
     active_con = nm_connection_mock.get_device_active_connection.return_value
     active_con.props.master = bridge_device
+    ifname = active_con.props.connection.get_interface_name.return_value
 
-    device_info = [(bridge_device, None), (port_device, None)]
+    device_info = [
+        (
+            bridge_device,
+            {"type_id": NM_mock.DeviceType.OVS_BRIDGE, "name": ifname},
+        ),
+        (
+            port_device,
+            {"type_id": NM_mock.DeviceType.OVS_PORT, "name": ifname},
+        ),
+    ]
     info = nm.ovs.get_ovs_info(context_mock, bridge_device, device_info)
 
     expected_info = {
@@ -100,24 +110,46 @@ def test_get_ovs_info_with_ports_without_interfaces(
     assert expected_info == info
 
 
-def test_get_ovs_info_with_ports_with_interfaces(
-    nm_connection_mock, NM_mock, context_mock
-):
+def test_get_ovs_info_with_ports_with_interfaces(nm_connection_mock, NM_mock):
     bridge_device = mock.MagicMock()
     port_device = mock.MagicMock()
+    interface_device = mock.MagicMock()
     bridge_active_con = mock.MagicMock()
     port_active_con = mock.MagicMock()
-    context_mock.get_nm_dev.return_value = port_device
+    iface_active_con = mock.MagicMock()
     _mock_port_profile(nm_connection_mock)
-    nm_connection_mock.get_device_active_connection = (
-        lambda dev: bridge_active_con
-        if dev == bridge_device
-        else port_active_con
-    )
-    bridge_active_con.props.master = bridge_device
-    port_active_con.props.master = port_device
 
-    device_info = [(bridge_device, None), (port_device, None)]
+    def get_dev_active_connection(dev):
+        if dev == bridge_device:
+            return bridge_active_con
+        elif dev == port_device:
+            return port_active_con
+        else:
+            return iface_active_con
+
+    nm_connection_mock.get_device_active_connection = get_dev_active_connection
+    brname = bridge_active_con.props.connection.get_interface_name.return_value
+    port_active_con.props.master = bridge_device
+    portname = port_active_con.props.connection.get_interface_name.return_value
+    iface_active_con.props.master = port_device
+    ifacename = (
+        iface_active_con.props.connection.get_interface_name.return_value
+    )
+
+    device_info = [
+        (
+            bridge_device,
+            {"type_id": NM_mock.DeviceType.OVS_BRIDGE, "name": brname},
+        ),
+        (
+            port_device,
+            {"type_id": NM_mock.DeviceType.OVS_PORT, "name": portname},
+        ),
+        (
+            interface_device,
+            {"type_id": NM_mock.DeviceType.OVS_INTERFACE, "name": ifacename},
+        ),
+    ]
     info = nm.ovs.get_ovs_info(context_mock, bridge_device, device_info)
 
     assert len(info[OVSBridge.PORT_SUBTREE]) == 1


### PR DESCRIPTION
In case of an existing OVS deployment which uses an identical name for
the bridge, port and interface, libnmstate.show() exploded.

It is now possible to report such deployments.

Ref: #1363 