### PR TITLE
[nmstate-0.3] nm, bridge, ovs: Collect only existing profiles

### DIFF
--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -260,9 +260,9 @@ def _get_slave_profiles_by_name(master_device):
     for dev in master_device.get_slaves():
         active_con = connection.get_device_active_connection(dev)
         if active_con:
-            slaves_profiles_by_name[
-                dev.get_iface()
-            ] = active_con.props.connection
+            profile = active_con.props.connection
+            if profile:
+                slaves_profiles_by_name[dev.get_iface()] = profile
     return slaves_profiles_by_name
 
 

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -279,5 +279,7 @@ def _get_slave_profiles(master_device, devices_info):
         if active_con:
             master = active_con.props.master
             if master and (master.get_iface() == master_device.get_iface()):
-                slave_profiles.append(active_con.props.connection)
+                profile = active_con.props.connection
+                if profile:
+                    slave_profiles.append(profile)
     return slave_profiles


### PR DESCRIPTION
During the reporting flow, connections that are in teardown process
no longer point to a valid profile. Avoid collecting such profiles (in
practice, these are actually `None` objects).