### PR TITLE
veth: retry import device when activating new veth peer

### DIFF
--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -43,6 +43,7 @@ VETH2PEER = "veth2peer"
     nm_major_minor_version() >= 1.28,
     reason="Modifying veth interfaces is supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_add_veth_not_supported():
     desired_state = {
         Interface.KEY: [
@@ -63,6 +64,7 @@ def test_add_veth_not_supported():
     nm_major_minor_version() <= 1.28,
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_add_and_remove_veth():
     with veth_interface(VETH1, VETH1PEER) as desired_state:
         assertlib.assert_state(desired_state)
@@ -75,6 +77,7 @@ def test_add_and_remove_veth():
     nm_major_minor_version() <= 1.28,
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_add_veth_both_up():
     with veth_interface(VETH1, VETH1PEER):
         c_state = statelib.show_only(
@@ -94,6 +97,7 @@ def test_add_veth_both_up():
     nm_major_minor_version() <= 1.28,
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_add_veth_as_bridge_port():
     with veth_interface(VETH1, VETH1PEER):
         with bridges_with_port() as desired_state:
@@ -104,6 +108,7 @@ def test_add_veth_as_bridge_port():
     nm_major_minor_version() <= 1.28,
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_add_veth_and_bring_both_up():
     with veth_interface_both_up(VETH1, VETH1PEER):
         c_state = statelib.show_only(
@@ -120,6 +125,7 @@ def test_add_veth_and_bring_both_up():
     nm_major_minor_version() <= 1.28,
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
+@pytest.mark.tier1
 def test_modify_veth_peer():
     with veth_interface(VETH1, VETH1PEER) as d_state:
         d_state[Interface.KEY][0][Veth.CONFIG_SUBTREE][Veth.PEER] = VETH2PEER


### PR DESCRIPTION
NetworkManager takes some extra time on creating the device object for
the new veth peer. Trying to activate an interface without importing the
device will end up on NetworkManager trying to create a new device for
the interface and that will end up on an error.

In order to fix this, Nmstate will retry to import the device up to 5
times with an interval of 0.5 seconds. If the device is not imported
during this time, then nmstate will try to activate it anyway.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>