### PR TITLE
team: deprecate 'ports' in favor of 'port'

### DIFF
--- a/examples/team0_with_port.yml
+++ b/examples/team0_with_port.yml
@@ -4,7 +4,7 @@ interfaces:
     type: team
     state: up
     team:
-      ports:
+      port:
         - name: eth1
         - name: eth2
       runner:

--- a/libnmstate/ifaces/team.py
+++ b/libnmstate/ifaces/team.py
@@ -18,13 +18,21 @@
 #
 
 from operator import itemgetter
+import warnings
 
 from libnmstate.schema import Team
 
 from .base_iface import BaseIface
 
 
+DEPRECATED_PORTS = "ports"
+
+
 class TeamIface(BaseIface):
+    def __init__(self, info, save_to_disk=True):
+        super().__init__(info, save_to_disk)
+        self._replace_deprecated_terms()
+
     @property
     def port(self):
         ports = self.raw.get(Team.CONFIG_SUBTREE, {}).get(
@@ -53,3 +61,9 @@ class TeamIface(BaseIface):
                 s for s in port_config if s[Team.Port.NAME] != port_name
             ]
         self.sort_port()
+
+    def _replace_deprecated_terms(self):
+        team_cfg = self.raw.get(Team.CONFIG_SUBTREE)
+        if team_cfg and team_cfg.get(DEPRECATED_PORTS):
+            team_cfg[Team.PORT_SUBTREE] = team_cfg.pop(DEPRECATED_PORTS)
+            warnings.warn("Using 'ports' is deprecated, use 'port' instead.")

--- a/libnmstate/nm/team.py
+++ b/libnmstate/nm/team.py
@@ -63,12 +63,12 @@ def _convert_team_config_to_teamd_format(team_config, ifname):
     team_config = copy.deepcopy(team_config)
     team_config[TEAMD_JSON_DEVICE] = ifname
 
-    team_ports = team_config.get(Team.PORT_SUBTREE, ())
+    team_ports = team_config.pop(Team.PORT_SUBTREE, ())
     team_ports_formatted = {
         port[Team.Port.NAME]: _dict_key_filter(port, Team.Port.NAME)
         for port in team_ports
     }
-    team_config[Team.PORT_SUBTREE] = team_ports_formatted
+    team_config[TEAMD_JSON_PORTS] = team_ports_formatted
 
     return team_config
 

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -372,7 +372,7 @@ class Team:
     TYPE = InterfaceType.TEAM
     CONFIG_SUBTREE = InterfaceType.TEAM
 
-    PORT_SUBTREE = "ports"
+    PORT_SUBTREE = "port"
     RUNNER_SUBTREE = "runner"
 
     class Port:


### PR DESCRIPTION
In order to unify the API keys and make it more consistent, this patch
is deprecating 'ports' in favor of 'port' which is already used by
other interfaces like bond, ovs..

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>