### PR TITLE
Makefile: use the correct path for clib tests

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -57,11 +57,11 @@ check:
 	if [ "CHK$(CI)" != "CHKtrue" ]; then \
 		cargo test -- --test-threads=1 --show-output --ignored; \
 	fi
-	make check -C test/clib
+	make check -C src/clib/test
 
 clean:
 	cargo clean
-	make clean -C test/clib
+	make clean -C src/clib/test
 
 install: $(CLI_EXEC_RELEASE)
 	install -p -v -D -m755 $(CLI_EXEC_RELEASE) \


### PR DESCRIPTION
The path test/clib is incorrect. The correct path for clib tests is
src/clib/test.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>