### PR TITLE
rust: add golang bindings

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -58,10 +58,12 @@ check:
 		cargo test -- --test-threads=1 --show-output --ignored; \
 	fi
 	make check -C src/clib/test
+	make check -C $(GO_MODULE_SRC)
 
 clean:
 	cargo clean
 	make clean -C src/clib/test
+	make clean -C $(GO_MODULE_SRC)
 
 install: $(CLI_EXEC_RELEASE)
 	install -p -v -D -m755 $(CLI_EXEC_RELEASE) \

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -334,3 +334,13 @@ pub extern "C" fn nmstate_err_msg_free(err_msg: *mut c_char) {
         }
     }
 }
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn nmstate_checkpoint_free(checkpoint: *mut c_char) {
+    unsafe {
+        if !checkpoint.is_null() {
+            drop(CString::from_raw(checkpoint));
+        }
+    }
+}

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -150,7 +150,7 @@ int nmstate_net_state_apply(uint32_t flags, const char *state, uint32_t rollback
  *          * NMSTATE_FAIL
  *              On failure.
  */
-void nmstate_checkpoint_commit(const char *checkpoint, char **log, char **err_kind, 
+int nmstate_checkpoint_commit(const char *checkpoint, char **log, char **err_kind,
                           char **err_msg);
 
 /**
@@ -182,7 +182,7 @@ void nmstate_checkpoint_commit(const char *checkpoint, char **log, char **err_ki
  *          * NMSTATE_FAIL
  *              On failure.
  */
-void nmstate_checkpoint_rollback(const char *checkpoint, char **log, char **err_kind, 
+int nmstate_checkpoint_rollback(const char *checkpoint, char **log, char **err_kind,
                                  char **err_msg);
 
 /**

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -253,6 +253,23 @@ void nmstate_err_kind_free(char *err_kind);
  */
 void nmstate_log_free(char *log);
 
+/**
+ * nmstate_checkpoint_free - free the checkpoint memory
+ *
+ * Version:
+ *      0.1
+ *
+ * Description:
+ *      Free the memory of checkpoint.
+ *
+ * @checkpoint:
+ *      Pointer of char array for checkpoint.
+ *
+ * Return:
+ *      void
+ */
+void nmstate_checkpoint_free(char *checkpoint);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/rust/src/go/nmstate/Makefile
+++ b/rust/src/go/nmstate/Makefile
@@ -1,0 +1,13 @@
+# This Makefile is handling the go build, install, test and clean. It is needed
+# to avoid isues with the GOROOT and GOPATH.
+
+all: build check install
+
+build:
+	go build;
+
+check:
+	go test;
+
+clean:
+	go clean;

--- a/rust/src/go/nmstate/go.mod
+++ b/rust/src/go/nmstate/go.mod
@@ -1,0 +1,5 @@
+module github.com/nmstate/nmstate/rust/src/go/nmstate
+
+go 1.16
+
+require github.com/stretchr/testify v1.7.0

--- a/rust/src/go/nmstate/go.sum
+++ b/rust/src/go/nmstate/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -1,0 +1,182 @@
+package nmstate
+
+// #cgo CFLAGS: -g -Wall
+// #cgo LDFLAGS: -lnmstate
+// #include <nmstate.h>
+// #include <stdlib.h>
+import "C"
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+type Nmstate struct {
+	timeout	    uint
+	logsWriter  io.Writer
+	flags	    byte
+}
+
+const (
+	kernelOnly = 1 << iota
+	noVerify
+	includeStatusData
+	includeSecrets
+	noCommit
+)
+
+func New(options ...func(*Nmstate)) *Nmstate {
+	return &Nmstate{}
+}
+
+func WithTimeout(timeout time.Duration) func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.timeout = uint(timeout.Seconds())
+	}
+}
+
+func WithLogsWritter(log_writter io.Writer) func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.logsWriter = log_writter
+	}
+}
+
+func WithKernelOnly() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | kernelOnly
+	}
+}
+
+func WithNoVerify() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | noVerify
+	}
+}
+
+func WithIncludeStatusData() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | includeStatusData
+	}
+}
+
+func WithIncludeSecrets() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | includeSecrets
+	}
+}
+
+func WithNoCommit() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | noCommit
+	}
+}
+
+// Retrieve the network state in json format. This function returns the current
+// network state or an error.
+func (n *Nmstate) RetrieveNetState() (string, error) {
+	var (
+		state    *C.char
+		log      *C.char
+		err_kind *C.char
+		err_msg  *C.char
+	)
+	rc := C.nmstate_net_state_retrieve(C.uint(n.flags), &state, &log, &err_kind, &err_msg)
+	defer func() {
+		C.nmstate_net_state_free(state)
+		C.nmstate_err_msg_free(err_msg)
+		C.nmstate_err_kind_free(err_kind)
+		C.nmstate_log_free(log)
+	}()
+	_, err := io.WriteString(n.logsWriter, C.GoString(log))
+	if err != nil {
+		return "", fmt.Errorf("failed writting logs: %v", err)
+	}
+	if rc != 0 {
+		return "", fmt.Errorf("failed retrieving nmstate net state with rc: %d, err_msg: %s, err_kind: %s", rc, C.GoString(err_msg), C.GoString(err_kind))
+	}
+	return C.GoString(state), nil
+}
+
+// Apply the network state in json format. This function returns the applied
+// network state or an error.
+func (n *Nmstate) ApplyNetState(state string) (string, error) {
+	var (
+		c_state  *C.char
+		log      *C.char
+		err_kind *C.char
+		err_msg  *C.char
+	)
+	c_state = C.CString(state)
+	rc := C.nmstate_net_state_apply(C.uint(n.flags), c_state, C.uint(n.timeout), &log, &err_kind, &err_msg)
+
+	defer func() {
+		C.nmstate_net_state_free(c_state)
+		C.nmstate_err_msg_free(err_msg)
+		C.nmstate_err_kind_free(err_kind)
+		C.nmstate_log_free(log)
+	}()
+	_, err := io.WriteString(n.logsWriter, C.GoString(log))
+	if err != nil {
+		return "", fmt.Errorf("failed writting logs: %v", err)
+	}
+	if rc != 0 {
+		return "", fmt.Errorf("failed applying nmstate net state %s with rc: %d, err_msg: %s, err_kind: %s", state, rc, C.GoString(err_msg), C.GoString(err_kind))
+	}
+	return state, nil
+}
+
+// Commit the checkpoint path provided. This function returns the committed
+// checkpoint path or an error.
+func (n *Nmstate) CommitCheckpoint(checkpoint string) (string, error) {
+	var (
+		c_checkpoint *C.char
+		log	     *C.char
+		err_kind     *C.char
+		err_msg      *C.char
+	)
+	c_checkpoint = C.CString(checkpoint)
+	rc := C.nmstate_checkpoint_commit(c_checkpoint, &log, &err_kind, &err_msg)
+
+	defer func() {
+		C.nmstate_checkpoint_free(c_checkpoint)
+		C.nmstate_err_msg_free(err_msg)
+		C.nmstate_err_kind_free(err_kind)
+		C.nmstate_log_free(log)
+	}()
+	_, err := io.WriteString(n.logsWriter, C.GoString(log))
+	if err != nil {
+		return "", fmt.Errorf("failed writting logs: %v", err)
+	}
+	if rc != 0 {
+		return "", fmt.Errorf("failed commiting checkpoint %s with rc: %d, err_msg: %s, err_kind: %s", checkpoint, rc, C.GoString(err_msg), C.GoString(err_kind))
+	}
+	return checkpoint, nil
+}
+
+// Rollback to the checkpoint provided. This function returns the checkpoint
+// path used for rollback or an error.
+func (n *Nmstate) RollbackCheckpoint(checkpoint string) (string, error) {
+	var (
+		c_checkpoint *C.char
+		log	     *C.char
+		err_kind     *C.char
+		err_msg      *C.char
+	)
+	c_checkpoint = C.CString(checkpoint)
+	rc := C.nmstate_checkpoint_rollback(c_checkpoint, &log, &err_kind, &err_msg)
+
+	defer func() {
+		C.nmstate_checkpoint_free(c_checkpoint)
+		C.nmstate_err_msg_free(err_msg)
+		C.nmstate_err_kind_free(err_kind)
+		C.nmstate_log_free(log)
+	}()
+	_, err := io.WriteString(n.logsWriter, C.GoString(log))
+	if err != nil {
+		return "", fmt.Errorf("failed writting logs: %v", err)
+	}
+	if rc != 0 {
+		return "", fmt.Errorf("failed when doing rollback checkpoint %s with rc: %d, err_msg: %s, err_kind: %s", checkpoint, rc, C.GoString(err_msg), C.GoString(err_kind))
+	}
+	return checkpoint, nil
+}

