### PR TITLE
nm: iterate the main context when refresh required

### DIFF
--- a/libnmstate/nm/context.py
+++ b/libnmstate/nm/context.py
@@ -69,6 +69,10 @@ class NmContext:
     def cancellable(self):
         return self._cancellable
 
+    def refresh(self):
+        while self.context.iteration(False):
+            pass
+
     @property
     def client(self):
         if self._quitting:

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -191,6 +191,8 @@ class NetworkManagerPlugin(NmstatePlugin):
 
     def refresh_content(self):
         self.__applied_configs = None
+        if self._ctx:
+            self._ctx.refresh()
 
     def apply_changes(self, net_state, save_to_disk):
         NmProfiles(self.context).apply_config(net_state, save_to_disk)


### PR DESCRIPTION
In CI, we noticed nmstate might not able to retried applied config
for DHCP interface even with retry. This might caused by outdated cache
in `NM.Client` and cache is not refreshed after simple sleep between
verification.

The fix is iterate the main context till all event processed when
refreshing is issued.