### PR TITLE
nm, ovs: Collect only existing profiles

### DIFF
--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -291,7 +291,9 @@ def _get_port_profiles(controller_device, devices_info):
             if controller and (
                 controller.get_iface() == controller_device.get_iface()
             ):
-                port_profiles.append(active_con.props.connection)
+                profile = active_con.props.connection
+                if profile:
+                    port_profiles.append(profile)
     return port_profiles
 
 


### PR DESCRIPTION
During the reporting flow, connections that are in teardown process
no longer point to a valid profile. Avoid collecting such profiles (in
practice, these are actually `None` objects).