### PR TITLE
ethtool: Introduce pause support

### DIFF
--- a/libnmstate/ifaces/ethtool.py
+++ b/libnmstate/ifaces/ethtool.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from copy import deepcopy
+import logging
+
+from libnmstate.schema import Ethtool
+
+
+class IfaceEthtool:
+    def __init__(self, ethtool_info):
+        self._info = ethtool_info
+        self._pause = None
+        if self._info.get(Ethtool.Pause.CONFIG_SUBTREE):
+            self._pause = IfaceEthtoolPause(
+                self._info[Ethtool.Pause.CONFIG_SUBTREE]
+            )
+
+    @property
+    def pause(self):
+        return self._pause
+
+    def pre_edit_validation_and_cleanup(self, original_desire):
+        if self.pause:
+            self.pause.pre_edit_validation_and_cleanup(
+                IfaceEthtoolPause(
+                    original_desire.get(Ethtool.Pause.CONFIG_SUBTREE, {})
+                )
+            )
+
+    def canonicalize(self):
+        if self.pause:
+            self.pause.canonicalize()
+
+    def to_dict(self):
+        if self.pause:
+            return {Ethtool.Pause.CONFIG_SUBTREE: self.pause.to_dict()}
+        else:
+            return {}
+
+
+class IfaceEthtoolPause:
+    def __init__(self, pause_info):
+        self._info = pause_info
+
+    @property
+    def autoneg(self):
+        return self._info.get(Ethtool.Pause.AUTO_NEGOTIATION)
+
+    @property
+    def rx(self):
+        return self._info.get(Ethtool.Pause.RX)
+
+    @property
+    def tx(self):
+        return self._info.get(Ethtool.Pause.TX)
+
+    def pre_edit_validation_and_cleanup(self, original_desire):
+        """
+        When AUTO_NEGOTIATION is enabled, RX and TX should be ignored.
+        Log warnning if desired has AUTO_NEGOTIATION: True and RX/TX
+        configured.
+        """
+        if self.autoneg and (
+            original_desire.rx is not None or original_desire.tx is not None
+        ):
+            logging.warn(
+                "Ignoring RX/TX configure of ethtool PAUSE when "
+                "AUTO_NEGOTIATION enabled"
+            )
+        self.canonicalize()
+
+    def canonicalize(self):
+        """
+        Remove RX/TX when AUTO_NEGOTIATION is enabled.
+        """
+        if self.autoneg:
+            self._info.pop(Ethtool.Pause.RX, None)
+            self._info.pop(Ethtool.Pause.TX, None)
+
+    def to_dict(self):
+        return deepcopy(self._info)

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -25,6 +25,7 @@ from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import Ethtool
 
 
 DEFAULT_MAC_ADDRESS = "00:00:00:00:00:00"
@@ -95,6 +96,10 @@ class NisporPluginBaseIface:
         ip_info = self._ip_info(config_only)
         if ip_info:
             iface_info.update(ip_info)
+        if self.np_iface.ethtool:
+            ethtool_info_dict = EthtoolInfo(self.np_iface.ethtool).to_dict()
+            if ethtool_info_dict:
+                iface_info[Ethtool.CONFIG_SUBTREE] = ethtool_info_dict
 
         return iface_info
 
@@ -162,3 +167,20 @@ def _is_dhcp_addr(np_addr, is_ipv6):
 
 def _is_autoconf_addr(np_addr):
     return np_addr.valid_lft != "forever" and np_addr.prefix_len == 64
+
+
+class EthtoolInfo:
+    def __init__(self, np_ethtool):
+        self._np_ethtool = np_ethtool
+
+    def to_dict(self):
+        np_pause = self._np_ethtool.pause
+        if np_pause:
+            return {
+                Ethtool.Pause.CONFIG_SUBTREE: {
+                    Ethtool.Pause.AUTO_NEGOTIATION: np_pause.auto_negotiate,
+                    Ethtool.Pause.TX: np_pause.tx,
+                    Ethtool.Pause.RX: np_pause.rx,
+                }
+            }
+        return {}

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -36,6 +36,7 @@ from .bridge import BRIDGE_TYPE as NM_LINUX_BRIDGE_TYPE
 from .bridge import create_port_setting as create_linux_bridge_port_setting
 from .bridge import create_setting as create_linux_bridge_setting
 from .common import NM
