### PR TITLE
nm.connection: enable autoconnect-slaves only in controllers

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -60,7 +60,7 @@ class _ConnectionSetting:
     def __init__(self, con_setting=None):
         self._setting = con_setting
 
-    def create(self, con_name, iface_name, iface_type):
+    def create(self, con_name, iface_name, iface_type, is_controller):
         con_setting = NM.SettingConnection.new()
         con_setting.props.id = con_name
         con_setting.props.interface_name = iface_name
@@ -69,11 +69,13 @@ class _ConnectionSetting:
         con_setting.props.autoconnect = True
         con_setting.props.autoconnect_slaves = (
             NM.SettingConnectionAutoconnectSlaves.YES
+            if is_controller
+            else NM.SettingConnectionAutoconnectSlaves.DEFAULT
         )
 
         self._setting = con_setting
 
-    def import_by_profile(self, profile):
+    def import_by_profile(self, profile, is_controller):
         base = profile.get_setting_connection()
         new = NM.SettingConnection.new()
         new.props.id = base.props.id
@@ -83,6 +85,8 @@ class _ConnectionSetting:
         new.props.autoconnect = True
         new.props.autoconnect_slaves = (
             NM.SettingConnectionAutoconnectSlaves.YES
+            if is_controller
+            else NM.SettingConnectionAutoconnectSlaves.DEFAULT
         )
 
         self._setting = new
@@ -109,10 +113,12 @@ def create_new_nm_simple_conn(iface, nm_profile):
     ]
     con_setting = _ConnectionSetting()
     if nm_profile and not is_multiconnect_profile(nm_profile):
-        con_setting.import_by_profile(nm_profile)
+        con_setting.import_by_profile(nm_profile, iface.is_controller)
         con_setting.set_profile_name(iface.name)
     else:
-        con_setting.create(iface.name, iface.name, nm_iface_type)
+        con_setting.create(
+            iface.name, iface.name, nm_iface_type, iface.is_controller
+        )
 
     apply_lldp_setting(con_setting, iface_info)
 

--- a/tests/lib/nm/connection_test.py
+++ b/tests/lib/nm/connection_test.py
@@ -37,7 +37,7 @@ def context_mock():
 
 def test_create_setting(NM_mock):
     con_setting = nm.connection._ConnectionSetting()
-    con_setting.create("con-name", "iface-name", "iface-type")
+    con_setting.create("con-name", "iface-name", "iface-type", True)
 
     assert con_setting.setting.props.id == "con-name"
     assert con_setting.setting.props.interface_name == "iface-name"
@@ -46,6 +46,20 @@ def test_create_setting(NM_mock):
     assert con_setting.setting.props.autoconnect is True
     assert con_setting.setting.props.autoconnect_slaves == (
         NM_mock.SettingConnectionAutoconnectSlaves.YES
+    )
+
+
+def test_create_setting_is_not_controller(NM_mock):
+    con_setting = nm.connection._ConnectionSetting()
+    con_setting.create("con-name", "iface-name", "iface-type", False)
+
+    assert con_setting.setting.props.id == "con-name"
+    assert con_setting.setting.props.interface_name == "iface-name"
+    assert con_setting.setting.props.uuid
+    assert con_setting.setting.props.type == "iface-type"
+    assert con_setting.setting.props.autoconnect is True
+    assert con_setting.setting.props.autoconnect_slaves == (
+        NM_mock.SettingConnectionAutoconnectSlaves.DEFAULT
     )
 
 


### PR DESCRIPTION
Only controller interfaces should use "autoconnect-slaves" property.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>