### PR TITLE
[nmstate-1.1] nmstatectl: fix long arguments support

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -223,14 +223,16 @@ def setup_subcommand_show(subparsers):
         dest="yaml",
     )
     parser_show.add_argument(
-        "-r, --running-config",
+        "-r",
+        "--running-config",
         help="Show running configurations",
         default=False,
         action="store_true",
         dest="running_config",
     )
     parser_show.add_argument(
-        "-s, --show-secrets",
+        "-s",
+        "--show-secrets",
         help="Show secrets also",
         default=False,
         action="store_true",

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -166,6 +166,38 @@ def test_show_command_only_non_existing():
     assert len(state[Constants.INTERFACES]) == 0
 
 
+def test_show_command_with_long_running_config():
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["--running-config"])
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+    assert LOOPBACK_YAML_CONFIG in out
+
+
+def test_show_command_with_long_show_secrets():
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["--show-secrets"])
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+    assert LOOPBACK_YAML_CONFIG in out
+
+
+def test_show_command_with_short_running_config():
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["-r"])
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+    assert LOOPBACK_YAML_CONFIG in out
+
+
+def test_show_command_with_short_show_secrets():
+    ret = cmdlib.exec_cmd(SHOW_CMD + ["-s"])
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+    assert LOOPBACK_YAML_CONFIG in out
+
+
 def test_apply_command_with_yaml_format():
     ret = cmdlib.exec_cmd(APPLY_CMD, stdin=ETH1_YAML_CONFIG)
     rc, out, err = ret


### PR DESCRIPTION
The support for long arguments is broken. This patch is fixing it and
solving the following errors:

```
[root@d0b4a6a0f7a5 nmstate-workspace]# nmstatectl show --running-config
usage: nmstatectl [-h] [--version]
                  {commit,edit,rollback,set,apply,show,version,gc} ...
nmstatectl: error: unrecognized arguments: --running-config
[root@d0b4a6a0f7a5 nmstate-workspace]# nmstatectl show --show-secrets
usage: nmstatectl [-h] [--version]
                  {commit,edit,rollback,set,apply,show,version,gc} ...
nmstatectl: error: unrecognized arguments: --show-secrets
```

Integration test case added.