### PR TITLE
[nmstate-1.0] .github: use ubuntu-18.04 on the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install git gnupg2 openssh-client tox xz-utils
+          sudo apt install git gnupg2 openssh-client python-tox xz-utils
 
       - name: Start docker service
         run: sudo service docker start


### PR DESCRIPTION
The VRF support has been dropped on the last update of ubuntu-latest on
github actions. In order to support VRF tests, Nmstate will use
ubuntu-18.04 on its CI.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>