### PR TITLE
route: Support routes created by iproute command

### DIFF
--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -34,6 +34,7 @@ from .veth import NisporPluginVethIface
 from .vlan import NisporPluginVlanIface
 from .vxlan import NisporPluginVxlanIface
 from .route import nispor_route_state_to_nmstate
+from .route import nispor_route_state_to_nmstate_static
 from .route_rule import nispor_route_rule_state_to_nmstate
 from .vrf import NisporPluginVrfIface
 from .ovs import NisporPluginOvsInternalIface
@@ -133,7 +134,12 @@ class NisporPlugin(NmstatePlugin):
 
     def get_routes(self):
         np_state = NisporNetState.retrieve()
-        return {Route.RUNNING: nispor_route_state_to_nmstate(np_state.routes)}
+        return {
+            Route.RUNNING: nispor_route_state_to_nmstate(np_state.routes),
+            Route.CONFIG: nispor_route_state_to_nmstate_static(
+                np_state.routes
+            ),
+        }
 
     def get_route_rules(self):
         np_state = NisporNetState.retrieve()

--- a/libnmstate/nispor/route.py
+++ b/libnmstate/nispor/route.py
@@ -23,12 +23,27 @@ from libnmstate.schema import Route
 IPV4_DEFAULT_GATEWAY_DESTINATION = "0.0.0.0/0"
 IPV6_DEFAULT_GATEWAY_DESTINATION = "::/0"
 
+LOCAL_ROUTE_TABLE = 255
+
 
 def nispor_route_state_to_nmstate(np_routes):
     return [
         _nispor_route_to_nmstate(rt)
         for rt in np_routes
-        if rt.scope == "universe"
+        if rt.scope in ["universe", "link"]
+        and rt.oif != "lo"
+        and rt.table != LOCAL_ROUTE_TABLE
+    ]
+
+
+def nispor_route_state_to_nmstate_static(np_routes):
+    return [
+        _nispor_route_to_nmstate(rt)
+        for rt in np_routes
+        if rt.scope in ["universe", "link"]
+        and rt.protocol not in ["kernel", "ra", "dhcp"]
+        and rt.oif != "lo"
+        and rt.table != LOCAL_ROUTE_TABLE
     ]
 
 

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -28,7 +28,6 @@ from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LLDP
-from libnmstate.schema import Route
 from libnmstate.plugin import NmstatePlugin
 
 
@@ -51,7 +50,6 @@ from .ovs import get_ovsdb_external_ids
 from .ovs import has_ovs_capability
 from .profiles import NmProfiles
 from .profiles import get_all_applied_configs
-from .route import get_running_config as get_route_running_config
 from .team import get_info as get_team_info
 from .team import has_team_capability
 from .translator import Nm2Api
@@ -132,6 +130,13 @@ class NetworkManagerPlugin(NmstatePlugin):
             if not dev.get_managed():
                 # Skip unmanaged interface
                 continue
+            nm_ac = dev.get_active_connection()
+            if (
+                nm_ac
+                and nm_ac.get_state_flags() & NM.ActivationStateFlags.EXTERNAL
+            ):
+                # Skip external managed interface
+                continue
 
             iface_info = Nm2Api.get_common_device_info(devinfo)
             applied_config = applied_configs.get(iface_info[Interface.NAME])
@@ -175,7 +180,7 @@ class NetworkManagerPlugin(NmstatePlugin):
         return iface_infos
 
     def get_routes(self):
