### PR TITLE
route rule: Remove left over codes

### DIFF
--- a/libnmstate/nispor/route_rule.py
+++ b/libnmstate/nispor/route_rule.py
@@ -32,13 +32,14 @@ def nispor_route_rule_state_to_nmstate(np_rules):
 
 
 def _nispor_route_rule_to_nmstate(np_rl):
-    priority = (
-        np_rl.priority if np_rl.priority else RouteRule.USE_DEFAULT_PRIORITY
-    )
-
-    return {
+    rule = {
         RouteRule.ROUTE_TABLE: np_rl.table,
-        RouteRule.PRIORITY: priority,
-        RouteRule.IP_FROM: np_rl.src if np_rl.src else "",
-        RouteRule.IP_TO: np_rl.dst if np_rl.dst else "",
+        RouteRule.PRIORITY: np_rl.priority
+        if np_rl.priority
+        else RouteRule.USE_DEFAULT_PRIORITY,
     }
+    if np_rl.src:
+        rule[RouteRule.IP_FROM] = np_rl.src
+    if np_rl.dst:
+        rule[RouteRule.IP_TO] = np_rl.dst
+    return rule

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -154,7 +154,3 @@ def is_dynamic(active_connection):
     if ip_profile:
         return ip_profile.get_method() == NM.SETTING_IP4_CONFIG_METHOD_AUTO
     return False
-
-
-def get_routing_rule_config(nm_client):
-    return nm_route.get_routing_rule_config(acs_and_ip_profiles(nm_client))

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -209,7 +209,3 @@ def is_dynamic(active_connection):
             NM.SETTING_IP6_CONFIG_METHOD_DHCP,
         )
     return False
-
-
-def get_routing_rule_config(nm_client):
-    return nm_route.get_routing_rule_config(acs_and_ip_profiles(nm_client))

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -27,7 +27,6 @@ from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
-from libnmstate.schema import RouteRule
 from libnmstate.plugin import NmstatePlugin
 
 
@@ -41,9 +40,7 @@ from .dns import get_running as get_dns_running
 from .dns import get_running_config as get_dns_running_config
 from .infiniband import get_info as get_infiniband_info
 from .ipv4 import get_info as get_ipv4_info
-from .ipv4 import get_routing_rule_config as get_ipv4_routing_rule_config
 from .ipv6 import get_info as get_ipv6_info
-from .ipv6 import get_routing_rule_config as get_ipv6_routing_rule_config
 from .lldp import get_info as get_lldp_info
 from .macvlan import get_current_macvlan_type
 from .ovs import get_interface_info as get_ovs_interface_info
@@ -165,12 +162,10 @@ class NetworkManagerPlugin(NmstatePlugin):
         return {Route.CONFIG: get_route_running_config(self._applied_configs)}
 
     def get_route_rules(self):
-        return {
-            RouteRule.CONFIG: (
-                get_ipv4_routing_rule_config(self.client)
-                + get_ipv6_routing_rule_config(self.client)
-            )
-        }
+        """
+        Nispor will provide running config of route rule from kernel.
+        """
+        return {}
 
     def get_dns_client_config(self):
         return {

--- a/libnmstate/nm/route.py
+++ b/libnmstate/nm/route.py
@@ -160,44 +160,6 @@ def get_static_gateway_iface(family, iface_routes):
     return None
 
 
-def get_routing_rule_config(acs_and_ip_profiles):
-    rules = []
-    for (_, ip_profile) in acs_and_ip_profiles:
-        for i in range(ip_profile.get_num_routing_rules()):
-            nm_rule = ip_profile.get_routing_rule(i)
-            rules.append(_nm_rule_to_info(nm_rule))
-
-    return rules
-
-
-def _nm_rule_to_info(nm_rule):
-    info = {
-        RouteRule.IP_FROM: _nm_rule_get_from(nm_rule),
-        RouteRule.IP_TO: _nm_rule_get_to(nm_rule),
-        RouteRule.PRIORITY: nm_rule.get_priority(),
-        RouteRule.ROUTE_TABLE: nm_rule.get_table(),
-    }
-    cleanup_keys = [key for key, val in info.items() if val is None]
-    for key in cleanup_keys:
-        del info[key]
-
-    return info
-
-
-def _nm_rule_get_from(nm_rule):
-    if nm_rule.get_from():
-        return iplib.to_ip_address_full(
-            nm_rule.get_from(), nm_rule.get_from_len()
-        )
-    return None
-
-
-def _nm_rule_get_to(nm_rule):
-    if nm_rule.get_to():
-        return iplib.to_ip_address_full(nm_rule.get_to(), nm_rule.get_to_len())
-    return None
-
-
 def add_route_rules(setting_ip, family, rules):
     for rule in rules:
         setting_ip.add_routing_rule(_rule_info_to_nm_rule(rule, family))

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -74,12 +74,6 @@ def show_with_plugins(plugins, include_status_data=None):
 
     report[RouteRule.KEY] = _get_route_rules_from_plugins(plugins)
 
-    route_rule_plugin = _find_plugin_for_capability(
-        plugins, NmstatePlugin.PLUGIN_CAPABILITY_ROUTE_RULE
-    )
-    if route_rule_plugin:
-        report[RouteRule.KEY] = route_rule_plugin.get_route_rules()
-
     dns_plugin = _find_plugin_for_capability(
         plugins, NmstatePlugin.PLUGIN_CAPABILITY_DNS
     )


### PR DESCRIPTION
With `_get_route_rules_from_plugins()`, we don't need a exclusive plugin
for route rule query.

Removed unused code from NetworkManager plugin.
Changed nispor plugin to not include empty `from` or `to` property in
route rule.