### PR TITLE
gitignore: add clib test binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _kubevirtci
 
 rust/Cargo.lock
 rust/target
+rust/src/clib/test/nmstate_test


### PR DESCRIPTION
The binaries should not be tracked by git.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>