### PR TITLE
README: Modify IRC server reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Sprint tracking happens in
 ([Github projects](https://github.com/nmstate/nmstate/projects)).
 
 There is also `#nmstate` on
-[Freenode IRC](https://freenode.net/kb/answer/chat).
+[Libera IRC](https://libera.chat/).
 
 ## Contributing
 


### PR DESCRIPTION
Nmstate is moving the official IRC channel to libera community.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>