### PR TITLE
query: new function for showing saved config

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -108,6 +108,12 @@ change the output format to \fIJSON\fR.
 Showing the running network configuration.
 .RE
 
+.B -s, --saved-config
+.RS
+Showing the saved network configuration which will be actived on next OS
+reboot.
+.RE
+
 .IP \fB--no-verify
 skip the desired network state verification.
 .IP \fB--no-commit

--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -27,6 +27,7 @@ from .netapplier import commit
 from .netapplier import rollback
 from .netinfo import show
 from .netinfo import show_running_config
+from .netinfo import show_saved_config
 
 from .prettystate import PrettyState
 
@@ -42,6 +43,7 @@ __all__ = [
     "schema",
     "show",
     "show_running_config",
+    "show_saved_config",
 ]
 
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -18,8 +18,9 @@
 #
 
 from .nmstate import plugin_context
-from .nmstate import show_with_plugins
 from .nmstate import show_running_config_with_plugins
+from .nmstate import show_saved_config_with_plugins
+from .nmstate import show_with_plugins
 
 
 def show(*, include_status_data=False):
@@ -39,3 +40,11 @@ def show(*, include_status_data=False):
 def show_running_config():
     with plugin_context() as plugins:
         return show_running_config_with_plugins(plugins)
+
+
+def show_saved_config():
+    """
+    Reports configuration saved to persistent after reboot.
+    """
+    with plugin_context() as plugins:
+        return show_saved_config_with_plugins(plugins)

--- a/libnmstate/nispor/bridge.py
+++ b/libnmstate/nispor/bridge.py
@@ -62,6 +62,7 @@ LSM_BRIDGE_OPTIONS_2_NISPOR = {
     OPT.MULTICAST_QUERY_RESPONSE_INTERVAL: "multicast_query_response_interval",
     OPT.MULTICAST_STARTUP_QUERY_COUNT: "multicast_startup_query_count",
     OPT.MULTICAST_STARTUP_QUERY_INTERVAL: "multicast_startup_query_interval",
+    OPT.MULTICAST_MEMBERSHIP_INTERVAL: "multicast_membership_interval",
 }
 
 

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -106,3 +106,20 @@ def _get_bond_options_from_profiles(bond_setting):
             if name != "mode":
                 ret[name] = value
     return ret
+
+
+def get_bond_config(nm_profile, subordinate_nm_profiles):
+    nm_setting = nm_profile.get_setting_bond()
+    if nm_setting:
+        bond_options = _get_bond_options_from_profiles(nm_setting)
+        bond_mode = nm_setting.get_option_by_name("mode")
+        return {
+            Bond.MODE: bond_mode,
+            Bond.OPTIONS_SUBTREE: bond_options,
+            Bond.PORT: [
+                port_profile.get_interface_name()
+                for port_profile in subordinate_nm_profiles
+            ],
+        }
+
+    return {}

--- a/libnmstate/nm/bridge_port_vlan.py
+++ b/libnmstate/nm/bridge_port_vlan.py
@@ -18,6 +18,7 @@
 #
 
 from libnmstate.ifaces import NmstateLinuxBridgePortVlan
+from libnmstate.ifaces import KernelBridgePortVlans
 
 from .common import NM
 
@@ -31,3 +32,20 @@ def nmstate_port_vlan_to_nm(nmstate_vlan_config):
         nm_vlan.set_pvid(kernel_vlan.is_pvid)
         nm_vlans.append(nm_vlan)
     return nm_vlans
+
+
+def get_linux_bridge_port_vlan_config(nm_setting):
+    kernel_vlans = []
+    for nm_vlan in nm_setting.props.vlans:
+        _, vid_min, vid_max = nm_vlan.get_vid_range()
+        kernel_vlans.append(
+            KernelBridgePortVlans(
+                vid_min,
+                vid_max,
+                nm_vlan.is_pvid(),
+                nm_vlan.is_untagged(),
+            )
+        )
+    return NmstateLinuxBridgePortVlan.new_from_kernel_vlans(
+        kernel_vlans
+    ).to_dict()

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -66,10 +66,10 @@ def get_running(context):
     return dns_state
 
 
-def get_running_config(applied_configs):
+def get_dns_config_from_nm_profiles(nm_profiles):
     dns_conf = {DNS.SERVER: [], DNS.SEARCH: []}
-    tmp_dns_confs = _get_dns_config(applied_configs, Interface.IPV6)
-    tmp_dns_confs.extend(_get_dns_config(applied_configs, Interface.IPV4))
+    tmp_dns_confs = _get_dns_config(nm_profiles, Interface.IPV6)
+    tmp_dns_confs.extend(_get_dns_config(nm_profiles, Interface.IPV4))
     # NetworkManager sorts the DNS entries based on various criteria including
     # which profile was activated first when profiles are activated. Therefore
     # the configuration does not completely define the order. To define the

