### PR TITLE
[nmstate-0.3] bridge/bond: New property `Interface.COPY_MAC_FROM`

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -391,6 +391,20 @@ class BaseIface:
         for family, rules in route_rule_metadata.items():
             self.raw[family][BaseIface.ROUTE_RULES_METADATA] = rules
 
+    @property
+    def copy_mac_from(self):
+        return self._info.get(Interface.COPY_MAC_FROM)
+
+    def apply_copy_mac_from(self, mac):
+        """
+        * Add MAC to original desire.
+        * Remove Interface.COPY_MAC_FROM from original desire.
+        * Update MAC of merge iface
+        """
+        self.raw[Interface.MAC] = mac
+        self._origin_info[Interface.MAC] = mac
+        self._origin_info.pop(Interface.COPY_MAC_FROM, None)
+
 
 def _remove_empty_description(state):
     if state.get(Interface.DESCRIPTION) == "":

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -44,6 +44,7 @@ class Interface:
 
     MAC = "mac-address"
     MTU = "mtu"
+    COPY_MAC_FROM = "copy-mac-from"
 
 
 class Route:

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -249,6 +249,8 @@ definitions:
           type: string
           enum:
             - bond
+        copy-mac-from:
+          type: string
         link-aggregation:
           type: object
           properties:
@@ -267,6 +269,8 @@ definitions:
         - $ref: "#/definitions/interface-linux-bridge/ro"
     ro:
       properties:
+        copy-mac-from:
+          type: string
         bridge:
           type: object
           properties:

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -887,3 +887,16 @@ def test_remove_mode4_bond_and_create_mode5_with_the_same_slaves(
         BOND99, slaves, extra_iface_state=extra_iface_state
     ) as state:
         assertlib.assert_state_match(state)
+
+
+@pytest.mark.tier1
+def test_create_bond_with_copy_mac_from(eth1_up, eth2_up):
+    eth2_mac = eth2_up[Interface.KEY][0][Interface.MAC]
+
+    with bond_interface(
+        BOND99,
+        ["eth1", "eth2"],
+        extra_iface_state={Interface.COPY_MAC_FROM: "eth2"},
+    ):
+        current_state = statelib.show_only((BOND99,))
+        assert_mac_address(current_state, eth2_mac)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -751,3 +751,17 @@ def test_change_multicast_snooping_from_false_to_true(port0_up, port1_up):
             LinuxBridge.Options.MULTICAST_SNOOPING
         ] = True
         libnmstate.apply(lb_state)
+
+
+@pytest.mark.tier1
+def test_create_linux_bridge_with_copy_mac_from(eth1_up, eth2_up):
+    eth2_mac = eth2_up[Interface.KEY][0][Interface.MAC]
+    bridge_state = _create_bridge_subtree_config(["eth1", "eth2"])
+
+    with linux_bridge(
+        TEST_BRIDGE0,
+        bridge_state,
+        extra_iface_state={Interface.COPY_MAC_FROM: "eth2"},
+    ):
+        current_state = show_only((TEST_BRIDGE0,))
+        assert_mac_address(current_state, eth2_mac)


### PR DESCRIPTION
Introducing `Interface.COPY_MAC_FROM` allowing bridge or bond
to use MAC address from specified port.

Example:

```yaml
---
interfaces:
- name: bond99
  type: bond
  state: up
  copy-mac-from: eth1
  link-aggregation:
    mode: balance-rr
    port:
    - eth2
    - eth1
```

Integration test case included.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>