### PR TITLE
SR-IOV: increase the verification timeout if SR-IOV is present

### DIFF
--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -65,6 +65,12 @@ class EthernetIface(BaseIface):
     def is_peer(self):
         return self._is_peer
 
+    @property
+    def is_sriov(self):
+        return self.raw.get(Ethernet.CONFIG_SUBTREE, {}).get(
+            Ethernet.SRIOV_SUBTREE
+        )
+
     def create_sriov_vf_ifaces(self):
         return [
             EthernetIface(

--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -62,6 +62,14 @@ class EthernetIface(BaseIface):
         )
 
     @property
+    def sriov_vfs(self):
+        return (
+            self.raw.get(Ethernet.CONFIG_SUBTREE, {})
+            .get(Ethernet.SRIOV_SUBTREE, {})
+            .get(Ethernet.SRIOV.VFS_SUBTREE, [])
+        )
+
+    @property
     def is_peer(self):
         return self._is_peer
 
@@ -107,6 +115,9 @@ class EthernetIface(BaseIface):
             f"{self.name}v{i}"
             for i in range(self.sriov_total_vfs, old_sriov_total_vfs)
         ]
+
+    def check_total_vfs_matches_vf_list(self, total_vfs):
+        return total_vfs == len(self.sriov_vfs)
 
 
 def _capitalize_sriov_vf_mac(state):

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -238,6 +238,8 @@ class Ifaces:
                     if new_iface.name not in self._kernel_ifaces:
                         new_iface.mark_as_desired()
                         new_ifaces.append(new_iface)
+                    else:
+                        self._kernel_ifaces[new_iface.name].mark_as_desired()
         for new_iface in new_ifaces:
             self._kernel_ifaces[new_iface.name] = new_iface
 
@@ -656,6 +658,18 @@ class Ifaces:
                                 cur_iface.state_for_verify(),
                             )
                         )
+                    elif (
+                        iface.type == InterfaceType.ETHERNET and iface.is_sriov
+                    ):
+                        if not cur_iface.check_total_vfs_matches_vf_list(
+                            iface.sriov_total_vfs
+                        ):
+                            raise NmstateVerificationError(
+                                "The NIC exceeded the waiting time for "
+                                "verification and it is failing because "
+                                "the `total_vfs` does not match the VF "
+                                "list length."
+                            )
 
     def gen_dns_metadata(self, dns_state, route_state):
         iface_metadata = dns_state.gen_metadata(self, route_state)


### PR DESCRIPTION
Certain drivers like i40e take a long time to modify the VFs in the
kernel. Nmstate is timing out on verification because of that. In order
to fix this, nmstate is incresing the verification time if SR-IOV is
present on the desired state.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>