### PR TITLE
github: remove Edy github PR default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 # Default reviewers for everything
-* @cathay4t @EdDev @ffmancera
+* @cathay4t @ffmancera


### PR DESCRIPTION
Edy has new interest to play on, let's save him from github emails on
requesting PR review.