### PR TITLE
[nmstate-0.3] ovs: do not set ovs-bridge as master if duplicate names are present

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -295,8 +295,15 @@ class BaseIface:
     def gen_metadata(self, ifaces):
         if self.is_master and not self.is_absent:
             for slave_name in self.slaves:
-                slave_iface = ifaces[slave_name]
-                slave_iface.set_master(self.name, self.type)
+                if slave_name != self.name:
+                    slave_iface = ifaces[slave_name]
+                    slave_iface.set_master(self.name, self.type)
+                else:
+                    logging.warning(
+                        f"The interface {self.name} is setting {slave_name} as"
+                        " port. Multiple interfaces with names are not"
+                        " supported and unexpected errors may occur."
+                    )
 
     def update(self, info):
         self._info.update(info)

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -158,6 +158,10 @@ def _get_interface_info_from_plugins(plugins):
             iface[IFACE_PRIORITY_METADATA] = plugin.priority
             iface_name = iface[Interface.NAME]
             if iface_name in all_ifaces:
+                logging.debug(
+                    f"Interface {iface_name} found. Merging the interface "
+                    "information."
+                )
                 existing_iface = all_ifaces[iface_name]
                 existing_priority = existing_iface[IFACE_PRIORITY_METADATA]
                 current_priority = plugin.priority

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -18,6 +18,7 @@
 #
 
 from collections import defaultdict
+import logging
 
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
@@ -171,6 +172,11 @@ class RouteState:
                 self._cur_routes[rt.next_hop_interface].add(rt)
                 if not ifaces or rt.is_valid(ifaces):
                     self._routes[rt.next_hop_interface].add(rt)
+                else:
+                    logging.debug(
+                        f"The current route {entry} has been discarded due"
+                        f" to {rt.invalid_reason}"
+                    )
         if des_route_state:
             self._merge_routes(des_route_state, ifaces)
 

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -34,12 +34,16 @@ from libnmstate.schema import VLAN
 from .testlib import main_context
 from ..testlib import cmdlib
 from ..testlib import assertlib
+from ..testlib.retry import retry_till_true_or_timeout
 
 
 BRIDGE0 = "brtest0"
 ETH1 = "eth1"
 ETH2 = "eth2"
 BOND0 = "bond0"
+OVS_DUP_NAME = "br-ex"
+
+VERIFY_RETRY_TMO = 5
 
 
 @pytest.fixture
@@ -378,6 +382,105 @@ def ovs_bridge_over_bond_system_iface_with_same_name(eth1_up, eth2_up):
     time.sleep(1)
 
 
