### PR TITLE
[nmstate-1.1] iface: The original desire should be empty for non-desired interface

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -213,8 +213,11 @@ class BaseIface:
         return deepcopy(self._info)
 
     @property
-    def original_dict(self):
-        return self._origin_info
+    def original_desire_dict(self):
+        if self.is_desired:
+            return self._origin_info
+        else:
+            return {}
 
     @property
     def permanent_mac_address(self):
@@ -236,8 +239,8 @@ class BaseIface:
         """
         This function is called after metadata generation finished.
         Will do
-         * Raise NmstateValueError when user desire(self.original_dict) is
-           illegal.
+         * Raise NmstateValueError when user desire(self.original_desire_dict)
+           is illegal.
          * Clean up illegal setting introduced by merging.
         We don't split validation from clean up as they might sharing the same
         check code.
@@ -412,7 +415,7 @@ class BaseIface:
         self._capitalize_mac()
         if self.ethtool:
             self.ethtool.canonicalize(
-                self.original_dict.get(Ethtool.CONFIG_SUBTREE, {})
+                self.original_desire_dict.get(Ethtool.CONFIG_SUBTREE, {})
             )
             self._info[Ethtool.CONFIG_SUBTREE] = self.ethtool.to_dict()
         self.sort_port()
@@ -422,7 +425,8 @@ class BaseIface:
             self._info[family] = ip_state.to_dict()
         state = self.to_dict()
         _remove_empty_description(state)
-        _remove_undesired_data(state, self.original_dict)
+        if self.is_desired:
+            _remove_undesired_data(state, self.original_desire_dict)
         _remove_lldp_neighbors(state)
         if Interface.STATE not in state:
             state[Interface.STATE] = InterfaceState.UP

--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -105,7 +105,7 @@ class BondIface(BaseIface):
             )
             self.raw[Bond.CONFIG_SUBTREE][
                 Bond.OPTIONS_SUBTREE
-            ] = self.original_dict.get(Bond.CONFIG_SUBTREE, {}).get(
+            ] = self.original_desire_dict.get(Bond.CONFIG_SUBTREE, {}).get(
                 Bond.OPTIONS_SUBTREE, {}
             )
             self._normalize_options_values()
@@ -118,7 +118,7 @@ class BondIface(BaseIface):
 
     def _fix_mac_restriced_mode(self):
         if self.is_in_mac_restricted_mode:
-            if self.original_dict.get(Interface.MAC):
+            if self.original_desire_dict.get(Interface.MAC):
                 raise NmstateValueError(
                     "MAC address cannot be specified in bond interface along "
                     "with fail_over_mac active on active backup mode"
@@ -239,7 +239,7 @@ class BondIface(BaseIface):
 
     def _validate_ad_actor_system_mac_address(self):
         desire_mac = (
-            self.original_dict.get(Bond.CONFIG_SUBTREE, {})
+            self.original_desire_dict.get(Bond.CONFIG_SUBTREE, {})
             .get(Bond.OPTIONS_SUBTREE, {})
             .get("ad_actor_system")
         )

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -453,7 +453,7 @@ class Ifaces:
                     or parent_iface.is_changed
                 ):
                     if (
-                        Interface.STATE not in iface.original_dict
+                        Interface.STATE not in iface.original_desire_dict
                         or parent_iface.is_down
                         or parent_iface.is_absent
                     ):
@@ -611,14 +611,14 @@ class Ifaces:
                 if (
                     iface.is_virtual
                     and iface.type != InterfaceType.VETH
-                    and iface.original_dict.get(Interface.STATE)
+                    and iface.original_desire_dict.get(Interface.STATE)
                     in (InterfaceState.DOWN, InterfaceState.ABSENT)
                 ):
                     cur_iface = cur_ifaces.get_iface(iface.name, iface.type)
                     if cur_iface:
                         raise NmstateVerificationError(
                             format_desired_current_state_diff(
-                                iface.original_dict,
+                                iface.original_desire_dict,
                                 cur_iface.state_for_verify(),
                             )
                         )
@@ -627,7 +627,7 @@ class Ifaces:
                     if not cur_iface:
                         raise NmstateVerificationError(
                             format_desired_current_state_diff(
-                                iface.original_dict, {}
+                                iface.original_desire_dict, {}
                             )
                         )
                     elif not iface.match(cur_iface):

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -63,7 +63,7 @@ class LinuxBridgeIface(BridgeIface):
         self._validate_vlan_filtering_enable_native()
 
     def _validate_vlan_filtering_trunk_tags(self):
-        for port_config in self.original_dict.get(
+        for port_config in self.original_desire_dict.get(
             LinuxBridge.CONFIG_SUBTREE, {}
         ).get(LinuxBridge.PORT_SUBTREE, []):
             port_vlan_state = port_config.get(
@@ -92,7 +92,7 @@ class LinuxBridgeIface(BridgeIface):
         The "tag" is valid in access mode or tunk mode with
         "enable-native:True".
         """