--- a/libnmstate/nm/infiniband.py
+++ b/libnmstate/nm/infiniband.py
@@ -28,16 +28,16 @@ _NM_IB_MODE_DATAGRAM = "datagram"
 _NM_IB_MODE_CONNECTED = "connected"
 
 
-def get_info(applied_config):
-    if applied_config:
-        ib_setting = applied_config.get_setting_infiniband()
+def get_infiniband_config(nm_profile):
+    if nm_profile:
+        ib_setting = nm_profile.get_setting_infiniband()
         if ib_setting:
             mode = _nm_ib_mode_to_nmstate(ib_setting.get_transport_mode())
             if not mode:
                 logging.warning(
                     "Unknown InfiniBand transport mode "
                     f"{ib_setting.get_transport_mode()} for interface "
-                    f"{applied_config.get_interface_name()}"
+                    f"{nm_profile.get_interface_name()}"
                 )
                 return {}
 

--- a/libnmstate/nm/macvlan.py
+++ b/libnmstate/nm/macvlan.py
@@ -88,3 +88,18 @@ def get_current_macvlan_type(applied_config):
     if is_macvtap(applied_config):
         return {Interface.TYPE: InterfaceType.MAC_VTAP}
     return {}
+
+
+def get_macvtap_config(nm_profile):
+    nm_setting = nm_profile.get_setting_macvlan()
+    nm_mode_to_nmstate = {v: k for k, v in NMSTATE_MODE_TO_NM_MODE.items()}
+    if nm_setting:
+        return {
+            MacVlan.MODE: nm_mode_to_nmstate.get(
+                nm_setting.get_mode(), MacVlan.Mode.UNKNOWN
+            ),
+            MacVlan.BASE_IFACE: nm_setting.props.parent,
+            MacVlan.PROMISCUOUS: nm_setting.props.promiscuous,
+        }
+
+    return {}

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -16,21 +16,38 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
+
+from collections import defaultdict
 from distutils.version import StrictVersion
 import logging
 from operator import itemgetter
 
 from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateValueError
+from libnmstate.ifaces.base_iface import BaseIface
 from libnmstate.ifaces.ovs import is_ovs_running
+from libnmstate.plugin import NmstatePlugin
+from libnmstate.schema import Bond
 from libnmstate.schema import DNS
+from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LLDP
+from libnmstate.schema import LinuxBridge
+from libnmstate.schema import MacVlan
+from libnmstate.schema import MacVtap
+from libnmstate.schema import OVSBridge
+from libnmstate.schema import OVSInterface
 from libnmstate.schema import Route
-from libnmstate.plugin import NmstatePlugin
+from libnmstate.schema import Team
+from libnmstate.schema import VLAN
+from libnmstate.schema import VRF
+from libnmstate.schema import VXLAN
+from libnmstate.schema import Veth
 
 
+from .bond import get_bond_config
+from .bridge import get_linux_bridge_config
 from .checkpoint import CheckPoint
 from .checkpoint import get_checkpoints
 from .common import NM
@@ -38,24 +55,40 @@ from .context import NmContext
 from .device import get_device_common_info
 from .device import list_devices
 from .dns import get_running as get_dns_running
-from .dns import get_running_config as get_dns_running_config
-from .infiniband import get_info as get_infiniband_info
-from .ipv4 import get_info as get_ipv4_info
-from .ipv6 import get_info as get_ipv6_info
-from .lldp import get_info as get_lldp_info
+from .dns import get_dns_config_from_nm_profiles
+from .infiniband import get_infiniband_config
+from .ipv4 import get_ipv4_config
+from .ipv6 import get_ipv6_config
+from .lldp import get_lldp_config
 from .macvlan import get_current_macvlan_type
+from .macvlan import get_macvtap_config
 from .ovs import get_interface_info as get_ovs_interface_info
+from .ovs import get_ovs_bridge_config
 from .ovs import get_ovs_bridge_info
+from .ovs import get_ovs_patch_iface_config
 from .ovs import has_ovs_capability
+from .profile import get_basic_iface_info
 from .profiles import NmProfiles
 from .profiles import get_all_applied_configs
-from .route import get_running_config as get_route_running_config
+from .route import get_routes_from_nm_profiles
+from .route import get_route_rules_from_nm_profiles
+from .sriov import get_sriov_config
 from .team import get_info as get_team_info
+from .team import get_team_config
 from .team import has_team_capability
 from .translator import Nm2Api
-from .user import get_info as get_user_info
+from .user import get_user_config
 from .veth import get_current_veth_type
+from .veth import get_veth_config
+from .vlan import get_vlan_config
+from .vrf import get_vrf_config
+from .vxlan import get_vxlan_config
 from .wired import get_info as get_wired_info
+from .wired import get_wired_config
+
+_METADATA_PROFILE_PRIORITY = "_priority"
+_METADATA_PROFILE_TIMESTAMP = "_timestamp"
+_METADATA_NM_PROFILE = "_nm_profile"
 
 
 class NetworkManagerPlugin(NmstatePlugin):
