### PR TITLE
ifaces: do not remove unmanaged orphan interfaces

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -378,7 +378,7 @@ class Ifaces:
 
     def _mark_orphan_as_absent(self):
         for iface in self._kernel_ifaces.values():
-            if iface.need_parent:
+            if iface.need_parent and (iface.is_desired or iface.is_changed):
                 parent_iface = self._get_parent_iface(iface)
                 if parent_iface is None or parent_iface.is_absent:
                     iface.mark_as_changed()

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from contextlib import contextmanager
 import pytest
 
 import libnmstate
@@ -67,6 +68,8 @@ OVS_BOND_YAML_STATE = f"""
         - name: {ETH1}
         - name: {ETH2}
 """
+
+RC_SUCCESS = 0
 
 
 @pytest.fixture
@@ -623,3 +626,26 @@ def test_remove_all_ovs_ports(bridge_with_ports):
         }
     )
     assertlib.assert_absent(PORT1)
+
+
+def test_modify_state_do_not_remove_unmanaged_ovs(eth1_up):
+    with unmanaged_ovs_bridge():
+        eth1_up[Interface.KEY][0][Interface.MTU] = 1400
+        libnmstate.apply(eth1_up)
+        current_state = statelib.show_only((BRIDGE0,))
+        assert len(current_state[Interface.KEY])
+        assert current_state[Interface.KEY][0][Interface.NAME] == BRIDGE0
+
+
+@contextmanager
+def unmanaged_ovs_bridge():
+    rc, _, _ = cmdlib.exec_cmd(
+        "ovs-vsctl add-br br0 -- set Bridge br0 fail-mode=secure".split(),
+        check=True,
+    )
+    assert rc == RC_SUCCESS
+    try:
+        yield
+    finally:
+        rc, _, _ = cmdlib.exec_cmd("ovs-vsctl del-br br0".split(), check=True)
+        assert rc == RC_SUCCESS


### PR DESCRIPTION
If there are unmanaged OVS interface present in the network state, NM
may report uncomplete information. Therefore, nmstate could consider
them as orphan and remove it when modifying the network state.

In order to fix this, nmstate should not consider it orphan and remove
it when it is not on desired state or marked as changed.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>