### PR TITLE
 ovs: Ignore OVS capabilities at get interfaces

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -114,7 +114,6 @@ class NetworkManagerPlugin(NmstatePlugin):
 
     def get_interfaces(self):
         info = []
-        capabilities = self.capabilities
 
         applied_configs = self._applied_configs
 
@@ -141,16 +140,13 @@ class NetworkManagerPlugin(NmstatePlugin):
             iface_info.update(get_infiniband_info(applied_config))
             iface_info.update(get_current_macvlan_type(applied_config))
 
-            if NmstatePlugin.OVS_CAPABILITY in capabilities:
-                if iface_info[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
-                    iface_info.update(get_ovs_bridge_info(dev))
-                    iface_info = _remove_ovs_bridge_unsupported_entries(
-                        iface_info
-                    )
-                elif iface_info[Interface.TYPE] == InterfaceType.OVS_INTERFACE:
-                    iface_info.update(get_ovs_interface_info(act_con))
-                elif iface_info[Interface.TYPE] == InterfaceType.OVS_PORT:
-                    continue
+            if iface_info[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
+                iface_info.update(get_ovs_bridge_info(dev))
+                iface_info = _remove_ovs_bridge_unsupported_entries(iface_info)
+            elif iface_info[Interface.TYPE] == InterfaceType.OVS_INTERFACE:
+                iface_info.update(get_ovs_interface_info(act_con))
+            elif iface_info[Interface.TYPE] == InterfaceType.OVS_PORT:
+                continue
 
             info.append(iface_info)
 


### PR DESCRIPTION
At containerize nmstate we cannot run "systemctl openvswitch status" so
even with a openvswitch running at host it will appear as non running
but the ovs information will arrive from NM dbus interface. This breaks
nmstatectl show since ovs-port is not part of nmstate and is not
included in the schema. This change remove the OVS check so ovs-port
is always excluded.

In case we want to have OVS working at containerize nmstate then we have to find an alternative to `systemctl status openvswitch`