### PR TITLE
bridge/bond: User permanent MAC address for `Interface.COPY_MAC_FROM`

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -130,6 +130,7 @@ class BaseIface:
     ROUTE_RULES_METADATA = "_route_rules"
     RULE_CHANGED_METADATA = "_changed"
     ROUTE_CHANGED_METADATA = "_changed"
+    PERMANENT_MAC_ADDRESS_METADATA = "_permanent_mac_address"
 
     def __init__(self, info, save_to_disk=True):
         self._origin_info = deepcopy(info)
@@ -214,6 +215,10 @@ class BaseIface:
     @property
     def original_dict(self):
         return self._origin_info
+
+    @property
+    def permanent_mac_address(self):
+        return self._info.get(BaseIface.PERMANENT_MAC_ADDRESS_METADATA)
 
     def ip_state(self, family):
         return IPState(family, self._info.get(family, {}))

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -194,8 +194,10 @@ class Ifaces:
                     f"{Interface.COPY_MAC_FROM} property "
                     f"as the port {iface.copy_mac_from} does not exists yet"
                 )
-
-            iface.apply_copy_mac_from(port_iface.mac)
+            if port_iface.permanent_mac_address:
+                iface.apply_copy_mac_from(port_iface.permanent_mac_address)
+            else:
+                iface.apply_copy_mac_from(port_iface.mac)
 
     def _create_virtual_port(self):
         """

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -20,6 +20,7 @@
 import logging
 from operator import attrgetter
 
+from libnmstate.ifaces import BaseIface
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv6
@@ -91,6 +92,10 @@ class NisporPluginBaseIface:
             Interface.MAC: self.mac,
             Interface.ACCEPT_ALL_MAC_ADDRESSES: self.accept_all_mac_addresses,
         }
+        if self._np_iface.permanent_mac_address:
+            iface_info[
+                BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+            ] = self._np_iface.permanent_mac_address
         if self.mtu:
             iface_info[Interface.MTU] = self.mtu
         ip_info = self._ip_info(config_only)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -103,7 +103,7 @@ def _logging_setup():
 
 
 def _ethx_init():
-    """ Remove any existing definitions on the ethX interfaces. """
+    """Remove any existing definitions on the ethX interfaces."""
     ifacelib.ifaces_init("eth1", "eth2")
 
 

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -31,6 +31,7 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 
 from libnmstate.ifaces.ifaces import Ifaces
+from libnmstate.ifaces.ifaces import BaseIface
 from libnmstate.ifaces.ifaces import OvsBridgeIface
 from libnmstate.state import state_match
 
@@ -39,6 +40,7 @@ from .testlib.bridgelib import PORT1_IFACE_NAME
 from .testlib.bridgelib import PORT2_IFACE_NAME
 from .testlib.bridgelib import gen_bridge_iface_info
 from .testlib.constants import MAC_ADDRESS1
+from .testlib.constants import MAC_ADDRESS2
 from .testlib.ifacelib import gen_foo_iface_info_static_ip
 from .testlib.ifacelib import gen_foo_iface_info
 from .testlib.ovslib import OVS_BRIDGE_IFACE_NAME
@@ -453,6 +455,49 @@ class TestIfaces:
 
         ifaces = Ifaces(des_iface_infos, cur_iface_infos)
         ifaces.verify(cur_iface_infos)
+
+    def test_copy_mac_from_permanent_mac_address(self):
+        cur_iface_infos = [gen_foo_iface_info(), gen_foo_iface_info()]
+        cur_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        cur_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        cur_iface_infos[1][Interface.MAC] = MAC_ADDRESS1
+        cur_iface_infos[1][
+            BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+        ] = MAC_ADDRESS2
+        cur_iface_infos.append(gen_bridge_iface_info())
+        des_iface_infos = [gen_foo_iface_info(), gen_foo_iface_info()]
+        des_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        des_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        des_bridge_info = gen_bridge_iface_info()
+        des_bridge_info[Interface.NAME] = LINUX_BRIDGE_IFACE_NAME
+        des_bridge_info[Interface.COPY_MAC_FROM] = PORT2_IFACE_NAME
+        des_iface_infos.append(des_bridge_info)
+
+        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
+        assert (
+            ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME].mac
+            == MAC_ADDRESS2
+        )
+
+    def test_copy_mac_from(self):
+        cur_iface_infos = [gen_foo_iface_info(), gen_foo_iface_info()]
+        cur_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        cur_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        cur_iface_infos[1][Interface.MAC] = MAC_ADDRESS1
+        cur_iface_infos.append(gen_bridge_iface_info())
+        des_iface_infos = [gen_foo_iface_info(), gen_foo_iface_info()]
+        des_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        des_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        des_bridge_info = gen_bridge_iface_info()
+        des_bridge_info[Interface.NAME] = LINUX_BRIDGE_IFACE_NAME
+        des_bridge_info[Interface.COPY_MAC_FROM] = PORT2_IFACE_NAME
+        des_iface_infos.append(des_bridge_info)
+
+        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
+        assert (
+            ifaces.all_kernel_ifaces[LINUX_BRIDGE_IFACE_NAME].mac
+            == MAC_ADDRESS1
+        )
 
 
 class TestIfacesSriov:

--- a/tests/lib/testlib/constants.py
+++ b/tests/lib/testlib/constants.py
@@ -21,6 +21,7 @@ from libnmstate.schema import InterfaceIP
 
 FOO_IFACE_NAME = "foo"
 MAC_ADDRESS1 = "01:23:45:67:89:AB"
+MAC_ADDRESS2 = "01:23:45:67:89:AC"
 
 IPV6_ADDRESS1 = "2001:db8:1::1"
 IPV6_ADDRESS1_FULL = "2001:db8:1:0:0:0:0:1"


### PR DESCRIPTION
Use permanent MAC address when possible for `Interface.COPY_MAC_FROM`.

Integration test case added by require real NIC to test using. Example:

   sudo env TEST_REAL_NIC="enp7s0" pytest -k \
      test_create_linux_bridge_with_copy_mac_from_permanent_mac

Tested on e100e in RHEL 8.4 VM.