### PR TITLE
[nmstate-1.0] ovs: Regenerate iface metadata after RouteRule metadata generation

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -350,8 +350,9 @@ class BaseIface:
     def gen_metadata(self, ifaces):
         if self.is_controller and not self.is_absent:
             for port_name in self.port:
-                port_iface = ifaces.all_kernel_ifaces[port_name]
-                port_iface.set_controller(self.name, self.type)
+                port_iface = ifaces.all_kernel_ifaces.get(port_name)
+                if port_iface:
+                    port_iface.set_controller(self.name, self.type)
 
     def update(self, info):
         self._info.update(info)

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -158,7 +158,7 @@ class Ifaces:
             self._validate_infiniband_as_bridge_port()
             self._validate_infiniband_as_bond_port()
             self._apply_copy_mac_from()
-            self._gen_metadata()
+            self.gen_metadata()
             for iface in self.all_ifaces():
                 iface.pre_edit_validation_and_cleanup()
 
@@ -569,7 +569,7 @@ class Ifaces:
             else:
                 self._kernel_ifaces[iface.name] = iface
 
-    def _gen_metadata(self):
+    def gen_metadata(self):
         for iface in self.all_ifaces():
             # Generate metadata for all interface in case any of them
             # been marked as changed by DNS/Route/RouteRule.

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -125,9 +125,13 @@ class LinuxBridgeIface(BridgeIface):
         super().gen_metadata(ifaces)
         if not self.is_absent:
             for port_config in self.port_configs:
-                ifaces.all_kernel_ifaces[
+                port_iface = ifaces.all_kernel_ifaces.get(
                     port_config[LinuxBridge.Port.NAME]
-                ].update({BridgeIface.BRPORT_OPTIONS_METADATA: port_config})
+                )
+                if port_iface:
+                    port_iface.update(
+                        {BridgeIface.BRPORT_OPTIONS_METADATA: port_config}
+                    )
 
     def remove_port(self, port_name):
         if self._bridge_config:

--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -72,6 +72,9 @@ class NetState:
             self._ifaces.gen_dns_metadata(self._dns, self._route)
             self._ifaces.gen_route_metadata(self._route)
             self._ifaces.gen_route_rule_metadata(self._route_rule, self._route)
+            # DND/Route/RouteRule might introduced new changed interface
+            # Regnerate interface metadata
+            self._ifaces.gen_metadata()
 
     def _mark_ignored_kernel_ifaces(self, ignored_ifnames):
         for iface_name in ignored_ifnames:


### PR DESCRIPTION
When desire state only contain route rule for OVS interface route table
ID, NetworkManager will complains:

    A connection with a 'ovs-interface' setting must have a master.

The root cause is because interface metadata is not generated if desire
state has no interface at all.

The fix is regenerate interface metadata after route rule metadata
generation.

Integration test case added and marked as tier1 due to RHV requirement.