### PR TITLE
veth: fix setting veth with ethernet peer

### DIFF
--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -26,6 +26,10 @@ from .base_iface import BaseIface
 
 
 class EthernetIface(BaseIface):
+    def __init__(self, info, save_to_disk=True):
+        super().__init__(info, save_to_disk)
+        self._is_peer = False
+
     def merge(self, other):
         """
         Given the other_state, update the ethernet interfaces state base on
@@ -56,6 +60,10 @@ class EthernetIface(BaseIface):
             .get(Ethernet.SRIOV_SUBTREE, {})
             .get(Ethernet.SRIOV.TOTAL_VFS, 0)
         )
+
+    @property
+    def is_peer(self):
+        return self._is_peer
 
     def create_sriov_vf_ifaces(self):
         return [

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -163,7 +163,7 @@ class NmProfile:
             self._add_action(NmProfile.ACTION_DELETE_PROFILE)
             if self._iface.is_virtual and self._nm_dev:
                 self._add_action(NmProfile.ACTION_DELETE_DEVICE)
-        elif self._iface.is_up and self._iface.type != InterfaceType.VETH:
+        elif self._iface.is_up and not self._needs_veth_activation():
             self._add_action(NmProfile.ACTION_MODIFIED)
             if not self._nm_dev:
                 if self._iface.type == InterfaceType.OVS_PORT:
@@ -194,7 +194,7 @@ class NmProfile:
             else:
                 self._add_action(NmProfile.ACTION_TOP_MASTER)
 
-        if self._iface.is_up and self._iface.type == InterfaceType.VETH:
+        if self._iface.is_up and self._needs_veth_activation():
             if self._iface.is_peer:
                 self._add_action(NmProfile.ACTION_NEW_VETH_PEER)
             else:
@@ -242,6 +242,11 @@ class NmProfile:
             # activate the newly created profile to remove all kernel
             # settings.
             self._add_action(NmProfile.ACTION_ACTIVATE_FIRST)
+
+    def _needs_veth_activation(self):
+        return self._iface.type == InterfaceType.VETH or (
+            self._iface.type == InterfaceType.ETHERNET and self._iface.is_peer
+        )
 
     def prepare_config(self, save_to_disk, gen_conf_mode=False):
         if self._iface.is_absent or self._iface.is_down:

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -67,6 +67,38 @@ def test_add_veth_not_supported():
     reason="Modifying veth interfaces is not supported on NetworkManager.",
 )
 @pytest.mark.tier1
+def test_add_veth_with_ethernet_peer():
+    d_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VETH1,
+                Interface.TYPE: Veth.TYPE,
+                Interface.STATE: InterfaceState.UP,
+                Veth.CONFIG_SUBTREE: {
+                    Veth.PEER: VETH1PEER,
+                },
+            },
+            {
+                Interface.NAME: VETH1PEER,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+            },
+        ]
+    }
+    try:
+        libnmstate.apply(d_state)
+        assertlib.assert_state_match(d_state)
+    finally:
+        d_state[Interface.KEY][0][Interface.STATE] = InterfaceState.ABSENT
+        d_state[Interface.KEY][1][Interface.STATE] = InterfaceState.ABSENT
+        libnmstate.apply(d_state)
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() <= 1.28,
+    reason="Modifying veth interfaces is not supported on NetworkManager.",
+)
+@pytest.mark.tier1
 def test_add_and_remove_veth():
     with veth_interface(VETH1, VETH1PEER) as desired_state:
         assertlib.assert_state(desired_state)


### PR DESCRIPTION
Nmstate should allow adding a veth interface with an ethernet peer
profile. Example:

```yaml
---
interfaces:
- name: veth1
  type: veth
  state: up
  veth:
    peer: veth2
- name: veth2
  type: ethernet
  state: up
```

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>