### PR TITLE
[nmstate-1.0] CI: install procps-ng for centos-stream

### DIFF
--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -37,6 +37,7 @@ RUN dnf install -y centos-release-stream && \
                    tcpreplay \
                    wpa_supplicant \
                    hostapd \
+                   procps-ng \
                    && \
     alternatives --set python /usr/bin/python3 && \
     ln -s /usr/bin/pytest-3 /usr/bin/pytest && \


### PR DESCRIPTION
`procps-ng` is not installed by default anymore on centos-stream. This
was unexpected, in order to avoid this error in the future, the
Dockerfile will install it anyway.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>