@@ -133,13 +166,15 @@ class NetworkManagerPlugin(NmstatePlugin):
             applied_config = applied_configs.get(iface_info[Interface.NAME])
 
             act_con = dev.get_active_connection()
-            iface_info[Interface.IPV4] = get_ipv4_info(act_con, applied_config)
-            iface_info[Interface.IPV6] = get_ipv6_info(act_con, applied_config)
+            iface_info[Interface.IPV4] = get_ipv4_config(applied_config)
+            iface_info[Interface.IPV6] = get_ipv6_config(applied_config)
             iface_info.update(get_wired_info(dev))
-            iface_info.update(get_user_info(self.context, dev))
-            iface_info.update(get_lldp_info(self.client, dev))
+            iface_info.update(get_user_config(applied_config))
+            iface_info[LLDP.CONFIG_SUBTREE] = get_lldp_config(
+                applied_config, nmdev=dev
+            )
             iface_info.update(get_team_info(dev))
-            iface_info.update(get_infiniband_info(applied_config))
+            iface_info.update(get_infiniband_config(applied_config))
             iface_info.update(get_current_macvlan_type(applied_config))
             iface_info.update(get_current_veth_type(applied_config))
 
@@ -167,8 +202,98 @@ class NetworkManagerPlugin(NmstatePlugin):
                 )
         return iface_infos
 
+    def _get_iface_info_from_saved_profiles(self):
+        iface_infos = {}
+        for nm_profile in self.client.get_connections():
+            profile_flags = nm_profile.get_flags()
+            if (
+                NM.SettingsConnectionFlags.UNSAVED & profile_flags
+                or NM.SettingsConnectionFlags.VOLATILE & profile_flags
+            ):
+                continue
+            iface_info = get_basic_iface_info(nm_profile)
+            iface_type = iface_info[Interface.TYPE]
+            iface_name = iface_info[Interface.NAME]
+            nm_conn_setting = nm_profile.get_setting_connection()
+            if not nm_conn_setting:
+                continue
+            iface_info[
+                _METADATA_PROFILE_PRIORITY
+            ] = nm_conn_setting.get_autoconnect_priority()
+            iface_info[
+                _METADATA_PROFILE_TIMESTAMP
+            ] = nm_conn_setting.get_timestamp()
+            if not iface_name or iface_type == InterfaceType.UNKNOWN:
+                # TODO: Support matching interface via MAC
+                continue
+            iface_index = iface_info[Interface.NAME]
+            if iface_type in (
+                InterfaceType.OVS_BRIDGE,
+                InterfaceType.OVS_PORT,
+            ):
+                iface_index = f"{iface_type} {iface_name}"
+            cur_iface_info = iface_infos.get(iface_index)
+            should_save = False
+            if not cur_iface_info:
+                should_save = True
+            else:
+                cur_priority = cur_iface_info[_METADATA_PROFILE_PRIORITY]
+                new_priority = iface_infos[_METADATA_PROFILE_PRIORITY]
+                if new_priority > cur_priority:
+                    should_save = True
+                elif new_priority == cur_priority:
+                    cur_timestamp = cur_iface_info[_METADATA_PROFILE_TIMESTAMP]
+                    new_timestamp = iface_info[_METADATA_PROFILE_TIMESTAMP]
+                    if new_timestamp > cur_timestamp:
+                        should_save = True
+
+            if should_save:
+                iface_info[_METADATA_NM_PROFILE] = nm_profile
+                iface_name = iface_info[Interface.NAME]
+                iface_type = iface_info[Interface.TYPE]
+                if iface_type in (
+                    InterfaceType.OVS_BRIDGE,
+                    InterfaceType.OVS_PORT,
+                ):
+                    iface_infos[f"{iface_type} {iface_name}"] = iface_info
+                else:
+                    iface_infos[iface_name] = iface_info
+        return iface_infos
+
+    def get_saved_config_interfaces(self):
+        iface_infos = self._get_iface_info_from_saved_profiles()
+
+        _fill_interface_specific_info(iface_infos)
+
+        for iface_info in iface_infos.values():
+            metadata_keys = [
+                key for key in iface_info.keys() if key.startswith("_")
+            ]
+            for key in metadata_keys:
+                iface_info.pop(key)
+
+        return sorted(
+            [
+                iface_info
+                for iface_info in iface_infos.values()
+                if iface_info[Interface.TYPE] != InterfaceType.OVS_PORT
+            ],
+            key=itemgetter(Interface.NAME),
+        )
+
     def get_routes(self):
-        return {Route.CONFIG: get_route_running_config(self._applied_configs)}
+        return {
+            Route.CONFIG: get_routes_from_nm_profiles(self._applied_configs)
+        }
+
+    def get_saved_routes(self):
+        iface_infos = self._get_iface_info_from_saved_profiles()
+        return get_routes_from_nm_profiles(
+            {
+                iface_info[Interface.NAME]: iface_info[_METADATA_NM_PROFILE]
+                for iface_info in iface_infos.values()
+            }
+        )
 
     def get_route_rules(self):
         """
@@ -176,11 +301,29 @@ class NetworkManagerPlugin(NmstatePlugin):
         """
         return {}
 
