### PR TITLE
linux bridge: Allowing mixed case for group address

### DIFF
--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -140,6 +140,7 @@ class LinuxBridgeIface(BridgeIface):
     def state_for_verify(self):
         self._normalize_bridge_port_vlan()
         self._remove_read_only_bridge_options()
+        self._change_to_upper_group_addr()
         return super().state_for_verify()
 
     @staticmethod
@@ -193,6 +194,15 @@ class LinuxBridgeIface(BridgeIface):
             self._bridge_config.get(LinuxBridge.OPTIONS_SUBTREE, {}).pop(
                 key, None
             )
+
+    def _change_to_upper_group_addr(self):
+        cur_group_addr = self._bridge_config.get(
+            LinuxBridge.OPTIONS_SUBTREE, {}
+        ).get(LinuxBridge.Options.GROUP_ADDR)
+        if cur_group_addr:
+            self.raw[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.OPTIONS_SUBTREE][
+                LinuxBridge.Options.GROUP_ADDR
+            ] = cur_group_addr.upper()
 
 
 def _assert_vlan_filtering_trunk_tag(trunk_tag_state):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -791,3 +791,14 @@ def test_empty_state_does_not_change_bridge_options(bridge0_with_port0):
     original_state = show_only((TEST_BRIDGE0,))
     libnmstate.apply({Interface.KEY: [{Interface.NAME: TEST_BRIDGE0}]})
     assertlib.assert_state_match(original_state)
+
+
+def test_create_bridge_with_mixed_case_group_addr():
+    bridge_state = _create_bridge_subtree_config([])
+
+    bridge_state[LinuxBridge.OPTIONS_SUBTREE][
+        LinuxBridge.Options.GROUP_ADDR
+    ] = "01:80:C2:00:00:0a"
+    print(bridge_state)
+    with linux_bridge(TEST_BRIDGE0, bridge_state) as lb_state:
+        assertlib.assert_state_match(lb_state)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -120,6 +120,7 @@ class State:
         self._sort_interfaces_by_name()
         self._canonicalize_iface_ipv6_addresses()
         self._normalize_linux_bridge_port_vlan()
+        self._upper_linux_bridge_group_addr()
         self._sort_ovs_lag_ports()
 
     def match(self, other):
@@ -245,6 +246,23 @@ class State:
             for port in ports:
                 if not port.get(LinuxBridge.Port.VLAN_SUBTREE):
                     port[LinuxBridge.Port.VLAN_SUBTREE] = {}
+
+    def _upper_linux_bridge_group_addr(self):
+        linux_bridges = (
+            iface
+            for iface in self._state.get(Interface.KEY, [])
+            if iface[Interface.TYPE] == LinuxBridge.TYPE
+        )
+        for lb in linux_bridges:
+            cur_group_addr = (
+                lb.get(LinuxBridge.CONFIG_SUBTREE, {})
+                .get(LinuxBridge.OPTIONS_SUBTREE, {})
+                .get(LinuxBridge.Options.GROUP_ADDR)
+            )
+            if cur_group_addr:
+                lb[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.OPTIONS_SUBTREE][
+                    LinuxBridge.Options.GROUP_ADDR
+                ] = cur_group_addr.upper()
 
     def _sort_ovs_lag_ports(self):
         for iface_state in self._state[Interface.KEY]:


### PR DESCRIPTION
Automatically convert linux bridge group address to upper case.

Integration test case added.