### PR TITLE
[nmstate-1.1] veth: throw better error when peer is missing

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -283,6 +283,7 @@ class Ifaces:
         self._validate_ovs_patch_peers()
         self._remove_unknown_type_interfaces()
         self._validate_vrf_table_id_changes()
+        self._validate_veth_peers()
 
     def _bring_port_up_if_not_in_desire(self):
         """
@@ -439,6 +440,19 @@ class Ifaces:
                     raise NmstateNotSupportedError(
                         "Changing route table ID of existing VRF Interface "
                         "is not supported yet"
+                    )
+
+    def _validate_veth_peers(self):
+        for ifname, iface in self._kernel_ifaces.items():
+            if (
+                iface.type == InterfaceType.VETH
+                and iface.is_up
+                and not iface.peer
+            ):
+                if not self._cur_kernel_ifaces.get(iface.name):
+                    raise NmstateValueError(
+                        f"Veth interface {iface.name} does not exists,"
+                        "peer name is required for creating it"
                     )
 
     def _match_child_iface_state_with_parent(self):

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -23,6 +23,7 @@ import pytest
 
 import libnmstate
 from libnmstate.error import NmstateLibnmError
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Bridge
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
@@ -239,6 +240,26 @@ def test_veth_enable_and_disable_accept_all_mac_addresses():
 
     assertlib.assert_absent(VETH1)
     assertlib.assert_absent(VETH1PEER)
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() <= 1.28,
+    reason="Modifying veth interfaces is not supported on NetworkManager.",
+)
+@pytest.mark.tier1
+def test_veth_without_peer_fails():
+    d_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VETH1,
+                Interface.TYPE: InterfaceType.VETH,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(d_state)
 
 
 @contextmanager


### PR DESCRIPTION
When creating a veth interface if the peer is missing, Nmstate is now
throwing a better error.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>