+    def get_saved_route_rules(self):
+        iface_infos = self._get_iface_info_from_saved_profiles()
+        return get_route_rules_from_nm_profiles(
+            [
+                iface_info[_METADATA_NM_PROFILE]
+                for iface_info in iface_infos.values()
+            ]
+        )
+
     def get_dns_client_config(self):
         return {
             DNS.RUNNING: get_dns_running(self.client),
-            DNS.CONFIG: get_dns_running_config(self._applied_configs),
+            DNS.CONFIG: get_dns_config_from_nm_profiles(self._applied_configs),
         }
+
+    def get_saved_dns_client_config(self):
+        iface_infos = self._get_iface_info_from_saved_profiles()
+        return get_dns_config_from_nm_profiles(
+            {
+                iface_index: iface_info[_METADATA_NM_PROFILE]
+                for iface_index, iface_info in iface_infos.items()
+            }
+        )
 
     def refresh_content(self):
         self.__applied_configs = None
@@ -260,3 +403,89 @@ def _remove_ovs_bridge_unsupported_entries(iface_info):
 
 def _nm_utils_decode_version():
     return f"{NM.MAJOR_VERSION}.{NM.MINOR_VERSION}.{NM.MICRO_VERSION}"
+
+
+def _fill_interface_specific_info(iface_infos):
+    for iface_index, iface_info in iface_infos.items():
+        iface_name = iface_info[Interface.NAME]
+        nm_profile = iface_info[_METADATA_NM_PROFILE]
+        subordinate_nm_profiles = [
+            tmp_iface_info[_METADATA_NM_PROFILE]
+            for tmp_iface_info in iface_infos.values()
+            if tmp_iface_info[BaseIface.CONTROLLER_METADATA] == iface_name
+            and tmp_iface_info[BaseIface.CONTROLLER_TYPE_METADATA]
+            == nm_profile.get_connection_type()
+        ]
+        iface_info[Interface.IPV4] = get_ipv4_config(
+            nm_profile, full_config=True
+        )
+        iface_info[Interface.IPV6] = get_ipv6_config(
+            nm_profile, full_config=True
+        )
+        iface_info.update(get_wired_config(nm_profile))
+        iface_info.update(get_user_config(nm_profile))
+        iface_info[LLDP.CONFIG_SUBTREE] = get_lldp_config(
+            nm_profile, config_only=True
+        )
+        sriov_config = get_sriov_config(nm_profile)
+        if sriov_config:
+            iface_info[Ethernet.SRIOV_SUBTREE] = sriov_config
+
+        iface_type = iface_info[Interface.TYPE]
+        if iface_type == InterfaceType.TEAM:
+            iface_info[Team.CONFIG_SUBTREE] = get_team_config(
+                nm_profile, subordinate_nm_profiles
+            )
+        elif iface_type == InterfaceType.INFINIBAND:
+            iface_info.update(get_infiniband_config(nm_profile))
+        elif iface_type == InterfaceType.OVS_BRIDGE:
+            _fill_ovs_bridge_iface_info(
+                iface_info, iface_infos, subordinate_nm_profiles
+            )
+        elif iface_type == InterfaceType.OVS_INTERFACE:
+            ovs_patch_info = get_ovs_patch_iface_config(nm_profile)
+            if ovs_patch_info:
+                iface_info[OVSInterface.PATCH_CONFIG_SUBTREE] = ovs_patch_info
+        elif iface_type == InterfaceType.BOND:
+            iface_info[Bond.CONFIG_SUBTREE] = get_bond_config(
+                nm_profile, subordinate_nm_profiles
+            )
+        elif iface_type == InterfaceType.VLAN:
+            iface_info[VLAN.CONFIG_SUBTREE] = get_vlan_config(nm_profile)
+        elif iface_type == InterfaceType.VXLAN:
+            iface_info[VXLAN.CONFIG_SUBTREE] = get_vxlan_config(nm_profile)
+        elif iface_type == InterfaceType.LINUX_BRIDGE:
+            iface_info[LinuxBridge.CONFIG_SUBTREE] = get_linux_bridge_config(
+                nm_profile, subordinate_nm_profiles
+            )
+        elif iface_type == InterfaceType.MAC_VTAP:
+            iface_info[MacVtap.CONFIG_SUBTREE] = get_macvtap_config(nm_profile)
+        elif iface_type == InterfaceType.MAC_VLAN:
+            iface_info[MacVlan.CONFIG_SUBTREE] = get_macvtap_config(nm_profile)
+        elif iface_type == InterfaceType.VRF:
+            iface_info[VRF.CONFIG_SUBTREE] = get_vrf_config(
+                nm_profile, subordinate_nm_profiles
+            )
+        elif iface_type == InterfaceType.VETH:
+            iface_info[Veth.CONFIG_SUBTREE] = get_veth_config(nm_profile)
+
+
+def _fill_ovs_bridge_iface_info(iface_info, iface_infos, ovs_port_nm_profiles):
+    nm_profile = iface_info[_METADATA_NM_PROFILE]
+    ovs_iface_nm_profiles = defaultdict(list)
+    for nm_ovs_port_profile in ovs_port_nm_profiles:
+        ovs_port_name = nm_ovs_port_profile.get_interface_name()
+        for tmp_iface_info in iface_infos.values():
+            if (
+                tmp_iface_info[BaseIface.CONTROLLER_METADATA] == ovs_port_name
+                and tmp_iface_info[BaseIface.CONTROLLER_TYPE_METADATA]
+                == InterfaceType.OVS_PORT
+            ):
+                ovs_iface_nm_profiles[ovs_port_name].append(
+                    tmp_iface_info[_METADATA_NM_PROFILE]
+                )
+
+    iface_info[OVSBridge.CONFIG_SUBTREE] = get_ovs_bridge_config(
+        nm_profile, ovs_port_nm_profiles, ovs_iface_nm_profiles
+    )
+    _remove_ovs_bridge_unsupported_entries(iface_info)

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -109,3 +109,27 @@ def _set_nm_attribute(vf_object, key, value):
 def _remove_sriov_vfs_in_setting(vfs_config, sriov_setting, vf_ids_to_remove):
     for vf_id in vf_ids_to_remove:
         yield vf_id
