### PR TITLE
ovsdb: Allowing change external_ids of OVS system interfaces

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -32,6 +32,7 @@ from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import LLDP
+from libnmstate.schema import OvsDB
 
 from ..state import state_match
 from ..state import merge_dict
@@ -349,6 +350,7 @@ class BaseIface:
             * Explicitly set state as UP if not defined.
             * Remove IPv6 link local addresses.
             * Remove empty description.
+            * Change OVSDB value to string.
         """
         self._capitalize_mac()
         self.sort_port()
@@ -364,6 +366,7 @@ class BaseIface:
             state[Interface.STATE] = InterfaceState.UP
         if self.is_absent and not self._save_to_disk:
             state[Interface.STATE] = InterfaceState.DOWN
+        _convert_ovs_external_ids_values_to_string(state)
 
         return state
 
@@ -432,3 +435,11 @@ def _remove_undesired_data(state, desire):
             _remove_undesired_data(value, desire[key])
     for key in key_to_remove:
         state.pop(key)
+
+
+def _convert_ovs_external_ids_values_to_string(iface_info):
+    external_ids = iface_info.get(OvsDB.OVS_DB_SUBTREE, {}).get(
+        OvsDB.EXTERNAL_IDS, {}
+    )
+    for key, value in external_ids.items():
+        external_ids[key] = str(value)

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -29,7 +29,6 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import OVSBridge
 from libnmstate.schema import OVSInterface
-from libnmstate.schema import OvsDB
 
 from .bridge import BridgeIface
 from .base_iface import BaseIface
@@ -151,11 +150,6 @@ class OvsBridgeIface(BridgeIface):
         ] = new_port_configs
         self.sort_port()
 
-    def state_for_verify(self):
-        state = super().state_for_verify()
-        _convert_external_ids_values_to_string(state)
-        return state
-
     def _replace_deprecated_terms(self):
         port_info = self.raw.get(OVSBridge.CONFIG_SUBTREE, {}).get(
             OVSBridge.PORT_SUBTREE, []
@@ -218,11 +212,6 @@ class OvsInternalIface(BaseIface):
     def patch_config(self):
         return self._info.get(OVSInterface.PATCH_CONFIG_SUBTREE)
 
-    def state_for_verify(self):
-        state = super().state_for_verify()
-        _convert_external_ids_values_to_string(state)
-        return state
-
     @property
     def is_patch_port(self):
         return self.patch_config and self.patch_config.get(
@@ -274,14 +263,6 @@ def is_ovs_running():
         return True
     except Exception:
         return False
-
-
-def _convert_external_ids_values_to_string(iface_info):
-    external_ids = iface_info.get(OvsDB.OVS_DB_SUBTREE, {}).get(
-        OvsDB.EXTERNAL_IDS, {}
-    )
-    for key, value in external_ids.items():
-        external_ids[key] = str(value)
 
 
 def is_ovs_lag_port(port_state):

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -26,7 +26,6 @@ from ovs.db.idl import Transaction, Idl, SchemaHelper
 from libnmstate.plugin import NmstatePlugin
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
-from libnmstate.schema import OVSInterface
 from libnmstate.schema import OVSBridge
 from libnmstate.schema import OvsDB
 from libnmstate.error import NmstateNotImplementedError
@@ -200,7 +199,7 @@ class NmstateOvsdbPlugin(NmstatePlugin):
                 continue
             if iface.type == OVSBridge.TYPE:
                 table_name = "Bridge"
-            elif iface.type == OVSInterface.TYPE:
+            elif OvsDB.OVS_DB_SUBTREE in iface.to_dict():
                 table_name = "Interface"
             else:
                 continue

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -388,6 +388,20 @@ def test_ovsdb_new_bridge_with_external_id():
         )
 
 
+def test_ovsdb_set_external_ids_for_ovs_system_interface(bridge_with_ports):
+    system_port_name = "eth1"
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: system_port_name,
+                OvsDB.OVS_DB_SUBTREE: {OvsDB.EXTERNAL_IDS: {"foo": 1000}},
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+
 def test_ovsdb_set_external_ids_for_existing_bridge(bridge_with_ports):
     bridge = bridge_with_ports
     bridge.set_ovs_db({OvsDB.EXTERNAL_IDS: {"foo": "abc", "bak": 1}})


### PR DESCRIPTION
Expanding ovsdb plugin to support setting external_ids on OVS system
interfaces.

Integration test case included.