### PR TITLE
ifaces: Remove PERMANENT_MAC_ADDRESS_METADATA before verification

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -411,6 +411,7 @@ class BaseIface:
             * Remove empty description.
             * Change OVSDB value to string.
             * Remove RX/TX when Ethtool.Pause.AUTO_NEGOTIATION is True
+            * Remove metadata of PERMANENT_MAC_ADDRESS_METADATA
         """
         self._capitalize_mac()
         if self.ethtool:
@@ -433,6 +434,7 @@ class BaseIface:
         if self.is_absent and not self._save_to_disk:
             state[Interface.STATE] = InterfaceState.DOWN
         _convert_ovs_external_ids_values_to_string(state)
+        state.pop(BaseIface.PERMANENT_MAC_ADDRESS_METADATA, None)
 
         return state
 

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -192,3 +192,13 @@ class TestBaseIface:
         iface.mark_as_desired()
         iface.raw["foo_a"] = "b"
         assert iface.original_desire_dict == gen_foo_iface_info()
+
+    def test_state_for_verify_remove_metadata(self):
+        iface_info = gen_foo_iface_info()
+        iface_info[BaseIface.PERMANENT_MAC_ADDRESS_METADATA] = MAC_ADDRESS1
+        iface = BaseIface(iface_info)
+
+        assert (
+            BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+            not in iface.state_for_verify()
+        )


### PR DESCRIPTION
Unit test case included.