### PR TITLE
[nmstate-1.0] ovs: Fix `is_ovs_running()` in container environment.

### DIFF
--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -19,7 +19,6 @@
 
 from copy import deepcopy
 from operator import itemgetter
-import subprocess
 import warnings
 
 from libnmstate.error import NmstateValueError
@@ -250,20 +249,6 @@ class OvsInternalIface(BaseIface):
             else:
                 self._info.pop(Interface.MTU, None)
                 self._info.pop(Interface.MAC, None)
-
-
-def is_ovs_running():
-    try:
-        subprocess.run(
-            ("systemctl", "status", "openvswitch"),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
-            timeout=SYSTEMCTL_TIMEOUT_SECONDS,
-        )
-        return True
-    except Exception:
-        return False
 
 
 def is_ovs_lag_port(port_state):

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -23,7 +23,6 @@ from operator import itemgetter
 from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateValueError
-from libnmstate.ifaces.ovs import is_ovs_running
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
@@ -103,7 +102,7 @@ class NetworkManagerPlugin(NmstatePlugin):
     @property
     def capabilities(self):
         capabilities = []
-        if has_ovs_capability(self.client) and is_ovs_running():
+        if has_ovs_capability(self.client):
             capabilities.append(NmstatePlugin.OVS_CAPABILITY)
         if has_team_capability(self.client):
             capabilities.append(NmstatePlugin.TEAM_CAPABILITY)

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -22,7 +22,6 @@ import logging
 
 import jsonschema as js
 
-from libnmstate.ifaces.ovs import is_ovs_running
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.error import NmstateDependencyError
@@ -50,7 +49,6 @@ def validate_interface_capabilities(ifaces_state, capabilities):
     ifaces_types = {iface_state.get("type") for iface_state in ifaces_state}
     has_ovs_capability = NmstatePlugin.OVS_CAPABILITY in capabilities
     has_team_capability = NmstatePlugin.TEAM_CAPABILITY in capabilities
-    ovs_is_running = is_ovs_running()
     for iface_type in ifaces_types:
         is_ovs_type = iface_type in (
             InterfaceType.OVS_BRIDGE,
@@ -58,18 +56,12 @@ def validate_interface_capabilities(ifaces_state, capabilities):
             InterfaceType.OVS_PORT,
         )
         if is_ovs_type and not has_ovs_capability:
-            if not ovs_is_running:
-                raise NmstateDependencyError(
-                    "openvswitch service is not started."
-                )
-            else:
-                raise NmstateDependencyError(
-                    "Open vSwitch NetworkManager support not installed "
-                    "and started"
-                )
+            raise NmstateDependencyError(
+                "Open vSwitch support not properly installed or started"
+            )
         elif iface_type == InterfaceType.TEAM and not has_team_capability:
             raise NmstateDependencyError(
-                "NetworkManager-team plugin not installed and started"
+                "Team support not properly installed or started"
             )
 
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -44,8 +44,8 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
+from .testlib.nmplugin import mount_devnull_to_path
 from .testlib.ovslib import Bridge
-from .testlib.servicelib import disable_service
 from .testlib.vlan import vlan_interface
 
 
@@ -213,31 +213,24 @@ def test_nm_ovs_plugin_missing():
             )
 
 
-def test_ovs_service_missing():
-    with disable_service("openvswitch"):
-        with pytest.raises(NmstateDependencyError):
-            libnmstate.apply(
-                {
-                    Interface.KEY: [
-                        {
-                            Interface.NAME: BRIDGE1,
-                            Interface.TYPE: InterfaceType.OVS_BRIDGE,
-                            Interface.STATE: InterfaceState.UP,
-                        }
-                    ]
-                }
-            )
+def test_ovs_service_missing_with_system_port_only(eth1_up):
+    bridge = Bridge(BRIDGE1)
+    bridge.add_system_port(ETH1)
 
-    libnmstate.apply(
-        {
-            Interface.KEY: [
-                {
-                    Interface.NAME: BRIDGE1,
-                    Interface.STATE: InterfaceState.ABSENT,
-                }
-            ]
-        }
-    )
+    with mount_devnull_to_path("/var/run/openvswitch/db.sock"):
+        with pytest.raises(NmstateDependencyError):
+            with bridge.create():
+                pass
+
+
+def test_ovs_service_missing_with_internal_port_only():
+    bridge = Bridge(BRIDGE1)
+    bridge.add_internal_port(PORT1)
+
+    with mount_devnull_to_path("/var/run/openvswitch/db.sock"):
+        with pytest.raises(NmstateDependencyError):
+            with bridge.create():
+                pass
 
 
 @pytest.fixture


### PR DESCRIPTION
In k8s container environment, the OVS database socket
/var/run/openvswitch/db.sock is mounted from host, so NM can managed it
without the ovs daemon running in container.

To support that, this patch removed the top level checking on
`is_ovs_running()` and trust plugin raise the proper error on failure.

Patched the NM plugin to check the error
`NM.DeviceStateReason.OVSDB_FAILED` on activation failure, raise
`NmstateDependencyError` if OVS DB failed to connected.

NM will not raise any error when creating OVS internal interface with
OVSDB mounted to /dev/null, NM will keep showing the OVS interface as
ACTIVATING, changed the fallback checker to give only 30 seconds for OVS
interface to exit `NM.DeviceState.PREPARE`, if not treat it as OVS
daemon malfunctioning.

Updated integration test case to mask(mount /dev/null) the OVS DB socket
file for simulating the stopped OVS daemon.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>