### PR TITLE
[nmstate-0.3] nm bond: Ignore ad_actor_system=00:00:00:00:00:00

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -38,6 +38,8 @@ NM_SUPPORTED_BOND_OPTIONS = NM.SettingBond.get_valid_options(
 
 SYSFS_BOND_OPTION_FOLDER_FMT = "/sys/class/net/{ifname}/bonding"
 
+BOND_AD_ACTOR_SYSTEM_USE_BOND_MAC = "00:00:00:00:00:00"
+
 
 def create_setting(options, wired_setting):
     bond_setting = NM.SettingBond.new()
@@ -48,6 +50,13 @@ def create_setting(options, wired_setting):
         ):
             # When in MAC restricted mode, MAC address should be unset.
             wired_setting.props.cloned_mac_address = None
+        if (
+            option_name == "ad_actor_system"
+            and option_value == BOND_AD_ACTOR_SYSTEM_USE_BOND_MAC
+        ):
+            # The all zero ad_actor_system is the kernel default value
+            # And it is invalid to set as all zero
+            continue
         if option_value != SYSFS_EMPTY_VALUE:
             success = bond_setting.add_option(option_name, str(option_value))
             if not success:

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -27,6 +27,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
 from .testlib import main_context
+from ..testlib import cmdlib
 from ..testlib.retry import retry_till_true_or_timeout
 
 
@@ -166,3 +167,14 @@ def _convert_slaves_devices_to_iface_names(info):
 
 def _verify_bond_state(nm_plugin, expected_state):
     return _get_bond_current_state(nm_plugin, BOND0) == expected_state
+
+
+def test_bond_all_zero_ad_actor_system_been_ignored(nm_plugin):
+    bond_options = {"ad_actor_system": "00:00:00:00:00:00"}
+    with _bond_interface(nm_plugin.context, BOND0, bond_options):
+        _, output, _ = cmdlib.exec_cmd(
+            f"nmcli --fields bond.options c show {BOND0}".split(), check=True
+        )
+        assert "ad_actor_system" not in output
+
+    assert not _get_bond_current_state(plugin=nm_plugin, name=BOND0)


### PR DESCRIPTION
The ad_actor_system=00:00:00:00:00:00 is invalid in kernel as that's the
default value of ad_actor_system.

NM plugin should not set that value.

Test case included.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>