### PR TITLE
CI: install libndp as new dependency of NetworkManager

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -280,6 +280,12 @@ function upgrade_nm_from_copr {
     clean_dnf_cache
     exec_cmd "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
     exec_cmd "yum copr enable --assumeyes ${copr_repo}"
+    if [ $CONTAINER_IMAGE == $CENTOS_STREAM_IMAGE_DEV ];then
+	# centos-stream NetworkManager package is providing the alpha builds.
+	# Sometimes it could be greater than the one packaged on Copr.
+        exec_cmd "dnf remove --assumeyes NetworkManager"
+        exec_cmd "dnf install --assumeyes NetworkManager --disablerepo '*' --enablerepo '${copr_repo_id}'"
+    fi
     # Update only from Copr to limit the changes in the environment
     exec_cmd "yum update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
     exec_cmd "systemctl restart NetworkManager"

--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -36,6 +36,7 @@ RUN dnf update -y && \
                    tcpreplay \
                    wpa_supplicant \
                    hostapd \
+                   libndp \
                    && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \


### PR DESCRIPTION
In addition, this patch is fixing the Copr installation of
NetworkManager-main in centos-stream.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>