### PR TITLE
[nmstate-1.1] k8s: fix customize argument when using --k8s option

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -385,10 +385,10 @@ if [ -n "${RUN_BAREMETAL}" ];then
     run_customize_command
     start_machine_services
 elif [ -n "${RUN_K8S}" ]; then
-    run_customize_command
     #start_machine_services
     k8s::start_cluster
     k8s::pre_test_setup
+    run_customize_command
 else
     container_pre_test_setup
     run_customize_command


### PR DESCRIPTION
The customize commands must run after setting up everything, if not,
they will fail because there is no pod specified.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>