### PR TITLE
.github: set test_artifacts/ permissions before uploading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,10 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: .github/workflows/run_test.sh ${{ matrix.job_type }}
 
+      - name: Set artifacts permissions
+        if: ${{ failure() }}
+        run: sudo chmod 777 test_artifacts/*
+
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
When reporting a coredump upload-artifact does not have permissions to
read it. Therefore, we are setting all the test_artifacts/ files to 777.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>