### PR TITLE
test, integ: fix expected output of a plugin test

### DIFF
--- a/tests/integration/plugin_test.py
+++ b/tests/integration/plugin_test.py
@@ -126,6 +126,7 @@ LO_IFACE_INFO = {
     Interface.NAME: "lo",
     Interface.TYPE: InterfaceType.UNKNOWN,
     Interface.STATE: InterfaceState.UP,
+    Interface.ACCEPT_ALL_MAC_ADDRESSES: False,
     Interface.IPV4: {
         InterfaceIPv4.ENABLED: True,
         InterfaceIPv4.ADDRESS: [


### PR DESCRIPTION
This patch is fixing the expected output of the plugin test
`test_network_manager_plugin_with_daemon_stopped`.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>