### PR TITLE
vrf: Ignore MAC and accept_all_mac_addresses=false

### DIFF
--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -43,6 +43,7 @@ TEST_ROUTE_TABLE_ID0 = 100
 TEST_ROUTE_TABLE_ID1 = 101
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV6_ADDRESS1 = "2001:db8:1::1"
+TEST_MAC_ADDRESS = "00:00:5E:00:53:01"
 
 
 @pytest.fixture
@@ -251,3 +252,27 @@ class TestVrf:
 
     def test_takes_over_unmanaged_vrf(self, vrf1_with_unmanaged_port):
         pass
+
+    def test_vrf_ignore_mac_address(self, vrf0_with_port0):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VRF0,
+                        Interface.MAC: TEST_MAC_ADDRESS,
+                    }
+                ]
+            }
+        )
+
+    def test_vrf_ignore_accept_all_mac_addresses_false(self, vrf0_with_port0):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VRF0,
+                        Interface.ACCEPT_ALL_MAC_ADDRESSES: False,
+                    }
+                ]
+            }
+        )

--- a/tests/lib/ifaces/vrf_iface_test.py
+++ b/tests/lib/ifaces/vrf_iface_test.py
@@ -21,10 +21,12 @@ import pytest
 
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import VRF
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
 from libnmstate.ifaces.vrf import VrfIface
 
+from ..testlib.constants import MAC_ADDRESS1
 from ..testlib.ifacelib import gen_foo_iface_info
 
 PORT1_IFACE_NAME = "port1"
@@ -67,5 +69,28 @@ class TestVrfIface:
         iface_info = self._gen_iface_info()
         iface_info[VRF.CONFIG_SUBTREE].pop(VRF.ROUTE_TABLE_ID)
         iface = VrfIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
+
+    def test_remove_mac_address(self):
+        iface_info = self._gen_iface_info()
+        iface_info[Interface.MAC] = MAC_ADDRESS1
+        iface = VrfIface(iface_info)
+        iface.mark_as_desired()
+        iface.pre_edit_validation_and_cleanup()
+        assert Interface.MAC not in iface.original_desire_dict
+        assert Interface.MAC not in iface.to_dict()
+
+    def test_remove_accept_all_mac_addresses_false(self):
+        iface_info = self._gen_iface_info()
+        iface_info[Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
+        iface = VrfIface(iface_info)
+        iface.mark_as_desired()
+        iface.pre_edit_validation_and_cleanup()
+
+        assert (
+            Interface.ACCEPT_ALL_MAC_ADDRESSES
+            not in iface.original_desire_dict
+        )
+        assert Interface.ACCEPT_ALL_MAC_ADDRESSES not in iface.to_dict()


### PR DESCRIPTION
The VRF does not support changing MAC address and
accept_all_mac_addresses mode.

This patch ignore mac address in desire state with warning.
This patch also ignore `ACCEPT_ALL_MAC_ADDRESSES=False` in desire state
without any warning.

For `ACCEPT_ALL_MAC_ADDRESSES=True`, user will get verification error
which unrelated to this patch.

Unit and integration test cases are included.