### PR TITLE
bond: add support to vlan+srcmac tx hashing option

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -260,6 +260,7 @@ _BOND_OPTIONS_NUMERIC_TO_NAMED_MAP = {
         "layer2+3",
         "encap2+3",
         "encap3+4",
+        "vlan+srcmac",
     ),
 }
 


### PR DESCRIPTION
The new vlan+srcmac tx hashing option is now available at kernel
upstream. Nmstate is now supporting it.

Ref: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=7b8fc0103bb51d1d3e1fb5fd67958612e709f883

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>