### PR TITLE
SRIOV: Remove VF interface when total-vfs decrease

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -194,6 +194,11 @@ class BaseIface:
     def mark_as_desired(self):
         self._is_desired = True
 
+    def mark_as_absent_by_desire(self):
+        self.mark_as_desired()
+        self._info[Interface.STATE] = InterfaceState.ABSENT
+        self._origin_info[Interface.STATE] = InterfaceState.ABSENT
+
     def to_dict(self):
         return deepcopy(self._info)
 

--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -82,6 +82,26 @@ class EthernetIface(BaseIface):
             for i in range(0, self.sriov_total_vfs)
         ]
 
+    def remove_vfs_entry_when_total_vfs_decreased(self):
+        vfs_count = len(
+            self._info[Ethernet.CONFIG_SUBTREE]
+            .get(Ethernet.SRIOV_SUBTREE, {})
+            .get(Ethernet.SRIOV.VFS_SUBTREE, [])
+        )
+        if vfs_count > self.sriov_total_vfs:
+            [
+                self._info[Ethernet.CONFIG_SUBTREE][Ethernet.SRIOV_SUBTREE][
+                    Ethernet.SRIOV.VFS_SUBTREE
+                ].pop()
+                for _ in range(self.sriov_total_vfs, vfs_count)
+            ]
+
+    def get_delete_vf_interface_names(self, old_sriov_total_vfs):
+        return [
+            f"{self.name}v{i}"
+            for i in range(self.sriov_total_vfs, old_sriov_total_vfs)
+        ]
+
 
 def _capitalize_sriov_vf_mac(state):
     vfs = (

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -157,6 +157,7 @@ class Ifaces:
 
             self._create_virtual_port()
             self._create_sriov_vfs_when_changed()
+            self._mark_vf_interface_as_absent_when_sriov_vf_decrease()
             self._validate_unknown_port()
             self._validate_unknown_parent()
             self._validate_infiniband_as_bridge_port()
@@ -239,6 +240,29 @@ class Ifaces:
                         new_ifaces.append(new_iface)
         for new_iface in new_ifaces:
             self._kernel_ifaces[new_iface.name] = new_iface
+
+    def _mark_vf_interface_as_absent_when_sriov_vf_decrease(self):
+        """
+        When SRIOV TOTAL_VFS decreased, we should mark certain VF interfaces
+        as absent and also remove the entry in `Ethernet.SRIOV.VFS_SUBTREE`.
+        """
+        for iface_name, iface in self._kernel_ifaces.items():
+            if iface.type != InterfaceType.ETHERNET or not iface.is_up:
+                continue
+            if iface_name not in self._cur_kernel_ifaces:
+                continue
+            cur_iface = self._cur_kernel_ifaces[iface_name]
+            if (
+                cur_iface.sriov_total_vfs != 0
+                and iface.sriov_total_vfs < cur_iface.sriov_total_vfs
+            ):
+                iface.remove_vfs_entry_when_total_vfs_decreased()
+                for vf_name in iface.get_delete_vf_interface_names(
+                    cur_iface.sriov_total_vfs
+                ):
+                    vf_iface = self._kernel_ifaces.get(vf_name)
+                    if vf_iface:
+                        vf_iface.mark_as_absent_by_desire()
 
     def _pre_edit_validation_and_cleanup(self):
         self._validate_over_booked_port()

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -496,3 +496,66 @@ class TestIfacesSriov:
         assert ifaces.get_iface(
             FOO1_IFACE_NAME, InterfaceType.ETHERNET
         ).is_desired
+
+    def test_vf_been_mark_as_absent_when_srio_total_vf_decreased(self):
+        cur_iface_infos = [
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+        ]
+        cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 3}
+        }
+        cur_iface_infos[1][Interface.NAME] = f"{FOO1_IFACE_NAME}v0"
+        cur_iface_infos[2][Interface.NAME] = f"{FOO1_IFACE_NAME}v1"
+        cur_iface_infos[3][Interface.NAME] = f"{FOO1_IFACE_NAME}v2"
+
+        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
+        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        des_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
+        }
+        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
+
+        absent_iface = ifaces.get_iface(
+            f"{FOO1_IFACE_NAME}v2", InterfaceType.ETHERNET
+        )
+        assert absent_iface.is_desired
+        assert absent_iface.is_absent
+
+    def test_vfs_been_updated_according_to_decreased_total_vfs(self):
+        cur_iface_infos = [
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+        ]
+        cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {
+                Ethernet.SRIOV.TOTAL_VFS: 3,
+                Ethernet.SRIOV.VFS_SUBTREE: [1, 2, 3],
+            }
+        }
+        cur_iface_infos[1][Interface.NAME] = f"{FOO1_IFACE_NAME}v0"
+        cur_iface_infos[2][Interface.NAME] = f"{FOO1_IFACE_NAME}v1"
+        cur_iface_infos[3][Interface.NAME] = f"{FOO1_IFACE_NAME}v2"
+
+        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
+        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        des_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
+        }
+        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
+
+        pf_iface = ifaces.get_iface(FOO1_IFACE_NAME, InterfaceType.ETHERNET)
+        assert (
+            len(
+                pf_iface.to_dict()[Ethernet.CONFIG_SUBTREE][
+                    Ethernet.SRIOV_SUBTREE
+                ][Ethernet.SRIOV.VFS_SUBTREE]
+            )
+            == 2
+        )


### PR DESCRIPTION
When `Ethernet.SRIOV.TOTAL_VFS` decrease, we should mark removed VF
interface as absent.

Both integration and unit test cases have been include.
The integration test has been tested on real SRIOV hardware.