### PR TITLE
Add VXLAN properties required to support an external control plane (BGP-EVPN)

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -321,6 +321,7 @@ class Ifaces:
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
                 and iface.is_up
+                and iface.parent
             ):
                 if (
                     self._kernel_ifaces[iface.parent].type
@@ -345,6 +346,7 @@ class Ifaces:
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
                 and iface.is_up
                 and iface.mtu
+                and iface.parent
             ):
                 base_iface = self._kernel_ifaces.get(iface.parent)
                 if not base_iface.mtu:

--- a/libnmstate/ifaces/vxlan.py
+++ b/libnmstate/ifaces/vxlan.py
@@ -72,7 +72,8 @@ class VxlanIface(BaseIface):
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mandatory_properties(self):
-        for prop in (VXLAN.ID, VXLAN.BASE_IFACE, VXLAN.REMOTE):
+        # TODO: Figure out
+        for prop in (VXLAN.ID): #, VXLAN.BASE_IFACE, VXLAN.REMOTE):
             if prop not in self._vxlan_config:
                 raise NmstateValueError(
                     f"Vxlan tunnel {self.name} has missing mandatory "

--- a/libnmstate/ifaces/vxlan.py
+++ b/libnmstate/ifaces/vxlan.py
@@ -34,7 +34,10 @@ class VxlanIface(BaseIface):
 
     @property
     def need_parent(self):
-        return True
+        # TODO: Do we want to return a value conditional to
+        # if BASE_IF is defined or just a static False since
+        # all configurations don't need one?
+        return False
 
     @property
     def _vxlan_config(self):
@@ -72,8 +75,9 @@ class VxlanIface(BaseIface):
         super().pre_edit_validation_and_cleanup()
 
     def _validate_mandatory_properties(self):
-        # TODO: Figure out
-        for prop in (VXLAN.ID): #, VXLAN.BASE_IFACE, VXLAN.REMOTE):
+        # TODO: Do we want to validate alternative working configurations, 
+        # or the minimum shared by all configurations? (What even is *actually* required?)
+        for prop in (VXLAN.ID,): #, VXLAN.BASE_IFACE, VXLAN.REMOTE):
             if prop not in self._vxlan_config:
                 raise NmstateValueError(
                     f"Vxlan tunnel {self.name} has missing mandatory "

--- a/libnmstate/nispor/vxlan.py
+++ b/libnmstate/nispor/vxlan.py
@@ -33,6 +33,8 @@ class NisporPluginVxlanIface(NisporPluginBaseIface):
         info[VXLAN.CONFIG_SUBTREE] = {
             VXLAN.ID: self._np_iface.vxlan_id,
             VXLAN.BASE_IFACE: self._np_iface.base_iface,
+            VXLAN.LEARNING: self._np_iface.learning,
+            VXLAN.LOCAL: self._np_iface.local,
             VXLAN.REMOTE: self._np_iface.remote,
             VXLAN.DESTINATION_PORT: self._np_iface.dst_port,
         }

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -36,7 +36,9 @@ def create_setting(iface_state, base_con_profile):
         vxlan_setting = NM.SettingVxlan.new()
 
     vxlan_setting.props.id = vxlan[VXLAN.ID]
-    vxlan_setting.props.parent = vxlan.get(VXLAN.BASE_IFACE)
+    vxlan_base_if = vxlan.get(VXLAN.BASE_IFACE)
+    if vxlan_base_if:
+        vxlan_setting.props.parent = vxlan_base_if
     vxlan_setting.props.learning = vxlan.get(VXLAN.LEARNING)
     vxlan_local = vxlan.get(VXLAN.LOCAL)
     vxlan_setting.props.local = vxlan_local if vxlan_local else None

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -39,7 +39,9 @@ def create_setting(iface_state, base_con_profile):
     vxlan_base_if = vxlan.get(VXLAN.BASE_IFACE)
     if vxlan_base_if:
         vxlan_setting.props.parent = vxlan_base_if
-    vxlan_setting.props.learning = vxlan.get(VXLAN.LEARNING)
+    vxlan_learning = vxlan.get(VXLAN.LEARNING)
+    if vxlan_learning:
+        vxlan_setting.props.learning = vxlan_learning
     vxlan_local = vxlan.get(VXLAN.LOCAL)
     vxlan_setting.props.local = vxlan_local if vxlan_local else None
     vxlan_remote = vxlan.get(VXLAN.REMOTE)

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -36,7 +36,7 @@ def create_setting(iface_state, base_con_profile):
         vxlan_setting = NM.SettingVxlan.new()
 
     vxlan_setting.props.id = vxlan[VXLAN.ID]
-    vxlan_setting.props.parent = vxlan[VXLAN.BASE_IFACE]
+    vxlan_setting.props.parent = vxlan.get(VXLAN.BASE_IFACE)
     vxlan_setting.props.learning = vxlan.get(VXLAN.LEARNING)
     vxlan_local = vxlan.get(VXLAN.LOCAL)
     vxlan_setting.props.local = vxlan_local if vxlan_local else None

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -37,6 +37,9 @@ def create_setting(iface_state, base_con_profile):
 
     vxlan_setting.props.id = vxlan[VXLAN.ID]
     vxlan_setting.props.parent = vxlan[VXLAN.BASE_IFACE]
+    vxlan_setting.props.learning = vxlan.get(VXLAN.LEARNING)
+    vxlan_local = vxlan.get(VXLAN.LOCAL)
+    vxlan_setting.props.local = vxlan_local if vxlan_local else None
     vxlan_remote = vxlan.get(VXLAN.REMOTE)
     vxlan_setting.props.remote = vxlan_remote if vxlan_remote else None
     vxlan_destination_port = vxlan.get(VXLAN.DESTINATION_PORT)

--- a/libnmstate/nm/vxlan.py
+++ b/libnmstate/nm/vxlan.py
@@ -40,7 +40,7 @@ def create_setting(iface_state, base_con_profile):
     if vxlan_base_if:
         vxlan_setting.props.parent = vxlan_base_if
     vxlan_learning = vxlan.get(VXLAN.LEARNING)
-    if vxlan_learning:
+    if vxlan_learning is not None:
         vxlan_setting.props.learning = vxlan_learning
     vxlan_local = vxlan.get(VXLAN.LOCAL)
     vxlan_setting.props.local = vxlan_local if vxlan_local else None

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -334,6 +334,8 @@ class VXLAN:
 
     ID = "id"
     BASE_IFACE = "base-iface"
+    LEARNING = "learning"
+    LOCAL = "local"
     REMOTE = "remote"
     DESTINATION_PORT = "destination-port"
 

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -256,6 +256,10 @@ definitions:
               type: integer
               minimum: 0
               maximum: 16777215
+            learning:
+              type: boolean
+            local:
+              type: string
             remote:
               type: string
             destination-port:


### PR DESCRIPTION
A work in progress state and request for feedback. 
Will squash, etc. once any TODOs/issues have been fixed.

Add support for a configuration where a VXLAN interface is created in a non-learning mode without predefined remote VTEPs. MAC learning and VTEP configuration are handled by an external process (e.g. a BGP daemon like FRR for BGP-EVPN setups). 

In this configuration the VXLAN interface might also not have an explicit parent interface, and instead traffic could go over any number of physical interfaces based on host routes (ECMP over equal links).

I've briefly tested these modifications on Fedora and been running them on CentOS 8 Stream for a while now (https://copr.fedorainfracloud.org/coprs/varesa/nmstate-git/package/nmstate/). I'll look at the project internal test suite to see how the VXLAN side is currently tested there and if it needs adding. And how to run the test suite, of course :)