### PR TITLE
ovs: Support user space only interface

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -166,7 +166,7 @@ class DnsState:
     def _find_ifaces_with_auto_dns_false(self, ifaces):
         ipv4_iface = None
         ipv6_iface = None
-        for iface in ifaces.values():
+        for iface in ifaces.all_kernel_ifaces.values():
             if ipv4_iface and ipv6_iface:
                 return (ipv4_iface, ipv6_iface)
             for family in (Interface.IPV4, Interface.IPV6):

--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -139,6 +139,19 @@ class BaseIface:
     def can_have_ip_as_port(self):
         return False
 
+    @property
+    def is_user_space_only(self):
+        """
+        Whether this interface is user space only.
+        User space network interface means:
+            * Can have duplicate interface name against kernel network
+              interfaces
+            * Cannot be used subordinate of other kernel interfaces.
+            * Due to limtation of nmstate, currently cannot be used as
+              subordinate of other user space interfaces.
+        """
+        return False
+
     def sort_port(self):
         pass
 
@@ -300,7 +313,7 @@ class BaseIface:
     def gen_metadata(self, ifaces):
         if self.is_controller and not self.is_absent:
             for port_name in self.port:
-                port_iface = ifaces[port_name]
+                port_iface = ifaces.all_kernel_ifaces[port_name]
                 port_iface.set_controller(self.name, self.type)
 
     def update(self, info):

--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -77,7 +77,7 @@ class BondIface(BaseIface):
 
     def _generate_bond_mode_change_metadata(self, ifaces):
         if self.is_up:
-            cur_iface = ifaces.current_ifaces.get(self.name)
+            cur_iface = ifaces.get_cur_iface(self.name, self.type)
             if cur_iface and self.bond_mode != cur_iface.bond_mode:
                 self._set_bond_mode_changed_metadata(True)
 

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -45,6 +45,25 @@ from .vxlan import VxlanIface
 from .vrf import VrfIface
 
 
+class _UserSpaceIfaces:
+    def __init__(self):
+        self._ifaces = {}
+
+    def set(self, iface):
+        self._ifaces[f"{iface.name}.{iface.type}"] = iface
+
+    def get(self, iface_name, iface_type):
+        return self._ifaces.get(f"{iface_name}.{iface_type}")
+
+    def remove(self, iface):
+        if self.get(iface.name, iface.type):
+            del self._ifaces[f"{iface.name}.{iface.type}"]
+
+    def __iter__(self):
+        for iface in self._ifaces.values():
+            yield iface
+
+
 class Ifaces:
     """
     The Ifaces class hold both desired state(optional) and current state.
@@ -64,22 +83,36 @@ class Ifaces:
     def __init__(self, des_iface_infos, cur_iface_infos, save_to_disk=True):
         self._save_to_disk = save_to_disk
         self._des_iface_infos = des_iface_infos
-        self._cur_ifaces = {}
-        self._ifaces = {}
-        self._ignored_iface_names = set()
+        self._cur_kernel_ifaces = {}
+        self._kernel_ifaces = {}
+        self._user_space_ifaces = _UserSpaceIfaces()
+        self._cur_user_space_ifaces = _UserSpaceIfaces()
+        self._ignored_ifaces = set()
         if cur_iface_infos:
             for iface_info in cur_iface_infos:
                 cur_iface = _to_specific_iface_obj(iface_info, save_to_disk)
-                self._ifaces[cur_iface.name] = cur_iface
-                self._cur_ifaces[cur_iface.name] = cur_iface
+                if cur_iface.is_user_space_only:
+                    self._user_space_ifaces.set(cur_iface)
+                    self._cur_user_space_ifaces.set(cur_iface)
+                else:
+                    self._kernel_ifaces[cur_iface.name] = cur_iface
+                    self._cur_kernel_ifaces[cur_iface.name] = cur_iface
 
         if des_iface_infos:
             for iface_info in des_iface_infos:
                 iface = BaseIface(iface_info, save_to_disk)
-                cur_iface = self._ifaces.get(iface.name)
+                if iface.type == InterfaceType.UNKNOWN:
+                    cur_ifaces = self._get_cur_ifaces(iface.name)
+                    if len(cur_ifaces) > 1:
+                        raise NmstateValueError(
+                            f"Got multiple interface with name {iface.name}, "
+                            "please specify the interface type explicitly"
+                        )
+                cur_iface = self.get_iface(iface.name, iface.type)
                 if cur_iface and cur_iface.is_desired:
                     raise NmstateValueError(
-                        f"Duplicate interfaces names detected: {iface.name}"
+                        f"Duplicate interfaces names detected: {iface.name} "
+                        f"for type {cur_iface.type}"
                     )
 
                 if iface_info.get(Interface.TYPE) is None:
@@ -99,11 +132,16 @@ class Ifaces:
                     # Ignore interface with unknown type
                     continue
                 if iface.is_ignore:
-                    self._ignored_iface_names.add(iface.name)
+                    self._ignored_ifaces.add(
+                        (iface.name, iface.type, iface.is_user_space_only)
+                    )
                 if cur_iface:
                     iface.merge(cur_iface)
                 iface.mark_as_desired()
-                self._ifaces[iface.name] = iface
+                if iface.is_user_space_only:
+                    self._user_space_ifaces.set(iface)
+                else:
+                    self._kernel_ifaces[iface.name] = iface
 
             self._create_virtual_port()
             self._validate_unknown_port()
@@ -111,7 +149,7 @@ class Ifaces:
             self._validate_infiniband_as_bridge_port()
             self._validate_infiniband_as_bond_port()
             self._gen_metadata()
-            for iface in self._ifaces.values():
+            for iface in self.all_ifaces():
                 iface.pre_edit_validation_and_cleanup()
 
             self._pre_edit_validation_and_cleanup()
@@ -125,15 +163,17 @@ class Ifaces:
         only in port list of OVS bridge.
         """
         new_ifaces = []
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if iface.is_up and iface.is_controller:
                 for port_name in iface.port:
-                    if port_name not in self._ifaces.keys():
+                    # nmstate does not support port interface to be user
+                    # space interface
+                    if port_name not in self._kernel_ifaces.keys():
                         new_port = iface.create_virtual_port(port_name)
                         if new_port:
                             new_ifaces.append(new_port)
         for iface in new_ifaces:
-            self._ifaces[iface.name] = iface
+            self._kernel_ifaces[iface.name] = iface
 
     def _pre_edit_validation_and_cleanup(self):
         self._validate_over_booked_port()
