### PR TITLE
[nmstate-0.3] nm.ipv6: call clear_routing_rules() when creating the setting

### DIFF
--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -106,6 +106,7 @@ def create_setting(config, base_con_profile):
             setting_ip.props.never_default = False
             setting_ip.props.ignore_auto_dns = False
             setting_ip.clear_routes()
+            setting_ip.clear_routing_rules()
             setting_ip.props.gateway = None
             setting_ip.props.route_table = Route.USE_DEFAULT_ROUTE_TABLE
             setting_ip.props.route_metric = Route.USE_DEFAULT_METRIC

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -666,6 +666,21 @@ def test_route_rule_add_from_to_single_host(route_rule_test_env):
     _check_ip_rules(rules)
 
 
+def test_route_rule_clear_state_with_ipv6(route_rule_test_env):
+    state = route_rule_test_env
+    rules = [
+        {RouteRule.IP_FROM: "2001:db8:a::", RouteRule.IP_TO: "2001:db8:f::/64"}
+    ]
+    state[RouteRule.KEY] = {RouteRule.CONFIG: rules}
+    libnmstate.apply(state)
+    _check_ip_rules(rules)
+
+    state[RouteRule.KEY] = {RouteRule.CONFIG: []}
+    libnmstate.apply(state)
+    current_state = libnmstate.show()
+    assert len(current_state[RouteRule.KEY][RouteRule.CONFIG]) == 0
+
+
 def _check_ip_rules(rules):
     for rule in rules:
         iprule.ip_rule_exist_in_os(


### PR DESCRIPTION
In order to remove IPv6 routing rules Nmstate needs to call
clear_routing_rules() on the IPv6 setting as it is done on the IPv4
setting.

Added a testcase for this.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>