### PR TITLE
libnmstate: introduce show_secrets argument

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -3,7 +3,7 @@
 .SH NAME
 nmstatectl \- A nmstate command line tool
 .SH SYNOPSIS
-.B nmstatectl show \fR[\fIINTERFACE_NAME\fR] [\fB--json\fR]
+.B nmstatectl show \fR[\fIINTERFACE_NAME\fR] [\fB--json\fR] [\fB--show-secrets\fR]
 .br
 .B nmstatectl show [\fB-r, --running-config\fR]
 .br
@@ -28,8 +28,12 @@ nmstatectl \- A nmstate command line tool
 .B show
 .RS
 Query the current network state. \fIYAML\fR is the default output format. Use
-the \fB--json\fR argument to change the output format to \fIJSON\fR. To limit
-the output state to include certain interfaces only, please specify the
+the \fB--json\fR argument to change the output format to \fIJSON\fR.
+.PP
+By default \fInmstatectl\fR does not include sensitive data in the report. Use
+\fB--show-secrets\fR in order to report sensitive data.
+.PP
+To limit the output state to include certain interfaces only, please specify the
 interface name. Please be advised, global config like DNS will be included.
 .PP
 For multiple interface names, use comma to separate them. You can also use

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -23,7 +23,7 @@ from .nmstate import show_with_plugins
 from .nmstate import show_running_config_with_plugins
 
 
-def show(*, include_status_data=False):
+def show(*, include_status_data=False, show_secrets=False):
     """
     Reports configuration and status data on the system.
     Configuration data is the set of writable data which can change the system
@@ -35,10 +35,14 @@ def show(*, include_status_data=False):
     """
     with plugin_context() as plugins:
         return remove_metadata_leftover(
-            show_with_plugins(plugins, include_status_data)
+            show_with_plugins(
+                plugins, include_status_data, show_secrets=show_secrets
+            )
         )
 
 
-def show_running_config():
+def show_running_config(show_secrets=False):
     with plugin_context() as plugins:
-        return show_running_config_with_plugins(plugins)
+        return show_running_config_with_plugins(
+            plugins, show_secrets=show_secrets
+        )

--- a/libnmstate/nispor/plugin.py
+++ b/libnmstate/nispor/plugin.py
@@ -132,10 +132,10 @@ class NisporPlugin(NmstatePlugin):
                 )
         return ifaces
 
-    def get_interfaces(self):
+    def get_interfaces(self, show_secrets=False):
         return self._get_interfaces(_INFO_TYPE_RUNNING)
 
-    def get_running_config_interfaces(self):
+    def get_running_config_interfaces(self, show_secrets=False):
         return self._get_interfaces(_INFO_TYPE_RUNNING_CONFIG)
 
     def get_routes(self):

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -112,7 +112,7 @@ class NetworkManagerPlugin(NmstatePlugin):
             NmstatePlugin.PLUGIN_CAPABILITY_DNS,
         ]
 
-    def get_interfaces(self):
+    def get_interfaces(self, show_secrets=False):
         info = []
 
         applied_configs = self._applied_configs
@@ -145,7 +145,9 @@ class NetworkManagerPlugin(NmstatePlugin):
             iface_info.update(get_infiniband_info(applied_config))
             iface_info.update(get_current_macvlan_type(applied_config))
             iface_info.update(get_current_veth_type(applied_config))
