### PR TITLE
libnmstate: do not report perm_mac_address when showing

### DIFF
--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2018-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -30,6 +30,7 @@ from .nmstate import create_checkpoints
 from .nmstate import destroy_checkpoints
 from .nmstate import plugin_context
 from .nmstate import plugins_capabilities
+from .nmstate import remove_metadata_leftover
 from .nmstate import rollback_checkpoints
 from .nmstate import show_with_plugins
 from .net_state import NetState
@@ -141,7 +142,7 @@ def _net_state_contains_sriov_interface(net_state):
 
 
 def _verify_change(plugins, net_state):
-    current_state = show_with_plugins(plugins)
+    current_state = remove_metadata_leftover(show_with_plugins(plugins))
     net_state.verify(current_state)
 
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2018-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -18,6 +18,7 @@
 #
 
 from .nmstate import plugin_context
+from .nmstate import remove_metadata_leftover
 from .nmstate import show_with_plugins
 from .nmstate import show_running_config_with_plugins
 
@@ -33,7 +34,9 @@ def show(*, include_status_data=False):
     configuration data is reported.
     """
     with plugin_context() as plugins:
-        return show_with_plugins(plugins, include_status_data)
+        return remove_metadata_leftover(
+            show_with_plugins(plugins, include_status_data)
+        )
 
 
 def show_running_config():

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -29,6 +29,7 @@ from libnmstate import validator
 from libnmstate.error import NmstateError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateDependencyError
+from libnmstate.ifaces import BaseIface
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
@@ -103,6 +104,18 @@ def plugins_capabilities(plugins):
     for plugin in plugins:
         capabilities.update(set(plugin.capabilities))
     return list(capabilities)
+
+
+def remove_metadata_leftover(info):
+    """
+    Remove the metadata introduced on the original state. Nmstate should not
+    report metadata to the users.
+    """
+    for iface_info in info.get(Interface.KEY, []):
+        # Remove _perm_mac_address metadata from Nispor
+        iface_info.pop(BaseIface.PERMANENT_MAC_ADDRESS_METADATA, None)
+
+    return info
 
 
 def _load_plugins():


### PR DESCRIPTION
Nmstate is currently showing _perm_mac_address when showing. This is not
correct because perm_mac_address is only for metadata.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>