### PR TITLE
tests, integ: remove xfail on bridge multicast-snooping from 0 to 1

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -46,7 +46,6 @@ from .testlib.bridgelib import generate_vlan_id_range_config
 from .testlib.bridgelib import linux_bridge
 from .testlib.cmdlib import exec_cmd
 from .testlib.env import is_fedora
-from .testlib.env import is_el8_kernel
 from .testlib.env import is_ubuntu_kernel
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
@@ -768,12 +767,6 @@ def test_explicitly_ignore_a_bridge_port(bridge0_with_port0, port1_up):
     assert cur_port_config[1][LinuxBridge.Port.NAME] == port1_name
 
 
-@pytest.mark.xfail(
-    is_el8_kernel(),
-    reason="https://bugzilla.redhat.com/1855160",
-    raises=NmstateVerificationError,
-    strict=True,
-)
 def test_change_multicast_snooping_from_false_to_true(port0_up, port1_up):
     bridge_name = TEST_BRIDGE0
     port0_name = port0_up[Interface.KEY][0][Interface.NAME]

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -26,7 +26,3 @@ def is_fedora():
 
 def is_ubuntu_kernel():
     return "Ubuntu" in os.uname().version
-
-
-def is_el8_kernel():
-    return "el8" in os.uname().release


### PR DESCRIPTION
The bug has been fixed and it is not failing anymore. Therefore, the
xfail must be removed. Indeed, this seems it was failing only in 4.18.0
kernel.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1859244

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>