### PR TITLE
[nmstate-1.1] Backport patches from main branch

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -24,11 +24,16 @@ COPR_ARG=""
 
 if [ $OS_TYPE == "el8" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
+    CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;'
 elif [ $OS_TYPE == "stream" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos-stream-nmstate-dev"
+    CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'

--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -134,6 +134,12 @@ change the output format to \fIJSON\fR.
 Showing the running network configuration.
 .RE
 
+.B -s, --show-secrets
+.RS
+Showing with the secrets. By default, nmstate is masking the passwords by
+\fI<_password_hid_by_nmstate>\fR.
+.RE
+
 .IP \fB--no-verify
 skip the desired network state verification.
 .IP \fB--no-commit

--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -36,8 +36,9 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import LLDP
 from libnmstate.schema import OvsDB
 
-from ..state import state_match
+from ..state import hide_the_secrets
 from ..state import merge_dict
+from ..state import state_match
 from .ethtool import IfaceEthtool
 
 
@@ -210,7 +211,9 @@ class BaseIface:
         self._origin_info[Interface.STATE] = InterfaceState.ABSENT
 
     def to_dict(self):
-        return deepcopy(self._info)
+        info = deepcopy(self._info)
+        hide_the_secrets(info)
+        return info
 
     @property
     def original_desire_dict(self):

--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -411,6 +411,7 @@ class BaseIface:
             * Remove empty description.
             * Change OVSDB value to string.
             * Remove RX/TX when Ethtool.Pause.AUTO_NEGOTIATION is True
+            * Remove metadata of PERMANENT_MAC_ADDRESS_METADATA
         """
         self._capitalize_mac()
         if self.ethtool:
@@ -433,6 +434,7 @@ class BaseIface:
         if self.is_absent and not self._save_to_disk:
             state[Interface.STATE] = InterfaceState.DOWN
         _convert_ovs_external_ids_values_to_string(state)
+        state.pop(BaseIface.PERMANENT_MAC_ADDRESS_METADATA, None)
 
         return state
 

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -236,11 +236,16 @@ class Ifaces:
                 and iface.sriov_total_vfs > 0
             ):
                 for new_iface in iface.create_sriov_vf_ifaces():
-                    if new_iface.name not in self._kernel_ifaces:
+                    cur_iface = self._kernel_ifaces.get(new_iface.name)
+                    if cur_iface and cur_iface.is_desired:
+                        raise NmstateNotSupportedError(
+                            "Does not support changing SR-IOV PF interface "
+                            "along with VF interface in the single desire "
+                            f"state: PF {iface.name}, VF {cur_iface.name}"
+                        )
+                    else:
                         new_iface.mark_as_desired()
                         new_ifaces.append(new_iface)
-                    else:
-                        self._kernel_ifaces[new_iface.name].mark_as_desired()
         for new_iface in new_ifaces:
             self._kernel_ifaces[new_iface.name] = new_iface
 

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -23,7 +23,7 @@ from .nmstate import show_with_plugins
 from .nmstate import show_running_config_with_plugins
 
 
-def show(*, include_status_data=False):
+def show(*, include_status_data=False, include_secrets=False):
     """
     Reports configuration and status data on the system.
     Configuration data is the set of writable data which can change the system
@@ -35,10 +35,14 @@ def show(*, include_status_data=False):
     """
     with plugin_context() as plugins:
         return remove_metadata_leftover(
-            show_with_plugins(plugins, include_status_data)
+            show_with_plugins(
+                plugins,
+                include_status_data=include_status_data,
+                include_secrets=include_secrets,
+            )
         )
 
 
-def show_running_config():
+def show_running_config(include_secrets=False):
     with plugin_context() as plugins:
-        return show_running_config_with_plugins(plugins)
+        return show_running_config_with_plugins(plugins, include_secrets)

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -96,6 +96,15 @@ class NisporPluginBaseIface:
             iface_info[
                 BaseIface.PERMANENT_MAC_ADDRESS_METADATA
             ] = self._np_iface.permanent_mac_address
+        elif (
+            self._np_iface.controller_type == "bond"
+            and self._np_iface.subordinate_state.perm_hwaddr
+        ):
+            # Bond port also hold perm_hwaddr which is the mac address before
+            # this interface been assgined to bond as subordinate.
+            iface_info[
+                BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+            ] = self._np_iface.subordinate_state.perm_hwaddr
         if self.mtu:
             iface_info[Interface.MTU] = self.mtu
         ip_info = self._ip_info(config_only)

--- a/libnmstate/nm/context.py
+++ b/libnmstate/nm/context.py
@@ -69,6 +69,10 @@ class NmContext:
     def cancellable(self):
         return self._cancellable
 
+    def refresh(self):
+        while self.context.iteration(False):
+            pass
+
     @property
     def client(self):
         if self._quitting:

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -196,6 +196,8 @@ class NetworkManagerPlugin(NmstatePlugin):
 
     def refresh_content(self):
         self.__applied_configs = None
+        if self._ctx:
+            self._ctx.refresh()
 
     def apply_changes(self, net_state, save_to_disk):
         NmProfiles(self.context).apply_config(net_state, save_to_disk)

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -39,9 +39,6 @@ from .veth import create_iface_for_nm_veth_peer
 from .veth import is_nm_veth_supported
 
 
-IS_GENERATED_VF_METADATA = "_is_generated_vf"
-
-
 class NmProfiles:
     def __init__(self, context):
         self._ctx = context
@@ -70,7 +67,7 @@ class NmProfiles:
             for iface in sorted(
                 list(net_state.ifaces.all_ifaces()), key=attrgetter("name")
             )
-            if not _is_only_for_verify(iface)
+            if not getattr(iface, "is_generated_vf", None)
         ]
 
         for profile in all_profiles:
@@ -393,7 +390,3 @@ def _nm_ovs_port_has_child(nm_profile, ovs_bridge_iface, net_state):
         ):
             return True
     return False
-
-
-def _is_only_for_verify(iface):
-    return iface.to_dict().get(IS_GENERATED_VF_METADATA)

--- a/tests/ctl/nmstatectl_test.py
+++ b/tests/ctl/nmstatectl_test.py
@@ -96,16 +96,23 @@ def test_run_ctl_directly_set():
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show"])
-@mock.patch.object(nmstatectl.libnmstate, "show", lambda: {})
+@mock.patch.object(nmstatectl.libnmstate, "show", lambda *args, **kwargs: {})
 def test_run_ctl_directly_show_empty():
     nmstatectl.main()
 
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "non_existing_interface"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
+@mock.patch.object(
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
+)
 def test_run_ctl_directly_show_only_empty(mock_stdout):
     nmstatectl.main()
     assert mock_stdout.getvalue() == EMPTY_YAML_STATE
@@ -113,7 +120,9 @@ def test_run_ctl_directly_show_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_only(mock_stdout):
@@ -125,7 +134,9 @@ def test_run_ctl_directly_show_only(mock_stdout):
     "sys.argv", ["nmstatectl", "show", "--json", "non_existing_interface"]
 )
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(EMPTY_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only_empty(mock_stdout):
@@ -135,7 +146,9 @@ def test_run_ctl_directly_show_json_only_empty(mock_stdout):
 
 @mock.patch("sys.argv", ["nmstatectl", "show", "--json", "lo"])
 @mock.patch.object(
-    nmstatectl.libnmstate, "show", lambda: json.loads(LO_JSON_STATE)
+    nmstatectl.libnmstate,
+    "show",
+    lambda *args, **kwargs: json.loads(LO_JSON_STATE),
 )
 @mock.patch("nmstatectl.nmstatectl.sys.stdout", new_callable=io.StringIO)
 def test_run_ctl_directly_show_json_only(mock_stdout):

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1146,3 +1146,26 @@ def test_bond_ad_actor_system_with_multicast_mac_address(bond99_with_2_port):
 
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+@pytest.mark.tier1
+def test_create_bond_with_copy_mac_from_bond_port_perm_hwaddr(
+    eth1_up, eth2_up
+):
+    eth1_mac = eth1_up[Interface.KEY][0][Interface.MAC]
+    eth2_mac = eth2_up[Interface.KEY][0][Interface.MAC]
+
+    with bond_interface(
+        BOND99,
+        ["eth1", "eth2"],
+        extra_iface_state={Interface.COPY_MAC_FROM: "eth2"},
+    ):
+        current_state = statelib.show_only((BOND99,))
+        assert_mac_address(current_state, eth2_mac)
+        with bond_interface(
+            BOND99,
+            ["eth1", "eth2"],
+            extra_iface_state={Interface.COPY_MAC_FROM: "eth1"},
+        ):
+            current_state = statelib.show_only((BOND99,))
+            assert_mac_address(current_state, eth1_mac)

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -75,7 +75,7 @@ def _iface_macs(state):
 
 
 def _prepare_state_for_verify(desired_state_data):
-    current_state_data = libnmstate.show()
+    current_state_data = libnmstate.show(include_secrets=True)
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -35,14 +35,17 @@ from libnmstate.schema import LinuxBridge
 from libnmstate.schema import OVSBridge
 
 
-def show_only(ifnames):
+def show_only(ifnames, include_secrets=False):
     """
     Report the current state, filtering based on the given interface names.
     """
     base_filter_state = {
         Interface.KEY: [{Interface.NAME: ifname} for ifname in ifnames]
     }
-    current_state = State(libnmstate.show())
+    if include_secrets:
+        current_state = State(libnmstate.show(include_secrets=True))
+    else:
+        current_state = State(libnmstate.show())
     current_state.filter(base_filter_state)
     return current_state.state
 

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -43,6 +43,7 @@ TEST_ROUTE_TABLE_ID0 = 100
 TEST_ROUTE_TABLE_ID1 = 101
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV6_ADDRESS1 = "2001:db8:1::1"
+TEST_MAC_ADDRESS = "00:00:5E:00:53:01"
 
 
 @pytest.fixture
@@ -251,3 +252,27 @@ class TestVrf:
 
     def test_takes_over_unmanaged_vrf(self, vrf1_with_unmanaged_port):
         pass
+
+    def test_vrf_ignore_mac_address(self, vrf0_with_port0):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VRF0,
+                        Interface.MAC: TEST_MAC_ADDRESS,
+                    }
+                ]
+            }
+        )
+
+    def test_vrf_ignore_accept_all_mac_addresses_false(self, vrf0_with_port0):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VRF0,
+                        Interface.ACCEPT_ALL_MAC_ADDRESSES: False,
+                    }
+                ]
+            }
+        )

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -192,3 +192,13 @@ class TestBaseIface:
         iface.mark_as_desired()
         iface.raw["foo_a"] = "b"
         assert iface.original_desire_dict == gen_foo_iface_info()
+
+    def test_state_for_verify_remove_metadata(self):
+        iface_info = gen_foo_iface_info()
+        iface_info[BaseIface.PERMANENT_MAC_ADDRESS_METADATA] = MAC_ADDRESS1
+        iface = BaseIface(iface_info)
+
+        assert (
+            BaseIface.PERMANENT_MAC_ADDRESS_METADATA
+            not in iface.state_for_verify()
+        )

--- a/tests/lib/ifaces/base_iface_test.py
+++ b/tests/lib/ifaces/base_iface_test.py
@@ -202,3 +202,10 @@ class TestBaseIface:
             BaseIface.PERMANENT_MAC_ADDRESS_METADATA
             not in iface.state_for_verify()
         )
+
+    def test_to_dict_hide_the_password(self):
+        iface_info = gen_foo_iface_info()
+        iface_info["password"] = "foo"
+        iface = BaseIface(iface_info)
+
+        assert iface.to_dict()["password"] != "foo"

--- a/tests/lib/ifaces/vrf_iface_test.py
+++ b/tests/lib/ifaces/vrf_iface_test.py
@@ -21,10 +21,12 @@ import pytest
 
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import VRF
+from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 
 from libnmstate.ifaces.vrf import VrfIface
 
+from ..testlib.constants import MAC_ADDRESS1
 from ..testlib.ifacelib import gen_foo_iface_info
 
 PORT1_IFACE_NAME = "port1"
@@ -67,5 +69,28 @@ class TestVrfIface:
         iface_info = self._gen_iface_info()
         iface_info[VRF.CONFIG_SUBTREE].pop(VRF.ROUTE_TABLE_ID)
         iface = VrfIface(iface_info)
+        iface.mark_as_desired()
         with pytest.raises(NmstateValueError):
             iface.pre_edit_validation_and_cleanup()
+
+    def test_remove_mac_address(self):
+        iface_info = self._gen_iface_info()
+        iface_info[Interface.MAC] = MAC_ADDRESS1
+        iface = VrfIface(iface_info)
+        iface.mark_as_desired()
+        iface.pre_edit_validation_and_cleanup()
+        assert Interface.MAC not in iface.original_desire_dict
+        assert Interface.MAC not in iface.to_dict()
+
+    def test_remove_accept_all_mac_addresses_false(self):
+        iface_info = self._gen_iface_info()
+        iface_info[Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
+        iface = VrfIface(iface_info)
+        iface.mark_as_desired()
+        iface.pre_edit_validation_and_cleanup()
+
+        assert (
+            Interface.ACCEPT_ALL_MAC_ADDRESSES
+            not in iface.original_desire_dict
+        )
+        assert Interface.ACCEPT_ALL_MAC_ADDRESSES not in iface.to_dict()


### PR DESCRIPTION
Backported below patches from main/base branch:

2f8278c SR-IOV: Fix issue when VF pre-exist before PF changes.
92b1b30 802.1x: Hide the password from output by default
cbece70 ifaces: Remove PERMANENT_MAC_ADDRESS_METADATA before verification
3a9825f nm: iterate the main context when refresh required
9408ae4 bond: Use perm_hwaddr of bond port as fallback for copy_mac_from
1634391 vrf: Ignore MAC and accept_all_mac_addresses=false

The python3-varlink rpm has been removed from container image, instead of maintaining different container images for different branches, added a patch just instruct github ci to install that rpm before test.