### PR TITLE
tests, bond: remove replacing port keeps mac test 

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -387,23 +387,6 @@ def test_adding_port_to_empty_bond_doesnt_keep_mac(eth1_up):
         )
 
 
-@pytest.mark.tier1
-def test_replacing_port_keeps_mac_of_existing_bond(bond99_with_eth2, eth1_up):
-    desired_state = bond99_with_eth2
-    bond_state = desired_state[Interface.KEY][0]
-    eth1_name = eth1_up[Interface.KEY][0][Interface.NAME]
-    bond_state[Bond.CONFIG_SUBTREE][Bond.PORT] = [eth1_name]
-
-    current_state = statelib.show_only((bond_state[Interface.NAME],))
-
-    libnmstate.apply(desired_state)
-    modified_state = statelib.show_only((bond_state[Interface.NAME],))
-    assert (
-        modified_state[Interface.KEY][0][Interface.MAC]
-        == current_state[Interface.KEY][0][Interface.MAC]
-    )
-
-
 def test_removing_port_keeps_mac_of_existing_bond(bond99_with_2_port, eth1_up):
     desired_state = bond99_with_2_port
     bond_state = desired_state[Interface.KEY][0]


### PR DESCRIPTION
Due to commit [1], NetworkManager is not keeping the bond mac address
when replacing ports. This change affects NM 1.30 and greater.

[1] https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/190fd9aa9f3fbf5705c2b80b9fc64c89d22b7593

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>