### PR TITLE
nm.connection: use iface type and object on setting creation

### DIFF
--- a/libnmstate/ifaces/macvlan.py
+++ b/libnmstate/ifaces/macvlan.py
@@ -44,6 +44,18 @@ class MacVlanIface(BaseIface):
     def can_have_ip_when_enslaved(self):
         return False
 
+    @property
+    def mode(self):
+        return self.config_subtree[MacVlan.MODE]
+
+    @property
+    def base_iface(self):
+        return self.config_subtree[MacVlan.BASE_IFACE]
+
+    @property
+    def promiscuous(self):
+        return self.config_subtree.get(MacVlan.PROMISCUOUS)
+
     def pre_edit_validation_and_cleanup(self):
         if self.is_up:
             self._validate_mode()

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -24,11 +24,8 @@ import uuid
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge as LB
-from libnmstate.schema import MacVlan
-from libnmstate.schema import MacVtap
 from libnmstate.schema import OVSBridge as OvsB
 from libnmstate.schema import OVSInterface
-from libnmstate.schema import VRF
 
 from libnmstate.ifaces.bridge import BridgeIface
 
@@ -196,16 +193,14 @@ def create_new_nm_simple_conn(iface, nm_profile):
     if team_setting:
         settings.append(team_setting)
 
-    if VRF.CONFIG_SUBTREE in iface_info:
-        settings.append(create_vrf_setting(iface_info[VRF.CONFIG_SUBTREE]))
+    if iface.type == InterfaceType.VRF:
+        settings.append(create_vrf_setting(iface))
 
-    if MacVlan.CONFIG_SUBTREE in iface_info:
-        settings.append(create_macvlan_setting(iface_info, nm_profile))
+    if iface.type == InterfaceType.MAC_VLAN:
+        settings.append(create_macvlan_setting(iface, nm_profile))
 
-    if MacVtap.CONFIG_SUBTREE in iface_info:
-        settings.append(
-            create_macvlan_setting(iface_info, nm_profile, tap=True)
-        )
+    if iface.type == InterfaceType.MAC_VTAP:
+        settings.append(create_macvlan_setting(iface, nm_profile, tap=True))
 
     if iface.type == InterfaceType.VETH:
         veth_setting = create_veth_setting(iface, nm_profile)

--- a/libnmstate/nm/vrf.py
+++ b/libnmstate/nm/vrf.py
@@ -17,11 +17,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.schema import VRF
 from .common import NM
 
 
-def create_vrf_setting(vrf_config):
+def create_vrf_setting(vrf_iface):
     vrf_setting = NM.SettingVrf.new()
-    vrf_setting.props.table = vrf_config[VRF.ROUTE_TABLE_ID]
+    vrf_setting.props.table = vrf_iface.route_table_id
     return vrf_setting

--- a/tests/lib/ifaces/mac_vlan_test.py
+++ b/tests/lib/ifaces/mac_vlan_test.py
@@ -45,6 +45,7 @@ class TestMacVlanIface:
         iface_info[MacVlan.CONFIG_SUBTREE] = {
             MacVlan.BASE_IFACE: BASE_IFACE_NAME,
             MacVlan.MODE: MacVlan.Mode.PASSTHRU,
+            MacVlan.PROMISCUOUS: True,
         }
         return iface_info
 
@@ -61,6 +62,19 @@ class TestMacVlanIface:
         assert not MacVlanIface(
             self._gen_iface_info()
         ).can_have_ip_when_enslaved
+
+    def test_get_mode(self):
+        assert (
+            MacVlanIface(self._gen_iface_info()).mode == MacVlan.Mode.PASSTHRU
+        )
+
+    def test_get_base_iface(self):
+        assert (
+            MacVlanIface(self._gen_iface_info()).base_iface == BASE_IFACE_NAME
+        )
+
+    def test_get_promiscuous(self):
+        assert MacVlanIface(self._gen_iface_info()).promiscuous
 
     def test_add_macvlan_without_mode(self):
         iface_info = self._gen_iface_info()


### PR DESCRIPTION
When creating the setting Nmstate should use the interface type to
decide which setting should create. In addition, the create setting
functions should use `BaseIface` object instead of the dict in order to
simplify the information parsing when creating the setting.