### PR TITLE
[nmstate-0.3] sriov: Use verification retry to wait VF been created

### DIFF
--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -68,7 +68,7 @@ def create_setting(context, iface_state, base_con_profile):
     sriov_config = iface_state.get(Ethernet.CONFIG_SUBTREE, {}).get(
         Ethernet.SRIOV_SUBTREE
     )
-    if sriov_config:
+    if sriov_config and sriov_config.get(Ethernet.SRIOV.TOTAL_VFS):
         if not _has_sriov_capability(context, ifname):
             raise NmstateNotSupportedError(
                 f"Interface '{ifname}' does not support SR-IOV"

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -22,122 +22,212 @@ import os
 import pytest
 
 import libnmstate
-from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
 
 from .testlib import assertlib
+from .testlib import statelib
 
 
-SRIOV_CONFIG = {Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}}
+MAC1 = "00:11:22:33:44:55"
+MAC2 = "00:11:22:33:44:66"
+MAC3 = "00:11:22:33:44:FF"
+MAC_MIX_CASE = "00:11:22:33:44:Ff"
+
+VF0_CONF = {
+    Ethernet.SRIOV.VFS.ID: 0,
+    Ethernet.SRIOV.VFS.SPOOF_CHECK: True,
+    Ethernet.SRIOV.VFS.MAC_ADDRESS: MAC1,
+    Ethernet.SRIOV.VFS.TRUST: False,
+}
+
+VF1_CONF = {
+    Ethernet.SRIOV.VFS.ID: 1,
+    Ethernet.SRIOV.VFS.SPOOF_CHECK: True,
+    Ethernet.SRIOV.VFS.MAC_ADDRESS: MAC2,
+    Ethernet.SRIOV.VFS.TRUST: False,
+}
 
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get("CI") == "true", reason="CI devices do not support SR-IOV",
+def _test_nic_name():
+    return os.environ.get("TEST_REAL_NIC")
+
+
+@pytest.fixture
+def disable_sriov():
+    pf_name = _test_nic_name()
+    iface_info = {
+        Interface.NAME: pf_name,
+        Interface.STATE: InterfaceState.UP,
+        Ethernet.CONFIG_SUBTREE: {
+            Ethernet.SRIOV_SUBTREE: {
+                Ethernet.SRIOV.TOTAL_VFS: 0,
+                Ethernet.SRIOV.VFS_SUBTREE: [],
+            }
+        },
+    }
+    desired_state = {Interface.KEY: [iface_info]}
+    libnmstate.apply(desired_state)
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def sriov_interface(disable_sriov):
+    pf_name = _test_nic_name()
+    iface_info = {
+        Interface.NAME: pf_name,
+        Interface.STATE: InterfaceState.UP,
+        Ethernet.CONFIG_SUBTREE: {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+        },
+    }
+    desired_state = {Interface.KEY: [iface_info]}
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+@pytest.fixture
+def sriov_iface_vf(disable_sriov):
+    pf_name = _test_nic_name()
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: pf_name,
+                Ethernet.CONFIG_SUBTREE: {
+                    Ethernet.SRIOV_SUBTREE: {
+                        Ethernet.SRIOV.TOTAL_VFS: 2,
+                        Ethernet.SRIOV.VFS_SUBTREE: [VF0_CONF, VF1_CONF],
+                    }
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
+def test_sriov_with_no_vfs_config(sriov_interface):
+    assertlib.assert_state_match(sriov_interface)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
-)
-def test_sriov_zero_vfs(sriov_interface):
-    assertlib.assert_state(sriov_interface)
-
-
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
 def test_sriov_increase_vfs(sriov_interface):
-    eth_config = sriov_interface[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    desired_state = sriov_interface
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
     eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.TOTAL_VFS] = 5
-    libnmstate.apply(sriov_interface)
-    assertlib.assert_state(sriov_interface)
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
 def test_sriov_decrease_vfs(sriov_interface):
-    eth_config = sriov_interface[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
-    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.TOTAL_VFS] = 0
-    libnmstate.apply(sriov_interface)
-    assertlib.assert_state(sriov_interface)
+    desired_state = sriov_interface
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.TOTAL_VFS] = 1
+    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE] = [VF0_CONF]
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
-def test_sriov_create_vf_config(sriov_interface):
-    eth_config = sriov_interface[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
-    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE] = [
-        {
-            Ethernet.SRIOV.VFS.ID: 0,
-            Ethernet.SRIOV.VFS.SPOOF_CHECK: True,
-            Ethernet.SRIOV.VFS.MAC_ADDRESS: "00:11:22:33:44:55",
-            Ethernet.SRIOV.VFS.TRUST: False,
-        }
-    ]
-    libnmstate.apply(sriov_interface)
-    assertlib.assert_state(sriov_interface)
+def test_sriov_create_vf_config(sriov_iface_vf):
+    assertlib.assert_state_match(sriov_iface_vf)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
 def test_sriov_edit_vf_config(sriov_iface_vf):
