### PR TITLE
nm.context: remove refresh_content() calls

### DIFF
--- a/libnmstate/nm/context.py
+++ b/libnmstate/nm/context.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -83,11 +83,6 @@ class NmContext:
             )
         return self._context
 
-    def refresh_content(self):
-        if self.context:
-            while self.context.iteration(False):
-                pass
-
     def clean_up(self):
         if self._cancellable:
             self._cancellable.cancel()
@@ -105,8 +100,6 @@ class NmContext:
             )
             self._client = None
             self._quitting = True
-
-            self.refresh_content()
 
             if not is_done:
                 timeout_source = GLib.timeout_source_new(50)
@@ -212,7 +205,6 @@ class NmContext:
         if self._error:
             # The queue and error should be flush and perpare for another run
             self._cancellable.cancel()
-            self.refresh_content()
             self._init_queue()
             self._init_cancellable()
             tmp_error = self._error

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -184,7 +184,6 @@ class NetworkManagerPlugin(NmstatePlugin):
 
     def refresh_content(self):
         self.__applied_configs = None
-        self._ctx.refresh_content()
 
     def apply_changes(self, net_state, save_to_disk):
         NmProfiles(self.context).apply_config(net_state, save_to_disk)

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -24,6 +24,7 @@ import pytest
 from libnmstate.nm.checkpoint import CheckPoint
 from libnmstate.nm.checkpoint import get_checkpoints
 from libnmstate.error import NmstateConflictError
+from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateValueError
 
 
@@ -63,7 +64,6 @@ def test_getting_a_checkpoint(nm_context):
 
     checkpoint = CheckPoint.create(nm_context)
 
-    nm_context.refresh_content()
     checkpoints = get_checkpoints(nm_context.client)
 
     assert len(checkpoints) == 1
@@ -132,6 +132,5 @@ def test_plugin_create_checkpoint_and_timeout(nm_plugin):
     plugin.create_checkpoint(timeout=1)
     time.sleep(2)
 
-    nm_plugin.refresh_content()
-    checkpoints = get_checkpoints(nm_plugin.context.client)
-    assert len(checkpoints) == 0
+    with pytest.raises(NmstateLibnmError):
+        plugin.rollback_checkpoint()


### PR DESCRIPTION
NetworkManager plugin refresh_content() is not needed anymore because
most of the information is being retrieved from Nispor.

The function has been moved to `tests/integration/nm/checkpoint.py`
because there is one integration test that need it.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>