### PR TITLE
[nmstate-1.0] CI: Install python3-jsonschema before test

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -25,15 +25,15 @@ COPR_ARG=""
 if [ $OS_TYPE == "el8" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util;'
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema;'
 elif [ $OS_TYPE == "stream" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos-stream-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util;'
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema;'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="docker.io/nmstate/centos8-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util;
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'


### PR DESCRIPTION
The `python3-jsonschema` is removed from container image, instead of
keeping different container image between branches, this patch just
instruct github CI to install that package before test starts.

Signed-off-by: Gris Ge <fge@redhat.com>