### PR TITLE
nm: Better handling for timeout

### DIFF
--- a/libnmstate/nm/context.py
+++ b/libnmstate/nm/context.py
@@ -31,8 +31,7 @@ from .common import Gio
 # last finish async action.
 IDLE_CHECK_INTERNAL = 5
 
-# libnm dbus connection has reply timeout 25 seconds.
-IDLE_TIMEOUT = 25
+IDLE_TIMEOUT = 60 * 5  # 5 minitues
 
 # NetworkManage is using dbus in libnm while the dbus has limitation on
 # maximum number of pending replies per connection.(RHEL/CentOS 8 is 1024)

--- a/tests/integration/timeout_test.py
+++ b/tests/integration/timeout_test.py
@@ -31,7 +31,7 @@ from libnmstate.schema import VLAN
 @pytest.mark.slow
 def test_lot_of_vlans_with_bridges(eth1_up):
     interfaces = []
-    for i in range(100, 400):
+    for i in range(100, 600):
         interfaces.extend(
             [
                 {


### PR DESCRIPTION
When creating 1000 VLAN along with 1000 bridge using each VLAN,
NetworkManager might trigger two timeout:

 * The callback raises `Gio.IOErrorEnum.TIMED_OUT` error.
 * NetworkManager never call callback, nmstate idle check trigger the
   timeout.

To solve above issue:

 * Increase the nmstate idle check timeout to 5 minutes.

 * For actions like add profile, activate profile, add a
   fallback checker which check whether requested action is already
   finished using `GLib.timeout_source_new()`

 * When `Gio.IOErrorEnum.TIMED_OUT` happens, ignore the failure and wait
   fallback checker.

 * The fallback checker is only started 15 seconds after action started,
   so this does not impact small desire state.

Test results on RHEL 8.3 i7-8665U 2G RAM:

    13m3.895s to create 1000 VLAN and 1000 bridge over each VLAN.