### PR TITLE
[nmstate-0.3] bridge: ignore unmanaged ports always

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -193,7 +193,7 @@ class Ifaces:
         if not defiend in desire state
         """
         for iface in self._ifaces.values():
-            if iface.is_up and iface.is_master:
+            if iface.is_desired and iface.is_up and iface.is_master:
                 cur_iface = self.current_ifaces.get(iface.name)
                 for slave_name in iface.slaves:
                     if cur_iface and slave_name in cur_iface.slaves:
@@ -353,14 +353,17 @@ class Ifaces:
 
     def _remove_unknown_interface_type_slaves(self):
         """
-        When master containing slaves with unknown interface type, they should
-        be removed from master slave list before verifying.
+        When master containing slaves with unknown interface type or down
+        state, they should be removed from master slave list before verifying.
         """
         for iface in self._ifaces.values():
             if iface.is_up and iface.is_master and iface.slaves:
                 for slave_name in iface.slaves:
                     slave_iface = self._ifaces[slave_name]
-                    if slave_iface.type == InterfaceType.UNKNOWN:
+                    if (
+                        slave_iface.type == InterfaceType.UNKNOWN
+                        or slave_iface.state != InterfaceState.UP
+                    ):
                         iface.remove_slave(slave_name)
 
     def verify(self, cur_iface_infos):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -700,6 +700,7 @@ def test_linux_bridge_replace_unmanaged_port(bridge_unmanaged_port, eth1_up):
     iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE] = [
         {LinuxBridge.Port.NAME: "eth1"}
     ]
+    iface_state.pop(Interface.MAC)
     libnmstate.apply({Interface.KEY: [iface_state]})
 
 

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -360,28 +360,7 @@ def test_reapply_bridge_state_does_not_managed_ports(nm_down_unmanaged_dummy1):
 
 
 @pytest.mark.tier1
-def test_remove_unmanaged_bridge_port_managed_it(nm_down_unmanaged_dummy1):
-    with linux_bridge(
-        BRIDGE0,
-        bridge_subtree_state={
-            LB.OPTIONS_SUBTREE: {LB.STP_SUBTREE: {LB.STP.ENABLED: False}}
-        },
-    ) as desired_state:
-        cmdlib.exec_cmd(
-            f"ip link set {DUMMY1} master {BRIDGE0}".split(), check=True
-        )
-        bridge_iface_state = desired_state[Interface.KEY][0]
-        bridge_iface_state[LB.CONFIG_SUBTREE] = {LB.PORT_SUBTREE: []}
-        libnmstate.apply(desired_state)
-        _, out, _ = cmdlib.exec_cmd(
-            f"nmcli -f GENERAL.STATE d show {DUMMY1}".split(), check=True
-        )
-
-        assert "unmanaged" not in out
-
-
-@pytest.mark.tier1
-def test_remove_bridge_manage_unmanaged_port(nm_down_unmanaged_dummy1):
+def test_remove_bridge_manage_not_managed_port(nm_down_unmanaged_dummy1):
     with linux_bridge(
         BRIDGE0,
         bridge_subtree_state={
@@ -396,7 +375,7 @@ def test_remove_bridge_manage_unmanaged_port(nm_down_unmanaged_dummy1):
         f"nmcli -f GENERAL.STATE d show {DUMMY1}".split(), check=True
     )
 
-    assert "unmanaged" not in out
+    assert "unmanaged" in out
 
 
 @pytest.mark.tier1
@@ -412,10 +391,7 @@ def test_attach_port_does_not_manage_unmanage_ports(nm_down_unmanaged_dummy1):
         )
         bridge_iface_state = desired_state[Interface.KEY][0]
         bridge_iface_state[LB.CONFIG_SUBTREE] = {
-            LB.PORT_SUBTREE: [
-                {Bridge.Port.NAME: DUMMY1},
-                {Bridge.Port.NAME: ETH1},
-            ]
+            LB.PORT_SUBTREE: [{Bridge.Port.NAME: ETH1}]
         }
         libnmstate.apply(desired_state)
         _, out, _ = cmdlib.exec_cmd(


### PR DESCRIPTION
Nmstate will ignore unmanaged ports. If an existing unmanaged port of a
bridge is not being included in the desired state bridge port list, it
will not be removed. Basically, Nmstate will not be able to remove
unmanaged ports from a bridge.

Ref: https://bugzilla.redhat.com/1932247

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>