-            iface_info.update(get_802_1x_info(self.context, act_con))
+            iface_info.update(
+                get_802_1x_info(self.context, act_con, show_secrets)
+            )
 
             if iface_info[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
                 iface_info.update(get_ovs_bridge_info(dev))
@@ -164,8 +166,8 @@ class NetworkManagerPlugin(NmstatePlugin):
 
         return info
 
-    def get_running_config_interfaces(self):
-        iface_infos = self.get_interfaces()
+    def get_running_config_interfaces(self, show_secrets=False):
+        iface_infos = self.get_interfaces(show_secrets)
         # Remove LLDP neighber information
         for iface_info in iface_infos:
             if LLDP.CONFIG_SUBTREE in iface_info:

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -68,7 +68,10 @@ def plugin_context():
 
 
 def show_with_plugins(
-    plugins, include_status_data=None, info_type=_INFO_TYPE_RUNNING
+    plugins,
+    include_status_data=None,
+    info_type=_INFO_TYPE_RUNNING,
+    show_secrets=False,
 ):
     for plugin in plugins:
         plugin.refresh_content()
@@ -77,7 +80,7 @@ def show_with_plugins(
         report["capabilities"] = plugins_capabilities(plugins)
 
     report[Interface.KEY] = _get_interface_info_from_plugins(
-        plugins, info_type
+        plugins, info_type, show_secrets
     )
 
     report[Route.KEY] = _get_routes_from_plugins(plugins, info_type)
@@ -178,7 +181,7 @@ def _find_plugin_for_capability(plugins, capability):
     return chose_plugin
 
 
-def _get_interface_info_from_plugins(plugins, info_type):
+def _get_interface_info_from_plugins(plugins, info_type, show_secrets=False):
     all_ifaces = {}
     IFACE_PRIORITY_METADATA = "_plugin_priority"
     IFACE_PLUGIN_SRC_METADATA = "_plugin_source"
@@ -190,9 +193,9 @@ def _get_interface_info_from_plugins(plugins, info_type):
             continue
         try:
             if info_type == _INFO_TYPE_RUNNING_CONFIG:
-                ifaces = plugin.get_running_config_interfaces()
+                ifaces = plugin.get_running_config_interfaces(show_secrets)
             else:
-                ifaces = plugin.get_interfaces()
+                ifaces = plugin.get_interfaces(show_secrets)
         except NmstateDependencyError as e:
             logging.warning(f"Plugin {plugin.name} error: {e}")
             continue
@@ -392,8 +395,10 @@ def _get_iface_types_by_name(iface_infos, name):
     return iface_types
 
 
-def show_running_config_with_plugins(plugins):
-    return show_with_plugins(plugins, info_type=_INFO_TYPE_RUNNING_CONFIG)
+def show_running_config_with_plugins(plugins, show_secrets=False):
+    return show_with_plugins(
+        plugins, info_type=_INFO_TYPE_RUNNING_CONFIG, show_secrets=show_secrets
+    )
 
 
 def generate_configurations(desire_state):

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -52,7 +52,7 @@ class NmstatePlugin(metaclass=ABCMeta):
     def priority(self):
         return NmstatePlugin.DEFAULT_PRIORITY
 
-    def get_interfaces(self):
+    def get_interfaces(self, show_secrets=False):
         """
         Return a list of dict with network interface running status with
         mix of running status and running configure.
@@ -61,7 +61,7 @@ class NmstatePlugin(metaclass=ABCMeta):
             f"Plugin {self.name} BUG: get_interfaces() not implemented"
         )
 
-    def get_running_config_interfaces(self):
+    def get_running_config_interfaces(self, show_secrets=False):
         """
         Return a list of dict with network interface running configuration.
         Notes:

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -158,7 +158,7 @@ class NmstateOvsdbPlugin(NmstatePlugin):
     def plugin_capabilities(self):
         return NmstatePlugin.PLUGIN_CAPABILITY_IFACE
 
-    def get_interfaces(self):
+    def get_interfaces(self, show_secrets=False):
         ifaces = []
         for row in self._idl.tables["Interface"].rows.values():
             if row.type in ("internal", "patch"):

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -96,14 +96,16 @@ def test_run_ctl_directly_set():
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show"])
-@mock.patch.object(nmstatectl.libnmstate, "show", lambda: {})
+@mock.patch.object(nmstatectl.libnmstate, "show", lambda show_secrets: {})
 def test_run_ctl_directly_show_empty():
     nmstatectl.main()
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "non_existing_interface"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda show_secrets: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_only_empty(mock_stdout):
@@ -113,7 +115,9 @@ def test_run_ctl_directly_show_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda show_secrets: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_only(mock_stdout):
@@ -125,7 +129,9 @@ def test_run_ctl_directly_show_only(mock_stdout):
     "sys.argv", ["nmstatectl", "show", "--json", "non_existing_interface"]
 )
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda show_secrets: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only_empty(mock_stdout):
@@ -135,7 +141,9 @@ def test_run_ctl_directly_show_json_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "--json", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda show_secrets: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only(mock_stdout):

--- a/tests/integration/plugin_test.py
+++ b/tests/integration/plugin_test.py
@@ -103,7 +103,7 @@ TEST_ROUTE_RULE_STATE = {
 }
 
 GET_IFACES_FORMAT = """
-    def get_interfaces(self):
+    def get_interfaces(self, show_secrets):
         return {ifaces}
 """
 

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -75,7 +75,7 @@ def _iface_macs(state):
 
 
 def _prepare_state_for_verify(desired_state_data):
-    current_state_data = libnmstate.show()
+    current_state_data = libnmstate.show(show_secrets=True)
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -35,14 +35,14 @@ from libnmstate.schema import LinuxBridge
 from libnmstate.schema import OVSBridge
 
 
-def show_only(ifnames):
+def show_only(ifnames, show_secrets=False):
     """
     Report the current state, filtering based on the given interface names.
     """
     base_filter_state = {
         Interface.KEY: [{Interface.NAME: ifname} for ifname in ifnames]
     }
-    current_state = State(libnmstate.show())
+    current_state = State(libnmstate.show(show_secrets=show_secrets))
     current_state.filter(base_filter_state)
     return current_state.state
 
@@ -307,7 +307,7 @@ def filter_current_state(desired_state):
     in the desired state.
     In case there are no entities for filtering, all are reported.
     """
-    current_state = libnmstate.show()
+    current_state = libnmstate.show(show_secrets=True)
     desired_iface_names = {
         ifstate[Interface.NAME] for ifstate in desired_state[Interface.KEY]
     }


### PR DESCRIPTION
Nmstate needs to handle properly the secrets from the interfaces when
reporting, logging, crashing and verifying. In order to do that, this
patch is introducing the support for `show_secrets` argument for
`libnmstate.show()` and `--show-secrets` option for `nmstatectl show`.

Nmstate will not report, log, show when failing on verification or show
when crashing the sensitive data by default. When the new option is
present, Nmstate will show them on these situations. This can be used
for debugging or applying the current configuration in another host.

For `apply` and `edit` functions, Nmstate will only report, log or show
sensitive data if the desired state contains sensitive data. If the
desired state does not contain sensitive data, Nmstate will not do it.

Nmstatectl manpage documentation has been added.

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>