### PR TITLE
CI: install procps-ng for centos-stream

### DIFF
--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -35,6 +35,7 @@ RUN dnf update -y && \
                    wpa_supplicant \
                    hostapd \
                    libndp \
+                   procps-ng \
                    && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \


### PR DESCRIPTION
`procps-ng` is not installed by default anymore on centos-stream. This
was unexpected, in order to avoid this error in the future, the
Dockerfile will install it anyway.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>