### PR TITLE
test: Use deepcopy for constant IPV6_ADDRESSES

### DIFF
--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -29,7 +29,7 @@ from libnmstate.schema import InterfaceState
 from libnmstate.ifaces.base_iface import BaseIface
 from ..testlib.constants import MAC_ADDRESS1
 from ..testlib.constants import IPV6_LINK_LOCAL_ADDRESS1
-from ..testlib.constants import IPV6_ADDRESSES
+from ..testlib.constants import get_test_ipv6_addrs
 from ..testlib.ifacelib import gen_foo_iface_info
 
 
@@ -127,7 +127,7 @@ class TestBaseIface:
         iface_info = gen_foo_iface_info()
         ipv6_info = {
             InterfaceIPv6.ENABLED: True,
-            InterfaceIPv6.ADDRESS: IPV6_ADDRESSES,
+            InterfaceIPv6.ADDRESS: get_test_ipv6_addrs(),
         }
         iface_info[Interface.IPV6] = ipv6_info
         expected_iface_info = deepcopy(iface_info)

--- a/tests/lib/ifaces/ip_state_test.py
+++ b/tests/lib/ifaces/ip_state_test.py
@@ -28,11 +28,11 @@ from libnmstate.schema import InterfaceIPv6
 
 from libnmstate.ifaces.base_iface import IPState
 
-from ..testlib.constants import IPV4_ADDRESSES
 from ..testlib.constants import IPV6_ADDRESS1
 from ..testlib.constants import IPV6_ADDRESS1_FULL
 from ..testlib.constants import IPV6_LINK_LOCAL_ADDRESS1
-from ..testlib.constants import IPV6_ADDRESSES
+from ..testlib.constants import get_test_ipv4_addrs
+from ..testlib.constants import get_test_ipv6_addrs
 
 
 parametrize_ip_ver = pytest.mark.parametrize(
@@ -42,14 +42,14 @@ parametrize_ip_ver = pytest.mark.parametrize(
             Interface.IPV4,
             {
                 InterfaceIPv4.ENABLED: True,
-                InterfaceIPv4.ADDRESS: deepcopy(IPV4_ADDRESSES),
+                InterfaceIPv4.ADDRESS: get_test_ipv4_addrs(),
             },
         ),
         (
             Interface.IPV6,
             {
                 InterfaceIPv6.ENABLED: True,
-                InterfaceIPv6.ADDRESS: deepcopy(IPV6_ADDRESSES),
+                InterfaceIPv6.ADDRESS: get_test_ipv6_addrs(),
             },
         ),
     ],
@@ -178,7 +178,9 @@ class TestIPState:
         ip_info.update(dynamic_options)
         expected_ip_info = deepcopy(ip_info)
         ip_info[InterfaceIP.ADDRESS] = (
-            IPV4_ADDRESSES if family == InterfaceIPv4 else IPV6_ADDRESSES
+            get_test_ipv4_addrs()
+            if family == InterfaceIPv4
+            else get_test_ipv6_addrs()
         )
 
         ip_state = IPState(family, ip_info)

--- a/tests/lib/testlib/constants.py
+++ b/tests/lib/testlib/constants.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import copy
+
 from libnmstate.schema import InterfaceIP
 
 FOO_IFACE_NAME = "foo"
@@ -26,7 +28,7 @@ IPV6_ADDRESS1 = "2001:db8:1::1"
 IPV6_ADDRESS1_FULL = "2001:db8:1:0:0:0:0:1"
 IPV6_ADDRESS2 = "2001:db8:2::1"
 IPV6_LINK_LOCAL_ADDRESS1 = "fe80::1"
-IPV6_ADDRESSES = [
+_IPV6_ADDRESSES = [
     {
         InterfaceIP.ADDRESS_IP: IPV6_ADDRESS1,
         InterfaceIP.ADDRESS_PREFIX_LENGTH: 64,
@@ -39,7 +41,7 @@ IPV6_ADDRESSES = [
 
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV4_ADDRESS2 = "192.0.2.252"
-IPV4_ADDRESSES = [
+_IPV4_ADDRESSES = [
     {
         InterfaceIP.ADDRESS_IP: IPV4_ADDRESS1,
         InterfaceIP.ADDRESS_PREFIX_LENGTH: 24,
@@ -52,3 +54,11 @@ IPV4_ADDRESSES = [
 
 PORT1_IFACE_NAME = "port1"
 PORT2_IFACE_NAME = "port2"
+
+
+def get_test_ipv4_addrs():
+    return copy.deepcopy(_IPV4_ADDRESSES)
+
+
+def get_test_ipv6_addrs():
+    return copy.deepcopy(_IPV6_ADDRESSES)

--- a/tests/lib/testlib/ifacelib.py
+++ b/tests/lib/testlib/ifacelib.py
@@ -17,8 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from copy import deepcopy
-
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
@@ -28,8 +26,8 @@ from libnmstate.schema import InterfaceIPv6
 from libnmstate.ifaces.ifaces import Ifaces
 
 from .constants import FOO_IFACE_NAME
-from .constants import IPV4_ADDRESSES
-from .constants import IPV6_ADDRESSES
+from .constants import get_test_ipv4_addrs
+from .constants import get_test_ipv6_addrs
 
 
 def gen_foo_iface_info(iface_type=InterfaceType.ETHERNET):
@@ -49,12 +47,12 @@ def gen_foo_iface_info_static_ip(iface_type=InterfaceType.ETHERNET):
             Interface.IPV4: {
                 InterfaceIPv4.ENABLED: True,
                 InterfaceIPv4.DHCP: False,
-                InterfaceIPv4.ADDRESS: deepcopy(IPV4_ADDRESSES),
+                InterfaceIPv4.ADDRESS: get_test_ipv4_addrs(),
             },
             Interface.IPV6: {
                 InterfaceIPv6.ENABLED: True,
                 InterfaceIPv6.DHCP: False,
-                InterfaceIPv6.ADDRESS: deepcopy(IPV6_ADDRESSES),
+                InterfaceIPv6.ADDRESS: get_test_ipv6_addrs(),
                 InterfaceIPv6.AUTOCONF: False,
             },
         }


### PR DESCRIPTION
The unit test will fail when ran by `pytest *`. This is caused by test
case `test_state_for_verify_remove_link_local_address` changed the value
of `IPV6_ADDRESSES` which will fail `TestIfaces.test_mark_iface_as_absent.

Changed to `get_test_ipv4_addrs()` and `get_test_ipv6_addrs()` to
generate new dict at runtime.