-    eth_config = sriov_iface_vf[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    desired_state = sriov_iface_vf
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
     vf0 = eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE][0]
     vf0[Ethernet.SRIOV.VFS.TRUST] = True
-    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = "55:44:33:22:11:00"
-    libnmstate.apply(sriov_interface)
-    assertlib.assert_state(sriov_interface)
+    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = MAC3
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
+)
 @pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+    raises=libnmstate.error.NmstateVerificationError,
+    reason="https://github.com/nmstate/nmstate/issues/1454",
+    strict=True,
 )
 def test_sriov_remove_vf_config(sriov_iface_vf):
-    eth_config = sriov_iface_vf[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    desired_state = sriov_iface_vf
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
     eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE] = []
-    libnmstate.apply(sriov_interface)
-    assertlib.assert_state(sriov_interface)
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
-@pytest.mark.xfail(
-    raises=NmstateNotSupportedError,
-    reason="The device does not support SR-IOV.",
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
 )
 def test_sriov_vf_mac_mixed_case(sriov_iface_vf):
-    eth_config = sriov_iface_vf[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    desired_state = sriov_iface_vf
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
     vf0 = eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE][0]
-    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = "FF:EE:dd:CC:BB:aa"
-    libnmstate.apply(sriov_interface)
+    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = MAC_MIX_CASE
+    libnmstate.apply(desired_state)
+
+    vf0[Ethernet.SRIOV.VFS.MAC_ADDRESS] = MAC_MIX_CASE.upper()
+    assertlib.assert_state_match(desired_state)
 
 
-@pytest.fixture
-def sriov_interface(eth1_up):
-    eth1_up[Interface.KEY][0][Ethernet.CONFIG_SUBTREE] = SRIOV_CONFIG
-    libnmstate.apply(eth1_up)
-    yield eth1_up
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
+)
+def test_wait_sriov_vf_been_created():
+    pf_name = _test_nic_name()
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: pf_name,
+                Ethernet.CONFIG_SUBTREE: {
+                    Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
+                },
+            }
+        ]
+    }
+    try:
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
+        current_state = statelib.show_only((f"{pf_name}v0", f"{pf_name}v1"))
+        assert len(current_state[Interface.KEY]) == 2
 
-
-@pytest.fixture
-def sriov_iface_vf(eth1_up):
-    eth1_up[Interface.KEY][0][Ethernet.CONFIG_SUBTREE] = SRIOV_CONFIG
-    eth_config = eth1_up[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
-    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.VFS_SUBTREE] = [
-        {
-            Ethernet.SRIOV.VFS.ID: 0,
-            Ethernet.SRIOV.VFS.SPOOF_CHECK: True,
-            Ethernet.SRIOV.VFS.MAC_ADDRESS: "00:11:22:33:44:55",
-            Ethernet.SRIOV.VFS.TRUST: False,
-        }
-    ]
-    libnmstate.apply(eth1_up)
-    yield eth1_up
+    finally:
+        desired_state[Interface.KEY][0][
+            Interface.STATE
+        ] = InterfaceState.ABSENT
+        libnmstate.apply(desired_state)

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -150,6 +150,7 @@ def test_get_info_with_invalid_duplex(ethtool_mock, NM_mock):
     dev_mock.get_iface.return_value = "nmstate_test"
     dev_mock.get_hw_address.return_value = "ab:cd:ef:01:23:45"
     dev_mock.get_mtu.return_value = 1500
+    dev_mock.get_speed.return_value = 1000
     dev_mock.get_device_type.return_value = NM_mock.DeviceType.ETHERNET
 
     info = nm.wired.get_info(dev_mock)
@@ -157,6 +158,10 @@ def test_get_info_with_invalid_duplex(ethtool_mock, NM_mock):
     assert info == {
         schema.Interface.MAC: dev_mock.get_hw_address.return_value,
         schema.Interface.MTU: dev_mock.get_mtu.return_value,
+        schema.Ethernet.CONFIG_SUBTREE: {
+            schema.Ethernet.AUTO_NEGOTIATION: True,
+            schema.Ethernet.SPEED: 1000,
+        },
     }
 
 


### PR DESCRIPTION
When reactivating i40e interface with SR-IOV enabled, the kernel
takes some time(1 seconds or more in my test) to get the VF interface
ready in kernel. So at the time of libnmstate returns with success, the
VF interface might not be ready for use yet.

To fix that, we include VF interfaces in desire state when PV is
changed/desired. The verification retry will wait the VF to be ready for
use.

Unit test case and integration test case included.

Also fixed SRIOV integration test cases which are now all passing on i40e
NIC.

To test on real SRIOV NIC:

    cd tests/integration/
    sudo env TEST_REAL_NIC=ens1f1 pytest-3 sriov_test.py -vvv