### PR TITLE
query: new function for showing running config

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -5,6 +5,8 @@ nmstatectl \- A nmstate command line tool
 .SH SYNOPSIS
 .B nmstatectl show \fR[\fIINTERFACE_NAME\fR] [\fB--json\fR]
 .br
+.B nmstatectl show [\fB-r, --running-config\fR]
+.br
 .B nmstatectl set \fISTATE_FILE_PATH\fR [\fIOPTIONS\fR]
 .br
 .B nmstatectl edit \fR[\fIINTERFACE_NAME\fR] [\fIOPTIONS\fR]
@@ -100,6 +102,12 @@ example: nmstatectl varlink /run/nmstate.so &
 .RS
 change the output format to \fIJSON\fR.
 .RE
+
+.B -r, --running-config
+.RS
+Showing the running network configuration.
+.RE
+
 .IP \fB--no-verify
 skip the desired network state verification.
 .IP \fB--no-commit

--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -26,6 +26,7 @@ from .netapplier import apply
 from .netapplier import commit
 from .netapplier import rollback
 from .netinfo import show
+from .netinfo import show_running_config
 
 from .prettystate import PrettyState
 
@@ -33,13 +34,14 @@ from .prettystate import PrettyState
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 __all__ = [
-    "show",
+    "PrettyState",
     "apply",
     "commit",
-    "rollback",
     "error",
+    "rollback",
     "schema",
-    "PrettyState",
+    "show",
+    "show_running_config",
 ]
 
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -17,8 +17,9 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from .nmstate import show_with_plugins
 from .nmstate import plugin_context
+from .nmstate import show_with_plugins
+from .nmstate import show_running_config_with_plugins
 
 
 def show(*, include_status_data=False):
