### PR TITLE
route: mark interface as changed on gen_route_state()

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -125,6 +125,7 @@ class BaseIface:
     ROUTES_METADATA = "_routes"
     ROUTE_RULES_METADATA = "_route_rules"
     RULE_CHANGED_METADATA = "_changed"
+    ROUTE_CHANGED_METADATA = "_changed"
 
     def __init__(self, info, save_to_disk=True):
         self._origin_info = deepcopy(info)

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -455,6 +455,12 @@ class Ifaces:
     def gen_route_metadata(self, route_state):
         iface_metadata = route_state.gen_metadata(self)
         for iface_name, route_metadata in iface_metadata.items():
+            route_state = route_metadata.pop(
+                BaseIface.ROUTE_CHANGED_METADATA, None
+            )
+            if route_state:
+                self._ifaces[iface_name].mark_as_changed()
+
             self._ifaces[iface_name].store_route_metadata(route_metadata)
 
     def gen_route_rule_metadata(self, route_rule_state, route_state):

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -28,6 +28,7 @@ from libnmstate.prettystate import format_desired_current_state_diff
 from libnmstate.schema import Interface
 from libnmstate.schema import Route
 
+from .ifaces.base_iface import BaseIface
 from .state import StateEntry
 from .state import state_match
 
@@ -209,7 +210,6 @@ class RouteState:
                 if not rt.match(route):
                     new_routes.add(route)
             if new_routes != route_set:
-                ifaces[iface_name].mark_as_changed()
                 self._routes[iface_name] = new_routes
 
     def gen_metadata(self, ifaces):
@@ -229,6 +229,10 @@ class RouteState:
                 Interface.IPV4: [],
                 Interface.IPV6: [],
             }
+            if route_set != self._cur_routes[iface_name]:
+                route_metadata[iface_name][
+                    BaseIface.ROUTE_CHANGED_METADATA
+                ] = True
             for route in route_set:
                 family = Interface.IPV6 if route.is_ipv6 else Interface.IPV4
                 route_metadata[iface_name][family].append(route.to_dict())


### PR DESCRIPTION
As discussed for RouteRule, interfaces object should not be modified in
other modules.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>