### PR TITLE
nm: Don't touch unmanaged interface unless desired

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -322,6 +322,9 @@ class BaseIface:
     def mark_as_up(self):
         self.raw[Interface.STATE] = InterfaceState.UP
 
+    def mark_as_ignored(self):
+        self.raw[Interface.STATE] = InterfaceState.IGNORE
+
     @property
     def is_controller(self):
         return False

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -108,7 +108,13 @@ def rollback(*, checkpoint=None):
 
 def _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk):
     for plugin in plugins:
+        for iface_name in plugin.get_ignored_kernel_interface_names():
+            iface = net_state.ifaces.all_kernel_ifaces.get(iface_name)
+            if iface and not iface.is_desired:
+                iface.mark_as_ignored()
+    for plugin in plugins:
         plugin.apply_changes(net_state, save_to_disk)
+
     verified = False
     if verify_change:
         if _net_state_contains_sriov_interface(net_state):

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -159,7 +159,11 @@ class NisporPlugin(NmstatePlugin):
         np_state = NisporNetState.retrieve()
         logging.debug(f"Nispor: current network state {np_state}")
         for iface in net_state.ifaces.all_ifaces():
-            if iface.is_desired:
+            if iface.is_ignore:
+                logging.debug(
+                    f"Nispor: Interface {iface.name} {iface.type} ignored"
+                )
+            elif iface.is_desired:
                 logging.debug(
                     f"Nispor: desired network state {iface.to_dict()}"
                 )

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -128,3 +128,10 @@ class NmstatePlugin(metaclass=ABCMeta):
         persistently.
         """
         return []
+
+    def get_ignored_kernel_interface_names(self):
+        """
+        Return a list of kernel interface names which should be ignored
+        during verification stage.
+        """
+        return []

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -25,7 +25,6 @@ import yaml
 
 import libnmstate
 from libnmstate.error import NmstateKernelIntegerRoundedError
-from libnmstate.error import NmstateLibnmError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.prettystate import PrettyState
@@ -697,14 +696,9 @@ def test_moving_ports_from_absent_interface(bridge0_with_port0):
     )
 
 
-@pytest.mark.xfail(
-    reason="https://bugzilla.redhat.com/1869063 and "
-    "https://bugzilla.redhat.com/1869079",
-    raises=(NmstateLibnmError, NmstateVerificationError),
-    strict=True,
-)
 def test_linux_bridge_replace_unmanaged_port(bridge_unmanaged_port, eth1_up):
     iface_state = bridge_unmanaged_port[Interface.KEY][0]
+    iface_state.pop(Interface.MAC)
     iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE] = [
         {LinuxBridge.Port.NAME: "eth1"}
     ]


### PR DESCRIPTION
We should ignore NetworkManager unmanaged interface when applying and
verifying unless certain interface listed in desired state explicitly.

Introduced new plugin interface
`NmstatePlugin.get_ignored_kernel_interface_names()` where plugin may
include a list of interface names which should be ignored during
verification stage.

Integration test case added to simulate CNV usage on partial editing
a linux bridge holding NM unmanaged interface.