### PR TITLE
nm: Fix the format string

### DIFF
--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -261,7 +261,7 @@ class NetworkManagerPlugin(NmstatePlugin):
     def generate_configurations(self, net_state):
         if not hasattr(NM, "keyfile_write"):
             raise NmstateNotSupportedError(
-                f"Current NetworkManager version does not support generating "
+                "Current NetworkManager version does not support generating "
                 "configurations, please upgrade to 1.30 or later versoin."
             )
         return NmProfiles(None).generate_config_strings(net_state)


### PR DESCRIPTION
Remove the `f""` when no variable is used within.