### PR TITLE
nm.connection: add prefixes to OVS bridges and interfaces connections

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -113,8 +113,20 @@ def create_new_nm_simple_conn(iface, nm_profile):
     if nm_profile and not is_multiconnect_profile(nm_profile):
         con_setting.import_by_profile(nm_profile, iface.is_controller)
     else:
+        # OVS bridge and interfaces could sharing the same interface name, to
+        # distinguish them at NM connection level, instead of using interface
+        # name as connection name, we append a postfix.
+        con_name = iface.name
+        if iface.type == InterfaceType.OVS_BRIDGE:
+            con_name = con_name + "-br"
+        elif iface.type == InterfaceType.OVS_INTERFACE:
+            con_name = con_name + "-if"
+
         con_setting.create(
-            iface.name, iface.name, nm_iface_type, iface.is_controller
+            con_name,
+            iface.name,
+            nm_iface_type,
+            iface.is_controller,
         )
 
     apply_lldp_setting(con_setting, iface_info)

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -467,7 +467,7 @@ def ovs_bridge_with_internal_port():
 def test_ovs_profile_been_delete_by_state_absent(
     ovs_bridge_with_internal_port,
 ):
-    assert _profile_exists(NM_PROFILE_DIRECTORY + "ovs0.nmconnection")
+    assert _profile_exists(NM_PROFILE_DIRECTORY + "ovs0-if.nmconnection")
     libnmstate.apply(
         {
             Interface.KEY: [
@@ -478,7 +478,7 @@ def test_ovs_profile_been_delete_by_state_absent(
             ]
         }
     )
-    assert not _profile_exists(NM_PROFILE_DIRECTORY + "ovs0.nmconnection")
+    assert not _profile_exists(NM_PROFILE_DIRECTORY + "ovs0-if.nmconnection")
 
 
 @pytest.fixture
@@ -612,3 +612,19 @@ def test_nmstate_do_not_modify_conn_name(dummy_active_profile):
         "nmcli -g 802-3-ethernet.mtu c show testProfile".split(), check=True
     )
     assert "1400" in out
+
+
+@pytest.fixture
+def ovs_bridge_internal_dup_name():
+    bridge = OvsBridge(TEST_OVS_BRIDGE0)
+    bridge.add_internal_port(TEST_OVS_BRIDGE0)
+    with bridge.create():
+        yield bridge.state
+
+
+@pytest.mark.tier1
+def test_ovs_dup_name_different_conn_name(ovs_bridge_internal_dup_name):
+    _, out, _ = cmdlib.exec_cmd("nmcli -g name c show".split(), check=True)
+
+    assert "br0-br" in out
+    assert "br0-if" in out


### PR DESCRIPTION
When configuring an OVS bridge and interface with the same using
Nmstate, it will generate two connection with the same name. If the user
is willing to use nmcli to manage this profiles, it is not user friendly
because they will need to use the connection UUID instead.

In order to solve this, Nmstate is adding a prefix on the connection
name. "-if" for OVS interface and "-br" for OVS bridge.

Please, note that this issue does not affect kernel interfaces because
it is not possible to have duplicated interfaces names in kernel.

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>