### PR TITLE
route: workaround for removing IPv6 default gateway

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -49,6 +49,7 @@ from .translator import Api2Nm
 IMPORT_NM_DEV_TIMEOUT = 5
 IMPORT_NM_DEV_RETRY_INTERNAL = 0.5
 FALLBACK_CHECKER_INTERNAL = 15
+IPV6_ROUTE_REMOVED = "_ipv6_route_removed"
 
 
 class NmProfile:
@@ -161,6 +162,11 @@ class NmProfile:
                 self._add_action(NmProfile.ACTION_DEACTIVATE)
             elif self._iface.is_virtual and self._nm_dev:
                 self._add_action(NmProfile.ACTION_DELETE_DEVICE)
+
+        if self._iface.raw.get(IPV6_ROUTE_REMOVED):
+            # This is a workaround for NM bug:
+            # https://bugzilla.redhat.com/1837254
+            self._add_action(NmProfile.ACTION_DEACTIVATE_FIRST)
 
         if self._iface.is_controller and self._iface.is_up:
             if self._iface.controller:

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -33,6 +33,9 @@ from .state import StateEntry
 from .state import state_match
 
 
+IPV6_ROUTE_REMOVED = "_ipv6_route_removed"
+
+
 class RouteEntry(StateEntry):
     IPV4_DEFAULT_GATEWAY_DESTINATION = "0.0.0.0/0"
     IPV6_DEFAULT_GATEWAY_DESTINATION = "::/0"
@@ -211,6 +214,16 @@ class RouteState:
             for route in route_set:
                 if not rt.match(route):
                     new_routes.add(route)
+                if route.is_ipv6:
+                    # The routes match and therefore it is being removed.
+                    # Nmstate will check if it is an IPv6 route and if so,
+                    # marking the interface as deactivate first.
+                    #
+                    # This is a workaround for NM bug:
+                    # https://bugzilla.redhat.com/1837254
+                    ifaces.all_kernel_ifaces[iface_name].raw[
+                        IPV6_ROUTE_REMOVED
+                    ] = True
             if new_routes != route_set:
                 self._routes[iface_name] = new_routes
 


### PR DESCRIPTION
Due to NM bug [1], Nmstate is not removing IPv6 default gateway. In
order to workaround this, Nmstate is deactivating first the interface if
an IPv6 route has been removed.

Integration test added.

[1] https://bugzilla.redhat.com/1837254

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>