+
+
+def get_sriov_config(nm_profile):
+    nm_setting = nm_profile.get_setting_by_name(NM.SETTING_SRIOV_SETTING_NAME)
+    if nm_setting:
+        vfs_info = []
+        for nm_vf in nm_setting.props.vfs:
+            vf_info = {Ethernet.SRIOV.VFS.ID: nm_vf.get_index()}
+            attributes = nm_vf.get_attribute_names()
+            for key in (
+                Ethernet.SRIOV.VFS.SPOOF_CHECK,
+                Ethernet.SRIOV.VFS.MAC_ADDRESS,
+                Ethernet.SRIOV.VFS.TRUST,
+            ):
+                if key in attributes:
+                    vf_info[key] = nm_vf.get_attribute(key)
+
+            vfs_info.append(vf_info)
+
+        return {
+            Ethernet.SRIOV.TOTAL_VFS: nm_setting.props.total_vfs,
+            Ethernet.SRIOV.VFS_SUBTREE: vfs_info,
+        }
+    return {}

--- a/libnmstate/nm/user.py
+++ b/libnmstate/nm/user.py
@@ -52,26 +52,18 @@ def create_setting(iface_state, base_con_profile):
     return user_setting
 
 
-def get_info(context, device):
+def get_user_config(nm_profile, full_config=False):
     """
     Get description from user settings for a connection
     """
     info = {}
-    user_profile = None
-    act_conn = device.get_active_connection()
-    if act_conn:
-        user_profile = act_conn.props.connection
-    if not user_profile:
-        return info
-
-    try:
-        user_setting = user_profile.get_setting_by_name(
+    if nm_profile:
+        user_setting = nm_profile.get_setting_by_name(
             NM.SETTING_USER_SETTING_NAME
         )
-        description = user_setting.get_data(NMSTATE_DESCRIPTION)
-        if description:
-            info["description"] = description
-    except AttributeError:
-        pass
+        if user_setting:
+            description = user_setting.get_data(NMSTATE_DESCRIPTION)
+            if description:
+                info["description"] = description
 
     return info

--- a/libnmstate/nm/veth.py
+++ b/libnmstate/nm/veth.py
@@ -89,3 +89,10 @@ def create_iface_for_nm_veth_peer(iface):
             Veth.CONFIG_SUBTREE: {Veth.PEER: iface.name},
         }
     )
+
+
+def get_veth_config(nm_profile):
+    nm_setting = nm_profile.get_setting_by_name(NM.SETTING_VETH_SETTING_NAME)
+    if nm_setting:
+        return {Veth.PEER: nm_setting.get_peer()}
+    return {}

--- a/libnmstate/nm/vlan.py
+++ b/libnmstate/nm/vlan.py
@@ -42,3 +42,13 @@ def create_setting(iface_state, base_con_profile):
     vlan_setting.props.parent = vlan_base_iface
 
     return vlan_setting
+
+
+def get_vlan_config(nm_profile):
+    nm_setting = nm_profile.get_setting_vlan()
+    if nm_setting:
+        return {
+            VLAN.ID: nm_setting.props.id,
+            VLAN.BASE_IFACE: nm_setting.props.parent,
+        }
+    return {}

