### PR TITLE
nispor: fix show of empty next_hop_address and destination

### DIFF
--- a/libnmstate/nispor/route.py
+++ b/libnmstate/nispor/route.py
@@ -23,6 +23,9 @@ from libnmstate.schema import Route
 IPV4_DEFAULT_GATEWAY_DESTINATION = "0.0.0.0/0"
 IPV6_DEFAULT_GATEWAY_DESTINATION = "::/0"
 
+IPV4_EMPTY_NEXT_HOP_ADDRESS = "0.0.0.0"
+IPV6_EMPTY_NEXT_HOP_ADDRESS = "::"
+
 LOCAL_ROUTE_TABLE = 255
 
 
@@ -50,21 +53,23 @@ def nispor_route_state_to_nmstate_static(np_routes):
 def _nispor_route_to_nmstate(np_rt):
     if np_rt.dst:
         destination = np_rt.dst
-    elif np_rt.gateway:
+    else:
         destination = (
             IPV6_DEFAULT_GATEWAY_DESTINATION
             if np_rt.address_family == "ipv6"
             else IPV4_DEFAULT_GATEWAY_DESTINATION
         )
-    else:
-        destination = ""
 
     if np_rt.via:
         next_hop = np_rt.via
     elif np_rt.gateway:
         next_hop = np_rt.gateway
     else:
-        next_hop = ""
+        next_hop = (
+            IPV6_EMPTY_NEXT_HOP_ADDRESS
+            if np_rt.address_family == "ipv6"
+            else IPV4_EMPTY_NEXT_HOP_ADDRESS
+        )
 
     return {
         Route.TABLE_ID: np_rt.table,

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -40,8 +40,12 @@ IPV4_ADDRESS3 = "192.0.2.253"
 IPV4_LINK_LOCAL_ROUTE = "192.0.2.0/24"
 IPV4_ROUTE_TABLE_ID1 = 50
 IPV4_ROUTE_TABLE_ID2 = 51
+IPV4_EMPTY_ADDRESS = "0.0.0.0"
+IPV4_DEFAULT_GATEWAY = "0.0.0.0/0"
 
 IPV6_ADDRESS1 = "2001:db8:1::1"
+IPV6_EMPTY_ADDRESS = "::"
+IPV6_DEFAULT_GATEWAY = "::/0"
 IPV6_ROUTE_TABLE_ID1 = 50
 IPV6_ROUTE_TABLE_ID2 = 51
 
@@ -83,6 +87,30 @@ ETH1_INTERFACE_STATE = {
 @pytest.mark.tier1
 def test_add_static_routes(eth1_up):
     routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    _assert_routes(routes, cur_state)
+
+
+@pytest.mark.tier1
+def test_add_static_route_without_next_hop_address(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_DEFAULT_GATEWAY,
+            Route.NEXT_HOP_ADDRESS: IPV4_EMPTY_ADDRESS,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
+            Route.NEXT_HOP_ADDRESS: IPV6_EMPTY_ADDRESS,
+        },
+    ]
     libnmstate.apply(
         {
             Interface.KEY: [ETH1_INTERFACE_STATE],


### PR DESCRIPTION
The correct way of representing an empty next_hop_address is using
"0.0.0.0" for IPv4 and "::" for IPv6. This configuration is valid
because an user should be able to specify the following routes:

```
---
routes:
  config:
  - destination: 0.0.0.0/0
    next-hop-address: 0.0.0.0
    next-hop-interface: dummy
  - destination: ::/0
    next-hop-address: "::"
    next-hop-interface: dummy

```

That means each of the hosts within the range of the route are
considered to be directly connected through that interface.

For example, using iproute2 the user should introduce the following
command:

`ip route 0.0.0.0 0.0.0.0 dummy`

Integration test case added.

Ref: https://bugzilla.redhat.com/1985879

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>