### PR TITLE
[nmstate-0.3] SR-IOV: Do not create VF profiles automatically

### DIFF
--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -25,6 +25,9 @@ from libnmstate.schema import InterfaceState
 from .base_iface import BaseIface
 
 
+IS_NEW_SR_IOV_VF = "_is_new_sr_iov_vf"
+
+
 class EthernetIface(BaseIface):
     def merge(self, other):
         """
@@ -56,6 +59,13 @@ class EthernetIface(BaseIface):
             .get(Ethernet.SRIOV_SUBTREE, {})
             .get(Ethernet.SRIOV.TOTAL_VFS, 0)
         )
+
+    @property
+    def is_new_sr_iov_vf(self):
+        return self.raw.get(IS_NEW_SR_IOV_VF)
+
+    def mark_as_new_sr_iov_vf(self):
+        self.raw[IS_NEW_SR_IOV_VF] = True
 
     def create_sriov_vf_ifaces(self):
         return [

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -144,6 +144,7 @@ class Ifaces:
                 for new_iface in iface.create_sriov_vf_ifaces():
                     if new_iface.name not in self._ifaces:
                         new_iface.mark_as_desired()
+                        new_iface.mark_as_new_sr_iov_vf()
                         new_ifaces.append(new_iface)
         for new_iface in new_ifaces:
             self._ifaces[new_iface.name] = new_iface

--- a/libnmstate/nm/applier.py
+++ b/libnmstate/nm/applier.py
@@ -119,6 +119,11 @@ def apply_changes(context, net_state, save_to_disk):
         original_desired_iface_state = {}
         if net_state.ifaces.get(ifname):
             iface = net_state.ifaces[ifname]
+            if iface.type == InterfaceType.ETHERNET and iface.is_new_sr_iov_vf:
+                # For new vfs automatically added to the desired state is just
+                # for verification, Nmstate should not create a profile for
+                # them.
+                continue
             if iface.is_desired:
                 original_desired_iface_state = iface.original_dict
             if (

--- a/tests/integration/nm/sriov_test.py
+++ b/tests/integration/nm/sriov_test.py
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+
+import pytest
+
+import libnmstate
+from libnmstate.schema import Ethernet
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+
+from ..testlib import cmdlib
+
+
+def _test_nic_name():
+    return os.environ.get("TEST_REAL_NIC")
+
+
+@pytest.fixture
+def disable_sriov():
+    pf_name = _test_nic_name()
+    iface_info = {
+        Interface.NAME: pf_name,
+        Interface.STATE: InterfaceState.UP,
+        Ethernet.CONFIG_SUBTREE: {
+            Ethernet.SRIOV_SUBTREE: {
+                Ethernet.SRIOV.TOTAL_VFS: 0,
+                Ethernet.SRIOV.VFS_SUBTREE: [],
+            }
+        },
+    }
+    desired_state = {Interface.KEY: [iface_info]}
+    libnmstate.apply(desired_state)
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def sriov_interface(disable_sriov):
+    pf_name = _test_nic_name()
+    iface_info = {
+        Interface.NAME: pf_name,
+        Interface.STATE: InterfaceState.UP,
+        Ethernet.CONFIG_SUBTREE: {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+        },
+    }
+    desired_state = {Interface.KEY: [iface_info]}
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
+)
+def test_create_new_vfs_does_not_generate_a_profile(sriov_interface):
+    desired_state = sriov_interface
+    pf_name = sriov_interface[Interface.KEY][0][Interface.NAME]
+    eth_config = desired_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+    eth_config[Ethernet.SRIOV_SUBTREE][Ethernet.SRIOV.TOTAL_VFS] = 5
+    libnmstate.apply(desired_state)
+    _, out, _ = cmdlib.exec_cmd("nmcli c".split(), check=True)
+
+    assert f"{pf_name}v0" not in out
+    assert f"{pf_name}v1" not in out


### PR DESCRIPTION
As VFs are Ethernet type and Nmstate is automatically adding them to the
desired state and marking them as desired, the profile is being created.
This is wrong as Nmstate should only wait for verification of the VFs.

In order to fix this, the new VF interfaces are being marked as so. This
way Nmstate is not creating the profiles anymore.

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>