### PR TITLE
nm: Use fallback checker for profile modification

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -96,7 +96,7 @@ class _ConnectionSetting:
         return self._setting
 
 
-def create_new_nm_simple_conn(iface, nm_profile):
+def create_new_nm_simple_conn(iface, nm_profile, timestamp):
     nm_iface_type = Api2Nm.get_iface_type(iface.type)
     iface_info = iface.to_dict()
     settings = [
@@ -132,7 +132,7 @@ def create_new_nm_simple_conn(iface, nm_profile):
         if wired_setting:
             settings.append(wired_setting)
 
-    user_setting = create_user_setting(iface_info, nm_profile)
+    user_setting = create_user_setting(iface_info, nm_profile, timestamp)
     if user_setting:
         settings.append(user_setting)
 

--- a/libnmstate/nm/user.py
+++ b/libnmstate/nm/user.py
@@ -26,15 +26,13 @@ from libnmstate.error import NmstateValueError
 from .common import NM
 
 NMSTATE_DESCRIPTION = "nmstate.interface.description"
+NMSTATE_PROFILE_TIMESTAMP = "nmstate.profile.timestamp"
 
 
-def create_setting(iface_state, base_con_profile):
+def create_setting(iface_state, base_con_profile, timestamp):
     description = iface_state.get("description")
 
-    if not description:
-        return None
-
-    if not NM.SettingUser.check_val(description):
+    if description and not NM.SettingUser.check_val(description):
         raise NmstateValueError("Invalid description")
 
     user_setting = None
@@ -48,7 +46,9 @@ def create_setting(iface_state, base_con_profile):
     if not user_setting:
         user_setting = NM.SettingUser.new()
 
-    user_setting.set_data(NMSTATE_DESCRIPTION, description)
+    if description:
+        user_setting.set_data(NMSTATE_DESCRIPTION, description)
+    user_setting.set_data(NMSTATE_PROFILE_TIMESTAMP, timestamp)
     return user_setting
 
 
@@ -75,3 +75,11 @@ def get_info(context, device):
         pass
 
     return info
+
+
+def get_timestamp_of_profile(nm_profile):
+    nm_user_setting = nm_profile.get_setting_by_name(
+        NM.SETTING_USER_SETTING_NAME
+    )
+    if nm_user_setting:
+        return nm_user_setting.get_data(NMSTATE_PROFILE_TIMESTAMP)

--- a/tests/lib/nm/user_test.py
+++ b/tests/lib/nm/user_test.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import time
+
 import pytest
 
 from unittest import mock
@@ -31,15 +33,15 @@ def NM_mock():
 
 
 def test_create_no_setting(NM_mock):
-    setting = nm.user.create_setting({}, None)
-    assert setting is None
+    setting = nm.user.create_setting({}, None, f"{time.time()}")
+    assert setting
 
 
 def test_create_setting_duplicate(NM_mock):
     base_profile = mock.MagicMock()
 
     setting = nm.user.create_setting(
-        {"description": "test_interface"}, base_profile
+        {"description": "test_interface"}, base_profile, f"{time.time()}"
     )
     base_profile.get_setting_by_name.assert_called_with(
         NM_mock.SETTING_USER_SETTING_NAME
@@ -51,8 +53,14 @@ def test_create_setting_duplicate(NM_mock):
 
 
 def test_create_setting_description(NM_mock):
-    setting = nm.user.create_setting({"description": "test_interface"}, None)
+    timestamp = f"{time.time()}"
+    setting = nm.user.create_setting(
+        {"description": "test_interface"}, None, timestamp
+    )
     assert setting == NM_mock.SettingUser.new.return_value
-    setting.set_data.assert_called_with(
+    setting.set_data.assert_any_call(
         "nmstate.interface.description", "test_interface"
+    )
+    setting.set_data.assert_any_call(
+        "nmstate.profile.timestamp", timestamp
     )


### PR DESCRIPTION
When updating profile, store the timestamp into `NM.SettingUser` which
will be verified in fallback checker every 15 seconds.