### PR TITLE
DNS: Allowing unmixed dual stack name servers

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -197,10 +197,11 @@ class DnsState:
             len(self._config_servers) > 2
             and any(is_ipv6_address(n) for n in self._config_servers)
             and any(not is_ipv6_address(n) for n in self._config_servers)
+            and _is_mixed_dns_servers(self._config_servers)
         ):
             raise NmstateNotImplementedError(
-                "Three or more nameservers are only supported when using "
-                "either IPv4 or IPv6 nameservers but not both."
+                "Placing IPv4/IPv6 nameserver in the middlfe of IPv6/IPv4 "
+                "nameservers is not supported yet"
             )
 
     @property
@@ -229,3 +230,18 @@ def _is_dns_config_changed(des_dns_state, cur_dns_state):
     ) or _get_config_searches(des_dns_state) != _get_config_searches(
         cur_dns_state
     )
+
+
+def _is_mixed_dns_servers(servers):
+    """
+    Return True when an IPv6 server is in the middle of two IPv4 namesevers or
+    an IPv4 server is in the middle of two IPv6 servers.
+    """
+    pattern = ""
+    for server in servers:
+        if is_ipv6_address(server):
+            pattern += "6"
+        else:
+            pattern += "4"
+
+    return "464" in pattern or "646" in pattern

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -104,13 +104,22 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
     assert dns_config == current_state[DNS.KEY][DNS.CONFIG]
 
 
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "dns_servers",
     [
         (IPV4_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+        (IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+        (IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
         pytest.param(
-            (IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
+            (
+                [
+                    IPV4_DNS_NAMESERVERS[0],
+                    EXTRA_IPV6_DNS_NAMESERVER,
+                    IPV4_DNS_NAMESERVERS[1],
+                ]
+            ),
             marks=pytest.mark.xfail(
                 reason="Not supported",
                 raises=NmstateNotImplementedError,
@@ -118,17 +127,34 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
             ),
         ),
         pytest.param(
-            (IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
+            (
+                [
+                    IPV6_DNS_NAMESERVERS[0],
+                    EXTRA_IPV4_DNS_NAMESERVER,
+                    IPV6_DNS_NAMESERVERS[1],
+                ]
+            ),
             marks=pytest.mark.xfail(
                 reason="Not supported",
                 raises=NmstateNotImplementedError,
                 strict=True,
             ),
         ),
+        (IPV4_DNS_NAMESERVERS + IPV6_DNS_NAMESERVERS),
+        (IPV6_DNS_NAMESERVERS + IPV4_DNS_NAMESERVERS),
     ],
-    ids=["ipv4", "ipv6", "ipv4+ipv6", "ipv6+ipv4"],
+    ids=[
+        "3ipv4",
+        "3ipv6",
+        "2ipv4+ipv6",
+        "2ipv6+ipv4",
+        "ipv4+ipv6+ipv4",
+        "ipv6+ipv4+ipv6",
+        "2ipv4+2ipv6",
+        "2ipv6+2ipv4",
+    ],
 )
-def test_dns_edit_three_nameservers(dns_servers):
+def test_dns_edit_3_more_nameservers(dns_servers):
     dns_config = {
         DNS.SERVER: dns_servers,
         DNS.SEARCH: [],

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -203,12 +203,61 @@ class TestDnsState:
         with pytest.raises(NmstateVerificationError):
             dns_state.verify({DNS.CONFIG: DNS_CONFIG2})
 
-    def test_3_ipv4_ipv6_mixed_name_servers(self):
+    @pytest.mark.parametrize(
+        "dns_servers",
+        [
+            ([IPV4_DNS_SERVER1, IPV4_DNS_SERVER2, IPV4_DNS_SERVER3]),
+            ([IPV6_DNS_SERVER1, IPV6_DNS_SERVER2, IPV6_DNS_SERVER3]),
+            ([IPV4_DNS_SERVER1, IPV4_DNS_SERVER2, IPV6_DNS_SERVER1]),
+            ([IPV6_DNS_SERVER1, IPV6_DNS_SERVER2, IPV4_DNS_SERVER1]),
+            pytest.param(
+                ([IPV4_DNS_SERVER1, IPV6_DNS_SERVER1, IPV4_DNS_SERVER2]),
+                marks=pytest.mark.xfail(
+                    reason="Not supported",
+                    raises=NmstateNotImplementedError,
+                    strict=True,
+                ),
+            ),
+            pytest.param(
+                ([IPV6_DNS_SERVER1, IPV4_DNS_SERVER1, IPV6_DNS_SERVER2]),
+                marks=pytest.mark.xfail(
+                    reason="Not supported",
+                    raises=NmstateNotImplementedError,
+                    strict=True,
+                ),
+            ),
+            (
+                [
+                    IPV4_DNS_SERVER1,
+                    IPV4_DNS_SERVER2,
+                    IPV6_DNS_SERVER1,
+                    IPV6_DNS_SERVER2,
+                ]
+            ),
+            (
+                [
+                    IPV6_DNS_SERVER1,
+                    IPV6_DNS_SERVER2,
+                    IPV4_DNS_SERVER1,
+                    IPV4_DNS_SERVER2,
+                ]
+            ),
+        ],
+        ids=[
+            "3ipv4",
+            "3ipv6",
+            "2ipv4+ipv6",
+            "2ipv6+ipv4",
+            "ipv4+ipv6+ipv4",
+            "ipv6+ipv4+ipv6",
+            "2ipv4+2ipv6",
+            "2ipv6+2ipv4",
+        ],
+    )
+    def test_validate_3_more_name_servers(self, dns_servers):
         dns_config = deepcopy(DNS_CONFIG1)
-        dns_config[DNS.SERVER].append(IPV4_DNS_SERVER3)
-
-        with pytest.raises(NmstateNotImplementedError):
-            DnsState({DNS.CONFIG: dns_config}, {})
+        dns_config[DNS.SERVER] = dns_servers
+        DnsState({DNS.CONFIG: dns_config}, {})
 
     def test_3_dns_ipv4_servers(self):
         dns_config = deepcopy(DNS_CONFIG1)


### PR DESCRIPTION
This patch allowing configuring multiple dual stack DNS name servers
except placing IPv6/IPv4 name server in the middle of IPv4/IPv6 servers.

Test cases updated.