### PR TITLE
nm bond: Ignore ad_actor_system=00:00:00:00:00:00

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -35,6 +35,8 @@ NM_SUPPORTED_BOND_OPTIONS = NM.SettingBond.get_valid_options(
 
 SYSFS_BOND_OPTION_FOLDER_FMT = "/sys/class/net/{ifname}/bonding"
 
+BOND_AD_ACTOR_SYSTEM_USE_BOND_MAC = "00:00:00:00:00:00"
+
 
 def create_setting(iface, wired_setting, base_con_profile):
     bond_setting = NM.SettingBond.new()
@@ -58,6 +60,13 @@ def create_setting(iface, wired_setting, base_con_profile):
         if wired_setting and BondIface.is_mac_restricted_mode(mode, options):
             # When in MAC restricted mode, MAC address should be unset.
             wired_setting.props.cloned_mac_address = None
+        if (
+            option_name == "ad_actor_system"
+            and option_value == BOND_AD_ACTOR_SYSTEM_USE_BOND_MAC
+        ):
+            # The all zero ad_actor_system is the kernel default value
+            # And it is invalid to set as all zero
+            continue
         if option_value != SYSFS_EMPTY_VALUE:
             option_value = _nm_fix_bond_options(option_name, option_value)
             success = bond_setting.add_option(option_name, option_value)

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -28,6 +28,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
 from .testlib import main_context
+from ..testlib import cmdlib
 from ..testlib import statelib
 from ..testlib.retry import retry_till_true_or_timeout
 
@@ -182,3 +183,16 @@ def _create_connection_setting(bond, port_con_profile):
 
 def _verify_bond_state(option, expected_state):
     return _get_bond_current_state(BOND0, option) == expected_state
+
+
+def test_bond_all_zero_ad_actor_system_been_ignored(nm_plugin):
+    bond_options = {"ad_actor_system": "00:00:00:00:00:00"}
+    with _bond_interface(
+        nm_plugin.context, BOND0, BondMode.LACP, bond_options
+    ):
+        _, output, _ = cmdlib.exec_cmd(
+            f"nmcli --fields bond.options c show {BOND0}".split(), check=True
+        )
+        assert "ad_actor_system" not in output
+
+    assert not _get_bond_current_state(BOND0)


### PR DESCRIPTION
The ad_actor_system=00:00:00:00:00:00 is invalid in kernel as that's the
default value of ad_actor_system.

NM plugin should not set that value.

Test case included.