### PR TITLE
[nmstate-0.3] SRIOV: Remove VF interface when total-vfs decrease

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -177,6 +177,11 @@ class BaseIface:
     def mark_as_desired(self):
         self._is_desired = True
 
+    def mark_as_absent_by_desire(self):
+        self.mark_as_desired()
+        self._info[Interface.STATE] = InterfaceState.ABSENT
+        self._origin_info[Interface.STATE] = InterfaceState.ABSENT
+
     def to_dict(self):
         return deepcopy(self._info)
 

--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -74,6 +74,26 @@ class EthernetIface(BaseIface):
             for i in range(0, self.sriov_total_vfs)
         ]
 
+    def remove_vfs_entry_when_total_vfs_decreased(self):
+        vfs_count = len(
+            self._info[Ethernet.CONFIG_SUBTREE]
+            .get(Ethernet.SRIOV_SUBTREE, {})
+            .get(Ethernet.SRIOV.VFS_SUBTREE, [])
+        )
+        if vfs_count > self.sriov_total_vfs:
+            [
+                self._info[Ethernet.CONFIG_SUBTREE][Ethernet.SRIOV_SUBTREE][
+                    Ethernet.SRIOV.VFS_SUBTREE
+                ].pop()
+                for _ in range(self.sriov_total_vfs, vfs_count)
+            ]
+
+    def get_delete_vf_interface_names(self, old_sriov_total_vfs):
+        return [
+            f"{self.name}v{i}"
+            for i in range(self.sriov_total_vfs, old_sriov_total_vfs)
+        ]
+
 
 def _capitalize_sriov_vf_mac(state):
     vfs = (


### PR DESCRIPTION
When `Ethernet.SRIOV.TOTAL_VFS` decrease, we should mark removed VF
interface as absent.

Both integration and unit test cases have been include.
The integration test has been tested on real SRIOV hardware.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>