@@ -141,7 +181,7 @@ class Ifaces:
         self._validate_vlan_mtu()
         self._handle_controller_port_list_change()
         self._match_child_iface_state_with_parent()
-        self._mark_orphen_as_absent()
+        self._mark_orphan_as_absent()
         self._bring_port_up_if_not_in_desire()
         self._validate_ovs_patch_peers()
         self._remove_unknown_type_interfaces()
@@ -152,10 +192,10 @@ class Ifaces:
         When port been included in controller, automactially set it as state UP
         if not defiend in desire state
         """
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if iface.is_up and iface.is_controller:
                 for port_name in iface.port:
-                    port_iface = self._ifaces[port_name]
+                    port_iface = self._kernel_ifaces[port_name]
                     if not port_iface.is_desired and not port_iface.is_up:
                         port_iface.mark_as_up()
                         port_iface.mark_as_changed()
@@ -164,10 +204,10 @@ class Ifaces:
         """
         When OVS patch peer does not exist or is down, raise an error.
         """
-        for iface in self._ifaces.values():
+        for iface in self._kernel_ifaces.values():
             if iface.type == InterfaceType.OVS_INTERFACE and iface.is_up:
                 if iface.peer:
-                    peer_iface = self._ifaces.get(iface.peer)
+                    peer_iface = self._kernel_ifaces.get(iface.peer)
                     if not peer_iface or not peer_iface.is_up:
                         raise NmstateValueError(
                             f"OVS patch port peer {iface.peer} must exist and "
@@ -186,13 +226,16 @@ class Ifaces:
         """
         Validate that vlan is not being created over infiniband interface
         """
-        for iface in self._ifaces.values():
+        for iface in self._kernel_ifaces.values():
 
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
                 and iface.is_up
             ):
-                if self._ifaces[iface.parent].type == InterfaceType.INFINIBAND:
+                if (
+                    self._kernel_ifaces[iface.parent].type
+                    == InterfaceType.INFINIBAND
+                ):
                     raise NmstateValueError(
                         f"Interface {iface.name} of type {iface.type}"
                         " is not supported over base interface of "
@@ -206,14 +249,14 @@ class Ifaces:
 
         If base MTU is not present, set same as vlan MTU
         """
-        for iface in self._ifaces.values():
+        for iface in self._kernel_ifaces.values():
 
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
                 and iface.is_up
                 and iface.mtu
             ):
-                base_iface = self._ifaces.get(iface.parent)
+                base_iface = self._kernel_ifaces.get(iface.parent)
                 if not base_iface.mtu:
                     base_iface.mtu = iface.mtu
                 if iface.mtu > base_iface.mtu:
@@ -229,13 +272,13 @@ class Ifaces:
         The IPoIB NIC has no ethernet layer, hence is no way for adding a IPoIB
         NIC to linux bridge or OVS bridge
         """
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if iface.is_desired and iface.type in (
                 InterfaceType.LINUX_BRIDGE,
                 InterfaceType.OVS_BRIDGE,
             ):
                 for port_name in iface.port:
-                    port_iface = self._ifaces[port_name]
+                    port_iface = self._kernel_ifaces[port_name]
                     if port_iface.type == InterfaceType.INFINIBAND:
                         raise NmstateValueError(
                             f"The bridge {iface.name} cannot use "
@@ -248,14 +291,14 @@ class Ifaces:
         The IP over InfiniBand interface is only allowed to be port of
         bond in "active-backup" mode.
         """
-        for iface in self._ifaces.values():
+        for iface in self._kernel_ifaces.values():
             if (
                 iface.is_desired
                 and iface.type == InterfaceType.BOND
                 and iface.bond_mode != BondMode.ACTIVE_BACKUP
             ):
                 for port_name in iface.port:
