### PR TITLE
replace link in stale.yml with correct link

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,5 +8,5 @@ markComment: >
   recently. To avoid pull requests to pile up, an automated process marked this
   pull request as stale. It will close this pull request if no further activity
   occurs. The current policy is available at:
-  https://github.com/nmstate/nmstate/blob/master/.github/stale.yml
+  https://github.com/nmstate/nmstate/blob/base/.github/stale.yml
 only: pulls


### PR DESCRIPTION
This fixes #1399 
I have replaced the link in state.yml. The new link points to the base branch now. 