### PR TITLE
ifaces: Don't validate undesired interface for overbook

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -675,6 +675,12 @@ class Ifaces:
         """
         port_controller_map = {}
         for iface in self.all_ifaces():
+            if (
+                not (iface.is_changed or iface.is_desired)
+                or not iface.is_up
+                or iface.is_ignore
+            ):
+                continue
             for port_name in iface.port:
                 cur_controller = port_controller_map.get(port_name)
                 if cur_controller:

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -152,6 +152,18 @@ class TestIfaces:
         with pytest.raises(NmstateValueError):
             Ifaces([des_iface_info1, des_iface_info2], cur_iface_infos)
 
+    def test_ignore_overbooked_port_for_undesired_iface(self):
+        cur_iface_infos = self._gen_iface_infos()
+        cur_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        cur_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        cur_iface_info1 = gen_bridge_iface_info()
+        cur_iface_info2 = gen_bridge_iface_info()
+        cur_iface_info2[Interface.NAME] = "another_bridge"
+        cur_iface_infos.append(cur_iface_info1)
+        cur_iface_infos.append(cur_iface_info2)
+        des_iface_infos = self._gen_iface_infos()
+        Ifaces(des_iface_infos, cur_iface_infos)
+
     def test_remove_unknown_interfaces(self):
         des_iface_infos = self._gen_iface_infos()
         cur_iface_info = {


### PR DESCRIPTION
There is no need to validate overbooked interface for undesired
controller interface.