### PR TITLE
[nmstate-0.3] CI: CentOS changed repo name to `powertools`

### DIFF
--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -1,7 +1,7 @@
 FROM docker.io/library/centos:8
 
 RUN dnf -y install dnf-plugins-core epel-release && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf copr enable nmstate/ovs-el8 -y && \
     dnf copr enable networkmanager/NetworkManager-1.26 -y && \
     dnf -y install --setopt=install_weak_deps=False \


### PR DESCRIPTION
Changed from `PowerTools` to `powertools`.