### PR TITLE
ethtool: Add support of ethtool feature

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -248,7 +248,7 @@ class BaseIface:
                 ip_state.remove_link_local_address()
                 self._info[family] = ip_state.to_dict()
                 if self.ethtool:
-                    self.ethtool.pre_edit_validation_and_cleanup(
+                    self.ethtool.canonicalize(
                         self._origin_info.get(Ethtool.CONFIG_SUBTREE, {})
                     )
                     self._info[Ethtool.CONFIG_SUBTREE] = self.ethtool.to_dict()
@@ -406,7 +406,9 @@ class BaseIface:
         """
         self._capitalize_mac()
         if self.ethtool:
-            self.ethtool.canonicalize()
+            self.ethtool.canonicalize(
+                self.original_dict.get(Ethtool.CONFIG_SUBTREE, {})
+            )
             self._info[Ethtool.CONFIG_SUBTREE] = self.ethtool.to_dict()
         self.sort_port()
         for family in (Interface.IPV4, Interface.IPV6):

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -174,13 +174,15 @@ class EthtoolInfo:
         self._np_ethtool = np_ethtool
 
     def to_dict(self):
+        info = {}
         np_pause = self._np_ethtool.pause
         if np_pause:
-            return {
-                Ethtool.Pause.CONFIG_SUBTREE: {
-                    Ethtool.Pause.AUTO_NEGOTIATION: np_pause.auto_negotiate,
-                    Ethtool.Pause.TX: np_pause.tx,
-                    Ethtool.Pause.RX: np_pause.rx,
-                }
+            info[Ethtool.Pause.CONFIG_SUBTREE] = {
+                Ethtool.Pause.AUTO_NEGOTIATION: np_pause.auto_negotiate,
+                Ethtool.Pause.TX: np_pause.tx,
+                Ethtool.Pause.RX: np_pause.rx,
             }
-        return {}
+        np_features = self._np_ethtool.features
+        if np_features:
+            info[Ethtool.Feature.CONFIG_SUBTREE] = np_features.changeable
+        return info

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -119,6 +119,10 @@ class NisporPlugin(NmstatePlugin):
                     NisporPluginVrfIface(np_iface).to_dict(config_only)
                 )
             elif iface_type == "openv_switch":
+                # The `ovs-system` is reserved for OVS kernel datapath
+                if np_iface.name == "ovs-system":
+                    continue
+
                 ifaces.append(
                     NisporPluginOvsInternalIface(np_iface).to_dict(config_only)
                 )

--- a/libnmstate/nm/ethtool.py
+++ b/libnmstate/nm/ethtool.py
@@ -17,14 +17,13 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from libnmstate.error import NmstateValueError
+
 from .common import NM
 from .common import GLib
 
 
 def create_ethtool_setting(iface_ethtool, base_con_profile):
-    if not hasattr(NM, "ETHTOOL_OPTNAME_PAUSE_AUTONEG"):
-        return None
-
     nm_setting = None
 
     if base_con_profile:
@@ -37,7 +36,7 @@ def create_ethtool_setting(iface_ethtool, base_con_profile):
     if not nm_setting:
         nm_setting = NM.SettingEthtool.new()
 
-    if iface_ethtool.pause:
+    if iface_ethtool.pause and hasattr(NM, "ETHTOOL_OPTNAME_PAUSE_AUTONEG"):
         if iface_ethtool.pause.autoneg is not None:
             nm_setting.option_set(
                 # pylint: disable=no-member
@@ -60,4 +59,38 @@ def create_ethtool_setting(iface_ethtool, base_con_profile):
                 GLib.Variant.new_boolean(iface_ethtool.pause.tx),
             )
 
+    if iface_ethtool.feature:
+        for kernel_feature_name, value in iface_ethtool.feature.items():
+            nm_set_feature(nm_setting, kernel_feature_name, value)
+
     return nm_setting
+
+
+_KERNEL_FEATURE_TO_NM_MAP = {
+    "rx-checksum": "feature-rx",
+    "tx-scatter-gather": "feature-sg",
+    "tx-tcp-segmentation": "feature-tso",
+    "rx-gro": "feature-gro",
+    "tx-generic-segmentation": "feature-gso",
+    "rx-hashing": "feature-rxhash",
+    "rx-lro": "feature-lro",
+    "rx-ntuple-filter": "feature-ntuple",
+    "rx-vlan-hw-parse": "feature-rxvlan",
+    "tx-vlan-hw-insert": "feature-txvlan",
+}
+
+
+def nm_set_feature(nm_setting, kernel_feature_name, value):
+    """
+    NM is using different name for some features.
+    """
+    nm_feature_name = _KERNEL_FEATURE_TO_NM_MAP.get(
+        kernel_feature_name, f"feature-{kernel_feature_name}"
+    )
+    if NM.ethtool_optname_is_feature(nm_feature_name):
+        nm_setting.option_set_boolean(nm_feature_name, value)
+    else:
+        raise NmstateValueError(
+            f"Ethtool feature {kernel_feature_name} is invalid "
+            "or not supported by current NetworkManager"
+        )

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -470,3 +470,6 @@ class Ethtool:
         AUTO_NEGOTIATION = "autoneg"
         RX = "rx"
         TX = "tx"
+
+    class Feature:
+        CONFIG_SUBTREE = "feature"

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -636,6 +636,10 @@ definitions:
                   type: boolean
                 tx:
                   type: boolean
+            feature:
+              type: object
+              additionalProperties:
+                type: boolean
   interface-team:
     rw:
       properties:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -809,3 +809,7 @@ def test_create_mac_tap_over_ovs_iface_with_use_same_name_as_bridge(
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_ignore_ovs_system_kernel_nic(bridge_with_ports):
+    assert not statelib.show_only(("ovs-system",))[Interface.KEY]

--- a/tests/lib/ifaces/ethtool_test.py
+++ b/tests/lib/ifaces/ethtool_test.py
@@ -19,6 +19,8 @@
 
 from copy import deepcopy
 
+import pytest
+
 from libnmstate.schema import Ethtool
 
 from libnmstate.ifaces.base_iface import BaseIface
@@ -71,3 +73,67 @@ class TestIfaceEthtool:
         des_iface = BaseIface(des_info)
         cur_iface = BaseIface(cur_info)
         assert des_iface.match(cur_iface)
+
+    @pytest.mark.parametrize(
+        "ethtool_cli_alias",
+        [
+            ("rx", "rx-checksum"),
+            ("rx-checksumming", "rx-checksum"),
+            ("ufo", "tx-udp-fragmentation"),
+            ("gso", "tx-generic-segmentation"),
+            ("generic-segmentation-offload", "tx-generic-segmentation"),
+            ("gro", "rx-gro"),
+            ("generic-receive-offload", "rx-gro"),
+            ("lro", "rx-lro"),
+            ("large-receive-offload", "rx-lro"),
+            ("rxvlan", "rx-vlan-hw-parse"),
+            ("rx-vlan-offload", "rx-vlan-hw-parse"),
+            ("txvlan", "tx-vlan-hw-insert"),
+            ("tx-vlan-offload", "tx-vlan-hw-insert"),
+            ("ntuple", "rx-ntuple-filter"),
+            ("ntuple-filters", "rx-ntuple-filter"),
+            ("rxhash", "rx-hashing"),
+            ("receive-hashing", "rx-hashing"),
+        ],
+        ids=[
+            "rx",
+            "rx-checksumming",
+            "ufo",
+            "gso",
+            "generic-segmentation-offload",
+            "gro",
+            "generic-receive-offload",
+            "lro",
+            "large-receive-offload",
+            "rxvlan",
+            "rx-vlan-offload",
+            "txvlan",
+            "tx-vlan-offload",
+            "ntuple",
+            "ntuple-filters",
+            "rxhash",
+            "receive-hashing",
+        ],
+    )
+    def test_feature_canonicalize_expand_alias(self, ethtool_cli_alias):
+        alias, kernel_name = ethtool_cli_alias
+        des_info = gen_foo_iface_info()
+        des_info.update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Feature.CONFIG_SUBTREE: {alias: True}
+                }
+            }
+        )
+
+        cur_info = gen_foo_iface_info()
+        cur_info.update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Feature.CONFIG_SUBTREE: {kernel_name: True}
+                }
+            }
+        )
+        des_iface = BaseIface(des_info)
+        cur_iface = BaseIface(cur_info)
+        assert des_iface.state_for_verify() == cur_iface.state_for_verify()

--- a/tests/lib/schema_validation_test.py
+++ b/tests/lib/schema_validation_test.py
@@ -1044,3 +1044,27 @@ class TestEthtool:
         )
         with pytest.raises(js.ValidationError):
             libnmstate.validator.schema_validate(default_data)
+
+    def test_valid_ethtool_feature(self, default_data):
+        default_data[Interface.KEY][0].update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Feature.CONFIG_SUBTREE: {"rx-all": False}
+                }
+            }
+        )
+        libnmstate.validator.schema_validate(default_data)
+
+    def test_invalid_ethtool_feature_with_interger_value(self, default_data):
+        default_data[Interface.KEY][0].update(
+            {
+                Ethtool.CONFIG_SUBTREE: {
+                    Ethtool.Feature.CONFIG_SUBTREE: {
+                        "rx-all": False,
+                        "invalid-option": 100,
+                    }
+                }
+            }
+        )
+        with pytest.raises(js.ValidationError):
+            libnmstate.validator.schema_validate(default_data)


### PR DESCRIPTION
Example:

```yaml interfaces:
- name: eth1
type: ethernet
state: up
ethtool:
  feature:
    highdma: true
    rx-checksum: true
    rx-gro: true
```

Nmstate only shows changeable features via `libnmstate.show()`.

Unlike the ethtool CLI tool, nmstate show using feature name provided by
kernel instead of alias. When applying state, nmstate support desire state
to use these alias which pre-exists in ethtool CLI tool:
* `rx`
* `rx-checksumming`
* `ufo`
* `gso`
* `generic-segmentation-offload`
* `gro`
* `generic-receive-offload`
* `lro`
* `large-receive-offload`
* `rxvlan`
* `rx-vlan-offload`
* `txvlan`
* `tx-vlan-offload`
* `ntuple`
* `ntuple-filters`
* `rxhash`
* `receive-hashing`

The NetworkManager itself also has some alias, the nm plugin is taking care
of it.

Integration test case added testing both this alias processing and setting
`rx-checksum` value.

Unit test case included to test the alias processing.

#