-        for port_config in self.original_dict.get(
+        for port_config in self.original_desire_dict.get(
             LinuxBridge.CONFIG_SUBTREE, {}
         ).get(LinuxBridge.PORT_SUBTREE, []):
             vlan_config = _get_port_vlan_config(port_config)
@@ -106,7 +106,7 @@ class LinuxBridgeIface(BridgeIface):
                 )
 
     def _validate_vlan_filtering_enable_native(self):
-        for port_config in self.original_dict.get(
+        for port_config in self.original_desire_dict.get(
             LinuxBridge.CONFIG_SUBTREE, {}
         ).get(LinuxBridge.PORT_SUBTREE, []):
             vlan_config = _get_port_vlan_config(port_config)

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -233,14 +233,14 @@ class OvsInternalIface(BaseIface):
     def _validate_ovs_mtu_mac_confliction(self):
         if self.is_patch_port:
             if (
-                self.original_dict.get(Interface.IPV4, {}).get(
+                self.original_desire_dict.get(Interface.IPV4, {}).get(
                     InterfaceIP.ENABLED
                 )
-                or self.original_dict.get(Interface.IPV6, {}).get(
+                or self.original_desire_dict.get(Interface.IPV6, {}).get(
                     InterfaceIP.ENABLED
                 )
-                or self.original_dict.get(Interface.MTU)
-                or self.original_dict.get(Interface.MAC)
+                or self.original_desire_dict.get(Interface.MTU)
+                or self.original_desire_dict.get(Interface.MAC)
             ):
                 raise NmstateValueError(
                     "OVS Patch interface cannot contain MAC address, MTU"

--- a/libnmstate/nm/bond.py
+++ b/libnmstate/nm/bond.py
@@ -40,7 +40,7 @@ BOND_AD_ACTOR_SYSTEM_USE_BOND_MAC = "00:00:00:00:00:00"
 
 def create_setting(iface, wired_setting, base_con_profile):
     bond_setting = NM.SettingBond.new()
-    options = iface.original_dict.get(Bond.CONFIG_SUBTREE, {}).get(
+    options = iface.original_desire_dict.get(Bond.CONFIG_SUBTREE, {}).get(
         Bond.OPTIONS_SUBTREE
     )
     mode = iface.bond_mode

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -161,7 +161,7 @@ def create_new_nm_simple_conn(iface, nm_profile):
             linux_bridge_setting = create_linux_bridge_setting(
                 iface_info,
                 nm_profile,
-                iface.original_dict,
+                iface.original_desire_dict,
             )
             settings.append(linux_bridge_setting)
     elif iface.type == InterfaceType.OVS_BRIDGE:
@@ -179,7 +179,7 @@ def create_new_nm_simple_conn(iface, nm_profile):
         ib_setting = create_infiniband_setting(
             iface_info,
             nm_profile,
-            iface.original_dict,
+            iface.original_desire_dict,
         )
         if ib_setting:
             settings.append(ib_setting)
@@ -240,11 +240,13 @@ def create_new_nm_simple_conn(iface, nm_profile):
     if iface.ieee_802_1x_conf:
         settings.append(create_802_1x_setting(iface.ieee_802_1x_conf))
 
-    if Ethtool.CONFIG_SUBTREE in iface.original_dict and iface.is_desired:
+    if Ethtool.CONFIG_SUBTREE in iface.original_desire_dict:
         iface_ethtool = IfaceEthtool(
-            iface.original_dict[Ethtool.CONFIG_SUBTREE]
+            iface.original_desire_dict[Ethtool.CONFIG_SUBTREE]
         )
-        iface_ethtool.canonicalize(iface.original_dict[Ethtool.CONFIG_SUBTREE])
+        iface_ethtool.canonicalize(
+            iface.original_desire_dict[Ethtool.CONFIG_SUBTREE]
+        )
         setting = create_ethtool_setting(
             iface_ethtool,
             nm_profile,

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -286,7 +286,7 @@ class NmProfile:
             not gen_conf_mode
             and self._nm_profile is None
             and not self._iface.is_changed
-            and set(self._iface.original_dict)
+            and set(self._iface.original_desire_dict)
             <= set([Interface.STATE, Interface.NAME, Interface.TYPE])
         ):
             cur_nm_profile = self._get_first_nm_profile()

--- a/libnmstate/nm/wired.py
+++ b/libnmstate/nm/wired.py
@@ -69,7 +69,7 @@ class WiredSetting:
 
 
 def create_setting(iface, base_con_profile):
-    setting = WiredSetting(iface.original_dict)
+    setting = WiredSetting(iface.original_desire_dict)
 
     nm_wired_setting = None
     if base_con_profile:

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -218,7 +218,7 @@ class NmstateOvsdbPlugin(NmstatePlugin):
                 .get(OvsDB.OVS_DB_SUBTREE, {})
                 .get(OvsDB.EXTERNAL_IDS, {})
             )
-            original_desire_ids = iface.original_dict.get(
+            original_desire_ids = iface.original_desire_dict.get(
                 OvsDB.OVS_DB_SUBTREE, {}
             ).get(OvsDB.EXTERNAL_IDS)
 

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -158,6 +158,7 @@ class TestBaseIface:
 
         iface = BaseIface(iface_info)
         iface.raw["foo_a"] = "b"
+        iface.mark_as_desired()
 
         assert iface.state_for_verify() == expected_iface_info
 
@@ -179,3 +180,15 @@ class TestBaseIface:
         iface = BaseIface(gen_foo_iface_info())
         iface2 = BaseIface(gen_foo_iface_info())
         assert iface.config_changed_port(iface2) == []
+
+    def test_original_desire_dict(self):
+        iface = BaseIface(gen_foo_iface_info())
+
+        assert iface.original_desire_dict == {}
+
+        iface.mark_as_changed()
+        assert iface.original_desire_dict == {}
+
+        iface.mark_as_desired()
+        iface.raw["foo_a"] = "b"
+        assert iface.original_desire_dict == gen_foo_iface_info()

--- a/tests/lib/ifaces/ethernet_iface_test.py
+++ b/tests/lib/ifaces/ethernet_iface_test.py
@@ -130,4 +130,5 @@ class TestEthernetIface:
         ][0][Ethernet.SRIOV.VFS.MAC_ADDRESS] = expected_mac_addr
 
         iface = EthernetIface(iface_info)
+        iface.mark_as_desired()
         assert iface.state_for_verify() == expected_iface_info

--- a/tests/lib/ifaces/linux_bridge_iface_test.py
+++ b/tests/lib/ifaces/linux_bridge_iface_test.py
@@ -286,6 +286,7 @@ class TestLinuxBridgeIface:
         ]
 
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
 
@@ -295,6 +296,7 @@ class TestLinuxBridgeIface:
         port_config[Port.VLAN_SUBTREE].pop(Vlan.TRUNK_TAGS)
 
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
 
@@ -306,6 +308,7 @@ class TestLinuxBridgeIface:
         )
 
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
 
@@ -317,6 +320,7 @@ class TestLinuxBridgeIface:
         }
 
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
 
@@ -325,12 +329,14 @@ class TestLinuxBridgeIface:
         }
 
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
 
     def test_validate_tag_in_access_mode_and_native_trunk(self):
         iface_info = gen_bridge_iface_info_with_vlan_filter()
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
 
         iface.pre_edit_validation_and_cleanup()
 
