### PR TITLE
CI container: Add packages required for IEEE 802.1x.

### DIFF
--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -35,6 +35,8 @@ RUN dnf install -y centos-release-stream && \
                    python3-varlink \
                    libvarlink-util \
                    tcpreplay \
+                   wpa_supplicant \
+                   hostapd \
                    && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -1,7 +1,7 @@
 FROM docker.io/library/centos:8
 
 RUN dnf -y install dnf-plugins-core epel-release && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable networkmanager/NetworkManager-1.26 -y && \
     dnf copr enable nmstate/nispor -y && \
@@ -34,6 +34,8 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    python3-varlink \
                    tcpreplay \
                    libvarlink-util \
+                   wpa_supplicant \
+                   hostapd \
                    && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -11,17 +11,13 @@ RUN dnf -y install dnf-plugins-core && \
                    openvswitch \
                    python3-openvswitch \
                    systemd-udev \
-                   \
                    python3-gobject-base \
                    python3-jsonschema \
                    python3-pyyaml \
                    python3-setuptools \
                    python3-pip \
-                   \
                    python36 \
-                   \
                    python38 \
-                   \
                    dnsmasq \
                    git \
                    iproute \
@@ -31,7 +27,8 @@ RUN dnf -y install dnf-plugins-core && \
                    python3-pytest-cov \
                    rpm-build \
                    tcpreplay \
-                   \
+                   wpa_supplicant \
+                   hostapd \
                    # Below packages for pip (used by tox) to build
                    # python-gobject
                    cairo-devel \


### PR DESCRIPTION
To support IEEE 802.1x in NetworkManager, `wpa_supplicant` is required.

To simulate a IEEE 802.1x server for test purpose, `hostapd` is
required.