### PR TITLE
nm.connection: do not rename existing connections

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -97,9 +97,6 @@ class _ConnectionSetting:
             self._setting.props.master = controller
             self._setting.props.slave_type = port_type
 
-    def set_profile_name(self, con_name):
-        self._setting.props.id = con_name
-
     @property
     def setting(self):
         return self._setting
@@ -115,7 +112,6 @@ def create_new_nm_simple_conn(iface, nm_profile):
     con_setting = _ConnectionSetting()
     if nm_profile and not is_multiconnect_profile(nm_profile):
         con_setting.import_by_profile(nm_profile, iface.is_controller)
-        con_setting.set_profile_name(iface.name)
     else:
         con_setting.create(
             iface.name, iface.name, nm_iface_type, iface.is_controller

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2020 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -58,6 +58,20 @@ NMCLI_CON_ADD_DUMMY_CMD = [
     "testProfile",
     "connection.autoconnect",
     "no",
+    "ifname",
+    DUMMY0_IFNAME,
+]
+
+NMCLI_CON_ADD_AUTOCONNECT_DUMMY_CMD = [
+    "nmcli",
+    "con",
+    "add",
+    "type",
+    "dummy",
+    "con-name",
+    "testProfile",
+    "connection.autoconnect",
+    "yes",
     "ifname",
     DUMMY0_IFNAME,
 ]
@@ -156,6 +170,19 @@ def dummy_interface(ifname, save_to_disk=True):
 @pytest.fixture
 def dummy_inactive_profile():
     cmdlib.exec_cmd(NMCLI_CON_ADD_DUMMY_CMD)
+    profile_exists = _profile_exists(
+        NM_PROFILE_DIRECTORY + "testProfile.nmconnection"
+    )
+    assert profile_exists
+    try:
+        yield DUMMY0_IFNAME
+    finally:
+        cmdlib.exec_cmd(_nmcli_delete_connection("testProfile"))
+
+
+@pytest.fixture
+def dummy_active_profile():
+    cmdlib.exec_cmd(NMCLI_CON_ADD_AUTOCONNECT_DUMMY_CMD)
     profile_exists = _profile_exists(
         NM_PROFILE_DIRECTORY + "testProfile.nmconnection"
     )
@@ -564,3 +591,24 @@ def test_preserve_existing_wire_setting(eth1_up_static_ipv4_mtu_1400):
         "1400\n",
         "",
     )
+
+
+@pytest.mark.tier1
+def test_nmstate_do_not_modify_conn_name(dummy_active_profile):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY0_IFNAME,
+                    Interface.TYPE: InterfaceType.DUMMY,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.MTU: 1400,
+                },
+            ]
+        }
+    )
+
+    _, out, _ = cmdlib.exec_cmd(
+        "nmcli -g 802-3-ethernet.mtu c show testProfile".split(), check=True
+    )
+    assert "1400" in out


### PR DESCRIPTION
When an user is specifying a custom name for a connection and then use
Nmstate to modify the interface, it will be renamed. That makes
impossible to use other automation tools because it will require to use
the uuid instead.

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>