### PR TITLE
.github: artifact name depends on the job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,19 +14,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - job_type: "el8:nm_stable:format"
-          - job_type: "el8:nm_stable:lint"
-          - job_type: "el8:nm_stable:unit_py36"
-          - job_type: "el8:nm_stable:integ_tier1"
-          - job_type: "el8:nm_stable:integ_tier2"
-          - job_type: "el8:nm_stable:integ_slow"
-          - job_type: "el8:nm_master:integ_tier1"
-          - job_type: "el8:nm_master:integ_tier2"
-          - job_type: "el8:nm_master:integ_slow"
-          - job_type: "stream:nm_master:integ_tier1"
-          - job_type: "stream:nm_master:integ_slow"
-          - job_type: "ovs2_11:nm_stable:integ_tier1"
-          - job_type: "vdsm_el8:nm_master:vdsm"
+          - job_type: "el8-nm_stable-format"
+          - job_type: "el8-nm_stable-lint"
+          - job_type: "el8-nm_stable-unit_py36"
+          - job_type: "el8-nm_stable-integ_tier1"
+          - job_type: "el8-nm_stable-integ_tier2"
+          - job_type: "el8-nm_stable-integ_slow"
+          - job_type: "el8-nm_master-integ_tier1"
+          - job_type: "el8-nm_master-integ_tier2"
+          - job_type: "el8-nm_master-integ_slow"
+          - job_type: "stream-nm_master-integ_tier1"
+          - job_type: "stream-nm_master-integ_slow"
+          - job_type: "ovs2_11-nm_stable-integ_tier1"
+          - job_type: "vdsm_el8-nm_master-vdsm"
 
     steps:
       - uses: actions/checkout@v2
@@ -50,6 +50,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
-          name: nmstate-test-artifact
+          name: nmstate-test-artifact-${{ matrix.job_type }}
           path: test_artifacts/
           retention-days: 5

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -12,7 +12,7 @@ if [ -z "$JOB_TYPE" ];then
 fi
 
 
-IFS=':' read -r -a array <<< "$JOB_TYPE"
+IFS='-' read -r -a array <<< "$JOB_TYPE"
 
 OS_TYPE="${array[0]}"
 NM_TYPE="${array[1]}"


### PR DESCRIPTION
If multiple jobs fail this is avoiding the overwritting of the
artifacts.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>