### PR TITLE
[nmstate-0.3] nm vlan/vxlan: Use uuid for VLAN/VxLAN parent

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -63,6 +63,13 @@ class ConnectionProfile:
         if self.con_id:
             self.profile = self._ctx.client.get_connection_by_id(self.con_id)
 
+    def import_by_uuid(self, uuid):
+        for nm_profile in self._ctx.client.get_connections():
+            if nm_profile.get_uuid() == uuid:
+                self.profile = nm_profile
+                return
+        logging.debug(f"Failed to find {uuid} profile")
+
     def update(self, con_profile, save_to_disk=True):
         flags = NM.SettingsUpdate2Flags.BLOCK_AUTOCONNECT
         if save_to_disk:


### PR DESCRIPTION
When parent of VLAN/VxLAN is holding the same name of OVS bridge or OVS
port, NetworkManager will fail with error failed to find interface index
of that parent.

The root cause is NetworkManager try to use user space interface as
VLAN/VxLAN parent.

To workaround that, use profile UUID for `NM.SettingVlan.props.parent`
and `NM.SettingVxlan.props.parent`.

Integration test case included.