### PR TITLE
vlan: Raise exception if base iface is infiniband.

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -136,6 +136,7 @@ class Ifaces:
 
     def _pre_edit_validation_and_cleanup(self):
         self._validate_over_booked_port()
+        self._validate_vlan_not_over_infiniband()
         self._validate_vlan_mtu()
         self._handle_controller_port_list_change()
         self._match_child_iface_state_with_parent()
@@ -179,6 +180,23 @@ class Ifaces:
                             f"OVS patch port peer {iface.peer} must be an OVS"
                             " patch port"
                         )
+
+    def _validate_vlan_not_over_infiniband(self):
+        """
+        Validate that vlan is not being created over infiniband interface
+        """
+        for iface in self._ifaces.values():
+
+            if (
+                iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
+                and iface.is_up
+            ):
+                if self._ifaces[iface.parent].type == InterfaceType.INFINIBAND:
+                    raise NmstateValueError(
+                        f"Interface {iface.name} of type {iface.type}"
+                        " is not supported over base interface of "
+                        "type Infiniband"
+                    )
 
     def _validate_vlan_mtu(self):
         """

--- a/tests/lib/ifaces/vlan_iface_test.py
+++ b/tests/lib/ifaces/vlan_iface_test.py
@@ -22,6 +22,7 @@ import pytest
 from libnmstate.error import NmstateValueError
 from libnmstate.ifaces import Ifaces
 from libnmstate.schema import VLAN
+from libnmstate.schema import InfiniBand
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
@@ -93,3 +94,23 @@ class TestVlanIface:
         base_iface = ifaces.get(base_iface_info.get(Interface.NAME))
 
         assert base_iface.mtu == vlan_iface_info[Interface.MTU]
+
+    def test_add_vlan_with_base_iface_infiniband(self):
+        base_iface_info = gen_foo_iface_info(
+            iface_type=InterfaceType.INFINIBAND
+        )
+        base_iface_info[Interface.NAME] = "ib0"
+        base_iface_info[Interface.MTU] = 1500
+        base_iface_info[InfiniBand.CONFIG_SUBTREE] = {
+            InfiniBand.PKEY: InfiniBand.DEFAULT_PKEY,
+            InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+        }
+
+        vlan_iface_info = self._gen_iface_info()
+        vlan_iface_info[VLAN.CONFIG_SUBTREE][VLAN.BASE_IFACE] = "ib0"
+
+        with pytest.raises(NmstateValueError):
+            Ifaces(
+                des_iface_infos=[base_iface_info, vlan_iface_info],
+                cur_iface_infos=[],
+            )

--- a/tests/lib/ifaces/vxlan_iface_test.py
+++ b/tests/lib/ifaces/vxlan_iface_test.py
@@ -22,6 +22,7 @@ import pytest
 from libnmstate.error import NmstateValueError
 from libnmstate.ifaces import Ifaces
 from libnmstate.schema import VXLAN
+from libnmstate.schema import InfiniBand
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
@@ -98,3 +99,23 @@ class TestVxlanIface:
         base_iface = ifaces.get(base_iface_info.get(Interface.NAME))
 
         assert base_iface.mtu == vxlan_iface_info[Interface.MTU]
+
+    def test_add_vlan_with_base_iface_infiniband(self):
+        base_iface_info = gen_foo_iface_info(
+            iface_type=InterfaceType.INFINIBAND
+        )
+        base_iface_info[Interface.NAME] = "ib0"
+        base_iface_info[Interface.MTU] = 1500
+        base_iface_info[InfiniBand.CONFIG_SUBTREE] = {
+            InfiniBand.PKEY: InfiniBand.DEFAULT_PKEY,
+            InfiniBand.MODE: InfiniBand.Mode.DATAGRAM,
+        }
+
+        vxlan_iface_info = self._gen_iface_info()
+        vxlan_iface_info[VXLAN.CONFIG_SUBTREE][VXLAN.BASE_IFACE] = "ib0"
+
+        with pytest.raises(NmstateValueError):
+            Ifaces(
+                des_iface_infos=[base_iface_info, vxlan_iface_info],
+                cur_iface_infos=[],
+            )


### PR DESCRIPTION
Adds a validator that raises NmstateValueError if
base iface of Vlan/Vxlan is IB interface

Tests are also added

Fixes #1353

Signed-off-by: Adwait Thattey <coderdude1999@gmail.com>