@@ -33,3 +34,8 @@ def show(*, include_status_data=False):
     """
     with plugin_context() as plugins:
         return show_with_plugins(plugins, include_status_data)
+
+
+def show_running_config():
+    with plugin_context() as plugins:
+        return show_running_config_with_plugins(plugins)

--- a/libnmstate/nispor/bond.py
+++ b/libnmstate/nispor/bond.py
@@ -56,8 +56,8 @@ class NisporPluginBondIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.BOND
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[Bond.CONFIG_SUBTREE] = {
             Bond.MODE: self._np_iface.mode,
             Bond.PORT: self._np_iface.subordinates,

--- a/libnmstate/nispor/bridge.py
+++ b/libnmstate/nispor/bridge.py
@@ -107,8 +107,8 @@ class NisporPluginBridgeIface(NisporPluginBaseIface):
             info.append(port_info)
         return info
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[LB.CONFIG_SUBTREE] = {
             LB.OPTIONS_SUBTREE: self._options_to_dict(),
             LB.PORT_SUBTREE: self._ports_to_dict(),

--- a/libnmstate/nispor/ethernet.py
+++ b/libnmstate/nispor/ethernet.py
@@ -28,8 +28,8 @@ class NisporPluginEthernetIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.ETHERNET
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         if self.np_iface.sr_iov:
             vf_infos = []
             for vf in self.np_iface.sr_iov.vfs:

--- a/libnmstate/nispor/macvlan.py
+++ b/libnmstate/nispor/macvlan.py
@@ -41,8 +41,8 @@ class NisporPluginMacVlanIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.MAC_VLAN
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[MacVlan.CONFIG_SUBTREE] = {
             MacVlan.BASE_IFACE: self._np_iface.base_iface,
             MacVlan.MODE: MACVLAN_MODES.get(

--- a/libnmstate/nispor/macvtap.py
+++ b/libnmstate/nispor/macvtap.py
@@ -38,8 +38,8 @@ class NisporPluginMacVtapIface(NisporPluginMacVlanIface):
     def type(self):
         return InterfaceType.MAC_VTAP
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[MacVtap.CONFIG_SUBTREE] = {
             MacVtap.BASE_IFACE: self._np_iface.base_iface,
             MacVtap.MODE: MACVTAP_MODES.get(

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -38,6 +38,10 @@ from .vrf import NisporPluginVrfIface
 from .ovs import NisporPluginOvsInternalIface
 
 
+_INFO_TYPE_RUNNING = "running"
+_INFO_TYPE_RUNNING_CONFIG = "running_config"
+
+
 class NisporPlugin(NmstatePlugin):
     @property
     def name(self):
@@ -58,42 +62,73 @@ class NisporPlugin(NmstatePlugin):
         # yet.
         return NmstatePlugin.DEFAULT_PRIORITY - 1
 
-    def get_interfaces(self):
+    def _get_interfaces(self, info_type):
         np_state = NisporNetState.retrieve()
         ifaces = []
+        config_only = info_type == _INFO_TYPE_RUNNING_CONFIG
         for np_iface in np_state.ifaces.values():
             iface_type = np_iface.type
             if iface_type == "dummy":
-                ifaces.append(NisporPluginDummyIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginDummyIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "veth":
-                ifaces.append(NisporPluginEthernetIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginEthernetIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "ethernet":
-                ifaces.append(NisporPluginEthernetIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginEthernetIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "bond":
-                ifaces.append(NisporPluginBondIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginBondIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "vlan":
-                ifaces.append(NisporPluginVlanIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginVlanIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "vxlan":
-                ifaces.append(NisporPluginVxlanIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginVxlanIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "mac_vlan":
-                ifaces.append(NisporPluginMacVlanIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginMacVlanIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "mac_vtap":
-                ifaces.append(NisporPluginMacVtapIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginMacVtapIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "bridge":
                 np_ports = []
                 for port_name in np_iface.ports:
                     if port_name in np_state.ifaces.keys():
                         np_ports.append(np_state.ifaces[port_name])
                 ifaces.append(
-                    NisporPluginBridgeIface(np_iface, np_ports).to_dict()
+                    NisporPluginBridgeIface(np_iface, np_ports).to_dict(
+                        config_only
+                    )
                 )
             elif iface_type == "vrf":
-                ifaces.append(NisporPluginVrfIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginVrfIface(np_iface).to_dict(config_only)
+                )
             elif iface_type == "openv_switch":
-                ifaces.append(NisporPluginOvsInternalIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginOvsInternalIface(np_iface).to_dict(config_only)
+                )
             else:
-                ifaces.append(NisporPluginBaseIface(np_iface).to_dict())
+                ifaces.append(
+                    NisporPluginBaseIface(np_iface).to_dict(config_only)
+                )
         return ifaces
+
+    def get_interfaces(self):
+        return self._get_interfaces(_INFO_TYPE_RUNNING)
+
+    def get_running_config_interfaces(self):
+        return self._get_interfaces(_INFO_TYPE_RUNNING_CONFIG)
 
     def get_routes(self):
         np_state = NisporNetState.retrieve()

--- a/libnmstate/nispor/vlan.py
+++ b/libnmstate/nispor/vlan.py
@@ -28,8 +28,8 @@ class NisporPluginVlanIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.VLAN
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[VLAN.CONFIG_SUBTREE] = {
             VLAN.ID: self._np_iface.vlan_id,
             VLAN.BASE_IFACE: self._np_iface.base_iface,

--- a/libnmstate/nispor/vrf.py
+++ b/libnmstate/nispor/vrf.py
@@ -28,8 +28,8 @@ class NisporPluginVrfIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.VRF
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[VRF.CONFIG_SUBTREE] = {
             VRF.PORT_SUBTREE: self._np_iface.subordinates,
             VRF.ROUTE_TABLE_ID: self._np_iface.table_id,

--- a/libnmstate/nispor/vxlan.py
+++ b/libnmstate/nispor/vxlan.py
@@ -28,8 +28,8 @@ class NisporPluginVxlanIface(NisporPluginBaseIface):
     def type(self):
         return InterfaceType.VXLAN
 
-    def to_dict(self):
-        info = super().to_dict()
+    def to_dict(self, config_only):
+        info = super().to_dict(config_only)
         info[VXLAN.CONFIG_SUBTREE] = {
             VXLAN.ID: self._np_iface.vxlan_id,
             VXLAN.BASE_IFACE: self._np_iface.base_iface,

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -26,6 +26,7 @@ from libnmstate.ifaces.ovs import is_ovs_running
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import LLDP
 from libnmstate.schema import Route
 from libnmstate.plugin import NmstatePlugin
 
@@ -153,6 +154,16 @@ class NetworkManagerPlugin(NmstatePlugin):
         info.sort(key=itemgetter("name"))
 
         return info
+
+    def get_running_config_interfaces(self):
+        iface_infos = self.get_interfaces()
+        # Remove LLDP neighber information
+        for iface_info in iface_infos:
+            if LLDP.CONFIG_SUBTREE in iface_info:
+                iface_info[LLDP.CONFIG_SUBTREE].pop(
+                    LLDP.NEIGHBORS_SUBTREE, None
+                )
+        return iface_infos
 
     def get_routes(self):
         return {Route.CONFIG: get_route_running_config(self._applied_configs)}

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -54,9 +54,22 @@ class NmstatePlugin(metaclass=ABCMeta):
         return NmstatePlugin.DEFAULT_PRIORITY
 
     def get_interfaces(self):
+        """
+        Return a list of dict with network interface running status with
+        mix of running status and running configure.
+        """
         raise NmstatePluginError(
             f"Plugin {self.name} BUG: get_interfaces() not implemented"
         )
+
+    def get_running_config_interfaces(self):
+        """
+        Return a list of dict with network interface running configuration.
+        Notes:
+            * the IP/DHCP/Route retrieved from DHCP/Autoconf are not running
+              configuration.
+        """
+        return []
 
     def apply_changes(self, net_state, save_to_disk):
         pass

--- a/nmstatectl/io.nmstate.varlink
+++ b/nmstatectl/io.nmstate.varlink
@@ -33,6 +33,11 @@ method Show(arguments: [string]object) -> (
     log: []Logs
 )
 
+method ShowRunningConfig(arguments: [string]object) -> (
+    state: ?object,
+    log: []Logs
+)
+
 method Apply(arguments: [string]object) -> (
     log: []Logs
 )

--- a/nmstatectl/nmstate_varlink.py
+++ b/nmstatectl/nmstate_varlink.py
@@ -204,6 +204,17 @@ class NmstateVarlinkService:
                 logging.error(str(exception))
                 raise NmstateValueError(str(exception), log_handler.logs)
 
+    def ShowRunningConfig(self, arguments):
+        with nmstate_varlink_logger() as log_handler:
+            method_args = []
+            validate_method_arguments(arguments, method_args)
+            try:
+                configured_state = libnmstate.show_running_config()
+                return {"state": configured_state, "log": log_handler.logs}
+            except libnmstate.error.NmstateValueError as exception:
+                logging.error(str(exception))
+                raise NmstateValueError(str(exception), log_handler.logs)
+
     def Apply(self, arguments):
         """
         Apply desired state declared in json format