+def _nmcli_ovs_bridge_with_ipv4_dns():
+    nmcli_ovs_interface = (
+        "nmcli",
+        "connection",
+        "add",
+        "type",
+        "ovs-interface",
+        "slave-type",
+        "ovs-port",
+        "conn.interface",
+        "br-ex",
+        "master",
+        "ovs-port-br-ex",
+        "con-name",
+        "ovs-if-br-ex",
+        "ipv4.method",
+        "manual",
+        "ipv4.addr",
+        "192.0.2.2/24",
+        "ipv4.dns",
+        "192.0.2.1",
+        "ipv4.routes",
+        "0.0.0.0/0 192.0.2.1",
+    )
+    cmdlib.exec_cmd(nmcli_ovs_interface, check=True)
+
+
+def _verify_ovs_activated(ovs_name):
+    ret, out, err = cmdlib.exec_cmd(
+        f"nmcli --field GENERAL.STATE device show {ovs_name}".split(),
+        check=True,
+    )
+    connected = "connected" in out
+    ret, out, err = cmdlib.exec_cmd(
+        f"nmcli --field IP4.ADDRESS device show {ovs_name}".split(),
+        check=True,
+    )
+    ipv4_configured = "192.0.2.2/24" in out
+    ret, out, err = cmdlib.exec_cmd(
+        f"nmcli --field IP4.ROUTE device show {ovs_name}".split(), check=True,
+    )
+    route_configured = "0.0.0.0/0" in out
+    return connected and ipv4_configured and route_configured
+
+
+@pytest.fixture
+def ovs_bridge_first_and_ovs_interface_with_same_name_ipv4():
+    # The order on this function is important. The OVS bridge must be defined
+    # before the OVS interface.
+    cmdlib.exec_cmd(
+        "nmcli connection add type ovs-port conn.interface br-ex master br-ex "
+        "con-name ovs-port-br-ex".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        "nmcli connection add type ovs-bridge con-name br-ex conn.interface "
+        "br-ex".split(),
+        check=True,
+    )
+    _nmcli_ovs_bridge_with_ipv4_dns()
+    # Wait a little bit for NM to activate above interfaces to do not hit race
+    # problems.
+    assert retry_till_true_or_timeout(
+        VERIFY_RETRY_TMO, _verify_ovs_activated, OVS_DUP_NAME
+    )
+    yield
+    cmdlib.exec_cmd(
+        "nmcli connection del ovs-port-br-ex br-ex ovs-if-br-ex".split(),
+        check=True,
+    )
+
+
+@pytest.fixture
+def ovs_interface_first_and_ovs_bridge_with_same_name_ipv4():
+    # The order on this function is important. The OVS interface must be
+    # defined before the OVS bridge.
+    cmdlib.exec_cmd(
+        "nmcli connection add type ovs-port conn.interface br-ex master br-ex "
+        "con-name ovs-port-br-ex".split(),
+        check=True,
+    )
+    _nmcli_ovs_bridge_with_ipv4_dns()
+    cmdlib.exec_cmd(
+        "nmcli connection add type ovs-bridge con-name br-ex conn.interface "
+        "br-ex".split(),
+        check=True,
+    )
+    # Wait a little bit for NM to activate above interfaces to do not hit race
+    # problems.
+    assert retry_till_true_or_timeout(
+        VERIFY_RETRY_TMO, _verify_ovs_activated, OVS_DUP_NAME
+    )
+    yield
+    cmdlib.exec_cmd(
+        "nmcli connection del ovs-port-br-ex br-ex ovs-if-br-ex".split(),
+        check=True,
+    )
+
+
 @pytest.mark.tier1
 def test_create_vlan_over_ovs_system_interface_bond_with_same_name(
     ovs_bridge_over_bond_system_iface_with_same_name,
@@ -406,3 +509,36 @@ def test_create_vlan_over_ovs_system_interface_bond_with_same_name(
                 ]
             }
         )
+
+
+@pytest.mark.tier1
+def test_modify_state_with_ovs_dup_name_ovs_bridge_first_with_ipv4_dns(
+    ovs_bridge_first_and_ovs_interface_with_same_name_ipv4,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: ETH1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+
+@pytest.mark.tier1
+def test_modify_state_with_ovs_dup_name_ovs_interface_first_with_ipv4_dns(
+    ovs_interface_first_and_ovs_bridge_with_same_name_ipv4,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: ETH1,
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state(desired_state)


### PR DESCRIPTION
When OVS interfaces are present with duplicate names i.e ovs-bridge,
ovs-interface and ovs-port with the same name, Nmstate is merging the
information to show it.

As Nmstate needs to store the DNS configuration as part of the
configuration of an interface, When the ovs-bridge is being reported
first than the ovs-interface, the IP configuration is being removed
internally. If the DNS configuration was stored on the ovs-bridge, it
will fail because the IP configuration is required.

This solution only solves the following error and does not provide
duplicate names support.

```
  File "/usr/bin/nmstatectl", line 11, in <module>
    load_entry_point('nmstate==0.3.4', 'console_scripts', 'nmstatectl')()
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 67, in main
    return args.func(args)
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 267, in apply
    args.save_to_disk,
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 289, in apply_state
    save_to_disk=save_to_disk,
  File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 71, in apply
    net_state = NetState(desired_state, current_state, save_to_disk)
  File "/usr/lib/python3.6/site-packages/libnmstate/net_state.py", line 58, in __init__
    self._ifaces.gen_dns_metadata(self._dns, self._route)
  File "/usr/lib/python3.6/site-packages/libnmstate/ifaces/ifaces.py", line 408, in gen_dns_metadata
    iface_metadata = dns_state.gen_metadata(self, route_state)
  File "/usr/lib/python3.6/site-packages/libnmstate/dns.py", line 116, in gen_metadata
    "name servers: %s" % server
libnmstate.error.NmstateValueError: Failed to find suitable interface for saving DNS name servers: 8.8.8.8
```

Ref: https://bugzilla.redhat.com/1939557

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>