### PR TITLE
[nmstate-0.3] ifaces: do not remove unmanaged orphan interfaces

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -242,8 +242,10 @@ class Ifaces:
 
     def _mark_orphen_as_absent(self):
         for iface in self._ifaces.values():
-            if iface.need_parent and (
-                not iface.parent or not self._ifaces.get(iface.parent)
+            if (
+                iface.need_parent
+                and (not iface.parent or not self._ifaces.get(iface.parent))
+                and (iface.is_desired or iface.is_changed)
             ):
                 iface.mark_as_changed()
                 iface.state = InterfaceState.ABSENT


### PR DESCRIPTION
If there are unmanaged OVS interface present in the network state, NM
may report uncomplete information. Therefore, nmstate could consider
them as orphan and remove it when modifying the network state.

In order to fix this, nmstate should not consider it orphan and remove
it when it is not on desired state or marked as changed.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>