### PR TITLE
nm wired: Preserve existing wired setting

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -140,8 +140,12 @@ def create_new_nm_simple_conn(iface, nm_profile):
     if iface.is_desired and iface.type != InterfaceType.INFINIBAND:
         wired_setting = create_wired_setting(iface, nm_profile)
 
-        if wired_setting:
-            settings.append(wired_setting)
+    # Preserv the old wire setting
+    if wired_setting is None and nm_profile:
+        wired_setting = nm_profile.get_setting_wired()
+
+    if wired_setting:
+        settings.append(wired_setting)
 
     user_setting = create_user_setting(iface_info, nm_profile)
     if user_setting:


### PR DESCRIPTION
When a interface is marked as changed by route or route rule or DNS,
the interface will lose its ethernet/wired setting(like MTU).

The root cause is we only create wired setting when desired.
The fix is preserve existing wired setting.

Integration test case included.