### PR TITLE
[nmstate-0.3] nm: Enforcing auto-connect on ports

### DIFF
--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -51,6 +51,7 @@ from . import wired
 from .common import NM
 from .dns import get_dns_config_iface_names
 from .device import is_externally_managed
+from .device import is_unknown_interface_type
 
 
 MAXIMUM_INTERFACE_LENGTH = 15
@@ -290,7 +291,9 @@ def _set_ifaces_admin_state(context, ifaces_desired_state, con_profiles):
                     == InterfaceState.ABSENT
                 )
                 for affected_nmdev in nmdevs:
-                    if not is_externally_managed(affected_nmdev):
+                    if not is_unknown_interface_type(
+                        affected_nmdev
+                    ) and not is_externally_managed(affected_nmdev):
                         devs_to_deactivate[
                             affected_nmdev.get_iface()
                         ] = affected_nmdev

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -584,7 +584,9 @@ class ConnectionSetting:
         new.props.uuid = base.props.uuid
         new.props.type = base.props.type
         new.props.autoconnect = True
-        new.props.autoconnect_slaves = base.props.autoconnect_slaves
+        new.props.autoconnect_slaves = (
+            NM.SettingConnectionAutoconnectSlaves.YES
+        )
 
         self._setting = new
 

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -20,10 +20,12 @@
 import logging
 
 from libnmstate.error import NmstateLibnmError
+from libnmstate.schema import Interface
 
 from . import active_connection as ac
 from . import connection
 from .common import NM
+from .translator import Nm2Api
 
 
 def activate(context, dev=None, connection_id=None):
@@ -167,3 +169,9 @@ def get_device_common_info(dev):
 def is_externally_managed(nmdev):
     nm_ac = nmdev.get_active_connection()
     return nm_ac and NM.ActivationStateFlags.EXTERNAL & nm_ac.get_state_flags()
+
+
+def is_unknown_interface_type(nm_dev):
+    common_info = get_device_common_info(nm_dev)
+    iface_info = Nm2Api.get_common_device_info(common_info)
+    return iface_info[Interface.TYPE]

--- a/tests/lib/nm/connection_test.py
+++ b/tests/lib/nm/connection_test.py
@@ -129,7 +129,9 @@ def test_duplicate_settings(NM_mock):
     assert new.props.uuid == base.props.uuid
     assert new.props.type == base.props.type
     assert new.props.autoconnect is True
-    assert new.props.autoconnect_slaves == base.props.autoconnect_slaves
+    assert new.props.autoconnect_slaves == (
+        NM_mock.SettingConnectionAutoconnectSlaves.YES
+    )
 
 
 def test_set_master_setting():


### PR DESCRIPTION
Instead of preserving existing configure on
`connection.autoconnect-slaves`, nmstate should enforce it to True which
prevent us from bond/bridge/etc ports not activated.


The `test_ignore_unmanged_tap_as_bridge_port` test case updated, because:

 * After changed to `NM.SettingConnectionAutoconnectSlaves.YES`,
   NetworkManager will activate the external/in-memory profile of tap0
   which cause it lose `NM.ActivationStateFlags.EXTERNAL` flag.
 * Then nmstate will try to deactivate the tap0 profile, which cause its
   profile been auto removed from NetworkManager.
 * Then nmstate try to remove tap0 profile which is actually gone.

To fix the test case, nmstate will not touch unknown type interface.
