### PR TITLE
yaml: drop pyyaml dependency in favor of ruamel.yaml

### DIFF
--- a/libnmstate/prettystate.py
+++ b/libnmstate/prettystate.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2018-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -23,7 +23,7 @@ from copy import deepcopy
 import difflib
 import json
 
-import yaml
+from ruamel import yaml
 
 from .schema import DNS
 from .schema import Route

--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -27,7 +27,9 @@ import sys
 import tempfile
 import warnings
 
-import yaml
+from ruamel.yaml import parser
+from ruamel.yaml import scanner
+from ruamel.yaml import YAML
 
 import libnmstate
 from libnmstate import PrettyState
@@ -372,7 +374,7 @@ def _run_gen_config(args):
                 state = json.loads(statedata)
                 use_yaml = False
             else:
-                state = yaml.load(statedata, Loader=yaml.SafeLoader)
+                state = YAML(typ="safe").load(statedata)
                 use_yaml = True
             _print_state(
                 libnmstate.generate_configurations(state), use_yaml=use_yaml
@@ -388,7 +390,7 @@ def _apply_state(statedata, verify_change, commit, timeout, save_to_disk):
     if statedata[0] == "{":
         state = json.loads(statedata)
     else:
-        state = yaml.load(statedata, Loader=yaml.SafeLoader)
+        state = YAML(typ="safe").load(statedata)
         use_yaml = True
 
     try:
@@ -479,10 +481,10 @@ def _parse_state(txtstate, parse_yaml):
     state = {}
     if parse_yaml:
         try:
-            state = yaml.load(txtstate, Loader=yaml.SafeLoader)
-        except yaml.parser.ParserError as e:
+            state = YAML(typ="safe").load(txtstate)
+        except parser.ParserError as e:
             error = "Invalid YAML syntax: %s\n" % e
-        except yaml.parser.ScannerError as e:
+        except scanner.ScannerError as e:
             error = "Invalid YAML syntax: %s\n" % e
     else:
         try:

--- a/packaging/Dockerfile.centos-stream-nmstate-dev
+++ b/packaging/Dockerfile.centos-stream-nmstate-dev
@@ -15,7 +15,7 @@ RUN dnf update -y && \
                    systemd-udev \
                    python3-devel \
                    python3-gobject-base \
-                   python3-pyyaml \
+                   python3-ruamel-yaml \
                    python3-setuptools \
                    python36 \
                    dnsmasq \

--- a/packaging/Dockerfile.centos8-nmstate-dev
+++ b/packaging/Dockerfile.centos8-nmstate-dev
@@ -15,7 +15,7 @@ RUN dnf -y install dnf-plugins-core epel-release && \
                    systemd-udev \
                    python3-devel \
                    python3-gobject-base \
-                   python3-pyyaml \
+                   python3-ruamel-yaml \
                    python3-setuptools \
                    python36 \
                    dnsmasq \

--- a/packaging/Dockerfile.fedora-nmstate-dev
+++ b/packaging/Dockerfile.fedora-nmstate-dev
@@ -12,7 +12,7 @@ RUN dnf -y install dnf-plugins-core && \
                    python3-openvswitch \
                    systemd-udev \
                    python3-gobject-base \
-                   python3-pyyaml \
+                   python3-ruamel-yaml \
                    python3-setuptools \
                    python3-pip \
                    python36 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@
 #packageD!=0.13.0,<0.14,>=0.12.0
 
 PyGObject
-PyYAML
+ruamel.yaml
 setuptools
 nispor>=1.1.0

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -21,7 +21,8 @@ import os
 import time
 
 import pytest
-import yaml
+
+from ruamel.yaml import YAML
 
 import libnmstate
 from libnmstate.error import NmstateVerificationError
@@ -117,7 +118,7 @@ def bond99_with_eth2(eth2_up):
 
 @pytest.mark.tier1
 def test_add_and_remove_bond_with_two_port(eth1_up, eth2_up):
-    state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
+    state = YAML(typ="safe").load(BOND99_YAML_BASE)
     libnmstate.apply(state)
 
     assertlib.assert_state_match(state)
@@ -142,7 +143,7 @@ def test_add_and_remove_bond_with_two_port(eth1_up, eth2_up):
 
 @pytest.mark.tier1
 def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
-    state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
+    state = YAML(typ="safe").load(BOND99_YAML_BASE)
     bond_name = state[Interface.KEY][0][Interface.NAME]
 
     libnmstate.apply(state)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -22,8 +22,9 @@ import os
 import time
 
 import pytest
-import yaml
 import json
+
+from ruamel.yaml import YAML
 
 import libnmstate
 from libnmstate.error import NmstateKernelIntegerRoundedError
@@ -622,15 +623,15 @@ def test_add_invalid_port_ip_config(eth1_up):
 
 
 def _add_port_to_bridge(bridge_state, ifname):
-    port_state = yaml.load(BRIDGE_PORT_YAML, Loader=yaml.SafeLoader)
+    port_state = YAML(typ="safe").load(BRIDGE_PORT_YAML)
     add_port_to_bridge(bridge_state, ifname, port_state)
 
 
 def _create_bridge_subtree_config(port_names):
-    bridge_state = yaml.load(BRIDGE_OPTIONS_YAML, Loader=yaml.SafeLoader)
+    bridge_state = YAML(typ="safe").load(BRIDGE_OPTIONS_YAML)
 
     for port in port_names:
-        port_state = yaml.load(BRIDGE_PORT_YAML, Loader=yaml.SafeLoader)
+        port_state = YAML(typ="safe").load(BRIDGE_PORT_YAML)
         add_port_to_bridge(bridge_state, port, port_state)
 
     return bridge_state

--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -19,7 +19,8 @@
 from contextlib import contextmanager
 import os
 import time
-import yaml
+
+from ruamel.yaml import YAML
 
 import pytest
 
@@ -147,7 +148,7 @@ def test_lldp_yaml(lldptest_up):
         lldp_config = dstate[Interface.KEY][0][LLDP.CONFIG_SUBTREE]
         assert len(lldp_config[LLDP.NEIGHBORS_SUBTREE]) == 1
         test_neighbor = lldp_config[LLDP.NEIGHBORS_SUBTREE][0]
-        assert test_neighbor == yaml.safe_load(EXPECTED_LLDP_NEIGHBOR)
+        assert test_neighbor == YAML(typ="safe").load(EXPECTED_LLDP_NEIGHBOR)
 
 
 def test_lldp_system(lldptest_up):

--- a/tests/integration/testlib/examplelib.py
+++ b/tests/integration/testlib/examplelib.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2020 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -20,7 +20,7 @@
 from contextlib import contextmanager
 import os
 
-import yaml
+from ruamel.yaml import YAML
 
 import libnmstate
 
@@ -63,7 +63,7 @@ def load_example(name, substitute=None):
         yaml_str = yamlfile.read()
         if substitute:
             yaml_str = yaml_str.replace(substitute[0], substitute[1])
-        state = yaml.load(yaml_str, Loader=yaml.SafeLoader)
+        state = YAML(typ="safe").load(yaml_str)
 
     return state
 


### PR DESCRIPTION
Currently pyyaml implements YAML 1.1 which is causing us problems.

When an interface has a float64 name, nmstate does not quote the name.
That is causing the state reported cannot be applied back.

```yaml
interfaces:
- name: '60e+02'
  type: dummy
  state: down
```

This is solved by using ruamel.yaml because it is implementing YAML 1.2.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>