### PR TITLE
test: Only remove route/dns/route_rule before test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,7 +29,6 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
 from .testlib import ifacelib
-from .testlib.env import is_k8s
 
 
 REPORT_HEADER = """RPMs: {rpms}
@@ -74,26 +73,26 @@ def _mark_tier2_tests(items):
 def test_env_setup():
     _logging_setup()
     old_state = libnmstate.show()
-    if not is_k8s():
-        _empty_net_state()
+    _remove_dns_route_route_rule()
     _ethx_init()
     yield
     libnmstate.apply(old_state, verify_change=False)
     _diff_initial_state(old_state)
 
 
-def _empty_net_state():
+def _remove_dns_route_route_rule():
     """
     Remove existing DNS, routes, route rules in case it interference tests.
     """
-    desired_state = libnmstate.show()
-    desired_state[DNS.KEY] = {DNS.CONFIG: {}}
-    desired_state[Route.KEY] = {
-        Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}]
-    }
-    desired_state[RouteRule.KEY] = {RouteRule.CONFIG: []}
-
-    libnmstate.apply(desired_state)
+    libnmstate.apply(
+        {
+            DNS.KEY: {DNS.CONFIG: {}},
+            Route.KEY: {
+                Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}],
+            },
+            RouteRule.KEY: {RouteRule.CONFIG: []},
+        }
+    )
 
 
 def _logging_setup():

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2018-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -1258,5 +1258,10 @@ def test_show_running_config_does_not_include_auto_config(
             ipv6_addresses[0][InterfaceIPv6.ADDRESS_IP],
             ipv6_addresses[0][InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
         )
-    assert not running_config[DNS.KEY][DNS.CONFIG]
-    assert not running_config[RT.KEY][RT.CONFIG]
+    assert DHCP_SRV_IP4 not in running_config[DNS.KEY][DNS.CONFIG]
+    assert DHCP_SRV_IP6 not in running_config[DNS.KEY][DNS.CONFIG]
+    assert not any(
+        rt
+        for rt in running_config[RT.KEY][RT.CONFIG]
+        if rt[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+    )

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -44,7 +44,7 @@ def unmanaged_eth1_with_static_gw():
         )
         cmdlib.exec_cmd(
             f"ip route add default via 192.0.2.1 dev {ETH1} proto "
-            "static".split(),
+            "static metric 101".split(),
             check=True,
         )
         cmdlib.exec_cmd(f"ip link set {ETH1} up".split(), check=True)

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -580,8 +580,21 @@ def route_rule_test_env(eth1_static_gateway_dns):
     libnmstate.apply(
         {
             Interface.KEY: [ETH1_INTERFACE_STATE],
-            Route.KEY: {Route.CONFIG: []},
-            RouteRule.KEY: {RouteRule.CONFIG: []},
+            Route.KEY: {
+                Route.CONFIG: [
+                    {
+                        Route.NEXT_HOP_INTERFACE: "eth1",
+                        Route.STATE: Route.STATE_ABSENT,
+                    }
+                ]
+            },
+            RouteRule.KEY: {
+                RouteRule.CONFIG: [
+                    {
+                        RouteRule.STATE: RouteRule.STATE_ABSENT,
+                    }
+                ]
+            },
             DNS.KEY: {DNS.CONFIG: {}},
         },
         verify_change=False,


### PR DESCRIPTION
Since nmstate support changing DNS/route/route_rule without interface
defined, there is no need to include full state of all interface to
clean up the test environment.