--- a/rust/src/go/nmstate/nmstate_test.go
+++ b/rust/src/go/nmstate/nmstate_test.go
@@ -1,0 +1,29 @@
+package nmstate
+
+import "testing"
+import "os"
+import "github.com/stretchr/testify/assert"
+
+func TestRetrieveNetState(t *testing.T) {
+	f, err := os.Create("file.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	nms := New(WithLogsWritter(f))
+	netState, err := nms.RetrieveNetState()
+	assert.NoError(t, err, "must succeed calling retrieve_net_state c binding")
+	assert.NotEmpty(t, netState, "net state should not be empty")
+}
+
+func TestRetrieveNetStateKernelOnly(t *testing.T) {
+	f, err := os.Create("file.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	nms := New(WithLogsWritter(f), WithKernelOnly())
+	netState, err := nms.RetrieveNetState()
+	assert.NoError(t, err, "must succeed calling retrieve_net_state c binding")
+	assert.NotEmpty(t, netState, "net state should not be empty")
+}


### PR DESCRIPTION
This patch is introducing golang bindings for the C bindings of
nmstate. The following functions are being introduced:

 - RetrieveNetState(flags int)
   * Returns (state, error) where state is a string containing the
     current state.

 - ApplyNetState(flags int, state string)
   * Returns (state, error) where state is a string containing the
     desired state applied.

This needs to handle the logs better as currently they are being shown
only when Nmstate fails on the operation.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>