### PR TITLE
bond: Use perm_hwaddr of bond port as fallback for copy_mac_from

### DIFF
--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -96,6 +96,15 @@ class NisporPluginBaseIface:
             iface_info[
                 BaseIface.PERMANENT_MAC_ADDRESS_METADATA
             ] = self._np_iface.permanent_mac_address
+        elif (
+            self._np_iface.controller_type == "bond"
+            and self._np_iface.subordinate_state.perm_hwaddr
+        ):
+            # Bond port also hold perm_hwaddr which is the mac address before
+            # this interface been assgined to bond as subordinate.
+            iface_info[
+                BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+            ] = self._np_iface.subordinate_state.perm_hwaddr
         if self.mtu:
             iface_info[Interface.MTU] = self.mtu
         ip_info = self._ip_info(config_only)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1146,3 +1146,26 @@ def test_bond_ad_actor_system_with_multicast_mac_address(bond99_with_2_port):
 
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+@pytest.mark.tier1
+def test_create_bond_with_copy_mac_from_bond_port_perm_hwaddr(
+    eth1_up, eth2_up
+):
+    eth1_mac = eth1_up[Interface.KEY][0][Interface.MAC]
+    eth2_mac = eth2_up[Interface.KEY][0][Interface.MAC]
+
+    with bond_interface(
+        BOND99,
+        ["eth1", "eth2"],
+        extra_iface_state={Interface.COPY_MAC_FROM: "eth2"},
+    ):
+        current_state = statelib.show_only((BOND99,))
+        assert_mac_address(current_state, eth2_mac)
+        with bond_interface(
+            BOND99,
+            ["eth1", "eth2"],
+            extra_iface_state={Interface.COPY_MAC_FROM: "eth1"},
+        ):
+            current_state = statelib.show_only((BOND99,))
+            assert_mac_address(current_state, eth1_mac)


### PR DESCRIPTION
The kernel will store the bond port's original MAC address of `perm_hwaddr`
before assigning it to a bond controller.

When the NIC does not support ethtool permanent address, we should use
above address as fallback.

Add integration test case using veth which does not support ethtool
permanent address.