### PR TITLE
802.1x: Hide the password from output by default

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -124,6 +124,12 @@ change the output format to \fIJSON\fR.
 Showing the running network configuration.
 .RE
 
+.B -s, --show-secrets
+.RS
+Showing with the secrets. By default, nmstate is masking the passwords by
+\fI<_password_hid_by_nmstate>\fR.
+.RE
+
 .IP \fB--no-verify
 skip the desired network state verification.
 .IP \fB--no-commit

--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -36,8 +36,9 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import LLDP
 from libnmstate.schema import OvsDB
 
-from ..state import state_match
+from ..state import hide_the_secrets
 from ..state import merge_dict
+from ..state import state_match
 from .ethtool import IfaceEthtool
 
 
@@ -210,7 +211,9 @@ class BaseIface:
         self._origin_info[Interface.STATE] = InterfaceState.ABSENT
 
     def to_dict(self):
-        return deepcopy(self._info)
+        info = deepcopy(self._info)
+        hide_the_secrets(info)
+        return info
 
     @property
     def original_desire_dict(self):

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -23,7 +23,7 @@ from .nmstate import show_with_plugins
 from .nmstate import show_running_config_with_plugins
 
 
-def show(*, include_status_data=False):
+def show(*, include_status_data=False, include_secrets=False):
     """
     Reports configuration and status data on the system.
     Configuration data is the set of writable data which can change the system
@@ -35,10 +35,14 @@ def show(*, include_status_data=False):
     """
     with plugin_context() as plugins:
         return remove_metadata_leftover(
-            show_with_plugins(plugins, include_status_data)
+            show_with_plugins(
+                plugins,
+                include_status_data=include_status_data,
+                include_secrets=include_secrets,
+            )
         )
 
 
-def show_running_config():
+def show_running_config(include_secrets=False):
     with plugin_context() as plugins:
-        return show_running_config_with_plugins(plugins)
+        return show_running_config_with_plugins(plugins, include_secrets)

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -38,6 +38,7 @@ from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
+from libnmstate.state import hide_the_secrets
 
 
 def main():
@@ -227,6 +228,13 @@ def setup_subcommand_show(subparsers):
         dest="running_config",
     )
     parser_show.add_argument(
+        "-s, --show-secrets",
+        help="Show secrets also",
+        default=False,
+        action="store_true",
+        dest="include_secrets",
+    )
+    parser_show.add_argument(
         "only",
         default="*",
         nargs="?",
@@ -302,9 +310,11 @@ def rollback(args):
 
 def show(args):
     if args.running_config:
-        full_state = libnmstate.show_running_config()
+        full_state = libnmstate.show_running_config(
+            include_secrets=args.include_secrets
+        )
     else:
-        full_state = libnmstate.show()
+        full_state = libnmstate.show(include_secrets=args.include_secrets)
     state = _filter_state(full_state, args.only)
     print_state(state, use_yaml=args.yaml)
 
@@ -397,6 +407,7 @@ def apply_state(statedata, verify_change, commit, timeout, save_to_disk):
         )
         return os.EX_UNAVAILABLE
 
+    hide_the_secrets(state)
     print("Desired state applied: ")
     print_state(state, use_yaml=use_yaml)
     if checkpoint:

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -96,16 +96,23 @@ def test_run_ctl_directly_set():
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show"])
-@mock.patch.object(nmstatectl.libnmstate, "show", lambda: {})
+@mock.patch.object(nmstatectl.libnmstate, "show", lambda *args, **kwargs: {})
 def test_run_ctl_directly_show_empty():
     nmstatectl.main()
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "non_existing_interface"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
+@mock.patch.object(
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
+)
 def test_run_ctl_directly_show_only_empty(mock_stdout):
     nmstatectl.main()
     assert mock_stdout.getvalue() == EMPTY_YAML_STATE
@@ -113,7 +120,9 @@ def test_run_ctl_directly_show_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_only(mock_stdout):
@@ -125,7 +134,9 @@ def test_run_ctl_directly_show_only(mock_stdout):
     "sys.argv", ["nmstatectl", "show", "--json", "non_existing_interface"]
 )
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(EMPTY_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only_empty(mock_stdout):
@@ -135,7 +146,9 @@ def test_run_ctl_directly_show_json_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "--json", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only(mock_stdout):

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -75,7 +75,7 @@ def _iface_macs(state):
 
 
 def _prepare_state_for_verify(desired_state_data):
-    current_state_data = libnmstate.show()
+    current_state_data = libnmstate.show(include_secrets=True)
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -35,14 +35,17 @@ from libnmstate.schema import LinuxBridge
 from libnmstate.schema import OVSBridge
 
 
-def show_only(ifnames):
+def show_only(ifnames, include_secrets=False):
     """
     Report the current state, filtering based on the given interface names.
     """
     base_filter_state = {
         Interface.KEY: [{Interface.NAME: ifname} for ifname in ifnames]
     }
-    current_state = State(libnmstate.show())
+    if include_secrets:
+        current_state = State(libnmstate.show(include_secrets=True))
+    else:
+        current_state = State(libnmstate.show())
     current_state.filter(base_filter_state)
     return current_state.state
 

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -202,3 +202,10 @@ class TestBaseIface:
             BaseIface.PERMANENT_MAC_ADDRESS_METADATA
             not in iface.state_for_verify()
         )
+
+    def test_to_dict_hide_the_password(self):
+        iface_info = gen_foo_iface_info()
+        iface_info["password"] = "foo"
+        iface = BaseIface(iface_info)
+
+        assert iface.to_dict()["password"] != "foo"


### PR DESCRIPTION
Introduced new argument `include_secret=False|True` to:
    * `libnmstate.show_running_config()`
    * `libnmstate.show()`

which will mask the passwords with `<_password_hid_by_nmstate>` by
default(`include_secret=False`).

The passwords are also masked in logging and error message.

Added new argument:
    * `nmstatectl show -s `

Without `-s` switch, nmstatectl output will use the masked password.

Integration test case updated.
Unit test cases included.