### PR TITLE
nispor: Use default mac address when iface does not have

### DIFF
--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -40,10 +40,9 @@ class NisporPluginBaseIface:
 
     @property
     def mac(self):
-        mac = self._np_iface.mac_address.upper()
-        if not mac:
-            mac = DEFAULT_MAC_ADDRESS
-        return mac
+        if self._np_iface.mac_address:
+            return self._np_iface.mac_address.upper()
+        return DEFAULT_MAC_ADDRESS
 
     @property
     def mtu(self):


### PR DESCRIPTION
For TUN/TAP interface, the kernel will not include MAC address of it in
netlink, nmstate should use `00:00:00:00:00:00` in that case.