### PR TITLE
Allowing generate configurations by desire state

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -13,6 +13,8 @@ nmstatectl \- A nmstate command line tool
 .br
 .B nmstatectl edit \fR[\fIINTERFACE_NAME\fR] [\fIOPTIONS\fR]
 .br
+.B nmstatectl gc \fR[\fISTATE_FILE_PATH\fR] [\fIOPTIONS\fR]
+.br
 .B nmstatectl rollback \fR[\fICHECKPOINT_PATH\fR]
 .br
 .B nmstatectl commit \fR[\fICHECKPOINT_PATH\fR]
@@ -89,6 +91,18 @@ decide whether rollback to previous (before \fB"nmstatectl set/edit"\fR) state.
 rollback the network state from specified checkpoint file. \fBnmstatectl\fR
 will take the latest checkpoint if not defined as argument.
 .PP
+
+.B gc
+
+.RS
+Generates configuration files for specified network state file(s). The output
+will be dictinary with plugin name as key and an tuple as value.
+The tuple will holding configuration file name and configuration content.
+
+The generated configuration is not saved into system, users have to do it
+by themselves after refering to the network backend.
+.RE
+
 .B commit
 .RS
 commit the current network state. \fBnmstatectl\fR will take the latest

--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -27,7 +27,7 @@ from .netapplier import commit
 from .netapplier import rollback
 from .netinfo import show
 from .netinfo import show_running_config
-
+from .nmstate import generate_configurations
 from .prettystate import PrettyState
 
 
@@ -38,6 +38,7 @@ __all__ = [
     "apply",
     "commit",
     "error",
+    "generate_configurations",
     "rollback",
     "schema",
     "show",

--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -40,9 +40,10 @@ class DnsState:
         else:
             self._dns_state = des_dns_state
             self._validate()
-            self._config_changed = _is_dns_config_changed(
-                des_dns_state, cur_dns_state
-            )
+            if cur_dns_state:
+                self._config_changed = _is_dns_config_changed(
+                    des_dns_state, cur_dns_state
+                )
         self._cur_dns_state = deepcopy(cur_dns_state) if cur_dns_state else {}
 
     @property

--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -434,7 +434,10 @@ class BaseIface:
 
     def store_route_metadata(self, route_metadata):
         for family, routes in route_metadata.items():
-            self.raw[family][BaseIface.ROUTES_METADATA] = routes
+            try:
+                self.raw[family][BaseIface.ROUTES_METADATA] = routes
+            except KeyError:
+                self.raw[family] = {BaseIface.ROUTES_METADATA: routes}
 
     def store_route_rule_metadata(self, route_rule_metadata):
         for family, rules in route_rule_metadata.items():

--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -34,13 +34,20 @@ from .state import state_match
 
 
 class NetState:
-    def __init__(self, desire_state, current_state=None, save_to_disk=True):
+    def __init__(
+        self,
+        desire_state,
+        current_state=None,
+        save_to_disk=True,
+        gen_conf_mode=False,
+    ):
         if current_state is None:
             current_state = {}
         self._ifaces = Ifaces(
             desire_state.get(Interface.KEY),
             current_state.get(Interface.KEY),
             save_to_disk,
+            gen_conf_mode,
         )
         self._route = RouteState(
             self._ifaces,

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -121,3 +121,10 @@ class NmstatePlugin(metaclass=ABCMeta):
         Retrun False when plugin can report new interface.
         """
         return False
+
+    def generate_configurations(self, net_state):
+        """
+        Returning a list of strings for configurations which could be save
+        persistently.
+        """
+        return []

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -23,7 +23,10 @@ import pytest
 
 from .testlib import assertlib
 from .testlib.examplelib import example_state
+from .testlib.examplelib import find_examples_dir
+from .testlib.examplelib import load_example
 
+import libnmstate
 from libnmstate import netinfo
 from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import DNS
@@ -228,3 +231,17 @@ def test_add_veth_and_remove():
 
     assertlib.assert_absent("veth1")
     assertlib.assert_absent("veth1peer")
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() <= 1.30,
+    reason="Generating config is not supported on NetworkManager 1.30-",
+)
+def test_gen_conf_for_examples():
+    example_dir = find_examples_dir()
+    with os.scandir(example_dir) as example_dir_fd:
+        for example_file in example_dir_fd:
+            if example_file.name.endswith(".yml"):
+                libnmstate.generate_configurations(
+                    load_example(example_file.name)
+                )

--- a/tests/integration/plugin_test.py
+++ b/tests/integration/plugin_test.py
@@ -326,7 +326,7 @@ def test_network_manager_plugin_with_daemon_stopped(stop_nm_service):
     with pytest.raises(NmstateDependencyError):
         from libnmstate.nm import NetworkManagerPlugin
 
-        NetworkManagerPlugin()
+        NetworkManagerPlugin().context
 
     state = statelib.show_only(("lo",))
     assert state[Interface.KEY][0] == LO_IFACE_INFO


### PR DESCRIPTION
**NetworkManager 1.30 required**

Introduced below allowing user to get the configurations of desire
state. User can save the configuration in their preferred way.

 * Python API: `libnmstate.generate_configurations(desire_state)`
 * CLI: `nmstatectl gc state.yml`

It will return a dictionary with:
 * Key: plugin name
 * Value: list of tuple(file name and file content) for configurations
          used by that backend.

Example for `nmstatectl gc eth1_up.yml`

```yaml
---
NetworkManager:
- - eth1.nmconnection
  - '[connection]

    id=eth1

    uuid=091eaa84-f9da-408a-8144-3da890967b7b

    type=ethernet

    autoconnect-slaves=1

    interface-name=eth1

    permissions=

    [ethernet]

    mac-address-blacklist=

    mtu=1500

    [ipv4]

    dhcp-client-id=mac

    dns-search=

    method=disabled

    [ipv6]

    addr-gen-mode=eui64

    dhcp-duid=ll

    dhcp-iaid=mac

    dns-search=

    method=disabled

    [proxy]

    '
```
