### PR TITLE
nipsor: Use nispor for bond query

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -30,7 +30,6 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 from libnmstate.plugin import NmstatePlugin
 
-from . import bond as nm_bond
 from . import connection as nm_connection
 from . import device as nm_device
 from . import ipv4 as nm_ipv4
@@ -141,10 +140,7 @@ class NetworkManagerPlugin(NmstatePlugin):
             iface_info.update(nm_team.get_info(dev))
             iface_info.update(get_infiniband_info(applied_config))
 
-            if nm_bond.is_bond_type_id(type_id):
-                bondinfo = nm_bond.get_bond_info(dev)
-                iface_info.update(_ifaceinfo_bond(bondinfo))
-            elif NmstatePlugin.OVS_CAPABILITY in capabilities:
+            if NmstatePlugin.OVS_CAPABILITY in capabilities:
                 if iface_info[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
                     iface_info.update(nm_ovs.get_ovs_bridge_info(dev))
                     iface_info = _remove_ovs_bridge_unsupported_entries(
@@ -240,14 +236,6 @@ class NetworkManagerPlugin(NmstatePlugin):
                 nm_utils_version,
                 nm_client_version,
             )
-
-
-def _ifaceinfo_bond(devinfo):
-    # TODO: What about unmanaged devices?
-    bondinfo = nm_translator.Nm2Api.get_bond_info(devinfo)
-    if "link-aggregation" in bondinfo:
-        return bondinfo
-    return {}
 
 
 def _remove_ovs_bridge_unsupported_entries(iface_info):

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -435,9 +435,12 @@ class NmProfile:
         if user_setting:
             settings.append(user_setting)
 
-        bond_opts = translator.Api2Nm.get_bond_options(self.iface_info)
-        if bond_opts:
-            settings.append(bond.create_setting(bond_opts, wired_setting))
+        if self.iface.type == InterfaceType.BOND:
+            settings.append(
+                bond.create_setting(
+                    self.iface, wired_setting, self._remote_conn
+                )
+            )
         elif nm_iface_type == bridge.BRIDGE_TYPE:
             bridge_config = self.iface_info.get(LB.CONFIG_SUBTREE, {})
             bridge_options = bridge_config.get(LB.OPTIONS_SUBTREE)

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -273,7 +273,7 @@ def test_ipv4_dhcp_on_bond(dhcpcli_up):
     with bondlib.bond_interface(
         "bond99", port=[DHCP_CLI_NIC], extra_iface_state=ipv4_state
     ) as desired_state:
-        assertlib.assert_state(desired_state)
+        assertlib.assert_state_match(desired_state)
 
 
 def test_ipv4_dhcp_ignore_gateway(dhcpcli_up):

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -107,7 +107,7 @@ def test_add_new_bond_iface_with_vxlan(eth1_up):
                 bond_desired_state[Interface.KEY][0]
             )
             libnmstate.apply(desired_state)
-            assertlib.assert_state(desired_state)
+            assertlib.assert_state_match(desired_state)
 
     assertlib.assert_absent(vxlan.name)
     assertlib.assert_absent(bond_name)


### PR DESCRIPTION
Changed to use nispor for bond query.
Since nmstate are showing full bond options instead of on-disk
configures, when applying bond options, desired options will merge with
current options in config before applying to NM.

To reset all bond options back to default, please use

```python
    {
        Bond.OPTIONS_SUBTREE: {}
    }
```

Test cases are included.