### PR TITLE
nm: Fix auto connection when importing existing profile

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -81,7 +81,9 @@ class _ConnectionSetting:
         new.props.uuid = base.props.uuid
         new.props.type = base.props.type
         new.props.autoconnect = True
-        new.props.autoconnect_slaves = True
+        new.props.autoconnect_slaves = (
+            NM.SettingConnectionAutoconnectSlaves.YES
+        )
 
         self._setting = new
 


### PR DESCRIPTION
The `NM.SettingConnection.props.autoconnect_slaves` should be
`NM.SettingConnectionAutoconnectSlaves.YES` instead of bool.