### PR TITLE
[nmstate-1.1] ethtool: support backwards compatibility with NM 1.26

### DIFF
--- a/libnmstate/nm/ethtool.py
+++ b/libnmstate/nm/ethtool.py
@@ -17,7 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-from libnmstate.error import NmstateValueError
+import logging
 
 from .common import NM
 from .common import GLib
@@ -136,7 +136,7 @@ def nm_set_feature(nm_setting, kernel_feature_name, value):
     if NM.ethtool_optname_is_feature(nm_feature_name):
         nm_setting.option_set_boolean(nm_feature_name, value)
     else:
-        raise NmstateValueError(
+        logging.warning(
             f"Ethtool feature {kernel_feature_name} is invalid "
             "or not supported by current NetworkManager"
         )

--- a/tests/integration/ethtool_test.py
+++ b/tests/integration/ethtool_test.py
@@ -24,7 +24,7 @@ import time
 import pytest
 
 import libnmstate
-from libnmstate.error import NmstateValueError
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import Ethtool
 
@@ -124,7 +124,7 @@ def test_ethtool_invalid_feature(eth1_up):
             Ethtool.Feature.CONFIG_SUBTREE: {"no_exist_feature": False}
         },
     }
-    with pytest.raises(NmstateValueError):
+    with pytest.raises(NmstateVerificationError):
         libnmstate.apply({Interface.KEY: [desire_iface_state]})
 
 


### PR DESCRIPTION
NetworkManager 1.26 and 1.28 do not have full support of ethtool
options. If the user is using nmstate 1.1.0 and nispor 1.1.0 with
NetworkManager 1.26/1.28, they won't be able to edit the interface
because it will raise a NmstateValueError exception.

Instead, Nmstate will fail on verification if the property was modified
but not supported. This will allow the backwards compatibility.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>