### PR TITLE
iface:: No need to validate absent interfaces

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -223,14 +223,15 @@ class BaseIface:
         check code.
         """
         if self.is_desired:
-            for family in (Interface.IPV4, Interface.IPV6):
-                self.ip_state(family).validate(
-                    IPState(family, self._origin_info.get(family, {}))
-                )
-            self._validate_port_ip()
-            ip_state = self.ip_state(family)
-            ip_state.remove_link_local_address()
-            self._info[family] = ip_state.to_dict()
+            if not self.is_absent:
+                for family in (Interface.IPV4, Interface.IPV6):
+                    self.ip_state(family).validate(
+                        IPState(family, self._origin_info.get(family, {}))
+                    )
+                self._validate_port_ip()
+                ip_state = self.ip_state(family)
+                ip_state.remove_link_local_address()
+                self._info[family] = ip_state.to_dict()
             if self.is_absent and not self._save_to_disk:
                 self._info[Interface.STATE] = InterfaceState.DOWN
 

--- a/libnmstate/ifaces/bridge.py
+++ b/libnmstate/ifaces/bridge.py
@@ -88,7 +88,8 @@ class BridgeIface(BaseIface):
         )
 
     def pre_edit_validation_and_cleanup(self):
-        self.sort_port()
+        if self.is_up:
+            self.sort_port()
         super().pre_edit_validation_and_cleanup()
 
     def config_changed_port(self, cur_iface):

--- a/libnmstate/ifaces/infiniband.py
+++ b/libnmstate/ifaces/infiniband.py
@@ -44,9 +44,10 @@ class InfiniBandIface(BaseIface):
         return self.raw.get(InfiniBand.CONFIG_SUBTREE, {})
 
     def pre_edit_validation_and_cleanup(self):
-        _cannonicalize_pkey(self.raw)
-        self._validate_mandatory_properties()
-        self._validate_interface_name_format_for_pkey_nic()
+        if self.is_up:
+            _cannonicalize_pkey(self.raw)
+            self._validate_mandatory_properties()
+            self._validate_interface_name_format_for_pkey_nic()
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mandatory_properties(self):

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -48,8 +48,9 @@ class LinuxBridgeIface(BridgeIface):
         )
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate()
-        self._fix_vlan_filtering_mode()
+        if self.is_up:
+            self._validate()
+            self._fix_vlan_filtering_mode()
         super().pre_edit_validation_and_cleanup()
 
     @property

--- a/libnmstate/ifaces/macvlan.py
+++ b/libnmstate/ifaces/macvlan.py
@@ -45,8 +45,9 @@ class MacVlanIface(BaseIface):
         return False
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_mode()
-        self._validate_mandatory_properties()
+        if self.is_up:
+            self._validate_mode()
+            self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mode(self):
@@ -64,10 +65,9 @@ class MacVlanIface(BaseIface):
             )
 
     def _validate_mandatory_properties(self):
-        if self.is_up:
-            for prop in (MacVlan.MODE, MacVlan.BASE_IFACE):
-                if prop not in self.config_subtree:
-                    raise NmstateValueError(
-                        f"{self.type} tunnel {self.name} has missing mandatory"
-                        f" property: {prop}"
-                    )
+        for prop in (MacVlan.MODE, MacVlan.BASE_IFACE):
+            if prop not in self.config_subtree:
+                raise NmstateValueError(
+                    f"{self.type} tunnel {self.name} has missing mandatory"
+                    f" property: {prop}"
+                )

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -116,7 +116,8 @@ class OvsBridgeIface(BridgeIface):
 
     def pre_edit_validation_and_cleanup(self):
         super().pre_edit_validation_and_cleanup()
-        self._validate_ovs_lag_port_count()
+        if self.is_up:
+            self._validate_ovs_lag_port_count()
 
     def _validate_ovs_lag_port_count(self):
         for port in self.port_configs:

--- a/libnmstate/ifaces/vlan.py
+++ b/libnmstate/ifaces/vlan.py
@@ -45,14 +45,14 @@ class VlanIface(BaseIface):
         return False
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_mandatory_properties()
+        if self.is_up:
+            self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mandatory_properties(self):
-        if self.is_up:
-            for prop in (VLAN.ID, VLAN.BASE_IFACE):
-                if prop not in self._vlan_config:
-                    raise NmstateValueError(
-                        f"VLAN tunnel {self.name} has missing mandatory "
-                        f"property: {prop}"
-                    )
+        for prop in (VLAN.ID, VLAN.BASE_IFACE):
+            if prop not in self._vlan_config:
+                raise NmstateValueError(
+                    f"VLAN tunnel {self.name} has missing mandatory "
+                    f"property: {prop}"
+                )

--- a/libnmstate/ifaces/vxlan.py
+++ b/libnmstate/ifaces/vxlan.py
@@ -45,14 +45,14 @@ class VxlanIface(BaseIface):
         return False
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_mandatory_properties()
+        if self.is_up:
+            self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mandatory_properties(self):
-        if self.is_up:
-            for prop in (VXLAN.ID, VXLAN.BASE_IFACE, VXLAN.REMOTE):
-                if prop not in self._vxlan_config:
-                    raise NmstateValueError(
-                        f"Vxlan tunnel {self.name} has missing mandatory "
-                        f"property: {prop}"
-                    )
+        for prop in (VXLAN.ID, VXLAN.BASE_IFACE, VXLAN.REMOTE):
+            if prop not in self._vxlan_config:
+                raise NmstateValueError(
+                    f"Vxlan tunnel {self.name} has missing mandatory "
+                    f"property: {prop}"
+                )

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -644,3 +644,34 @@ def test_get_ip_address_from_unmanaged_dummy():
                 }
             ],
         }
+
+
+def test_ignore_invalid_ip_on_absent_interface(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.STATE: InterfaceState.ABSENT,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.ADDRESS: [
+                            {
+                                InterfaceIPv4.ADDRESS_IP: "a.a.a.a",
+                                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                            }
+                        ],
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.ADDRESS: [
+                            {
+                                InterfaceIPv6.ADDRESS_IP: "::g",
+                                InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
When user are marking certain interface as absent, there is no need
to any more validation on this interface.

Integration test case added.