### PR TITLE
query: Allowing duplicated interface name with different interface types

### DIFF
--- a/libnmstate/nispor/ovs.py
+++ b/libnmstate/nispor/ovs.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from libnmstate.schema import InterfaceType
+
+from .base_iface import NisporPluginBaseIface
+
+
+class NisporPluginOvsInternalIface(NisporPluginBaseIface):
+    @property
+    def type(self):
+        return InterfaceType.OVS_INTERFACE

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -32,6 +32,7 @@ from .vlan import NisporPluginVlanIface
 from .vxlan import NisporPluginVxlanIface
 from .route import nispor_route_state_to_nmstate
 from .vrf import NisporPluginVrfIface
+from .ovs import NisporPluginOvsInternalIface
 
 
 class NisporPlugin(NmstatePlugin):
@@ -82,6 +83,8 @@ class NisporPlugin(NmstatePlugin):
                 )
             elif iface_type == "Vrf":
                 ifaces.append(NisporPluginVrfIface(np_iface).to_dict())
+            elif iface_type == "OpenvSwitch":
+                ifaces.append(NisporPluginOvsInternalIface(np_iface).to_dict())
             else:
                 ifaces.append(NisporPluginBaseIface(np_iface).to_dict())
         return ifaces

--- a/libnmstate/nispor/vxlan.py
+++ b/libnmstate/nispor/vxlan.py
@@ -34,7 +34,7 @@ class NisporPluginVxlanIface(NisporPluginBaseIface):
             VXLAN.ID: self._np_iface.vxlan_id,
             VXLAN.BASE_IFACE: self._np_iface.base_iface,
             VXLAN.REMOTE: self._np_iface.remote,
-            VXLAN.DESTINATION_PORT: self._np_iface.dst_port_min,
+            VXLAN.DESTINATION_PORT: self._np_iface.dst_port,
         }
 
         return info

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -25,6 +25,7 @@ from libnmstate.error import NmstateValueError
 from libnmstate.ifaces.ovs import is_ovs_running
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 from libnmstate.plugin import NmstatePlugin
@@ -144,14 +145,12 @@ class NetworkManagerPlugin(NmstatePlugin):
                 bondinfo = nm_bond.get_bond_info(dev)
                 iface_info.update(_ifaceinfo_bond(bondinfo))
             elif NmstatePlugin.OVS_CAPABILITY in capabilities:
-                if nm_ovs.is_ovs_bridge_type_id(type_id):
-                    iface_info["bridge"] = nm_ovs.get_ovs_info(
-                        self.context, dev, devices_info
-                    )
+                if iface_info[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
+                    iface_info.update(nm_ovs.get_ovs_bridge_info(dev))
                     iface_info = _remove_ovs_bridge_unsupported_entries(
                         iface_info
                     )
-                elif nm_ovs.is_ovs_interface_type_id(type_id):
+                elif iface_info[Interface.TYPE] == InterfaceType.OVS_INTERFACE:
                     iface_info.update(nm_ovs.get_interface_info(act_con))
                 elif nm_ovs.is_ovs_port_type_id(type_id):
                     continue

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -619,7 +619,10 @@ def get_all_applied_configs(context):
         ):
             iface_name = nm_dev.get_iface()
             if iface_name:
-                action = f"Retrieve applied config: {iface_name}"
+                iface_type_str = nm_dev.get_type_description()
+                action = (
+                    f"Retrieve applied config: {iface_type_str} {iface_name}"
+                )
                 context.register_async(action, fast=True)
                 nm_dev.get_applied_connection_async(
                     flags=0,

--- a/libnmstate/nm/profile_state.py
+++ b/libnmstate/nm/profile_state.py
@@ -280,6 +280,7 @@ def get_applied_config_callback(nm_dev, result, user_data):
     context.finish_async(action)
     try:
         remote_conn, _ = nm_dev.get_applied_connection_finish(result)
+        # TODO: We should use both interface name and type as key below.
         applied_configs[nm_dev.get_iface()] = remote_conn
     except Exception as e:
         logging.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ PyGObject
 PyYAML
 setuptools
 varlink
-nispor>=0.5.1
+nispor>=0.6.1

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -159,13 +159,7 @@ def _get_bridge_current_state(nm_plugin):
     state = {}
     nmdev = nm_plugin.context.get_nm_dev(BRIDGE0)
     if nmdev:
-        devices_info = [
-            (dev, nm.device.get_device_common_info(dev))
-            for dev in nm.device.list_devices(nm_plugin.context.client)
-        ]
-        ovs_info = nm.ovs.get_ovs_info(nm_plugin.context, nmdev, devices_info)
-        if ovs_info:
-            state[OB.CONFIG_SUBTREE] = ovs_info
+        state = nm.ovs.get_ovs_bridge_info(nmdev)
     return state
 
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -630,3 +630,47 @@ def test_remove_all_ovs_ports(bridge_with_ports):
         }
     )
     assertlib.assert_absent(PORT1)
