### PR TITLE
tests, integ: create a vlan with different name and id

### DIFF
--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -32,6 +32,7 @@ from libnmstate.schema import InterfaceType
 from .testlib import assertlib
 from .testlib import statelib
 from .testlib.assertlib import assert_mac_address
+from .testlib.env import nm_major_minor_version
 from .testlib.vlan import vlan_interface
 
 VLAN_IFNAME = "eth1.101"
@@ -190,6 +191,19 @@ def test_add_new_base_iface_with_vlan():
         for ifstate in desired_state[Interface.KEY]:
             ifstate[Interface.STATE] = InterfaceState.ABSENT
         libnmstate.apply(desired_state, verify_change=False)
+
+
+@pytest.mark.xfail(
+    nm_major_minor_version() < 1.31,
+    reason="Ref: https://bugzilla.redhat.com/1902976",
+    raises=NmstateVerificationError,
+    strict=True,
+)
+def test_add_vlan_with_mismatching_name_and_id(eth1_up):
+    with vlan_interface(
+        VLAN_IFNAME, 200, eth1_up[Interface.KEY][0][Interface.NAME]
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
 
 
 @contextmanager


### PR DESCRIPTION
Due to a bug on NetworkManager it was not possible to create a vlan with
a different name and id. If the user specified vlan0 but set the id 10,
NetworkManager was creating the vlan0 with id 0 ignoring the id set by
the user.

Ref: https://bugzilla.redhat.com/1902976

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>