### PR TITLE
ifaces: fix validation of base_iface properties

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -87,7 +87,7 @@ class BondIface(BaseIface):
             self._generate_bond_mode_change_metadata(ifaces)
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_bond_properties()
         super().pre_edit_validation_and_cleanup()
         if self.is_up and self.is_desired:
             self._discard_bond_option_when_mode_change()
@@ -96,7 +96,7 @@ class BondIface(BaseIface):
             self._validate_miimon_conflict_with_arp_interval()
             self._validate_ad_actor_system_mac_address()
 
-    def _validate_properties(self):
+    def _validate_bond_properties(self):
         validate_string(
             self._info.get(Interface.COPY_MAC_FROM), Interface.COPY_MAC_FROM
         )

--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -107,10 +107,10 @@ class EthernetIface(BaseIface):
         return self.raw.get(Ethernet.CONFIG_SUBTREE, {}).get(Ethernet.DUPLEX)
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_ethernet_properties()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_ethernet_properties(self):
         validate_boolean(self.auto_negotiation, Ethernet.AUTO_NEGOTIATION)
         validate_string(self.duplex, Ethernet.DUPLEX, DUPLEX_VALID_VALUES)
         validate_integer(self.speed, Ethernet.SPEED, minimum=0)

--- a/libnmstate/ifaces/ethtool.py
+++ b/libnmstate/ifaces/ethtool.py
@@ -120,9 +120,9 @@ class IfaceEthtool:
         return info
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_ethtool_properties()
 
-    def _validate_properties(self):
+    def _validate_ethtool_properties(self):
         if self.pause:
             validate_boolean(
                 self.pause.autoneg, Ethtool.Pause.AUTO_NEGOTIATION

--- a/libnmstate/ifaces/infiniband.py
+++ b/libnmstate/ifaces/infiniband.py
@@ -51,14 +51,14 @@ class InfiniBandIface(BaseIface):
         return self.raw.get(InfiniBand.CONFIG_SUBTREE, {})
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_infiniband_properties()
         if self.is_up:
             _cannonicalize_pkey(self.raw)
             self._validate_mandatory_properties()
             self._validate_interface_name_format_for_pkey_nic()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_infiniband_properties(self):
         validate_string(
             self._ib_config.get(InfiniBand.MODE),
             InfiniBand.MODE,

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -76,13 +76,13 @@ class LinuxBridgeIface(BridgeIface):
         )
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_bridge_properties()
         if self.is_up:
             self._validate()
             self._fix_vlan_filtering_mode()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_bridge_properties(self):
         for port_info in self.port_configs:
             validate_string(port_info.get(Bridge.Port.NAME), Bridge.Port.NAME)
             validate_integer(

--- a/libnmstate/ifaces/macvlan.py
+++ b/libnmstate/ifaces/macvlan.py
@@ -69,13 +69,13 @@ class MacVlanIface(BaseIface):
         return self.config_subtree.get(MacVlan.PROMISCUOUS)
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_macvlan_properties()
         if self.is_up:
             self._validate_mode()
             self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_macvlan_properties(self):
         validate_string(self.base_iface, MacVlan.BASE_IFACE)
         validate_string(self.mode, MacVlan.MODE, VALID_MODES)
         validate_boolean(self.promiscuous, MacVlan.PROMISCUOUS)

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -118,12 +118,12 @@ class OvsBridgeIface(BridgeIface):
         return port_iface
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_ovs_properties()
         super().pre_edit_validation_and_cleanup()
         if self.is_up:
             self._validate_ovs_lag_port_count()
 
-    def _validate_properties(self):
+    def _validate_ovs_properties(self):
         for port_info in self.port_configs:
             validate_string(port_info.get(Bridge.Port.NAME), Bridge.Port.NAME)
             vlan_filtering_info = port_info.get(Bridge.Port.VLAN_SUBTREE)

--- a/libnmstate/ifaces/vlan.py
+++ b/libnmstate/ifaces/vlan.py
@@ -63,12 +63,12 @@ class VlanIface(BaseIface):
         return False
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_vlan_properties()
         if self.is_up:
             self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_vlan_properties(self):
         validate_string(self.base_iface, VLAN.BASE_IFACE)
         validate_integer(self.vlan_id, VLAN.ID, minimum=0, maximum=4095)
 

--- a/libnmstate/ifaces/vrf.py
+++ b/libnmstate/ifaces/vrf.py
@@ -50,14 +50,14 @@ class VrfIface(BaseIface):
         return True
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_vrf_properties()
         super().pre_edit_validation_and_cleanup()
         if self.is_up and (self.is_desired or self.is_changed):
             self._validate_route_table_id()
             self._remove_mac_address()
             self._remove_accept_all_mac_addresses_false()
 
-    def _validate_properties(self):
+    def _validate_vrf_properties(self):
         validate_list(self.port, VRF.PORT_SUBTREE, elem_type=str)
         validate_integer(self.route_table_id, VRF.ROUTE_TABLE_ID)
 

--- a/libnmstate/ifaces/vxlan.py
+++ b/libnmstate/ifaces/vxlan.py
@@ -81,12 +81,12 @@ class VxlanIface(BaseIface):
         super().gen_metadata(ifaces)
 
     def pre_edit_validation_and_cleanup(self):
-        self._validate_properties()
+        self._validate_vxlan_properties()
         if self.is_up:
             self._validate_mandatory_properties()
         super().pre_edit_validation_and_cleanup()
 
-    def _validate_properties(self):
+    def _validate_vxlan_properties(self):
         validate_string(self.base_iface, VXLAN.BASE_IFACE)
         validate_integer(self.vxlan_id, VXLAN.ID, minimum=0, maximum=16777215)
         validate_string(self.remote, VXLAN.REMOTE)


### PR DESCRIPTION
The function for validating properties cannot be the same for all the
interfaces type. This was causing the base interface properties were not
being validated correctly if the interface type was child of base
interface.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>