### PR TITLE
ovsdb: Support managing `Open_vSwitch` table

### DIFF
--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -89,6 +89,9 @@ def show_with_plugins(
         if info_type != _INFO_TYPE_RUNNING:
             report[DNS.KEY].pop(DNS.RUNNING, None)
 
+    for plugin in plugins:
+        report.update(plugin.get_global_state())
+
     validator.schema_validate(report)
     return report
 

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -106,6 +106,13 @@ class NmstatePlugin(metaclass=ABCMeta):
             f"Plugin {self.name} BUG: get_dns_client_config() not implemented"
         )
 
+    def get_global_state(self):
+        """
+        Allowing plugin to append global information to content of
+        `libnmstate.show()`.
+        """
+        return {}
+
     @property
     def is_supplemental_only(self):
         """

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -337,9 +337,11 @@ class VXLAN:
 
 
 class OvsDB:
+    KEY = "ovs-db"
     OVS_DB_SUBTREE = "ovs-db"
     # Don't use hypen as this is OVS data base entry
     EXTERNAL_IDS = "external_ids"
+    OTHER_CONFIG = "other_config"
 
 
 class OVSInterface(OvsDB):

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -62,6 +62,13 @@ properties:
       running:
         items:
           $ref: "#/definitions/dns"
+  ovs-db:
+    type: object
+    properties:
+      external_ids:
+        type: object
+      other_config:
+        type: object
 
 definitions:
   types:


### PR DESCRIPTION
Support querying and changing `external_ids` or `other_config` of OVS
database `Open_vSwitch` table.

The desire state(in yaml format) would be:

```yaml
ovs-db:
  external_ids:
    ovn-bridge-mappings: provider:br-provider
  other_config:
    stats-update-interval: "10000"
```

The desire state will be merging with current state, to remove a entry:

```yaml
ovs-db:
  external_ids:
    ovn-bridge-mappings: None
```

To remove all `external_ids` and `other_config`:

```yaml
ovs-db: {}
```

Limitations:
 * There is no rollback support in ovsdb plugin.
 * All value should be string, please quote the integer like above.

Design:
 * New plugin interface `NmstatePlugin.get_global_state()` allowing
   plugin to append any data to the top level of data returned by
   `libnmstate.show()`. Plugin which using this should do the state
   merging by themselves using `NetState.desire_state` and
   `NetState.current_state`. And the schema verification will not check
   these data.

 * These top level data will be verified by
   `NetState._verify_other_global_info()`.

 * Schema for global ovsdb state included.