### PR TITLE
[nmstate-1.0] nm bond: Fix preserving `all_slaves_active` option

### DIFF
--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -82,9 +82,9 @@ def create_setting(iface, wired_setting, base_con_profile):
 
 def _nm_fix_bond_options(option_name, option_value):
     if option_name == "all_slaves_active":
-        if option_value == "delivered":
+        if option_value in ("delivered", "1"):
             option_value = 1
-        elif option_value == "dropped":
+        elif option_value in ("dropped", "0"):
             option_value = 0
         else:
             raise NmstateNotImplementedError(

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1059,3 +1059,28 @@ def test_bond_flip_tlb_dynamic_lbs(bond99_with_2_port):
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_bond_preserve_existing_all_slaves_active_setting(bond99_with_2_port):
+    desired_state = bond99_with_2_port
+    bond_state = desired_state[Interface.KEY][0]
+    bond_state[Bond.CONFIG_SUBTREE][Bond.MODE] = BondMode.TLB
+    bond_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE] = {
+        "all_slaves_active": "dropped",
+    }
+
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+    bond_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE] = {
+        "tlb_dynamic_lb": False
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+    current_state = statelib.show_only((BOND99,))
+    assert (
+        current_state[Interface.KEY][0][Bond.CONFIG_SUBTREE][
+            Bond.OPTIONS_SUBTREE
+        ]["all_slaves_active"]
+        == "dropped"
+    )


### PR DESCRIPTION
When `all_slaves_active` was previously set via nmstate or NM, follow up
bond modification will fail with:

    NmstateNotImplementedError: Unsupported bond option: 'all_slaves_active'='0'

This is because the option returned by `_get_bond_options_from_profiles()` is
not canonicalized.

Expand the check to cover `1` and `0`.

Integration test case included.