### PR TITLE
SR-IOV: Fix issue when VF pre-exist before PF changes.

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -235,11 +235,16 @@ class Ifaces:
                 and iface.sriov_total_vfs > 0
             ):
                 for new_iface in iface.create_sriov_vf_ifaces():
-                    if new_iface.name not in self._kernel_ifaces:
+                    cur_iface = self._kernel_ifaces.get(new_iface.name)
+                    if cur_iface and cur_iface.is_desired:
+                        raise NmstateNotSupportedError(
+                            "Does not support changing SR-IOV PF interface "
+                            "along with VF interface in the single desire "
+                            f"state: PF {iface.name}, VF {cur_iface.name}"
+                        )
+                    else:
                         new_iface.mark_as_desired()
                         new_ifaces.append(new_iface)
-                    else:
-                        self._kernel_ifaces[new_iface.name].mark_as_desired()
         for new_iface in new_ifaces:
             self._kernel_ifaces[new_iface.name] = new_iface
 

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -39,9 +39,6 @@ from .veth import create_iface_for_nm_veth_peer
 from .veth import is_nm_veth_supported
 
 
-IS_GENERATED_VF_METADATA = "_is_generated_vf"
-
-
 class NmProfiles:
     def __init__(self, context):
         self._ctx = context
@@ -70,7 +67,7 @@ class NmProfiles:
             for iface in sorted(
                 list(net_state.ifaces.all_ifaces()), key=attrgetter("name")
             )
-            if not _is_only_for_verify(iface)
+            if not getattr(iface, "is_generated_vf", None)
         ]
 
         for profile in all_profiles:
@@ -393,7 +390,3 @@ def _nm_ovs_port_has_child(nm_profile, ovs_bridge_iface, net_state):
         ):
             return True
     return False
-
-
-def _is_only_for_verify(iface):
-    return iface.to_dict().get(IS_GENERATED_VF_METADATA)


### PR DESCRIPTION
With igb driver, after PF changed `total_vfs`, VF will be in unpredictable
state as kernel is resetting existing VFs which might bring NetworkManager
showing the VF as down or up depends on kernel progress. The verification
will fail on VF not in desired state down or up.

To fix the issue,
  * Ignore `Interface.STATE` at verification for generated VFs.
  * Raise exception when user try to change PF and VF in the same
    desire state.

Unit test case included. There is no known user who would place VF and PF
both controlled by NetworkManager, so no integration test case.

Manual tested on igb card.