### PR TITLE
ovs: Regenerate iface metadata after RouteRule metadata generation

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -376,8 +376,9 @@ class BaseIface:
     def gen_metadata(self, ifaces):
         if self.is_controller and not self.is_absent:
             for port_name in self.port:
-                port_iface = ifaces.all_kernel_ifaces[port_name]
-                port_iface.set_controller(self.name, self.type)
+                port_iface = ifaces.all_kernel_ifaces.get(port_name)
+                if port_iface:
+                    port_iface.set_controller(self.name, self.type)
 
     def update(self, info):
         self._info.update(info)

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -157,7 +157,7 @@ class Ifaces:
             self._validate_infiniband_as_bridge_port()
             self._validate_infiniband_as_bond_port()
             self._apply_copy_mac_from()
-            self._gen_metadata()
+            self.gen_metadata()
             for iface in self.all_ifaces():
                 iface.pre_edit_validation_and_cleanup()
 
@@ -575,7 +575,7 @@ class Ifaces:
             else:
                 self._kernel_ifaces[iface.name] = iface
 
-    def _gen_metadata(self):
+    def gen_metadata(self):
         for iface in self.all_ifaces():
             # Generate metadata for all interface in case any of them
             # been marked as changed by DNS/Route/RouteRule.

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -125,9 +125,13 @@ class LinuxBridgeIface(BridgeIface):
         super().gen_metadata(ifaces)
         if not self.is_absent:
             for port_config in self.port_configs:
-                ifaces.all_kernel_ifaces[
+                port_iface = ifaces.all_kernel_ifaces.get(
                     port_config[LinuxBridge.Port.NAME]
-                ].update({BridgeIface.BRPORT_OPTIONS_METADATA: port_config})
+                )
+                if port_iface:
+                    port_iface.update(
+                        {BridgeIface.BRPORT_OPTIONS_METADATA: port_config}
+                    )
 
     def remove_port(self, port_name):
         if self._bridge_config:

--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -72,6 +72,9 @@ class NetState:
             self._ifaces.gen_dns_metadata(self._dns, self._route)
             self._ifaces.gen_route_metadata(self._route)
             self._ifaces.gen_route_rule_metadata(self._route_rule, self._route)
+            # DND/Route/RouteRule might introduced new changed interface
+            # Regnerate interface metadata
+            self._ifaces.gen_metadata()
 
     def _mark_ignored_kernel_ifaces(self, ignored_ifnames):
         for iface_name in ignored_ifnames:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -32,6 +32,7 @@ from libnmstate.schema import MacVtap
 from libnmstate.schema import OVSBridge
 from libnmstate.schema import OVSInterface
 from libnmstate.schema import OvsDB
+from libnmstate.schema import RouteRule
 from libnmstate.schema import VLAN
 from libnmstate.schema import VXLAN
 from libnmstate.state import state_match
@@ -41,6 +42,7 @@ from libnmstate.error import NmstateValueError
 
 from .testlib import assertlib
 from .testlib import cmdlib
+from .testlib import iprule
 from .testlib import statelib
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
@@ -852,3 +854,41 @@ def test_set_static_to_ovs_interface_with_the_same_name_bridge(
             InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
         }
     ]
+
+
+@pytest.fixture
+def ovs_bridge_with_dhcp_route_table_500(bridge_with_ports):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: PORT1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.AUTO_ROUTE_TABLE_ID: 500,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    yield
+
+
+@pytest.mark.tier1
+def test_add_route_rule_to_ovs_interface_dhcp_auto_route_table(
+    ovs_bridge_with_dhcp_route_table_500,
+):
+    route_rule = {
+        RouteRule.IP_FROM: "192.0.2.0/24",
+        RouteRule.ROUTE_TABLE: 500,
+    }
+    desired_state = {RouteRule.KEY: {RouteRule.CONFIG: [route_rule]}}
+    libnmstate.apply(desired_state)
+
+    iprule.ip_rule_exist_in_os(
+        route_rule.get(RouteRule.IP_FROM),
+        route_rule.get(RouteRule.IP_TO),
+        route_rule.get(RouteRule.PRIORITY),
+        route_rule.get(RouteRule.ROUTE_TABLE),
+    )


### PR DESCRIPTION
When desire state only contain route rule for OVS interface route table
ID, NetworkManager will complains:

    A connection with a 'ovs-interface' setting must have a master.

The root cause is because interface metadata is not generated if desire
state has no interface at all.

The fix is regenerate interface metadata after route rule metadata
generation.

Integration test case added and marked as tier1 due to RHV requirement.