--- a/libnmstate/nm/vrf.py
+++ b/libnmstate/nm/vrf.py
@@ -25,3 +25,16 @@ def create_vrf_setting(vrf_config):
     vrf_setting = NM.SettingVrf.new()
     vrf_setting.props.table = vrf_config[VRF.ROUTE_TABLE_ID]
     return vrf_setting
+
+
+def get_vrf_config(nm_profile, subordinate_nm_profiles):
+    nm_setting = nm_profile.get_setting_by_name(NM.SETTING_VRF_SETTING_NAME)
+    if nm_setting:
+        return {
+            VRF.PORT_SUBTREE: [
+                port_profile.get_interface_name()
+                for port_profile in subordinate_nm_profiles
+            ],
+            VRF.ROUTE_TABLE_ID: nm_setting.props.table,
+        }
+    return {}

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -44,3 +44,13 @@ def create_setting(iface_state, base_con_profile):
         vxlan_setting.props.destination_port = vxlan_destination_port
 
     return vxlan_setting
+
+
+def get_vxlan_config(nm_profile):
+    nm_setting = nm_profile.get_setting_vxlan()
+    if nm_setting:
+        return {
+            VXLAN.ID: nm_setting.props.id,
+            VXLAN.BASE_IFACE: nm_setting.props.parent,
+        }
+    return {}

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -158,3 +158,32 @@ def _get_ethernet_info(device, iface):
         return None
 
     return ethernet
+
+
+def get_wired_config(nm_profile):
+    nm_wired_profile = nm_profile.get_setting_wired()
+    if not nm_wired_profile:
+        return {}
+    info = {}
+    mac = nm_wired_profile.get_cloned_mac_address()
+    if mac:
+        info[Interface.MAC] = mac.upper()
+    mtu = nm_wired_profile.get_mtu()
+    if mtu:
+        info[Interface.MTU] = mtu
+
+    if nm_profile.get_connection_type() == NM.DeviceType.ETHERNET:
+        eth_info = {}
+        if nm_wired_profile.get_auto_negotiate():
+            eth_info[Ethernet.AUTO_NEGOTIATION] = True
+        else:
+            eth_info[Ethernet.AUTO_NEGOTIATION] = False
+
+            if nm_wired_profile.get_duplex():
+                eth_info[Ethernet.DUPLEX] = nm_wired_profile.get_duplex()
+            if nm_wired_profile.get_speed():
+                eth_info[Ethernet.SPEED] = nm_wired_profile.get_speed()
+        if eth_info:
+            info[Ethernet.CONFIG_SUBTREE] = eth_info
+
+    return info

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -71,6 +71,17 @@ class NmstatePlugin(metaclass=ABCMeta):
         """
         return []
 
+    def get_saved_config_interfaces(self):
+        """
+        Return a list of dict with network interface saved(persistent after
+        reboot) configuration.
+        Notes:
+            * the IP/DHCP/Route retrieved from DHCP/Autoconf are not saved
+              configuration.
+            * Memory only configuration is not saved configration.
+        """
+        return []
+
     def apply_changes(self, net_state, save_to_disk):
         pass
 
@@ -96,15 +107,31 @@ class NmstatePlugin(metaclass=ABCMeta):
             f"Plugin {self.name} BUG: get_routes() not implemented"
         )
 
+    def get_saved_routes(self):
+        return []
+
     def get_route_rules(self):
         raise NmstatePluginError(
             f"Plugin {self.name} BUG: get_route_rules() not implemented"
         )
 
+    def get_saved_route_rules(self):
+        return []
+
     def get_dns_client_config(self):
         raise NmstatePluginError(
             f"Plugin {self.name} BUG: get_dns_client_config() not implemented"
         )
+
+    def get_global_state(self):
+        """
+        Allowing plugin to append global information to content of
+        `libnmstate.show()`.
+        """
+        return {}
+
+    def get_saved_dns_client_config(self):
+        return {}
 
     @property
     def is_supplemental_only(self):

--- a/nmstatectl/io.nmstate.varlink
+++ b/nmstatectl/io.nmstate.varlink
@@ -38,6 +38,11 @@ method ShowRunningConfig(arguments: [string]object) -> (
     log: []Logs
 )
 
+method ShowSavedConfig(arguments: [string]object) -> (
+    state: ?object,
+    log: []Logs
+)
+
 method Apply(arguments: [string]object) -> (
     log: []Logs
 )

--- a/nmstatectl/nmstate_varlink.py
+++ b/nmstatectl/nmstate_varlink.py
@@ -215,6 +215,17 @@ class NmstateVarlinkService:
                 logging.error(str(exception))
                 raise NmstateValueError(str(exception), log_handler.logs)
 
+    def ShowSavedConfig(self, arguments):
+        with nmstate_varlink_logger() as log_handler:
+            method_args = []
+            validate_method_arguments(arguments, method_args)
+            try:
+                configured_state = libnmstate.show_saved_config()
+                return {"state": configured_state, "log": log_handler.logs}
+            except libnmstate.error.NmstateValueError as exception:
+                logging.error(str(exception))
+                raise NmstateValueError(str(exception), log_handler.logs)
+
     def Apply(self, arguments):
         """
         Apply desired state declared in json format

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -181,6 +181,13 @@ def setup_subcommand_show(subparsers):
         dest="running_config",
     )
     parser_show.add_argument(
+        "-s, --saved-config",
+        help="Show saved configurations",
+        default=False,
+        action="store_true",
+        dest="saved_config",
+    )
+    parser_show.add_argument(
         "only",
         default="*",
         nargs="?",
@@ -257,6 +264,8 @@ def rollback(args):
 def show(args):
     if args.running_config:
         full_state = libnmstate.show_running_config()
+    elif args.saved_config:
+        full_state = libnmstate.show_saved_config()
     else:
         full_state = libnmstate.show()
     state = _filter_state(full_state, args.only)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -986,3 +986,21 @@ def test_ignore_verification_error_on_invalid_bond_option(eth1_up, eth2_up):
                 Bond.OPTIONS_SUBTREE
             ]
         )
