### PR TITLE
tests, integ: extend accept-all-mac-addresses testing

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1046,3 +1046,19 @@ def test_replacing_port_set_mac_of_new_port_on_bond(bond99_with_eth2, eth1_up):
         eth1_up[Interface.KEY][0][Interface.MAC]
         == current_state[Interface.KEY][0][Interface.MAC]
     )
+
+
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_major_minor_version() < 1.31,
+    reason="Modifying accept-all-mac-addresses is not supported on NM.",
+)
+def test_bond_enable_and_disable_accept_all_mac_addresses(bond88_with_port):
+    desired_state = bond88_with_port
+    desired_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = True
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+    desired_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -221,6 +221,26 @@ def test_veth_as_vlan_base_iface():
     libnmstate.apply(d_state)
 
 
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_major_minor_version() < 1.31,
+    reason="Modifying accept-all-mac-addresses is not supported on NM.",
+)
+@pytest.mark.tier1
+def test_veth_enable_and_disable_accept_all_mac_addresses():
+    with veth_interface(VETH1, VETH1PEER) as d_state:
+        d_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = True
+        libnmstate.apply(d_state)
+        assertlib.assert_state(d_state)
+
+        d_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
+        libnmstate.apply(d_state)
+        assertlib.assert_state(d_state)
+
+    assertlib.assert_absent(VETH1)
+    assertlib.assert_absent(VETH1PEER)
+
+
 @contextmanager
 def bridges_with_port():
     d_state = {

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -225,6 +225,26 @@ def test_add_vlan_and_modify_vlan_id(eth1_up):
     assertlib.assert_absent(VLAN_IFNAME)
 
 
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_major_minor_version() < 1.31,
+    reason="Modifying accept-all-mac-addresses is not supported on NM.",
+)
+def test_vlan_enable_and_disable_accept_all_mac_addresses(eth1_up):
+    with vlan_interface(
+        VLAN_IFNAME, 101, eth1_up[Interface.KEY][0][Interface.NAME]
+    ) as d_state:
+        d_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = True
+        libnmstate.apply(d_state)
+        assertlib.assert_state(d_state)
+
+        d_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
+        libnmstate.apply(d_state)
+        assertlib.assert_state(d_state)
+
+    assertlib.assert_absent(VLAN_IFNAME)
+
+
 @contextmanager
 def two_vlans_on_eth1():
     desired_state = create_two_vlans_state()


### PR DESCRIPTION
In NetworkManager `accept-all-mac-addresses` works in different ways
for virtual interfaces. These tests is making sure we are covering the
feature in the virtual interfaces too.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>