### PR TITLE
[nmstate-1.1] SR-IOV: Fix BCM57416 failure when creating VFs

### DIFF
--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -39,6 +39,9 @@ from .veth import create_iface_for_nm_veth_peer
 from .veth import is_nm_veth_supported
 
 
+IS_GENERATED_VF_METADATA = "_is_generated_vf"
+
+
 class NmProfiles:
     def __init__(self, context):
         self._ctx = context
@@ -67,6 +70,7 @@ class NmProfiles:
             for iface in sorted(
                 list(net_state.ifaces.all_ifaces()), key=attrgetter("name")
             )
+            if not _is_only_for_verify(iface)
         ]
 
         for profile in all_profiles:
@@ -389,3 +393,7 @@ def _nm_ovs_port_has_child(nm_profile, ovs_bridge_iface, net_state):
         ):
             return True
     return False
+
+
+def _is_only_for_verify(iface):
+    return iface.to_dict().get(IS_GENERATED_VF_METADATA)


### PR DESCRIPTION
Currently there is not a way to see the relation between a SR-IOV PF and
its VFs. Broadcom BCM57416 follows a different name pattern for PF and
VF, therefore it needs to be parsed if present.

PF name: ens2f0np0
VF name: ens2f0v0

The different name pattern is due to:
 1. The `n` is for `multi-port PCI device` support.
 2. The `p*` is `phys_port_name` provided by the BCM driver `bnxt_en`.

This is fixing the following error:

```
Traceback (most recent call last):
  File "/usr/bin/nmstatectl", line 11, in <module>
    load_entry_point('nmstate==0.3.4', 'console_scripts', 'nmstatectl')()
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 67, in main
    return args.func(args)
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 256, in apply
    args.save_to_disk,
  File "/usr/lib/python3.6/site-packages/nmstatectl/nmstatectl.py", line 289, in apply_state
    save_to_disk=save_to_disk,
  File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 73, in apply
    _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk)
  File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 123, in _apply_ifaces_state
    _verify_change(plugins, net_state)
  File "/usr/lib/python3.6/site-packages/libnmstate/netapplier.py", line 138, in _verify_change
    net_state.verify(current_state)
  File "/usr/lib/python3.6/site-packages/libnmstate/net_state.py", line 63, in verify
    self._ifaces.verify(current_state.get(Interface.KEY))
  File "/usr/lib/python3.6/site-packages/libnmstate/ifaces/ifaces.py", line 424, in verify
    iface.original_dict, {}
libnmstate.error.NmstateVerificationError:
desired
=======
---
name: ens2f0np0v0
type: ethernet
state: down

current
=======
--- {}

difference
==========
--- desired
+++ current
@@ -1,4 +1 @@
----
-name: ens2f0np0v0
-type: ethernet
-state: down
+--- {}
```

Ref: https://bugzilla.redhat.com/1959679

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>