### PR TITLE
CI container: Fix the centos-stream-nmstate-dev container

### DIFF
--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -3,7 +3,7 @@ FROM docker.io/library/centos:8
 RUN dnf install -y centos-release-stream && \
     dnf update -y && \
     dnf -y install dnf-plugins-core epel-release && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled Stream-PowerTools && \
     dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \


### PR DESCRIPTION
The centos-stream-nmstate-dev should be using `Stream-PowerTools` repo
instead of `PowerTools`.