--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -318,6 +318,24 @@ def test_lldp_empty_neighbors(lldptest_up):
         assert not lldp_state.get(LLDP.NEIGHBORS_SUBTREE, [])
 
 
+def test_show_running_config_has_no_lldp_neighbor(lldptest_up):
+    with lldp_enabled(lldptest_up):
+        _send_lldp_packet()
+        dstate = statelib.show_only((LLDPTEST,))
+        lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
+        assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
+        running_config = libnmstate.show_running_config()
+        for iface_config in running_config[Interface.KEY]:
+            if iface_config[Interface.NAME] == LLDPTEST:
+                lldp_iface_config = iface_config
+                break
+        assert lldp_iface_config[LLDP.CONFIG_SUBTREE][LLDP.ENABLED]
+        assert (
+            LLDP.NEIGHBORS_SUBTREE
+            not in lldp_iface_config[LLDP.CONFIG_SUBTREE]
+        )
+
+
 @contextmanager
 def lldp_enabled(ifstate):
     lldp_config = ifstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]

--- a/tests/integration/varlink_service_test.py
+++ b/tests/integration/varlink_service_test.py
@@ -87,6 +87,15 @@ def test_varlink_show(server):
         assert varlink_state["state"] == lib_state
 
 
+def test_varlink_show_running_config(server):
+    lib_state = libnmstate.show_running_config()
+    with varlink.Client(_format_address(server.server_address)).open(
+        VARLINK_INTERFACE, namespaced=False
+    ) as con:
+        varlink_state = con._call("ShowRunningConfig")
+        assert varlink_state["state"] == lib_state
+
+
 def test_varlink_apply_state(server):
     with varlink.Client(_format_address(server.server_address)).open(
         VARLINK_INTERFACE, namespaced=False


### PR DESCRIPTION
Introduced `libnmstate.show_running_config()` for querying
activated/running network configuration excluding:
* IP address retrieved by DHCP or IPv6 auto configuration.
* DNS client resolver retrieved by DHCP or IPv6 auto configuration.
* Routes retrieved by DHCPv4 or IPv6 router advertisement.
* LLDP neighbor information.

The output will use the same schema of `libnmstate.show().

The `-r` and `--running-config` option has been added to `show` subcommand
of nmstatectl.

The `io.nmstate.ShowRunningConfig` function has been added to varlink
interface of nmstatectl.

Integration test cases are included for API, CLI and varlink.