### PR TITLE
ovsdb plugin: Don't add new interface

### DIFF
--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -92,3 +92,12 @@ class NmstatePlugin(metaclass=ABCMeta):
         raise NmstatePluginError(
             f"Plugin {self.name} BUG: get_dns_client_config() not implemented"
         )
+
+    @property
+    def is_supplemental_only(self):
+        """
+        Return True when plugin can only append information to
+        interfaces reported by other plugin.
+        Retrun False when plugin can report new interface.
+        """
+        return False

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -63,6 +63,10 @@ class NmstateOvsdbPlugin(NmstatePlugin):
         self._load_schema()
         self._connect_to_ovs_db()
 
+    @property
+    def is_supplemental_only(self):
+        return True
+
     def unload(self):
         if self._transaction:
             self._transaction.abort()

--- a/tests/lib/plugin_test.py
+++ b/tests/lib/plugin_test.py
@@ -34,9 +34,11 @@ class TestPluginInfrastructure:
         plugin_a = mock.MagicMock()
         plugin_a.priority = 10
         plugin_a.plugin_capabilities = [NmstatePlugin.PLUGIN_CAPABILITY_IFACE]
+        plugin_a.is_supplemental_only = False
         plugin_b = mock.MagicMock()
         plugin_b.priority = 11
         plugin_b.plugin_capabilities = [NmstatePlugin.PLUGIN_CAPABILITY_IFACE]
+        plugin_b.is_supplemental_only = False
         return [plugin_a, plugin_b]
 
     def test_show_with_plugins_merge_by_type_and_name(self):
@@ -179,4 +181,32 @@ class TestPluginInfrastructure:
                 "foo3": "c",
             },
             {Interface.NAME: TEST_IFACE1, "foo2": "b"},
+        ]
+
+    def test_show_with_plugins_remove_new_iface_from_supplemental_plugin(self):
+        plugins = self._gen_plugin_mocks()
+        plugins[0].is_supplemental_only = True
+        plugins[0].get_interfaces.return_value = [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+            },
+            {
+                Interface.NAME: TEST_IFACE2,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                "foo3": "c",
+            },
+        ]
+
+        plugins[1].get_interfaces.return_value = [
+            {Interface.NAME: TEST_IFACE1, "foo2": "b"},
+        ]
+        assert show_with_plugins(plugins)[Interface.KEY] == [
+            {
+                Interface.NAME: TEST_IFACE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                "foo1": "a",
+                "foo2": "b",
+            },
         ]


### PR DESCRIPTION
When OVS bridge is unmanaged by NetworkManager, NetworkManager plugin
will not include any information regarding it, the nispor plugin
neither(ovs bridge is user space only interface). The ovsdb plugin will
show it name and type.
This will cause oVirt crash when try to access OVS bridge information of
it which nmstate-0.3 does not.

To fix it, introduced `NmstatePlugin.is_supplemental_only` which
indicate whether plugin can only amend existing interface or not.

Set the ovsdb as supplemental only so it will never add new interface to
the `libnmstate.show()`.