### PR TITLE
[nmstate-1.0] nm ovs: Fix OVS bridge and interface using the same name

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -24,11 +24,16 @@ COPR_ARG=""
 
 if [ $OS_TYPE == "el8" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
+    CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;'
 elif [ $OS_TYPE == "stream" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos-stream-nmstate-dev"
+    CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
+        dnf install -y python3-varlink libvarlink-util;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'

--- a/libnmstate/nm/device.py
+++ b/libnmstate/nm/device.py
@@ -198,3 +198,11 @@ def get_nm_dev(ctx, iface_name, iface_type):
         ):
             return nm_dev
     return None
+
+
+def is_kernel_iface(nm_dev):
+    iface_type = get_iface_type(nm_dev)
+    return iface_type != InterfaceType.UNKNOWN and iface_type not in (
+        InterfaceType.OVS_BRIDGE,
+        InterfaceType.OVS_PORT,
+    )

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -36,6 +36,7 @@ from .common import NM
 from .context import NmContext
 from .device import get_device_common_info
 from .device import get_iface_type
+from .device import is_kernel_iface
 from .device import list_devices
 from .dns import get_running as get_dns_running
 from .dns import get_running_config as get_dns_running_config
@@ -63,7 +64,8 @@ class NetworkManagerPlugin(NmstatePlugin):
     def __init__(self):
         self._ctx = None
         self._checkpoint = None
-        self.__applied_configs = None
+        self.__kernel_nic_applied_configs = None
+        self.__userspace_nic_applied_configs = None
 
     @property
     def priority(self):
@@ -79,10 +81,28 @@ class NetworkManagerPlugin(NmstatePlugin):
             self._ctx = None
 
     @property
-    def _applied_configs(self):
-        if self.__applied_configs is None:
-            self.__applied_configs = get_all_applied_configs(self.context)
-        return self.__applied_configs
+    def _kernel_nic_applied_configs(self):
+        if (
+            self.__kernel_nic_applied_configs is None
+            or self.__userspace_nic_applied_configs is None
+        ):
+            (
+                self.__kernel_nic_applied_configs,
+                self.__userspace_nic_applied_configs,
+            ) = get_all_applied_configs(self.context)
+        return self.__kernel_nic_applied_configs
+
+    @property
+    def _userspace_nic_applied_configs(self):
+        if (
+            self.__kernel_nic_applied_configs is None
+            or self.__userspace_nic_applied_configs is None
+        ):
+            (
+                self.__kernel_nic_applied_configs,
+                self.__userspace_nic_applied_configs,
+            ) = get_all_applied_configs(self.context)
+        return self.__userspace_nic_applied_configs
 
     @property
     def checkpoint(self):
@@ -120,8 +140,6 @@ class NetworkManagerPlugin(NmstatePlugin):
     def get_interfaces(self):
         info = []
 
-        applied_configs = self._applied_configs
-
         devices_info = [
             (dev, get_device_common_info(dev))
             for dev in list_devices(self.client)
@@ -131,6 +149,16 @@ class NetworkManagerPlugin(NmstatePlugin):
             if not dev.get_managed():
                 # Skip unmanaged interface
                 continue
+            if is_kernel_iface(dev):
+                applied_config = self._kernel_nic_applied_configs.get(
+                    dev.get_iface()
+                )
+            else:
+                iface_type = get_iface_type(dev)
+                applied_config = self._userspace_nic_applied_configs.get(
+                    f"{dev.get_iface()}{iface_type}"
+                )
+
             nm_ac = dev.get_active_connection()
             if (
                 nm_ac
@@ -140,7 +168,6 @@ class NetworkManagerPlugin(NmstatePlugin):
                 continue
 
             iface_info = Nm2Api.get_common_device_info(devinfo)
-            applied_config = applied_configs.get(iface_info[Interface.NAME])
 
             act_con = dev.get_active_connection()
             iface_info[Interface.IPV4] = get_ipv4_info(act_con, applied_config)
@@ -193,11 +220,14 @@ class NetworkManagerPlugin(NmstatePlugin):
     def get_dns_client_config(self):
         return {
             DNS.RUNNING: get_dns_running(self.client),
-            DNS.CONFIG: get_dns_running_config(self._applied_configs),
+            DNS.CONFIG: get_dns_running_config(
+                self._kernel_nic_applied_configs
+            ),
         }
 
     def refresh_content(self):
-        self.__applied_configs = None
+        self.__kernel_nic_applied_configs = None
+        self.__userspace_nic_applied_configs = None
 
     def apply_changes(self, net_state, save_to_disk):
         NmProfiles(self.context).apply_config(net_state, save_to_disk)
@@ -278,7 +308,7 @@ class NetworkManagerPlugin(NmstatePlugin):
                 nm_dev
                 and nm_dev.get_iface()
                 and not nm_dev.get_managed()
-                and _is_kernel_iface(nm_dev)
+                and is_kernel_iface(nm_dev)
             ):
                 ignored_ifaces.add(nm_dev.get_iface())
         return list(ignored_ifaces)
@@ -298,12 +328,3 @@ def _remove_ovs_bridge_unsupported_entries(iface_info):
 
 def _nm_utils_decode_version():
     return f"{NM.MAJOR_VERSION}.{NM.MINOR_VERSION}.{NM.MICRO_VERSION}"
-
-
-def _is_kernel_iface(nm_dev):
-    iface_type = get_iface_type(nm_dev)
-    return iface_type != InterfaceType.UNKNOWN and iface_type not in (
-        InterfaceType.OVS_BRIDGE,
-        InterfaceType.OVS_INTERFACE,
-        InterfaceType.OVS_PORT,
-    )

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -809,3 +809,42 @@ def test_create_mac_tap_over_ovs_iface_with_use_same_name_as_bridge(
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.tier1
+def test_set_static_to_ovs_interface_with_the_same_name_bridge(
+    ovs_bridge1_with_internal_port_same_name,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: BRIDGE1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: "192.0.2.1",
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    state = statelib.show_only((BRIDGE1,))
+    assert len(state[Interface.KEY]) == 2
+    cur_iface_state = None
+    for iface in state[Interface.KEY]:
+        if iface[Interface.TYPE] == InterfaceType.OVS_INTERFACE:
+            cur_iface_state = iface
+            break
+    assert cur_iface_state
+    assert cur_iface_state[Interface.IPV4][InterfaceIPv4.ADDRESS] == [
+        {
+            InterfaceIPv4.ADDRESS_IP: "192.0.2.1",
+            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+        }
+    ]


### PR DESCRIPTION
Nmstate will fail on verification when setting ip to OVS interface
sharing the same name with OVS bridge.

This is caused by NM plugin does not index with interface type when
retrieving interface applied configure which lead to OVS bridge or OVS
interface applied configure overlapping each other.

To fix this problem, we use `NetworkManagerPlugin._kernel_nic_applied_configs`
and `NetworkManagerPlugin._userspace_nic_applied_configs()` to
differentiate them. The kernel data is still indexed by interface name,
the user space data is indexed by interface name and type.

Integration test case included as tier 1 as OpenShift need it.