+
+
+def test_show_saved_config_with_bond_down(bond99_with_2_port):
+    running_state = statelib.show_only((BOND99,))
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BOND99,
+                    Interface.STATE: InterfaceState.DOWN,
+                }
+            ]
+        }
+    )
+    saved_state = statelib.show_saved_config_only((BOND99,))
+
+    assert saved_state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
+    assertlib.assert_state_match_full(saved_state, running_state)

--- a/tests/integration/infiniband_test.py
+++ b/tests/integration/infiniband_test.py
@@ -351,3 +351,23 @@ class TestInfiniBand:
             ] = BondMode.ROUND_ROBIN
             with pytest.raises(NmstateValueError):
                 libnmstate.apply(desired_state)
+
+    def test_show_saved_config_with_pkey_nic_down(self, ib_pkey_nic1):
+        iface_name = ib_pkey_nic1[Interface.NAME]
+        running_state = statelib.show_only((iface_name,))
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: iface_name,
+                        Interface.STATE: InterfaceState.DOWN,
+                    }
+                ]
+            }
+        )
+        saved_state = statelib.show_saved_config_only((iface_name,))
+
+        assert (
+            saved_state[Interface.KEY][0][Interface.STATE] == InterfaceState.UP
+        )
+        assertlib.assert_state_match_full(saved_state, running_state)

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -35,8 +35,9 @@ from . import statelib
 
 def assert_state(desired_state_data):
     """Given a state, assert it against the current state."""
+    current_state = libnmstate.show()
     desired_state, current_state = _prepare_state_for_verify(
-        desired_state_data
+        desired_state_data, current_state
     )
 
     assert desired_state.state == current_state.state