+from .ethtool import create_ethtool_setting
 from .ieee_802_1x import create_802_1x_setting
 from .infiniband import create_setting as create_infiniband_setting
 from .ipv4 import create_setting as create_ipv4_setting
@@ -235,6 +236,11 @@ def create_new_nm_simple_conn(iface, nm_profile):
 
     if iface.ieee_802_1x_conf:
         settings.append(create_802_1x_setting(iface.ieee_802_1x_conf))
+
+    if iface.ethtool:
+        setting = create_ethtool_setting(iface.ethtool, nm_profile)
+        if setting:
+            settings.append(setting)
 
     nm_simple_conn = NM.SimpleConnection.new()
     for setting in settings:

--- a/libnmstate/nm/ethtool.py
+++ b/libnmstate/nm/ethtool.py
@@ -1,0 +1,63 @@
+#
+# Copyright (c) 2018-2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from .common import NM
+from .common import GLib
+
+
+def create_ethtool_setting(iface_ethtool, base_con_profile):
+    if not hasattr(NM, "ETHTOOL_OPTNAME_PAUSE_AUTONEG"):
+        return None
+
+    nm_setting = None
+
+    if base_con_profile:
+        nm_setting = base_con_profile.get_setting_by_name(
+            NM.SETTING_ETHTOOL_SETTING_NAME
+        )
+        if nm_setting:
+            nm_setting = nm_setting.duplicate()
+
+    if not nm_setting:
+        nm_setting = NM.SettingEthtool.new()
+
+    if iface_ethtool.pause:
+        if iface_ethtool.pause.autoneg is not None:
+            nm_setting.option_set(
+                # pylint: disable=no-member
+                NM.ETHTOOL_OPTNAME_PAUSE_AUTONEG,
+                # pylint: enable=no-member
+                GLib.Variant.new_boolean(iface_ethtool.pause.autoneg),
+            )
+        if iface_ethtool.pause.rx is not None:
+            nm_setting.option_set(
+                # pylint: disable=no-member
+                NM.ETHTOOL_OPTNAME_PAUSE_RX,
+                # pylint: enable=no-member
+                GLib.Variant.new_boolean(iface_ethtool.pause.rx),
+            )
+        if iface_ethtool.pause.tx is not None:
+            nm_setting.option_set(
+                # pylint: disable=no-member
+                NM.ETHTOOL_OPTNAME_PAUSE_TX,
+                # pylint: enable=no-member
+                GLib.Variant.new_boolean(iface_ethtool.pause.tx),
+            )
+
+    return nm_setting

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -460,3 +460,13 @@ class Ieee8021X:
     PRIVATE_KEY_PASSWORD = "private-key-password"
     CLIENT_CERT = "client-cert"
     CA_CERT = "ca-cert"
+
+
+class Ethtool:
+    CONFIG_SUBTREE = "ethtool"
+
+    class Pause:
+        CONFIG_SUBTREE = "pause"
+        AUTO_NEGOTIATION = "autoneg"
+        RX = "rx"
+        TX = "tx"

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -15,7 +15,8 @@ properties:
       allOf:
         - $ref: "#/definitions/interface-base/rw"
         - $ref: "#/definitions/interface-base/ro"
-        - $ref: "#/definitions/interface-ip/all"
+        - $ref: "#/definitions/interface-ip/rw"
+        - $ref: "#/definitions/interface-ethtool/rw"
         - $ref: "#/definitions/lldp/rw"
         - $ref: "#/definitions/lldp/ro"
         - $ref: "#/definitions/802.1x/rw"
@@ -620,6 +621,21 @@ definitions:
                     type: boolean
                   state:
                     type: string