-                    port_iface = self._ifaces[port_name]
+                    port_iface = self._kernel_ifaces[port_name]
                     if port_iface.type == InterfaceType.INFINIBAND:
                         raise NmstateValueError(
                             "The IP over InfiniBand interface "
@@ -271,27 +314,27 @@ class Ifaces:
         * Mark port interface as changed if port config changed when
           controller said so.
         """
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if not iface.is_desired or not iface.is_controller:
                 continue
             des_port = set(iface.port)
             if iface.is_absent:
                 des_port = set()
-            cur_iface = self._cur_ifaces.get(iface.name)
+            cur_iface = self.get_cur_iface(iface.name, iface.type)
             cur_port = set(cur_iface.port) if cur_iface else set()
             if des_port != cur_port:
                 changed_port = (des_port | cur_port) - (des_port & cur_port)
                 for iface_name in changed_port:
-                    self._ifaces[iface_name].mark_as_changed()
+                    self._kernel_ifaces[iface_name].mark_as_changed()
             if cur_iface:
                 for port_name in iface.config_changed_port(cur_iface):
-                    if port_name in self._ifaces:
-                        self._ifaces[port_name].mark_as_changed()
+                    if port_name in self._kernel_ifaces:
+                        self._kernel_ifaces[port_name].mark_as_changed()
 
     def _validate_vrf_table_id_changes(self):
-        for iface in self._ifaces.values():
+        for iface in self._kernel_ifaces.values():
             if iface.is_desired and iface.type == InterfaceType.VRF:
-                cur_iface = self._cur_ifaces.get(iface.name)
+                cur_iface = self._cur_kernel_ifaces.get(iface.name)
                 if (
                     cur_iface
                     and cur_iface.route_table_id != iface.route_table_id
@@ -309,10 +352,14 @@ class Ifaces:
             * When changed/desired parent interface is marked as down or
               absent, child state should sync with parent.
         """
-        for iface in self._ifaces.values():
-            if iface.parent and self._ifaces.get(iface.parent):
-                parent_iface = self._ifaces[iface.parent]
-                if parent_iface.is_desired or parent_iface.is_changed:
+        for iface in self.all_ifaces():
+            if iface.parent:
+                parent_iface = self._get_parent_iface(iface)
+                if (
+                    parent_iface
+                    and parent_iface.is_desired
+                    or parent_iface.is_changed
+                ):
                     if (
                         Interface.STATE not in iface.original_dict
                         or parent_iface.is_down
@@ -321,66 +368,128 @@ class Ifaces:
                         iface.state = parent_iface.state
                         iface.mark_as_changed()
 
-    def _mark_orphen_as_absent(self):
-        for iface in self._ifaces.values():
-            if iface.need_parent and (
-                not iface.parent or not self._ifaces.get(iface.parent)
+    def _get_parent_iface(self, iface):
+        if not iface.parent:
+            return None
+        for cur_iface in self.all_ifaces():
+            if cur_iface.name == iface.parent and iface != cur_iface:
+                return cur_iface
+        return None
+
+    def _mark_orphan_as_absent(self):
+        for iface in self._kernel_ifaces.values():
+            if iface.need_parent:
+                parent_iface = self._get_parent_iface(iface)
+                if parent_iface is None or parent_iface.is_absent:
+                    iface.mark_as_changed()
+                    iface.state = InterfaceState.ABSENT
+
+    def all_ifaces(self):
+        for iface in self._kernel_ifaces.values():
+            yield iface
+        for iface in self._user_space_ifaces:
+            yield iface
+
+    @property
+    def all_kernel_ifaces(self):
+        """
+        Return a editable dict of kernel interfaces, indexed by interface name
+        """
+        return self._kernel_ifaces
+
+    @property
+    def all_user_space_ifaces(self):
+        """
+        Return a editable user space interfaces, the object has functions:
+            * set(iface)
+            * get(iface)
+            * remove(iface)
+            * __iter__()
+        """
+        return self._user_space_ifaces
+
+    def _get_cur_ifaces(self, iface_name):
+        return [
+            iface
+            for iface in (
+                list(self._cur_kernel_ifaces.values())
+                + list(self._cur_user_space_ifaces)
+            )
+            if iface.name == iface_name
+        ]
+
+    def get_iface(self, iface_name, iface_type):
+        iface = self._kernel_ifaces.get(iface_name)
+        if iface and iface_type in (None, InterfaceType.UNKNOWN, iface.type):
+            return iface
+
+        for iface in self._user_space_ifaces:
+            if iface.name == iface_name and iface_type in (
+                None,
+                InterfaceType.UNKNOWN,
+                iface.type,
             ):
-                iface.mark_as_changed()
-                iface.state = InterfaceState.ABSENT
+                return iface
+        return None
 
-    def get(self, iface_name):
-        return self._ifaces.get(iface_name)
+    def get_cur_iface(self, iface_name, iface_type):
 
-    def __getitem__(self, iface_name):
-        return self._ifaces[iface_name]
+        iface = self._cur_kernel_ifaces.get(iface_name)
+        if iface and iface_type in (None, InterfaceType.UNKNOWN, iface.type):
+            return iface
 
-    def __setitem__(self, iface_name, iface):
-        self._ifaces[iface_name] = iface
+        for iface in self._cur_user_space_ifaces:
+            if iface.name == iface_name and iface_type in (
+                None,
+                InterfaceType.UNKNOWN,
+                iface.type,
+            ):
+                return iface
+        return None
+
+    def _remove_iface(self, iface_name, iface_type):
+        cur_iface = self._cur_kernel_ifaces.get(iface_name, iface_type)
+        if cur_iface:
+            self._user_space_ifaces.remove(cur_iface)
+        else:
+            cur_iface = self._kernel_ifaces.get(iface_name)
+            if (
+                iface_type
+                and iface_type != InterfaceType.UNKNOWN
+                and iface_type == cur_iface.type
+            ):
+                del self._kernel_ifaces[iface_name]
+
+    def add_ifaces(self, ifaces):
+        for iface in ifaces:
+            if iface.is_user_space_only:
+                self._user_space_ifaces.set(iface)
+            else:
+                self._kernel_ifaces[iface.name] = iface
 
     def _gen_metadata(self):
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             # Generate metadata for all interface in case any of them
             # been marked as changed by DNS/Route/RouteRule.
             iface.gen_metadata(self)
-
-    def keys(self):
-        for iface in self._ifaces.keys():
-            yield iface
-
-    def values(self):
-        for iface in self._ifaces.values():
-            yield iface
-
-    def update(self, ifaces):
-        if ifaces:
-            self._ifaces.update(ifaces)
-
-    @property
-    def current_ifaces(self):
-        return self._cur_ifaces
 
     @property
     def state_to_edit(self):
         return [
             iface.to_dict()
-            for iface in self._ifaces.values()
+            for iface in self.all_ifaces()
             if (iface.is_changed or iface.is_desired) and not iface.is_ignore
         ]
-
-    @property
-    def cur_ifaces(self):
-        return self._cur_ifaces
 
     def _remove_unknown_interface_type_port(self):
         """
         When controller containing port with unknown interface type, they
         should be removed from controller port list before verifying.
         """
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if iface.is_up and iface.is_controller and iface.port:
                 for port_name in iface.port:
-                    port_iface = self._ifaces[port_name]
+                    port_iface = self._kernel_ifaces[port_name]
                     if port_iface.type == InterfaceType.UNKNOWN:
                         iface.remove_port(port_name)
 
@@ -391,14 +500,14 @@ class Ifaces:
             save_to_disk=self._save_to_disk,
         )
         cur_ifaces._remove_unknown_interface_type_port()
-        cur_ifaces._remove_ignore_interfaces(self._ignored_iface_names)
-        self._remove_ignore_interfaces(self._ignored_iface_names)
-        for iface in self._ifaces.values():
+        cur_ifaces._remove_ignore_interfaces(self._ignored_ifaces)
+        self._remove_ignore_interfaces(self._ignored_ifaces)
+        for iface in self.all_ifaces():
             if iface.is_desired:
                 if iface.is_virtual and iface.original_dict.get(
                     Interface.STATE
                 ) in (InterfaceState.DOWN, InterfaceState.ABSENT):
-                    cur_iface = cur_ifaces.get(iface.name)
+                    cur_iface = cur_ifaces.get_iface(iface.name, iface.type)
                     if cur_iface:
                         raise NmstateVerificationError(
                             format_desired_current_state_diff(
@@ -407,7 +516,7 @@ class Ifaces:
                             )
                         )
                 elif iface.is_up or (iface.is_down and not iface.is_virtual):
-                    cur_iface = cur_ifaces.get(iface.name)
+                    cur_iface = cur_ifaces.get_iface(iface.name, iface.type)
                     if not cur_iface:
                         raise NmstateVerificationError(
                             format_desired_current_state_diff(
@@ -448,9 +557,9 @@ class Ifaces:
     def gen_dns_metadata(self, dns_state, route_state):
         iface_metadata = dns_state.gen_metadata(self, route_state)
         for iface_name, dns_metadata in iface_metadata.items():
-            self._ifaces[iface_name].store_dns_metadata(dns_metadata)
+            self._kernel_ifaces[iface_name].store_dns_metadata(dns_metadata)
             if dns_state.config_changed:
-                self._ifaces[iface_name].mark_as_changed()
+                self._kernel_ifaces[iface_name].mark_as_changed()
 
     def gen_route_metadata(self, route_state):
         iface_metadata = route_state.gen_metadata(self)
@@ -459,22 +568,24 @@ class Ifaces:
                 BaseIface.ROUTE_CHANGED_METADATA, None
             )
             if route_state:
-                self._ifaces[iface_name].mark_as_changed()
+                self._kernel_ifaces[iface_name].mark_as_changed()
 
-            self._ifaces[iface_name].store_route_metadata(route_metadata)
+            self._kernel_ifaces[iface_name].store_route_metadata(
+                route_metadata
+            )
 
     def gen_route_rule_metadata(self, route_rule_state, route_state):
         iface_metadata = route_rule_state.gen_metadata(
-            route_state, self._ifaces
+            route_state, self._kernel_ifaces
         )
         for iface_name, route_rule_metadata in iface_metadata.items():
             rule_state = route_rule_metadata.pop(
                 BaseIface.RULE_CHANGED_METADATA, None
             )
             if rule_state:
-                self._ifaces[iface_name].mark_as_changed()
+                self._kernel_ifaces[iface_name].mark_as_changed()
 
-            self._ifaces[iface_name].store_route_rule_metadata(
+            self._kernel_ifaces[iface_name].store_route_rule_metadata(
                 route_rule_metadata
             )
 
@@ -482,32 +593,39 @@ class Ifaces:
         """
         Check the existance of port interface
         """
-        for iface in self._ifaces.values():
+        # All the user space interface already has interface type defined.
+        # And user space interface cannot be port of other interface.
+        # Hence no need to check `self._user_space_ifaces`
+        for iface in self._kernel_ifaces.values():
             for port_name in iface.port:
-                if not self._ifaces.get(port_name):
+                if not self._kernel_ifaces.get(port_name):
                     raise NmstateValueError(
-                        f"Interface {iface.name} has unknown port: "
-                        f"{port_name}"
+                        f"Interface {iface.name} has unknown port: {port_name}"
                     )
 
     def _validate_unknown_parent(self):
         """
         Check the existance of parent interface
         """
-        for iface in self._ifaces.values():
-            if iface.parent and not self._ifaces.get(iface.parent):
-                raise NmstateValueError(
-                    f"Interface {iface.name} has unknown parent: "
-                    f"{iface.parent}"
-                )
+        # All child interface should be in kernel space.
+        for iface in self._kernel_ifaces.values():
+            if iface.parent:
+                parent_iface = self._get_parent_iface(iface)
+                if not parent_iface:
+                    raise NmstateValueError(
+                        f"Interface {iface.name} has unknown parent: "
+                        f"{iface.parent}"
+                    )
 
     def _remove_unknown_type_interfaces(self):
         """
         Remove unknown type interfaces that are set as up.
         """
-        for iface in list(self._ifaces.values()):
+        # All the user space interface already has interface type defined.
+        # Hence no need to check `self._user_space_ifaces`
+        for iface in list(self._kernel_ifaces.values()):
             if iface.type == InterfaceType.UNKNOWN and iface.is_up:
-                self._ifaces.pop(iface.name, None)
+                self._kernel_ifaces.pop(iface.name, None)
                 logging.debug(
                     f"Interface {iface.name} is type {iface.type} and "
                     "will be ignored during the activation"
@@ -518,11 +636,15 @@ class Ifaces:
         Check whether any port is used by more than one controller
         """
         port_controller_map = {}
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             for port_name in iface.port:
                 cur_controller = port_controller_map.get(port_name)
                 if cur_controller:
-                    cur_controller_iface = self._ifaces.get(cur_controller)
+                    # Only kernel requires each interface to have
+                    # one controller interface at most.
+                    cur_controller_iface = self._kernel_ifaces.get(
+                        cur_controller
+                    )
                     if (
                         cur_controller_iface
                         and not cur_controller_iface.is_absent
@@ -534,15 +656,23 @@ class Ifaces:
                 else:
                     port_controller_map[port_name] = iface.name
 
-    def _remove_ignore_interfaces(self, ignored_iface_names):
+    def _remove_ignore_interfaces(self, ignored_ifaces):
+        for iface_name, iface_type, _ in ignored_ifaces:
+            self._remove_iface(iface_name, iface_type)
+
+        # Only kernel interface can be used as port
+        ignored_kernel_iface_names = set(
+            iface_name
+            for iface_name, _, is_user_space_only in ignored_ifaces
+            if not is_user_space_only
+        )
+
         # Remove ignored port
-        for iface in self._ifaces.values():
+        for iface in self.all_ifaces():
             if iface.is_up and iface.is_controller and iface.port:
                 for port_name in iface.port:
-                    if port_name in ignored_iface_names:
+                    if port_name in ignored_kernel_iface_names:
                         iface.remove_port(port_name)
-        for ignored_iface_name in ignored_iface_names:
-            self._ifaces.pop(ignored_iface_name, None)
 
 
 def _to_specific_iface_obj(info, save_to_disk):

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -124,9 +124,9 @@ class LinuxBridgeIface(BridgeIface):
         super().gen_metadata(ifaces)
         if not self.is_absent:
             for port_config in self.port_configs:
-                ifaces[port_config[LinuxBridge.Port.NAME]].update(
-                    {BridgeIface.BRPORT_OPTIONS_METADATA: port_config}
-                )
+                ifaces.all_kernel_ifaces[
+                    port_config[LinuxBridge.Port.NAME]
+                ].update({BridgeIface.BRPORT_OPTIONS_METADATA: port_config})
 
     def remove_port(self, port_name):
         if self._bridge_config:

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -26,7 +26,7 @@ from libnmstate.schema import OVSBridge as OB
 from libnmstate.schema import OVSInterface
 from libnmstate.ifaces import ovs
 from libnmstate.ifaces.bridge import BridgeIface
-from libnmstate.ifaces.base_iface import BaseIface
+from libnmstate.ifaces.ovs import OvsPortIface
 
 from .common import NM
 
@@ -278,7 +278,7 @@ def create_iface_for_nm_ovs_port(iface):
         port_name = port_options[OB.Port.NAME]
     else:
         port_name = PORT_PROFILE_PREFIX + iface_name
-    return BaseIface(
+    return OvsPortIface(
         {
             Interface.NAME: port_name,
             Interface.TYPE: InterfaceType.OVS_PORT,

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -193,7 +193,7 @@ class NmstateOvsdbPlugin(NmstatePlugin):
             ][OvsDB.EXTERNAL_IDS]
 
         pending_changes = []
-        for iface in net_state.ifaces.values():
+        for iface in net_state.ifaces.all_ifaces():
             if not iface.is_changed and not iface.is_desired:
                 continue
             if not iface.is_up:

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -122,7 +122,7 @@ class RouteEntry(StateEntry):
         if not self.destination:
             self._invalid_reason = "Route entry does not have destination"
             return False
-        iface = ifaces.get(self.next_hop_interface)
+        iface = ifaces.all_kernel_ifaces.get(self.next_hop_interface)
         if not iface:
             self._invalid_reason = (
                 f"Route {self.to_dict()} next hop to unknown interface"
@@ -191,7 +191,9 @@ class RouteState:
             rt = RouteEntry(entry)
             if not rt.absent:
                 if rt.is_valid(ifaces):
-                    ifaces[rt.next_hop_interface].mark_as_changed()
+                    ifaces.all_kernel_ifaces[
+                        rt.next_hop_interface
+                    ].mark_as_changed()
                     self._routes[rt.next_hop_interface].add(rt)
                 else:
                     raise NmstateValueError(rt.invalid_reason)

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -24,7 +24,6 @@ from libnmstate.schema import InterfaceType
 
 from ..testlib import statelib
 from ..testlib import cmdlib
-from ..testlib import assertlib
 
 
 BRIDGE0 = "brtest0"
@@ -42,49 +41,3 @@ def test_do_not_show_unmanaged_ovs_bridge(ovs_unmanaged_bridge):
     # The output should only contains the OVS internal interface
     ovs_internal_iface = statelib.show_only((BRIDGE0,))[Interface.KEY][0]
     assert ovs_internal_iface[Interface.TYPE] == InterfaceType.OVS_INTERFACE
-
-
-@pytest.fixture
-def ovs_bridge_with_internal_interface_and_identical_names():
-    cmdlib.exec_cmd(
-        f"nmcli c add type ovs-bridge conn.interface {BRIDGE0}".split(),
-        check=True,
-    )
-    cmdlib.exec_cmd(
-        f"nmcli c add type ovs-port conn.interface {BRIDGE0} "
-        f"master {BRIDGE0} slave-type ovs-bridge".split(),
-        check=True,
-    )
-    cmdlib.exec_cmd(
-        f"nmcli c add type ovs-interface conn.interface {BRIDGE0} "
-        f"master {BRIDGE0} slave-type ovs-port".split(),
-        check=True,
-    )
-
-    try:
-        yield BRIDGE0
-    finally:
-        _, con_names, _ = cmdlib.exec_cmd(
-            "nmcli -f NAME connection".split(),
-            check=True,
-        )
-        con_to_delete = " ".join(
-            [
-                con_name.strip()
-                for con_name in con_names.splitlines()
-                if BRIDGE0 in con_name
-            ]
-        )
-        cmdlib.exec_cmd(f"nmcli c delete {con_to_delete}".split(), check=True)
-
-        assertlib.assert_absent(BRIDGE0)
-
-
-@pytest.mark.tier1
-def test_ovs_internal_using_the_same_name_as_bridge(
-    ovs_bridge_with_internal_interface_and_identical_names,
-):
-    bridge_name = ovs_bridge_with_internal_interface_and_identical_names
-    state = statelib.show_only((bridge_name,))
-    assert state
-    assert len(state[Interface.KEY]) == 2

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -145,11 +145,7 @@ def test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac():
     assertlib.assert_absent(PORT1)
 
 
-@pytest.mark.xfail(
-    raises=NmstateValueError,
-    reason="https://nmstate.atlassian.net/browse/NMSTATE-286",
-    strict=True,
-)
+@pytest.mark.tier1
 def test_create_and_remove_ovs_bridge_with_internal_port_same_name():
     bridge = Bridge(BRIDGE1)
     bridge.add_internal_port(
@@ -157,7 +153,9 @@ def test_create_and_remove_ovs_bridge_with_internal_port_same_name():
     )
 
     with bridge.create() as state:
-        assertlib.assert_state_match(state)
+        state = statelib.show_only((BRIDGE1,))
+        assert state
+        assert len(state[Interface.KEY]) == 2
 
     assertlib.assert_absent(BRIDGE1)
 
@@ -231,12 +229,7 @@ class _OvsProfileStillExists(Exception):
 
 
 @pytest.mark.tier1
-@pytest.mark.xfail(
-    reason="https://bugzilla.redhat.com/show_bug.cgi?id=1857123",
-    raises=_OvsProfileStillExists,
-    strict=False,
-)
-def test_ovs_remove_port(bridge_with_ports):
+def test_remove_ovs_internal_iface_got_port_profile_removed(bridge_with_ports):
     for port_name in bridge_with_ports.ports_names:
         active_profiles = get_nm_active_profiles()
         assert port_name in active_profiles

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -90,8 +90,8 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         dns_state = DnsState({DNS.CONFIG: DNS_CONFIG1}, {})
         ifaces.gen_dns_metadata(dns_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert dns_state.config == DNS_CONFIG1
         assert ipv4_iface.to_dict()[Interface.IPV4][
@@ -114,8 +114,8 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         dns_state = DnsState({DNS.CONFIG: DNS_CONFIG2}, {})
         ifaces.gen_dns_metadata(dns_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert dns_state.config == DNS_CONFIG2
         assert ipv4_iface.to_dict()[Interface.IPV4][
@@ -138,8 +138,8 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         dns_state = DnsState({DNS.CONFIG: DNS_CONFIG1}, {})
         ifaces.gen_dns_metadata(dns_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert dns_state.config == DNS_CONFIG1
         assert ipv4_iface.to_dict()[Interface.IPV4][
@@ -163,8 +163,8 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         dns_state = DnsState({}, {DNS.CONFIG: DNS_CONFIG1})
         ifaces.gen_dns_metadata(dns_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert dns_state.config == DNS_CONFIG1
         assert ipv4_iface.to_dict()[Interface.IPV4][
@@ -273,7 +273,7 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         ifaces.gen_dns_metadata(dns_state, route_state)
 
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
 
         assert dns_state.config == dns_config
         assert ipv4_iface.to_dict()[Interface.IPV4][
@@ -296,7 +296,7 @@ class TestDnsState:
         route_state = self._gen_route_state(ifaces)
         dns_state = DnsState({DNS.CONFIG: dns_config}, {})
         ifaces.gen_dns_metadata(dns_state, route_state)
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert dns_state.config == dns_config
         assert ipv6_iface.to_dict()[Interface.IPV6][

--- a/tests/lib/ifaces/bond_iface_test.py
+++ b/tests/lib/ifaces/bond_iface_test.py
@@ -207,10 +207,10 @@ class TestBondIface:
                 self._gen_port2_iface_info(),
             ],
         )
-        bond_iface = ifaces[FOO_IFACE_NAME]
+        bond_iface = ifaces.all_kernel_ifaces[FOO_IFACE_NAME]
         bond_iface.gen_metadata(ifaces)
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
 
         assert port1_iface.controller == FOO_IFACE_NAME
         assert port2_iface.controller == FOO_IFACE_NAME
@@ -240,7 +240,7 @@ class TestBondIface:
                 self._gen_port2_iface_info(),
             ],
         )
-        bond_iface = ifaces[FOO_IFACE_NAME]
+        bond_iface = ifaces.all_kernel_ifaces[FOO_IFACE_NAME]
         bond_iface.gen_metadata(ifaces)
         bond_iface.pre_edit_validation_and_cleanup()
 
@@ -276,7 +276,7 @@ class TestBondIface:
                 self._gen_port2_iface_info(),
             ],
         )
-        bond_iface = ifaces[FOO_IFACE_NAME]
+        bond_iface = ifaces.all_kernel_ifaces[FOO_IFACE_NAME]
         bond_iface.gen_metadata(ifaces)
         bond_iface.pre_edit_validation_and_cleanup()
 

--- a/tests/lib/ifaces/infiniband_test.py
+++ b/tests/lib/ifaces/infiniband_test.py
@@ -175,8 +175,8 @@ class TestInfiniBandIface:
         base_iface_info = self._gen_base_iface_info()
         base_iface_info[Interface.STATE] = InterfaceState.ABSENT
         ifaces = Ifaces([base_iface_info, self._gen_iface_info()], [])
-        ifaces[PKEY_IFACE_NAME].state = InterfaceState.ABSENT
-        ifaces[BASE_IFACE_NAME].state = InterfaceState.ABSENT
+        ifaces.all_kernel_ifaces[PKEY_IFACE_NAME].state = InterfaceState.ABSENT
+        ifaces.all_kernel_ifaces[BASE_IFACE_NAME].state = InterfaceState.ABSENT
 
     def test_expect_exception_for_adding_ib_to_linux_bridge(self):
         base_iface_info = self._gen_base_iface_info()

--- a/tests/lib/ifaces/linux_bridge_iface_test.py
+++ b/tests/lib/ifaces/linux_bridge_iface_test.py
@@ -220,11 +220,11 @@ class TestLinuxBridgeIface:
             ],
             cur_iface_infos=[],
         )
-        br_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        br_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
         br_iface.gen_metadata(ifaces)
         br_iface.pre_edit_validation_and_cleanup()
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
 
         assert port1_iface.controller == LINUX_BRIDGE_IFACE_NAME
         assert port2_iface.controller == LINUX_BRIDGE_IFACE_NAME
@@ -252,11 +252,11 @@ class TestLinuxBridgeIface:
             ],
             cur_iface_infos=[],
         )
-        br_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        br_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
         br_iface.gen_metadata(ifaces)
         br_iface.pre_edit_validation_and_cleanup()
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
         assert port1_iface.controller is None
         assert port2_iface.controller is None
         assert (
@@ -402,11 +402,11 @@ class TestLinuxBridgeIface:
             ],
             cur_iface_infos=[],
         )
-        br_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        br_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
         br_iface.gen_metadata(ifaces)
         br_iface.pre_edit_validation_and_cleanup()
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
 
         assert port1_iface.controller is None
         assert port2_iface.controller is None

--- a/tests/lib/ifaces/ovs_iface_test.py
+++ b/tests/lib/ifaces/ovs_iface_test.py
@@ -148,11 +148,13 @@ class TestOvsBrigeIface:
             ],
             cur_iface_infos=[port1_iface_info, port2_iface_info],
         )
-        br_iface = ifaces[OVS_BRIDGE_IFACE_NAME]
+        br_iface = ifaces.get_iface(
+            OVS_BRIDGE_IFACE_NAME, InterfaceType.OVS_BRIDGE
+        )
         br_iface.gen_metadata(ifaces)
         br_iface.pre_edit_validation_and_cleanup()
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
 
         assert port1_iface.controller == OVS_BRIDGE_IFACE_NAME
         assert port2_iface.controller == OVS_BRIDGE_IFACE_NAME
@@ -176,7 +178,7 @@ class TestOvsBrigeIface:
             cur_iface_infos=[port1_iface_info, port2_iface_info],
         )
 
-        ovs_iface = ifaces[OVS_IFACE_NAME]
+        ovs_iface = ifaces.all_kernel_ifaces[OVS_IFACE_NAME]
         assert ovs_iface.type == InterfaceType.OVS_INTERFACE
         assert ovs_iface.parent == OVS_BRIDGE_IFACE_NAME
         assert ovs_iface.is_virtual

--- a/tests/lib/ifaces/vlan_iface_test.py
+++ b/tests/lib/ifaces/vlan_iface_test.py
@@ -91,7 +91,9 @@ class TestVlanIface:
             cur_iface_infos=[],
         )
 
-        base_iface = ifaces.get(base_iface_info.get(Interface.NAME))
+        base_iface = ifaces.all_kernel_ifaces.get(
+            base_iface_info.get(Interface.NAME)
+        )
 
         assert base_iface.mtu == vlan_iface_info[Interface.MTU]
 

--- a/tests/lib/ifaces/vxlan_iface_test.py
+++ b/tests/lib/ifaces/vxlan_iface_test.py
@@ -96,7 +96,9 @@ class TestVxlanIface:
             cur_iface_infos=[],
         )
 
-        base_iface = ifaces.get(base_iface_info.get(Interface.NAME))
+        base_iface = ifaces.all_kernel_ifaces.get(
+            base_iface_info.get(Interface.NAME)
+        )
 
         assert base_iface.mtu == vxlan_iface_info[Interface.MTU]
 

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -71,9 +71,11 @@ class TestIfaces:
             des_iface_infos=[], cur_iface_infos=self._gen_iface_infos()
         )
 
-        assert [
-            i.original_dict for i in ifaces.current_ifaces.values()
-        ] == self._gen_iface_infos()
+        for iface_info in self._gen_iface_infos():
+            cur_iface = ifaces.get_cur_iface(
+                iface_info[Interface.NAME], iface_info[Interface.TYPE]
+            )
+            assert cur_iface.original_dict == iface_info
 
     def test_init_des_iface_infos_only(self):
         ifaces = Ifaces(
@@ -81,7 +83,7 @@ class TestIfaces:
         )
 
         assert [
-            i.original_dict for i in ifaces.values()
+            i.original_dict for i in ifaces.all_ifaces()
         ] == self._gen_iface_infos()
 
     def test_add_new_iface(self):
@@ -90,12 +92,14 @@ class TestIfaces:
         new_iface_info[Interface.NAME] = FOO3_IFACE_NAME
 
         ifaces = Ifaces([new_iface_info], cur_iface_infos)
-        new_iface = ifaces[FOO3_IFACE_NAME]
-        iface1 = ifaces[FOO1_IFACE_NAME]
-        iface2 = ifaces[FOO2_IFACE_NAME]
+        new_iface = ifaces.all_kernel_ifaces[FOO3_IFACE_NAME]
+        iface1 = ifaces.all_kernel_ifaces[FOO1_IFACE_NAME]
+        iface2 = ifaces.all_kernel_ifaces[FOO2_IFACE_NAME]
 
-        assert len(ifaces.current_ifaces) == len(self._gen_iface_infos())
-        assert len(list(ifaces.keys())) == len(self._gen_iface_infos()) + 1
+        assert (
+            len(list(ifaces.all_kernel_ifaces.keys()))
+            == len(self._gen_iface_infos()) + 1
+        )
         assert new_iface.is_desired
         assert not iface1.is_desired
         assert not iface2.is_desired
@@ -107,7 +111,9 @@ class TestIfaces:
         expected_iface_info = deepcopy(des_iface_infos[0])
 
         ifaces = Ifaces(des_iface_infos, cur_iface_infos)
-        edit_iface = ifaces[des_iface_infos[0][Interface.NAME]]
+        edit_iface = ifaces.all_kernel_ifaces[
+            des_iface_infos[0][Interface.NAME]
+        ]
 
         assert state_match(expected_iface_info, edit_iface.to_dict())
         assert edit_iface.is_desired
@@ -119,7 +125,9 @@ class TestIfaces:
         expected_iface_info = deepcopy(des_iface_infos[0])
 
         ifaces = Ifaces(des_iface_infos, cur_iface_infos)
-        edit_iface = ifaces[des_iface_infos[0][Interface.NAME]]
+        edit_iface = ifaces.all_kernel_ifaces[
+            des_iface_infos[0][Interface.NAME]
+        ]
 
         assert state_match(expected_iface_info, edit_iface.to_dict())
         assert edit_iface.is_desired
@@ -152,7 +160,7 @@ class TestIfaces:
         }
 
         ifaces = Ifaces(des_iface_infos, [cur_iface_info])
-        assert cur_iface_info not in ifaces.values()
+        assert cur_iface_info not in ifaces.all_ifaces()
 
     def test_mark_port_as_changed_if_controller_marked_as_absent(self):
         cur_iface_infos = self._gen_iface_infos()
@@ -164,9 +172,9 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        port_iface1 = ifaces[PORT1_IFACE_NAME]
-        port_iface2 = ifaces[PORT2_IFACE_NAME]
-        controller_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        port_iface1 = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port_iface2 = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
+        controller_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
 
         assert port_iface1.is_changed
         assert port_iface2.is_changed
@@ -189,9 +197,9 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        port_iface1 = ifaces[PORT1_IFACE_NAME]
-        port_iface2 = ifaces[PORT2_IFACE_NAME]
-        controller_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        port_iface1 = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port_iface2 = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
+        controller_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
 
         assert not port_iface1.is_changed
         assert port_iface2.is_changed
@@ -209,9 +217,9 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        port_iface1 = ifaces[PORT1_IFACE_NAME]
-        port_iface2 = ifaces[PORT2_IFACE_NAME]
-        controller_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        port_iface1 = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port_iface2 = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
+        controller_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
 
         assert port_iface1.is_changed
         assert port_iface2.is_changed
@@ -233,9 +241,9 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        port_iface1 = ifaces[PORT1_IFACE_NAME]
-        port_iface2 = ifaces[PORT2_IFACE_NAME]
-        controller_iface = ifaces[LINUX_BRIDGE_IFACE_NAME]
+        port_iface1 = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port_iface2 = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
+        controller_iface = ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME]
 
         assert port_iface1.is_changed
         assert not port_iface2.is_changed
@@ -262,9 +270,9 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        child_iface = ifaces[CHILD_IFACE_NAME]
-        parent_iface = ifaces[PARENT_IFACE_NAME]
-        other_iface = ifaces[FOO2_IFACE_NAME]
+        child_iface = ifaces.all_kernel_ifaces[CHILD_IFACE_NAME]
+        parent_iface = ifaces.all_kernel_ifaces[PARENT_IFACE_NAME]
+        other_iface = ifaces.all_kernel_ifaces[FOO2_IFACE_NAME]
 
         assert parent_iface.is_desired
         assert child_iface.is_changed
@@ -295,10 +303,12 @@ class TestIfaces:
 
         ifaces = Ifaces([des_iface_info], cur_iface_infos)
 
-        ovs_iface = ifaces[OVS_IFACE_NAME]
-        bridge_iface = ifaces[OVS_BRIDGE_IFACE_NAME]
-        port1_iface = ifaces[PORT1_IFACE_NAME]
-        port2_iface = ifaces[PORT2_IFACE_NAME]
+        ovs_iface = ifaces.all_kernel_ifaces[OVS_IFACE_NAME]
+        bridge_iface = ifaces.get_iface(
+            OVS_BRIDGE_IFACE_NAME, InterfaceType.OVS_BRIDGE
+        )
+        port1_iface = ifaces.all_kernel_ifaces[PORT1_IFACE_NAME]
+        port2_iface = ifaces.all_kernel_ifaces[PORT2_IFACE_NAME]
 
         assert bridge_iface.is_desired
         assert ovs_iface.is_changed
@@ -337,7 +347,7 @@ class TestIfaces:
         cur_iface_infos = self._gen_iface_infos()
         ifaces = Ifaces([], cur_iface_infos)
 
-        for iface in ifaces.values():
+        for iface in ifaces.all_ifaces():
             iface.mark_as_changed()
 
         assert sorted(

--- a/tests/lib/route_rule_test.py
+++ b/tests/lib/route_rule_test.py
@@ -246,8 +246,8 @@ class TestRouteRuleState:
         )
         ifaces.gen_route_rule_metadata(route_rule_state, route_state)
 
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert ipv4_iface.to_dict()[Interface.IPV4][
             BaseIface.ROUTE_RULES_METADATA
@@ -294,8 +294,8 @@ class TestRouteRuleState:
             },
         )
         ifaces.gen_route_rule_metadata(route_rule_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert ipv4_iface.to_dict()[Interface.IPV4][
             BaseIface.ROUTE_RULES_METADATA
@@ -338,7 +338,7 @@ class TestRouteRuleState:
             },
         )
         ifaces.gen_route_rule_metadata(route_rule_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
 
         assert (
             BaseIface.ROUTE_RULES_METADATA
@@ -378,7 +378,7 @@ class TestRouteRuleState:
             },
         )
         ifaces.gen_route_rule_metadata(route_rule_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
 
         assert (
             BaseIface.ROUTE_RULES_METADATA
@@ -416,7 +416,7 @@ class TestRouteRuleState:
             },
         )
         ifaces.gen_route_rule_metadata(route_rule_state, route_state)
-        ipv4_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
 
         assert (
             BaseIface.ROUTE_RULES_METADATA

--- a/tests/lib/route_test.py
+++ b/tests/lib/route_test.py
@@ -308,7 +308,9 @@ class TestRouteState:
 
     def test_validate_route_to_abent_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].state = InterfaceState.ABSENT
+        ifaces.all_kernel_ifaces[
+            IPV4_ROUTE_IFACE_NAME
+        ].state = InterfaceState.ABSENT
 
         ipv4_route = gen_ipv4_route()
         with pytest.raises(NmstateValueError):
@@ -316,7 +318,9 @@ class TestRouteState:
 
     def test_validate_route_to_down_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].state = InterfaceState.DOWN
+        ifaces.all_kernel_ifaces[
+            IPV4_ROUTE_IFACE_NAME
+        ].state = InterfaceState.DOWN
 
         ipv4_route = gen_ipv4_route()
         with pytest.raises(NmstateValueError):
@@ -324,7 +328,7 @@ class TestRouteState:
 
     def test_validate_route_to_ipv4_disabled(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
+        ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
             InterfaceIPv4.ENABLED
         ] = False
 
@@ -334,7 +338,7 @@ class TestRouteState:
 
     def test_validate_route_to_ipv6_disabled(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.ENABLED
         ] = False
 
@@ -362,7 +366,7 @@ class TestRouteState:
 
     def test_validate_route_next_hop_to_dhcpv4_ifce(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
+        ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
             InterfaceIPv4.DHCP
         ] = True
 
@@ -372,7 +376,7 @@ class TestRouteState:
 
     def test_validate_route_next_hop_to_dhcpv6_ifce(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.DHCP
         ] = True
 
@@ -382,7 +386,7 @@ class TestRouteState:
 
     def test_validate_route_next_hop_to_ipv6_autoconf_ifce(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.AUTOCONF
         ] = True
 
@@ -392,7 +396,9 @@ class TestRouteState:
 
     def test_discard_route_next_hop_absent_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].state = InterfaceState.ABSENT
+        ifaces.all_kernel_ifaces[
+            IPV4_ROUTE_IFACE_NAME
+        ].state = InterfaceState.ABSENT
 
         ipv4_route = gen_ipv4_route()
         ipv6_route = gen_ipv6_route()
@@ -410,7 +416,9 @@ class TestRouteState:
 
     def test_discard_route_next_hop_down_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].state = InterfaceState.DOWN
+        ifaces.all_kernel_ifaces[
+            IPV4_ROUTE_IFACE_NAME
+        ].state = InterfaceState.DOWN
 
         ipv4_route = gen_ipv4_route()
         ipv6_route = gen_ipv6_route()
@@ -428,7 +436,7 @@ class TestRouteState:
 
     def test_discard_route_next_hop_ipv4_disabled_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
+        ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
             InterfaceIPv4.ENABLED
         ] = False
 
@@ -448,7 +456,7 @@ class TestRouteState:
 
     def test_discard_route_next_hop_ipv6_disabled_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.ENABLED
         ] = False
 
@@ -468,7 +476,7 @@ class TestRouteState:
 
     def test_discard_route_next_hop_dhcpv4_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
+        ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME].raw[Interface.IPV4][
             InterfaceIPv4.DHCP
         ] = True
 
@@ -488,7 +496,7 @@ class TestRouteState:
 
     def test_discard_route_next_hop_dhcpv6_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.DHCP
         ] = True
 
@@ -508,7 +516,7 @@ class TestRouteState:
 
     def test_discard_route_next_hop_ipv6_autoconf_iface(self):
         ifaces = self._gen_ifaces()
-        ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
+        ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME].raw[Interface.IPV6][
             InterfaceIPv6.AUTOCONF
         ] = True
 
@@ -537,8 +545,8 @@ class TestRouteState:
         )
         ifaces.gen_route_metadata(route_state)
 
-        ipv4_route_iface = ifaces[IPV4_ROUTE_IFACE_NAME]
-        ipv6_route_iface = ifaces[IPV6_ROUTE_IFACE_NAME]
+        ipv4_route_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_route_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
 
         assert ipv4_route_iface.to_dict()[Interface.IPV4][
             BaseIface.ROUTES_METADATA


### PR DESCRIPTION
The OVS bridge and OVS port is user space only iface which can hold the
duplicate name against kernel interfaces. In order to support that use
case, introduced:

* `OvsBridgeIface.is_user_space_only = True`
* `OvsPortIface.is_user_space_only = True`
* `Ifaces.all_ifaces()`
* `Ifaces.all_kernel_ifaces`
* `Ifaces.all_user_space_ifaces`
* `Ifaces.get_iface(iface_name, iface_type)`
* `Ifaces.get_cur_iface(iface_name, iface_type)`
* `Ifaces.add_ifaces()`

The limitation of user space interfaces are:
* Cannot be used subordinate of other kernel interfaces.
* Due to limtation of nmstate, currently cannot be used as
  subordinate of other user space interfaces.

Integration test case added.