### PR TITLE
ovs: Raise NmstateValueError when desired interface is orphan

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -378,11 +378,19 @@ class Ifaces:
 
     def _mark_orphan_as_absent(self):
         for iface in self._kernel_ifaces.values():
+            if not iface.is_up:
+                continue
             if iface.need_parent and (iface.is_desired or iface.is_changed):
                 parent_iface = self._get_parent_iface(iface)
-                if parent_iface is None or parent_iface.is_absent:
+                if (parent_iface and parent_iface.is_absent) or (
+                    parent_iface is None and not iface.is_desired
+                ):
                     iface.mark_as_changed()
                     iface.state = InterfaceState.ABSENT
+                elif parent_iface is None and iface.is_desired:
+                    raise NmstateValueError(
+                        f"Failed to find parent interface for {iface.name}"
+                    )
 
     def all_ifaces(self):
         for iface in self._kernel_ifaces.values():

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -663,3 +663,18 @@ def unmanaged_ovs_bridge():
     finally:
         rc, _, _ = cmdlib.exec_cmd("ovs-vsctl del-br br0".split(), check=True)
         assert rc == RC_SUCCESS
+
+
+def test_expect_failure_when_create_ovs_interface_without_bridge():
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "ovs0",
+                        Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                        Interface.STATE: InterfaceState.UP,
+                    }
+                ]
+            }
+        )


### PR DESCRIPTION
When orphan interface exists in desire state, raise NmstateValueError.

When orphan interface exists in desire state, but caused by absent of
existing parent, mark this orphan interface as absent.

Integration test case added.