### PR TITLE
[nmstate-0.3]  bridge: do not bring up existing ports 

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -194,7 +194,12 @@ class Ifaces:
         """
         for iface in self._ifaces.values():
             if iface.is_up and iface.is_master:
+                cur_iface = self.current_ifaces.get(iface.name)
                 for slave_name in iface.slaves:
+                    if cur_iface and slave_name in cur_iface.slaves:
+                        # Nmstate should not touch the port interface which has
+                        # already been included in current interface.
+                        continue
                     slave_iface = self._ifaces[slave_name]
                     if not slave_iface.is_desired and not slave_iface.is_up:
                         slave_iface.mark_as_up()


### PR DESCRIPTION
Nmstate should not manage linux bridge unmanaged ports if they are not
being removed from the linux bridge port list.

Nmstate will set the interface as managed in the following situations:

  * The unmanaged port is being removed from the Linux bridge.
  * The Linux bridge is being marked as absent, therefore Nmstate needs
    to manage the unmanaged port in order to deattach it.

Ref: https://bugzilla.redhat.com/1932247

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>