### PR TITLE
nm: Use UUID for controller and parent

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -19,14 +19,30 @@
 
 import pytest
 
+import libnmstate
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import VLAN
 
+from ..testlib import assertlib
 from ..testlib import statelib
 from ..testlib import cmdlib
+from ..testlib.ovslib import Bridge
 
 
 BRIDGE0 = "brtest0"
+IFACE0 = "ovstest0"
+
+
+@pytest.fixture
+def bridge_with_ports(eth1_up):
+    bridge = Bridge(BRIDGE0)
+    bridge.add_system_port("eth1")
+    bridge.add_internal_port(IFACE0, ipv4_state={InterfaceIPv4.ENABLED: False})
+    with bridge.create():
+        yield bridge
 
 
 @pytest.fixture
@@ -41,3 +57,103 @@ def test_do_not_show_unmanaged_ovs_bridge(ovs_unmanaged_bridge):
     # The output should only contains the OVS internal interface
     ovs_internal_iface = statelib.show_only((BRIDGE0,))[Interface.KEY][0]
     assert ovs_internal_iface[Interface.TYPE] == InterfaceType.OVS_INTERFACE
+
+
+@pytest.fixture
+def nmcli_created_ovs_bridge_with_same_name_iface():
+    cmdlib.exec_cmd(
+        "nmcli c add type ovs-bridge connection.id "
+        f"{BRIDGE0} ifname {BRIDGE0}".split()
+    )
+
+    cmdlib.exec_cmd(
+        "nmcli c add type ovs-port connection.id "
+        f"{IFACE0} ifname {IFACE0} "
+        f"connection.master {BRIDGE0} connection.slave-type ovs-bridge".split()
+    )
+
+    cmdlib.exec_cmd(
+        "nmcli c add type ovs-interface connection.id "
+        f"{IFACE0} ifname {IFACE0} "
+        f"ipv4.method disabled ipv6.method disabled "
+        f"connection.master {IFACE0} connection.slave-type ovs-port".split()
+    )
+
+    yield
+    cmdlib.exec_cmd(f"ovs-vsctl del-br {BRIDGE0} {IFACE0} ".split())
+
+
+@pytest.mark.tier1
+def test_create_vlan_over_existing_ovs_iface_with_use_same_name_as_bridge(
+    nmcli_created_ovs_bridge_with_same_name_iface,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "vlan101",
+                Interface.TYPE: InterfaceType.VLAN,
+                VLAN.CONFIG_SUBTREE: {VLAN.ID: 101, VLAN.BASE_IFACE: IFACE0},
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+
+class _OvsProfileStillExists(Exception):
+    pass
+
+
+@pytest.mark.tier1
+def test_remove_ovs_internal_iface_got_port_profile_removed(bridge_with_ports):
+    for ovs_iface_name in bridge_with_ports.ports_names:
+        active_profile_names, active_profile_uuids = _get_nm_active_profiles()
+        assert ovs_iface_name in active_profile_names
+        ovs_port_profile_uuid = _get_ovs_port_profile_uuid_of_ovs_interface(
+            ovs_iface_name
+        )
+        assert ovs_port_profile_uuid
+        assert ovs_port_profile_uuid in active_profile_uuids
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: ovs_iface_name,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
+        )
+
+        rc, output, _ = cmdlib.exec_cmd(
+            f"nmcli c show {ovs_port_profile_uuid}".split(" "),
+        )
+        if rc == 0:
+            raise _OvsProfileStillExists(
+                f"{ovs_port_profile_uuid} still exists: {output}"
+            )
+
+
+def _get_nm_active_profiles():
+    all_profile_names_output = cmdlib.exec_cmd(
+        "nmcli -g NAME connection show --active".split(" "), check=True
+    )[1]
+    all_profile_uuids_output = cmdlib.exec_cmd(
+        "nmcli -g UUID connection show --active".split(" "), check=True
+    )[1]
+    return (
+        all_profile_names_output.split("\n"),
+        all_profile_uuids_output.split("\n"),
+    )
+
+
+def _get_ovs_port_profile_uuid_of_ovs_interface(iface_name):
+    ovs_port_uuid = cmdlib.exec_cmd(
+        f"nmcli -g connection.master connection show {iface_name}".split(" "),
+        check=True,
+    )[1].strip()
+    cmdlib.exec_cmd(
+        f"nmcli -g connection.id connection show {ovs_port_uuid}".split(" "),
+        check=True,
+    )
+    return ovs_port_uuid

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -20,6 +20,8 @@ from contextlib import contextmanager
 
 from libnmstate import error
 
+from ..testlib import cmdlib
+
 
 class MainloopTestError(Exception):
     pass
@@ -32,3 +34,28 @@ def main_context(ctx):
         ctx.wait_all_finish()
     except error.NmstateLibnmError as ex:
         raise MainloopTestError(str(ex.args))
+
+
+def get_nm_active_profiles():
+    all_profile_names_output = cmdlib.exec_cmd(
+        "nmcli -g NAME connection show --active".split(" "), check=True
+    )[1]
+    all_profile_uuids_output = cmdlib.exec_cmd(
+        "nmcli -g UUID connection show --active".split(" "), check=True
+    )[1]
+    return (
+        all_profile_names_output.split("\n"),
+        all_profile_uuids_output.split("\n"),
+    )
+
+
+def get_proxy_port_profile_uuid_of_ovs_interface(iface_name):
+    proxy_port_uuid = cmdlib.exec_cmd(
+        f"nmcli -g connection.master connection show {iface_name}".split(" "),
+        check=True,
+    )[1].strip()
+    cmdlib.exec_cmd(
+        f"nmcli -g connection.id connection show {proxy_port_uuid}".split(" "),
+        check=True,
+    )
+    return proxy_port_uuid

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -19,7 +19,6 @@
 
 from contextlib import contextmanager
 import copy
-import re
 
 import libnmstate
 from libnmstate.schema import Interface
@@ -27,8 +26,6 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge
 from libnmstate.schema import OVSInterface
-
-from . import cmdlib
 
 
 class Bridge:
@@ -152,27 +149,3 @@ def _set_ifaces_state(ifaces, state):
     for iface in ifaces:
         iface[Interface.STATE] = state
     return ifaces
-
-
-def get_nm_active_profiles():
-    all_profiles_output = cmdlib.exec_cmd(
-        "nmcli -g NAME connection show --active".split(" "), check=True
-    )[1]
-    return all_profiles_output.split("\n")
-
-
-def get_proxy_port_profile_name_of_ovs_interface(iface_name):
-    proxy_port_iface_name = cmdlib.exec_cmd(
-        f"nmcli -g connection.master connection show {iface_name}".split(" "),
-        check=True,
-    )[1].strip()
-    all_profiles_output = cmdlib.exec_cmd(
-        "nmcli -g NAME,DEVICE connection show".split(" "), check=True
-    )[1]
-    proxy_port_re = re.compile(
-        f"^(?P<profile_name>.+):{proxy_port_iface_name}$"
-    )
-    for line in all_profiles_output.split("\n"):
-        match = proxy_port_re.match(line)
-        if match:
-            return match.group("profile_name")


### PR DESCRIPTION
When both user space only interface and kernel interface holding the
same name, NetworkManager might the user space interface for
controller/parent which lead to error as NetworkManager failed to find
kernel interface index for it.

Using UUID instead of interface name  in `NM.RemoteConnection.props.master`
, `NM.SettingVlan.props.parent` and etc could solve this problem.

Integration test cases included.