@@ -54,10 +55,18 @@ def assert_state_match(desired_state_data):
     Given a state, assert it against the current state by treating missing
     value in desired_state as match.
     """
+    current_state = libnmstate.show()
     desired_state, current_state = _prepare_state_for_verify(
-        desired_state_data
+        desired_state_data, current_state
     )
     assert desired_state.match(current_state)
+
+
+def assert_state_match_full(partial_state_data, full_state_data):
+    partial_state, full_state = _prepare_state_for_verify(
+        partial_state_data, full_state_data
+    )
+    assert partial_state.match(full_state)
 
 
 def assert_mac_address(state, expected_mac=None):
@@ -74,8 +83,7 @@ def _iface_macs(state):
         yield ifstate[Interface.MAC]
 
 
-def _prepare_state_for_verify(desired_state_data):
-    current_state_data = libnmstate.show()
+def _prepare_state_for_verify(desired_state_data, current_state_data):
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -47,6 +47,18 @@ def show_only(ifnames):
     return current_state.state
 
 
+def show_saved_config_only(ifnames):
+    """
+    Report the saved config, filtering based on the given interface names.
+    """
+    base_filter_state = {
+        Interface.KEY: [{Interface.NAME: ifname} for ifname in ifnames]
+    }
+    current_state = State(libnmstate.show_saved_config())
+    current_state.filter(base_filter_state)
+    return current_state.state
+
+
 class State:
     def __init__(self, state):
         self._state = copy.deepcopy(state)

--- a/tests/integration/varlink_service_test.py
+++ b/tests/integration/varlink_service_test.py
@@ -96,6 +96,15 @@ def test_varlink_show_running_config(server):
         assert varlink_state["state"] == lib_state
 
 
+def test_varlink_show_saved_config(server):
+    lib_state = libnmstate.show_saved_config()
+    with varlink.Client(_format_address(server.server_address)).open(
+        VARLINK_INTERFACE, namespaced=False
+    ) as con:
+        varlink_state = con._call("ShowSavedConfig")
+        assert varlink_state["state"] == lib_state
+
+
 def test_varlink_apply_state(server):
     with varlink.Client(_format_address(server.server_address)).open(
         VARLINK_INTERFACE, namespaced=False

--- a/tests/lib/nm/ipv4_test.py
+++ b/tests/lib/nm/ipv4_test.py
@@ -108,34 +108,21 @@ def test_create_setting_with_static_addresses(NM_mock):
     )
 
 
-def test_get_info_with_no_connection():
-    info = nm.ipv4.get_info(active_connection=None, applied_config=None)
-
-    assert info == {}
-
-
 def test_get_info_with_no_applied_config():
-    con_mock = mock.MagicMock()
-
-    info = nm.ipv4.get_info(active_connection=con_mock, applied_config=None)
-
+    info = nm.ipv4.get_ipv4_config(None)
     assert info == {}
 
 
 def test_get_info_with_no_ip_profile():
-    con_mock = mock.MagicMock()
     applied_config_mock = mock.MagicMock()
     applied_config_mock.get_setting_ip4_config.return_value = None
 
-    info = nm.ipv4.get_info(
-        active_connection=con_mock, applied_config=applied_config_mock
-    )
+    info = nm.ipv4.get_ipv4_config(applied_config_mock)
 
     assert info == {InterfaceIPv4.ENABLED: False, InterfaceIPv4.DHCP: False}
 
 
 def test_get_info_with_ip_profile(NM_mock):
-    act_con_mock = mock.MagicMock()
     applied_config_mock = mock.MagicMock()
     ip_profile = mock.MagicMock()
     applied_config_mock.get_setting_ip4_config.return_value = ip_profile
@@ -146,9 +133,7 @@ def test_get_info_with_ip_profile(NM_mock):
     ip_profile.props.ignore_auto_dns = False
     ip_profile.props.ignore_auto_routes = False
 
-    info = nm.ipv4.get_info(
-        active_connection=act_con_mock, applied_config=applied_config_mock
-    )
+    info = nm.ipv4.get_ipv4_config(applied_config_mock)
 
     assert info == {
         InterfaceIPv4.ENABLED: True,

--- a/tests/lib/nm/ipv6_test.py
+++ b/tests/lib/nm/ipv6_test.py
@@ -120,28 +120,17 @@ def test_create_setting_with_static_addresses(NM_mock):
     )
 
 
-def test_get_info_with_no_connection():
-    info = nm.ipv6.get_info(active_connection=None, applied_config=None)
-
-    assert info == {}
-
-
 def test_get_info_with_no_applied_config():
-    con_mock = mock.MagicMock()
-
-    info = nm.ipv6.get_info(active_connection=con_mock, applied_config=None)
+    info = nm.ipv6.get_ipv6_config(None)
 
     assert info == {}
 
 
 def test_get_info_with_no_ip_profile():
-    con_mock = mock.MagicMock()
     applied_config_mock = mock.MagicMock()
     applied_config_mock.get_setting_ip6_config.return_value = None
 
-    info = nm.ipv6.get_info(
-        active_connection=con_mock, applied_config=applied_config_mock
-    )
+    info = nm.ipv6.get_ipv6_config(applied_config_mock)
 
     assert info == {
         InterfaceIPv6.ENABLED: False,
@@ -151,7 +140,6 @@ def test_get_info_with_no_ip_profile():
 
 
 def test_get_info_with_ip_profile(NM_mock):
-    act_con_mock = mock.MagicMock()
     applied_config_mock = mock.MagicMock()
     ip_profile = mock.MagicMock()
     applied_config_mock.get_setting_ip6_config.return_value = ip_profile
@@ -162,9 +150,7 @@ def test_get_info_with_ip_profile(NM_mock):
     ip_profile.props.ignore_auto_dns = False
     ip_profile.props.ignore_auto_routes = False
 
-    info = nm.ipv6.get_info(
-        active_connection=act_con_mock, applied_config=applied_config_mock
-    )
+    info = nm.ipv6.get_ipv6_config(applied_config_mock)
 
     assert info == {
         InterfaceIPv6.ENABLED: True,

--- a/tests/lib/nm/ovs_test.py
+++ b/tests/lib/nm/ovs_test.py
@@ -155,7 +155,7 @@ def test_create_port_setting(NM_mock):
 def _mock_ovs_bridge_profile(bridge_device):
     act_con = bridge_device.get_active_connection.return_value
     conn = act_con.props.connection
-    bridge_setting = conn.get_setting.return_value
+    bridge_setting = conn.get_setting_ovs_bridge.return_value
     bridge_setting.props.stp_enable = False
     bridge_setting.props.rstp_enable = False
     bridge_setting.props.fail_mode = None


### PR DESCRIPTION
Introduced `libnmstate.show_saved_config()` for querying
saved network configuration persistent after reboot.

The output will use the same schema of `libnmstate.show().

The `-s` and `--saved-config` option has been added to `show`
subcommand of nmstatectl.

The `io.nmstate.ShowSavedConfig` function has been added to varlink
interface of nmstatectl.