@@ -339,6 +345,7 @@ class TestLinuxBridgeIface:
         port_conf = iface_info[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][1]
         port_conf[Port.VLAN_SUBTREE][Vlan.ENABLE_NATIVE] = False
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
 
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
@@ -348,6 +355,7 @@ class TestLinuxBridgeIface:
         port_conf = iface_info[LB.CONFIG_SUBTREE][LB.PORT_SUBTREE][0]
         port_conf[Port.VLAN_SUBTREE][Vlan.ENABLE_NATIVE] = True
         iface = LinuxBridgeIface(iface_info)
+        iface.mark_as_desired()
 
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
@@ -361,6 +369,7 @@ class TestLinuxBridgeIface:
 
         iface = LinuxBridgeIface(iface_info)
         iface.remove_port(PORT2_IFACE_NAME)
+        iface.mark_as_desired()
 
         assert iface.to_dict() == expected_iface_info
 

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -78,7 +78,7 @@ class TestIfaces:
             cur_iface = ifaces.get_cur_iface(
                 iface_info[Interface.NAME], iface_info[Interface.TYPE]
             )
-            assert cur_iface.original_dict == iface_info
+            assert cur_iface.to_dict() == iface_info
 
     def test_init_des_iface_infos_only(self):
         ifaces = Ifaces(
@@ -86,7 +86,7 @@ class TestIfaces:
         )
 
         assert [
-            i.original_dict for i in ifaces.all_ifaces()
+            i.original_desire_dict for i in ifaces.all_ifaces()
         ] == self._gen_iface_infos()
 
     def test_add_new_iface(self):

