### PR TITLE
nmstatectl: Fix return code of set command

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -323,7 +323,7 @@ def show(args):
 
 def set(args):
     warnings.warn("Using 'set' is deprecated, use 'apply' instead.")
-    apply(args)
+    return apply(args)
 
 
 def apply(args):


### PR DESCRIPTION
The deprecated command `set` should still return the error like
old behaviour.