### PR TITLE
CI: Use NM 1.30 for NM stable testing

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -3,7 +3,7 @@ FROM docker.io/library/centos:8
 RUN dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf copr enable nmstate/ovs-el8 -y && \
-    dnf copr enable networkmanager/NetworkManager-1.26 -y && \
+    dnf copr enable networkmanager/NetworkManager-1.30 -y && \
     dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -1,7 +1,7 @@
 FROM docker.io/library/fedora:32
 
 RUN dnf -y install dnf-plugins-core && \
-    dnf copr enable networkmanager/NetworkManager-1.26 -y && \
+    dnf copr enable networkmanager/NetworkManager-1.30 -y && \
     dnf copr enable nmstate/nispor -y && \
     dnf -y install --setopt=install_weak_deps=False \
                    NetworkManager \


### PR DESCRIPTION
Use NM 1.30 for testing against NM stable version.