--- a/tests/lib/nm/bond_test.py
+++ b/tests/lib/nm/bond_test.py
@@ -36,7 +36,7 @@ def nm_mock():
 
 
 def _gen_bond_iface(bond_options, mode=BondMode.ROUND_ROBIN):
-    return BondIface(
+    iface = BondIface(
         {
             Interface.NAME: "foo",
             Interface.TYPE: InterfaceType.BOND,
@@ -46,6 +46,8 @@ def _gen_bond_iface(bond_options, mode=BondMode.ROUND_ROBIN):
             },
         }
     )
+    iface.mark_as_desired()
+    return iface
 
 
 def test_create_setting(nm_mock):

--- a/tests/lib/nm/wired_test.py
+++ b/tests/lib/nm/wired_test.py
@@ -32,9 +32,15 @@ def NM_mock():
         yield m
 
 
+def _create_ethernet_iface(info):
+    iface = EthernetIface(info)
+    iface.mark_as_desired()
+    return iface
+
+
 def test_create_setting_None(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
             }
@@ -48,7 +54,7 @@ def test_create_setting_duplicate(NM_mock):
     base_profile = mock.MagicMock()
 
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
                 schema.Ethernet.CONFIG_SUBTREE: {schema.Ethernet.SPEED: 1000},
@@ -64,7 +70,7 @@ def test_create_setting_duplicate(NM_mock):
 
 def test_create_setting_mac(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
                 schema.Interface.MAC: "01:23:45:67:89:ab",
@@ -78,7 +84,7 @@ def test_create_setting_mac(NM_mock):
 
 def test_create_setting_mtu(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {schema.Interface.NAME: "foo", schema.Interface.MTU: 1500}
         ),
         None,
@@ -88,7 +94,7 @@ def test_create_setting_mtu(NM_mock):
 
 
 def test_create_setting_auto_negotiation_False(NM_mock):
-    iface = EthernetIface(
+    iface = _create_ethernet_iface(
         {
             schema.Interface.NAME: "foo",
             schema.Ethernet.CONFIG_SUBTREE: {
@@ -120,7 +126,7 @@ def test_create_setting_auto_negotiation_False(NM_mock):
 
 def test_create_setting_only_auto_negotiation_True(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
                 schema.Ethernet.CONFIG_SUBTREE: {
@@ -138,7 +144,7 @@ def test_create_setting_only_auto_negotiation_True(NM_mock):
 
 def test_create_setting_auto_negotiation_speed_duplex(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
                 schema.Ethernet.CONFIG_SUBTREE: {
@@ -158,7 +164,7 @@ def test_create_setting_auto_negotiation_speed_duplex(NM_mock):
 
 def test_create_setting_speed_duplex(NM_mock):
     setting = nm.wired.create_setting(
-        EthernetIface(
+        _create_ethernet_iface(
             {
                 schema.Interface.NAME: "foo",
                 schema.Ethernet.CONFIG_SUBTREE: {


### PR DESCRIPTION
When certain interface been marked as changed, the `Iface.original_dict`
will be the full current status, which is incorrect to its definition.

Renamed the property to `Iface.original_desire_dict` and return {} when
not desired.

Unit test case included.