### PR TITLE
nm ovs: Support modification of OVS external_ids

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -46,6 +46,7 @@ from .lldp import get_info as get_lldp_info
 from .macvlan import get_current_macvlan_type
 from .ovs import get_interface_info as get_ovs_interface_info
 from .ovs import get_ovs_bridge_info
+from .ovs import get_ovsdb_external_ids
 from .ovs import has_ovs_capability
 from .profiles import NmProfiles
 from .profiles import get_all_applied_configs
@@ -150,6 +151,9 @@ class NetworkManagerPlugin(NmstatePlugin):
                 iface_info.update(get_ovs_interface_info(act_con))
             elif iface_info[Interface.TYPE] == InterfaceType.OVS_PORT:
                 continue
+
+            if applied_config:
+                iface_info.update(get_ovsdb_external_ids(applied_config))
 
             info.append(iface_info)
 

--- a/tests/integration/plugin_test.py
+++ b/tests/integration/plugin_test.py
@@ -18,8 +18,6 @@
 #
 
 import copy
-import os
-import tempfile
 
 import pytest
 
@@ -37,6 +35,7 @@ from libnmstate.plugin import NmstatePlugin
 
 from .testlib import statelib
 from .testlib.servicelib import disable_service
+from .testlib.plugin import tmp_plugin_dir
 
 
 FOO_IFACE_NAME = "foo1"
@@ -151,37 +150,39 @@ LO_IFACE_INFO = {
 
 
 @pytest.fixture
-def tmp_plugin_dir():
-    with tempfile.TemporaryDirectory() as plugin_dir:
-        os.environ["NMSTATE_PLUGIN_DIR"] = plugin_dir
-        yield plugin_dir
-        os.environ.pop("NMSTATE_PLUGIN_DIR")
+def with_foo_plugin():
+    with tmp_plugin_dir() as plugin_dir:
+        _gen_plugin_foo(plugin_dir)
+        yield
 
 
 @pytest.fixture
-def with_foo_plugin(tmp_plugin_dir):
-    _gen_plugin_foo(tmp_plugin_dir)
+def with_multiple_plugins():
+    with tmp_plugin_dir() as plugin_dir:
+        _gen_plugin_foo(plugin_dir)
+        _gen_plugin_bar(plugin_dir)
+        yield
 
 
 @pytest.fixture
-def with_multiple_plugins(tmp_plugin_dir):
-    _gen_plugin_foo(tmp_plugin_dir)
-    _gen_plugin_bar(tmp_plugin_dir)
+def with_route_plugin():
+    with tmp_plugin_dir() as plugin_dir:
+        _gen_plugin_route_foo(plugin_dir)
+        yield
 
 
 @pytest.fixture
-def with_route_plugin(tmp_plugin_dir):
-    _gen_plugin_route_foo(tmp_plugin_dir)
+def with_route_rule_plugin():
+    with tmp_plugin_dir() as plugin_dir:
+        _gen_plugin_route_rule_foo(plugin_dir)
+        yield
 
 
 @pytest.fixture
-def with_route_rule_plugin(tmp_plugin_dir):
-    _gen_plugin_route_rule_foo(tmp_plugin_dir)
-
-
-@pytest.fixture
-def with_dns_plugin(tmp_plugin_dir):
-    _gen_plugin_dns_foo(tmp_plugin_dir)
+def with_dns_plugin():
+    with tmp_plugin_dir() as plugin_dir:
+        _gen_plugin_dns_foo(plugin_dir)
+        yield
 
 
 def _gen_plugin(

--- a/tests/integration/testlib/plugin.py
+++ b/tests/integration/testlib/plugin.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+import os
+import tempfile
+
+
+@contextmanager
+def tmp_plugin_dir():
+    with tempfile.TemporaryDirectory() as plugin_dir:
+        os.environ["NMSTATE_PLUGIN_DIR"] = plugin_dir
+        try:
+            yield plugin_dir
+        finally:
+            os.environ.pop("NMSTATE_PLUGIN_DIR")


### PR DESCRIPTION
NetworkManager 1.30+ has introduced the support of changing OVS
`external_ids`.

Integration test cases included.