### PR TITLE
nm: Enforcing auto-connect on ports

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -81,7 +81,7 @@ class _ConnectionSetting:
         new.props.uuid = base.props.uuid
         new.props.type = base.props.type
         new.props.autoconnect = True
-        new.props.autoconnect_slaves = base.props.autoconnect_slaves
+        new.props.autoconnect_slaves = True
 
         self._setting = new
 


### PR DESCRIPTION
Instead of preserving existing configure on
`connection.autoconnect-slaves`, nmstate should enforce it to True which
prevent us from bond/bridge/etc ports not activated.