+  interface-ethtool:
+    rw:
+      properties:
+        ethtool:
+          type: object
+          properties:
+            pause:
+              type: object
+              properties:
+                autoneg:
+                  type: boolean
+                rx:
+                  type: boolean
+                tx:
+                  type: boolean
   interface-team:
     rw:
       properties:

--- a/tests/integration/ethtool_test.py
+++ b/tests/integration/ethtool_test.py
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from contextlib import contextmanager
+import os
+import time
+
+import pytest
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import Ethtool
+
+from .testlib import assertlib
+from .testlib import cmdlib
+from .testlib.env import nm_major_minor_version
+
+MAX_NETDEVSIM_WAIT_TIME = 5
+
+TEST_NETDEVSIM_NIC = "sim0"
+
+
+@contextmanager
+def netdevsim_interface(ifname):
+    try:
+        cmdlib.exec_cmd("modprobe netdevsim".split(), check=True)
+        with open("/sys/bus/netdevsim/new_device", "w") as fd:
+            fd.write("1 1")
+
+        done = False
+        for i in range(0, MAX_NETDEVSIM_WAIT_TIME):
+            time.sleep(1)
+            i += 1
+            nics = _get_cur_netdevsim_ifnames()
+            if nics:
+                _ip_iface_rename(nics[0], ifname)
+                done = True
+                break
+        assert done
+        yield
+    finally:
+        cmdlib.exec_cmd("modprobe -r netdevsim".split())
+
+
+def _get_cur_netdevsim_ifnames():
+    return os.listdir("/sys/devices/netdevsim1/net/")
+
+
+def _ip_iface_rename(src_name, dst_name):
+    cmdlib.exec_cmd(f"ip link set {src_name} down".split(), check=True)
+    cmdlib.exec_cmd(
+        f"ip link set {src_name} name {dst_name}".split(), check=True
+    )
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() < 1.31 or os.environ.get("CI") == "true",
+    reason=(
+        "Ethtool pause test need NetworkManager 1.31+ and netdevsim kernel "
+        "module"
+    ),
+)
+def test_ethtool_pause_on_netdevsim():
+    desire_iface_state = {
+        Interface.NAME: TEST_NETDEVSIM_NIC,
+        Ethtool.CONFIG_SUBTREE: {
+            Ethtool.Pause.CONFIG_SUBTREE: {
+                Ethtool.Pause.AUTO_NEGOTIATION: False,
+                Ethtool.Pause.RX: True,
+                Ethtool.Pause.TX: True,
+            }
+        },
+    }
+    with netdevsim_interface(TEST_NETDEVSIM_NIC):
+        libnmstate.apply({Interface.KEY: [desire_iface_state]})
+        assertlib.assert_state_match({Interface.KEY: [desire_iface_state]})
+    assertlib.assert_absent(TEST_NETDEVSIM_NIC)

--- a/tests/lib/ifaces/ethtool_test.py
+++ b/tests/lib/ifaces/ethtool_test.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+from copy import deepcopy
+
+from libnmstate.schema import Ethtool
+
+from libnmstate.ifaces.base_iface import BaseIface
+from ..testlib.ifacelib import gen_foo_iface_info
+
+
+class TestIfaceEthtool:
+    def test_pause_canonicalize_remove_rx_tx(self):
+        des_info = gen_foo_iface_info()
+        des_info.update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Pause.CONFIG_SUBTREE: {
+                        Ethtool.Pause.AUTO_NEGOTIATION: True,
+                        Ethtool.Pause.RX: True,
+                        Ethtool.Pause.TX: True,
+                    }
+                }
+            }
+        )
+        iface = BaseIface(des_info)
+        iface.mark_as_desired()
+        iface.pre_edit_validation_and_cleanup()
+
+        assert iface.ethtool.pause.autoneg is True
+        assert iface.ethtool.pause.rx is None
+        assert iface.ethtool.pause.tx is None
+
+    def test_pause_match_ignore_rx_tx(self):
+        des_info = gen_foo_iface_info()
+        des_info.update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Pause.CONFIG_SUBTREE: {
+                        Ethtool.Pause.AUTO_NEGOTIATION: True,
+                        Ethtool.Pause.RX: True,
+                        Ethtool.Pause.TX: True,
+                    }
+                }
+            }
+        )
+        cur_info = deepcopy(des_info)
+        cur_info[Ethtool.CONFIG_SUBTREE][Ethtool.Pause.CONFIG_SUBTREE][
+            Ethtool.Pause.RX
+        ] = False
+        cur_info[Ethtool.CONFIG_SUBTREE][Ethtool.Pause.CONFIG_SUBTREE][
+            Ethtool.Pause.TX
+        ] = False
+
+        des_iface = BaseIface(des_info)
+        cur_iface = BaseIface(cur_info)
+        assert des_iface.match(cur_iface)