+
+
+@pytest.fixture
+def ovs_bridge_with_internal_interface_and_identical_names():
+    cmdlib.exec_cmd(
+        f"nmcli c add type ovs-bridge conn.interface {BRIDGE0}".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        f"nmcli c add type ovs-port conn.interface {BRIDGE0} "
+        f"master {BRIDGE0} slave-type ovs-bridge".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        f"nmcli c add type ovs-interface conn.interface {BRIDGE0} "
+        f"master {BRIDGE0} slave-type ovs-port".split(),
+        check=True,
+    )
+
+    try:
+        yield BRIDGE0
+    finally:
+        _, con_names, _ = cmdlib.exec_cmd(
+            "nmcli -f NAME connection".split(), check=True,
+        )
+        con_to_delete = " ".join(
+            [
+                con_name.strip()
+                for con_name in con_names.splitlines()
+                if BRIDGE0 in con_name
+            ]
+        )
+        cmdlib.exec_cmd(f"nmcli c delete {con_to_delete}".split(), check=True)
+
+        assertlib.assert_absent(BRIDGE0)
+
+
+def test_ovs_internal_using_the_same_name_as_bridge(
+    ovs_bridge_with_internal_interface_and_identical_names,
+):
+    bridge_name = ovs_bridge_with_internal_interface_and_identical_names
+    state = statelib.show_only((bridge_name,))
+    assert state
+    assert len(state[Interface.KEY]) == 2

--- a/tests/lib/plugin_test.py
+++ b/tests/lib/plugin_test.py
@@ -1,0 +1,182 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from unittest import mock
+
+from libnmstate.nmstate import show_with_plugins
+from libnmstate.plugin import NmstatePlugin
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+
+TEST_IFACE1 = "nic1"
+TEST_IFACE2 = "nic2"
+TEST_IFACE3 = "nic3"
+
+
+class TestPluginInfrastructure:
+    def _gen_plugin_mocks(self):
+        plugin_a = mock.MagicMock()
+        plugin_a.priority = 10
+        plugin_a.plugin_capabilities = [NmstatePlugin.PLUGIN_CAPABILITY_IFACE]
+        plugin_b = mock.MagicMock()
+        plugin_b.priority = 11
+        plugin_b.plugin_capabilities = [NmstatePlugin.PLUGIN_CAPABILITY_IFACE]
+        return [plugin_a, plugin_b]
+
+    def test_show_with_plugins_merge_by_type_and_name(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo2": "b",
+            },
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+                "foo2": "b",
+            }
+        ]
+
+    def test_show_with_plugins_merge_by_name_and_unknown_type(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.UNKNOWN,
+                "foo2": "b",
+            },
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+                "foo2": "b",
+            }
+        ]
+
+    def test_show_with_plugins_merge_by_name_without_type(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {Interface.NAME: TEST_IFACE1, "foo2": "b"},
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                "foo1": "a",
+                "foo2": "b",
+            }
+        ]
+
+    def test_show_with_plugins_with_merge_with_duplicate_iface_names(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+            },
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                "foo3": "c",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo2": "b",
+            },
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+                "foo2": "b",
+            },
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                "foo3": "c",
+            },
+        ]
+
+    def test_show_with_plugins_do_not_merge_if_not_uniqe(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+            },
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                "foo3": "c",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {Interface.NAME: TEST_IFACE1, "foo2": "b"},
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+            },
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                "foo3": "c",
+            },
+            {Interface.NAME: TEST_IFACE1, "foo2": "b"},
+        ]


### PR DESCRIPTION
As only OVS internal interface has kernel nic entry, it is allowed
for a OVS bridge hold the same name as OVS internal interface.

This patch change the upper level of nmstate to allow duplicated
interface name and only enforce unique interface name within the same
interface type.

When different plugins providing information regarding the same
interface, it is required they also provide the interface type.

If any unknown interface has single interface with valid name and type,
information will be merged also.

The nispor plugin has changed to support OVS internal interface.
The OVS db plugin has changed to include interface type also.