### PR TITLE
README: Fix link to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ these [instructions](CONTRIBUTING.md) to contribute.
 
 For Fedora 29+, `sudo dnf install nmstate`.
 
-For others distribution, please see the [install guide](https://www.nmstate.io/user/install.html).
+For others distribution, please see the [install guide](https://nmstate.io/user/install.html).
 
 ## Documentation
 


### PR DESCRIPTION
The README has a broken link to www.nmstate.io, which gives a certificate error since github returns a default certificate.

Fix the link to point to https://nmstate.io/user/install.html instead

Signed-off-by: Esa Varemo <git@esav.fi>