### PR TITLE
[nmstate-1.0] bond: Fix bond fail_over_mac=active

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -88,7 +88,7 @@ class BondIface(BaseIface):
 
     def pre_edit_validation_and_cleanup(self):
         super().pre_edit_validation_and_cleanup()
-        if self.is_up:
+        if self.is_up and (self.is_desired or self.is_changed):
             self._discard_bond_option_when_mode_change()
             self._validate_bond_mode()
             self._fix_mac_restriced_mode()

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1084,3 +1084,27 @@ def test_bond_preserve_existing_all_slaves_active_setting(bond99_with_2_port):
         ]["all_slaves_active"]
         == "dropped"
     )
+
+
+@pytest.mark.tier1
+def test_bond_mac_restriction_check_only_impact_desired(eth1_up, eth2_up):
+    with bond_interface(
+        name=BOND99,
+        port=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+                Bond.OPTIONS_SUBTREE: {"fail_over_mac": "active"},
+            },
+        },
+    ):
+        dummy_iface_state = {
+            Interface.NAME: "dummy0",
+            Interface.TYPE: InterfaceType.DUMMY,
+            Interface.STATE: InterfaceState.UP,
+        }
+        try:
+            libnmstate.apply({Interface.KEY: [dummy_iface_state]})
+        finally:
+            dummy_iface_state[Interface.STATE] = InterfaceState.ABSENT
+            libnmstate.apply({Interface.KEY: [dummy_iface_state]})

--- a/tests/lib/ifaces/bond_iface_test.py
+++ b/tests/lib/ifaces/bond_iface_test.py
@@ -285,9 +285,11 @@ class TestBondIface:
     def test_validate_bond_mode_undefined(self):
         iface_info = self._gen_iface_info()
         iface_info[Bond.CONFIG_SUBTREE].pop(Bond.MODE)
+        iface = BondIface(iface_info)
+        iface.mark_as_desired()
 
         with pytest.raises(NmstateValueError):
-            BondIface(iface_info).pre_edit_validation_and_cleanup()
+            iface.pre_edit_validation_and_cleanup()
 
     def test_validate_mac_restriced_mode_with_desire_has_no_mac(self):
         cur_iface_info = self._gen_iface_info()
@@ -299,6 +301,7 @@ class TestBondIface:
             "fail_over_mac": "active"
         }
         iface = BondIface(iface_info)
+        iface.mark_as_desired()
 
         iface.merge(cur_iface)
         iface.pre_edit_validation_and_cleanup()
@@ -314,6 +317,7 @@ class TestBondIface:
             "fail_over_mac": "active"
         }
         iface = BondIface(iface_info)
+        iface.mark_as_desired()
 
         iface.merge(cur_iface)
         with pytest.raises(NmstateValueError):
@@ -331,6 +335,7 @@ class TestBondIface:
         iface_info[Bond.CONFIG_SUBTREE].pop(Bond.OPTIONS_SUBTREE)
         iface_info[Interface.MAC] = MAC_ADDRESS1
         iface = BondIface(iface_info)
+        iface.mark_as_desired()
 
         iface.merge(cur_iface)
         with pytest.raises(NmstateValueError):


### PR DESCRIPTION
With bond interface in fail_over_mac=active and active-backup mode,
any future change via nmstate will fail as nmstate is validating
on current state instead of desire state for this bond mac restriction.

Fixed the code to only validate bond mac restriction on desired or
changed bond interface.

Integration test case include.