### PR TITLE
vrf: Allow vrf port to hold IP information

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -233,6 +233,7 @@ class BaseIface:
             if (
                 ip_state.is_enabled
                 and self.controller
+                and self.controller_type != InterfaceType.VRF
                 and not self.can_have_ip_as_port
             ):
                 raise NmstateValueError(
@@ -279,7 +280,10 @@ class BaseIface:
     def set_controller(self, controller_iface_name, controller_type):
         self._info[BaseIface.CONTROLLER_METADATA] = controller_iface_name
         self._info[BaseIface.CONTROLLER_TYPE_METADATA] = controller_type
-        if not self.can_have_ip_as_port:
+        if (
+            not self.can_have_ip_as_port
+            and controller_type != InterfaceType.VRF
+        ):
             for family in (Interface.IPV4, Interface.IPV6):
                 self._info[family] = {InterfaceIP.ENABLED: False}
 

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -23,6 +23,8 @@ import libnmstate
 
 from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import VRF
@@ -35,6 +37,8 @@ TEST_VRF_PORT0 = "eth1"
 TEST_VRF_PORT1 = "eth2"
 TEST_ROUTE_TABLE_ID0 = 100
 TEST_ROUTE_TABLE_ID1 = 101
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV6_ADDRESS1 = "2001:db8:1::1"
 
 
 @pytest.fixture
@@ -162,5 +166,37 @@ class TestVrf:
         vrf0_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [TEST_VRF_PORT1]
         vrf1_iface[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = [TEST_VRF_PORT0]
         desired_state = {Interface.KEY: [vrf0_iface, vrf1_iface]}
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+
+    def test_port_holding_ip(self, vrf0_with_port0):
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_VRF_PORT0,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: False,
+                        InterfaceIPv4.ADDRESS: [
+                            {
+                                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                            }
+                        ],
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: False,
+                        InterfaceIPv6.AUTOCONF: False,
+                        InterfaceIPv6.ADDRESS: [
+                            {
+                                InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                                InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
         libnmstate.apply(desired_state)
         assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
According to https://www.kernel.org/doc/Documentation/networking/vrf.txt
the vrf port is allowed to hold IP address.

Integration test case included.