-        return {Route.CONFIG: get_route_running_config(self._applied_configs)}
+        return {}
 
     def get_route_rules(self):
         """

--- a/tests/integration/nm/ip_test.py
+++ b/tests/integration/nm/ip_test.py
@@ -28,6 +28,14 @@ from ..testlib import cmdlib
 from ..testlib import assertlib
 
 
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV4_ADDRESS2 = "192.0.2.1"
+IPV4_NET1 = "198.51.100.0/24"
+IPV6_ADDRESS1 = "2001:db8:1::1"
+IPV6_ADDRESS2 = "2001:db8:1::2"
+IPV6_NET1 = "2001:db8:a::/64"
+
+
 def test_get_applied_config_for_dhcp_state_with_dhcp_enabeld_on_disk(eth1_up):
     iface_state = eth1_up[Interface.KEY][0]
     iface_name = iface_state[Interface.NAME]
@@ -73,3 +81,48 @@ def test_get_applied_config_for_dhcp_state_with_dhcp_disabled_on_disk(
     )
 
     assertlib.assert_state_match({Interface.KEY: [iface_state]})
+
+
+@pytest.fixture
+def eth1_up_with_static_ip_and_route_by_iproute():
+    cmdlib.exec_cmd("ip link set eth1 up".split(), check=True)
+    cmdlib.exec_cmd(
+        f"ip addr add {IPV4_ADDRESS1}/24 dev eth1 ".split(), check=True
+    )
+    cmdlib.exec_cmd(
+        f"ip -6 addr add {IPV6_ADDRESS1}/64 dev eth1 ".split(), check=True
+    )
+    cmdlib.exec_cmd(
+        f"ip route add {IPV4_NET1} via {IPV4_ADDRESS2} dev eth1 ".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        f"ip -6 route add {IPV6_NET1} via {IPV6_ADDRESS2} dev eth1 ".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd("nmcli c down eth1".split())
+    cmdlib.exec_cmd("nmcli c del eth1".split())
+
+
+def test_preserve_static_routes_created_by_iproute(
+    eth1_up_with_static_ip_and_route_by_iproute,
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                }
+            ],
+        }
+    )
+
+    assert (
+        cmdlib.exec_cmd("nmcli -g ipv4.routes c show eth1".split())[1].strip()
+        == "198.51.100.0/24 192.0.2.1 0 table=254"
+    )
+    assert (
+        cmdlib.exec_cmd("nmcli -g ipv6.routes c show eth1".split())[1].strip()
+        == r"2001\:db8\:a\:\:/64 2001\:db8\:1\:\:2 1024 table=254"
+    )

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -202,33 +202,33 @@ def _assert_routes(routes, state):
         if config_route[Route.NEXT_HOP_INTERFACE] == "eth1":
             config_routes.append(config_route)
 
-    config_routes.sort(key=_route_sort_key)
-    assert routes == config_routes
-
-    # The running routes contains more route entries than desired config
-    # The running routes also has different metric and table id for
+    # The kernel routes contains more route entries than desired config
+    # The kernel routes also has different metric and table id for
     # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
+    config_routes.sort(key=_route_sort_key)
+    for route in routes:
+        _assert_in_current_route(route, config_routes)
     running_routes = state[Route.KEY][Route.RUNNING]
     for route in routes:
-        _assert_in_running_route(route, running_routes)
+        _assert_in_current_route(route, running_routes)
 
 
-def _assert_in_running_route(route, running_routes):
-    route_in_running_routes = False
-    for running_route in running_routes:
+def _assert_in_current_route(route, current_routes):
+    route_in_current_routes = False
+    for current_route in current_routes:
         metric = route.get(Route.METRIC, Route.USE_DEFAULT_METRIC)
         table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
         if metric == Route.USE_DEFAULT_METRIC:
-            running_route = copy.deepcopy(running_route)
-            running_route[Route.METRIC] = Route.USE_DEFAULT_METRIC
+            current_route = copy.deepcopy(current_route)
+            current_route[Route.METRIC] = Route.USE_DEFAULT_METRIC
         if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
-            running_route = copy.deepcopy(running_route)
-            running_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+            current_route = copy.deepcopy(current_route)
+            current_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
 
-        if route == running_route:
-            route_in_running_routes = True
+        if route == current_route:
+            route_in_current_routes = True
             break
-    assert route_in_running_routes
+    assert route_in_current_routes
 
 
 def _get_ipv4_test_routes():


### PR DESCRIPTION
In order to persistent routes created by iproute, the `Route.CONFIG`
should also be reported by `nispor`, so that it could be merged and
send to backend for writing to profile.

To do that, we need:
 * NetworkManager don't report interface which is unmanaged or external
   managed.
 * Nispor will include static routes in `Route.CONFIG`.
 * Since we are verifying the kernel status, we should allow kernel
   appending additional routes besides routes in config. So do that,
   we hard coded the `Route.USE_DEFAULT_ROUTE_TABLE` as 254 and ignore
   route metric difference, so RouteEntry could used for `issubset()`
   check.

Integration test case included.