### PR TITLE
ovs: Ignore ovs-port always

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -123,6 +123,8 @@ class NetworkManagerPlugin(NmstatePlugin):
             if nm_bond.is_bond_type_id(type_id):
                 bondinfo = nm_bond.get_bond_info(dev)
                 iface_info.update(_ifaceinfo_bond(bondinfo))
+            elif nm_ovs.is_ovs_port_type_id(type_id):
+                continue
             elif NmstatePlugin.OVS_CAPABILITY in capabilities:
                 if nm_ovs.is_ovs_bridge_type_id(type_id):
                     iface_info["bridge"] = nm_ovs.get_ovs_info(
@@ -133,8 +135,6 @@ class NetworkManagerPlugin(NmstatePlugin):
                     )
                 elif nm_ovs.is_ovs_interface_type_id(type_id):
                     iface_info.update(nm_ovs.get_interface_info(act_con))
-                elif nm_ovs.is_ovs_port_type_id(type_id):
-                    continue
 
             info.append(iface_info)
 


### PR DESCRIPTION
At containerize nmstate we cannot run "systemctl openvswitch status" so
even with a openvswitch running at host it will appear as non running
but the ovs information will arrive from NM dbus interface. This breaks
nmstatectl show since ovs-port is not part of nmstate and is not
included in the schema. This change just ignore ovs-port even if
openvswitch appear as not running.

Signed-off-by: Quique Llorente <ellorent@redhat.com>