### PR TITLE
[nmstate-0.3] ifaces: Don't validate undesired interface for overbook

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -437,6 +437,8 @@ class Ifaces:
         """
         slave_master_map = {}
         for iface in self._ifaces.values():
+            if not (iface.is_changed or iface.is_desired) or not iface.is_up:
+                continue
             for slave_name in iface.slaves:
                 cur_master = slave_master_map.get(slave_name)
                 if cur_master:

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -143,6 +143,18 @@ class TestIfaces:
         with pytest.raises(NmstateValueError):
             Ifaces([des_iface_info1, des_iface_info2], cur_iface_infos)
 
+    def test_ignore_overbooked_port_for_undesired_iface(self):
+        cur_iface_infos = self._gen_iface_infos()
+        cur_iface_infos[0][Interface.NAME] = SLAVE1_IFACE_NAME
+        cur_iface_infos[1][Interface.NAME] = SLAVE2_IFACE_NAME
+        cur_iface_info1 = gen_bridge_iface_info()
+        cur_iface_info2 = gen_bridge_iface_info()
+        cur_iface_info2[Interface.NAME] = "another_bridge"
+        cur_iface_infos.append(cur_iface_info1)
+        cur_iface_infos.append(cur_iface_info2)
+        des_iface_infos = self._gen_iface_infos()
+        Ifaces(des_iface_infos, cur_iface_infos)
+
     def test_remove_unknown_interfaces(self):
         des_iface_infos = self._gen_iface_infos()
         cur_iface_info = {


### PR DESCRIPTION
There is no need to validate overbooked interface for undesired
controller interface.

Unit test case included.