### PR TITLE
sriov: Use verification retry to wait VF been created

### DIFF
--- a/libnmstate/nispor/ethernet.py
+++ b/libnmstate/nispor/ethernet.py
@@ -36,7 +36,7 @@ class NisporPluginEthernetIface(NisporPluginBaseIface):
                 vf_infos.append(
                     {
                         Ethernet.SRIOV.VFS.ID: vf.vf_id,
-                        Ethernet.SRIOV.VFS.MAC_ADDRESS: vf.mac,
+                        Ethernet.SRIOV.VFS.MAC_ADDRESS: vf.mac.upper(),
                         Ethernet.SRIOV.VFS.SPOOF_CHECK: vf.spoof_check,
                         Ethernet.SRIOV.VFS.TRUST: vf.trust,
                         Ethernet.SRIOV.VFS.MIN_TX_RATE: vf.min_tx_rate,

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -27,7 +27,6 @@ from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateInternalError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
-from libnmstate.schema import Ethernet
 
 from .active_connection import ActiveConnectionDeactivate
 from .active_connection import ProfileActivation
@@ -223,13 +222,11 @@ class NmProfile:
             )
 
     def _check_sriov_support(self):
-        sriov_config = (
-            self._iface.to_dict()
-            .get(Ethernet.CONFIG_SUBTREE, {})
-            .get(Ethernet.SRIOV_SUBTREE)
-        )
-
-        if self._nm_dev and sriov_config:
+        if (
+            self._nm_dev
+            and self._iface.type == InterfaceType.ETHERNET
+            and self._iface.sriov_total_vfs
+        ):
             if (
                 not self._nm_dev.props.capabilities
                 & NM.DeviceCapabilities.SRIOV


### PR DESCRIPTION
When reactivating i40e interface with SR-IOV enabled, the kernel
takes some time(1 seconds or more in my test) to get the VF interface
ready in kernel. So at the time of libnmstate returns with success, the
VF interface might not be ready for use yet.

To fix that, we include VF interfaces in desire state when PV is
changed/desired. The verification retry will wait the VF to be ready for
use.

Unit test case and integration test case included.

Also fixed SRIOV integration test cases which are now all passing on i40e
NIC.

To test on real SRIOV NIC:

    cd tests/integration/
    sudo env TEST_REAL_NIC=ens1f1 pytest-3 sriov_test.py -vvv