--- a/tests/lib/nm/ethtool_test.py
+++ b/tests/lib/nm/ethtool_test.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+from unittest import mock
+
+import libnmstate.nm.ethtool as nm_ethtool
+from libnmstate.schema import Ethtool
+from libnmstate.ifaces.ethtool import IfaceEthtool
+from libnmstate.nm.common import GLib
+
+
+@pytest.fixture
+def nm_mock():
+    with mock.patch.object(nm_ethtool, "NM") as m:
+        yield m
+
+
+def test_create_setting_pause(nm_mock):
+    iface_ethtool = IfaceEthtool(
+        {
+            Ethtool.Pause.CONFIG_SUBTREE: {
+                Ethtool.Pause.AUTO_NEGOTIATION: True,
+                Ethtool.Pause.RX: True,
+                Ethtool.Pause.TX: True,
+            }
+        }
+    )
+    nm_ethtool_setting_mock = nm_mock.SettingEthtool.new.return_value
+
+    nm_ethtool.create_ethtool_setting(iface_ethtool, base_con_profile=None)
+
+    nm_ethtool_setting_mock.option_set.assert_has_calls(
+        [
+            mock.call(
+                nm_mock.ETHTOOL_OPTNAME_PAUSE_AUTONEG,
+                GLib.Variant.new_boolean(True),
+            ),
+            mock.call(
+                nm_mock.ETHTOOL_OPTNAME_PAUSE_RX,
+                GLib.Variant.new_boolean(True),
+            ),
+            mock.call(
+                nm_mock.ETHTOOL_OPTNAME_PAUSE_TX,
+                GLib.Variant.new_boolean(True),
+            ),
+        ],
+        any_order=False,
+    )

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -26,6 +26,7 @@ import libnmstate
 from libnmstate.schema import Constants
 from libnmstate.schema import DNS
 from libnmstate.schema import Ethernet
+from libnmstate.schema import Ethtool
 from libnmstate.schema import InfiniBand
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
@@ -1008,6 +1009,37 @@ class TestVeth:
                 Interface.NAME: "veth1",
                 Interface.TYPE: InterfaceType.VETH,
                 Veth.CONFIG_SUBTREE: {},
+            }
+        )
+        with pytest.raises(js.ValidationError):
+            libnmstate.validator.schema_validate(default_data)
+
+
+class TestEthtool:
+    def test_valid_ethtool(self, default_data):
+        default_data[Interface.KEY][0].update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Pause.CONFIG_SUBTREE: {
+                        Ethtool.Pause.AUTO_NEGOTIATION: False,
+                        Ethtool.Pause.TX: True,
+                        Ethtool.Pause.RX: True,
+                    }
+                }
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_invalid_ethtool_with_interger_value(self, default_data):
+        default_data[Interface.KEY][0].update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Pause.CONFIG_SUBTREE: {
+                        Ethtool.Pause.AUTO_NEGOTIATION: 1,
+                        Ethtool.Pause.TX: 0,
+                        Ethtool.Pause.RX: 0,
+                    }
+                }
             }
         )
         with pytest.raises(js.ValidationError):


### PR DESCRIPTION
Example:

```
  ethtool:
    pause:
      autoneg: false
      rx: true
      tx: true
```

Unit test cases included.
Integration test requires netdevsim kernel driver which does not exists
in CI environment. The test passes in Fedora 34 with
NetworkManager-1.31.4-28344.copr.0ce59b5dc4.fc34.x86_64