### PR TITLE
[nmstate-1.0] bond: Don't validate current bond status

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -88,7 +88,7 @@ class BondIface(BaseIface):
 
     def pre_edit_validation_and_cleanup(self):
         super().pre_edit_validation_and_cleanup()
-        if self.is_up and (self.is_desired or self.is_changed):
+        if self.is_up and self.is_desired:
             self._discard_bond_option_when_mode_change()
             self._validate_bond_mode()
             self._fix_mac_restriced_mode()


### PR DESCRIPTION
If a bond interface is only marked as changed due to other
interface(like bridge port list change), its original desire information
is fully read from current status, there is no need to validate it.

The fix is only validate on desired bond interface.