### PR TITLE
On RHEL require python-openvswitch only if ovs is installed

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -39,9 +39,13 @@ Requires:       python3-nispor
 %package -n nmstate-plugin-ovsdb
 Summary:        nmstate plugin for OVS database manipulation
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
+%if 0%{?rhel}
 # The python-openvswitch rpm pacakge is not in the same repo with nmstate,
 # hence state it as Recommends, no requires.
-Requires:     python3dist(ovs)
+Recommends:     python3dist(ovs)
+%else
+Requires:       python3dist(ovs)
+%endif
 
 %description -n python3-%{libname}
 This package contains the Python 3 library for Nmstate.

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -42,7 +42,7 @@ Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
 %if 0%{?rhel}
 # The python-openvswitch rpm pacakge is not in the same repo with nmstate,
 # hence state it as Recommends, no requires.
-Recommends:     python3dist(ovs)
+Requires:       (python3dist(ovs) if openvswitch)
 %else
 Requires:       python3dist(ovs)
 %endif


### PR DESCRIPTION
 This has the advantage that if you have openvswitch installed, you can't remove python3-openvswitch without removing nmstate-plugin-ovsdb as well.