### PR TITLE
[nmstate-1.0] nm ipv4: Deactivate profile when route removed.

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -49,7 +49,7 @@ from .translator import Api2Nm
 IMPORT_NM_DEV_TIMEOUT = 5
 IMPORT_NM_DEV_RETRY_INTERNAL = 0.5
 FALLBACK_CHECKER_INTERNAL = 15
-IPV6_ROUTE_REMOVED = "_ipv6_route_removed"
+ROUTE_REMOVED = "_route_removed"
 
 
 class NmProfile:
@@ -193,9 +193,10 @@ class NmProfile:
             elif self._iface.is_virtual and self._nm_dev:
                 self._add_action(NmProfile.ACTION_DELETE_DEVICE)
 
-        if self._iface.raw.get(IPV6_ROUTE_REMOVED):
+        if self._iface.raw.get(ROUTE_REMOVED):
             # This is a workaround for NM bug:
             # https://bugzilla.redhat.com/1837254
+            # https://bugzilla.redhat.com/1962551
             self._add_action(NmProfile.ACTION_DEACTIVATE_FIRST)
 
         if self._iface.is_controller and self._iface.is_up:

--- a/libnmstate/route.py
+++ b/libnmstate/route.py
@@ -36,7 +36,7 @@ from .state import StateEntry
 DEFAULT_ROUTE_TABLE = 254
 
 
-IPV6_ROUTE_REMOVED = "_ipv6_route_removed"
+ROUTE_REMOVED = "_route_removed"
 
 
 class RouteEntry(StateEntry):
@@ -235,16 +235,13 @@ class RouteState:
             for route in route_set:
                 if not rt.match(route):
                     new_routes.add(route)
-                if route.is_ipv6:
-                    # The routes match and therefore it is being removed.
-                    # Nmstate will check if it is an IPv6 route and if so,
-                    # marking the interface as deactivate first.
-                    #
-                    # This is a workaround for NM bug:
-                    # https://bugzilla.redhat.com/1837254
-                    ifaces.all_kernel_ifaces[iface_name].raw[
-                        IPV6_ROUTE_REMOVED
-                    ] = True
+                # The routes match and therefore it is being removed.
+                # marking the interface as deactivate first.
+                #
+                # This is a workaround for NM bug:
+                # https://bugzilla.redhat.com/1837254
+                # https://bugzilla.redhat.com/1962551
+                ifaces.all_kernel_ifaces[iface_name].raw[ROUTE_REMOVED] = True
             if new_routes != route_set:
                 self._routes[iface_name] = new_routes
 


### PR DESCRIPTION
The bug https://bugzilla.redhat.com/show_bug.cgi?id=1962551 has shown
IPv4 route also share the same problem.

Whenever we got a route removal, we deactivate that profile via
NetworkManager.

Integration test case included.

Signed-off-by: Gris Ge <fge@redhat.com>
Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>