### PR TITLE
bond: normalize bond options for warnings

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -202,19 +202,37 @@ class BondIface(BaseIface):
             Bond.OPTIONS_SUBTREE, {}
         )
         for key, value in self_bond_options.items():
-            current_value = current_bond_options.get(key)
-            if current_value != value:
+            (
+                current_value,
+                value_set,
+            ) = self._normalize_bond_option_for_matching(
+                current_bond_options.get(key), value
+            )
+            if current_value != value_set:
                 if current_value is None:
                     logging.warning(
-                        f"Desire iface {self.name} bond option {key}={value} "
-                        f"is invalid in kernel for bond mode {self.bond_mode}"
+                        f"Desire iface {self.name} bond option "
+                        f"{key}={value_set} is invalid in kernel for bond mode"
+                        f" {self.bond_mode}"
                     )
                 else:
                     logging.warning(
-                        f"Desire iface {self.name} bond option {key}={value} "
-                        f"does not match with kernel value: {current_value}"
+                        f"Desire iface {self.name} bond option "
+                        f"{key}={value_set} does not match with kernel value:"
+                        f" {current_value}"
                     )
         return state_match(self_state, current_state)
+
+    def _normalize_bond_option_for_matching(self, current_value, value):
+        """
+        This is normalizing the values just for matching. This is required in
+        order to avoid false warnings like:
+            * Uppercase vs Lowercase
+        """
+        if isinstance(current_value, str) and isinstance(value, str):
+            return current_value.lower(), value.lower()
+        else:
+            return current_value, value
 
 
 class _BondNamedOptions:


### PR DESCRIPTION
Nmstate raises warning when bond options do not match i.e kernel option
does not match current option. When setting mac addresses values in
lowercase and then setting the same one in uppercase, Nmstate does not
modify kernel value and raises a warning.

This is solving the following issue for all string options like mac
addresses.

```
2020-11-09 17:30:48,647 root         WARNING  Desire iface bond1 bond
option ad_actor_system=d4:ee:07:25:42:5a does not match with kernel
value: D4:EE:07:25:42:5A
```

Ref: https://bugzilla.redhat.com/1895851

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>