### PR TITLE
rust: Order the activation

### DIFF
--- a/.github/workflows/rust_unit.yml
+++ b/.github/workflows/rust_unit.yml
@@ -1,4 +1,4 @@
-name: rust-lint
+name: rust-unit
 
 on:
   pull_request:
@@ -28,15 +28,6 @@ jobs:
       with:
           toolchain: ${{ matrix.rust_version }}
           override: true
-          components: rustfmt, clippy
 
     - name: Check fmt
-      if: matrix.rust_version == 'stable'
-      run: cd rust && cargo fmt -- --check
-
-    - name: Check clippy
-      if: matrix.rust_version == 'nightly'
-      run: cd rust && cargo clippy -- -D warnings
-
-    - name: Build
-      run: cd rust && cargo build --verbose --all
+      run: cd rust && cargo test -- --test-threads=1 --show-output

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ErrorKind {
     InvalidArgument,
     PluginFailure,

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -238,6 +238,7 @@ impl Interface {
         }
     }
 
+    // Return None if its is not controller
     pub fn ports(&self) -> Option<Vec<&str>> {
         match self {
             Self::LinuxBridge(iface) => iface.ports(),

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -27,6 +27,12 @@ pub struct BaseInterface {
     pub controller: Option<String>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
+    // The interface lowest up_priority will be activated first.
+    // The up_priority should be its controller's up_priority
+    // plus one.
+    // The 0 means top controller or no controller.
+    #[serde(skip)]
+    pub(crate) up_priority: u32,
     #[serde(flatten)]
     pub _other: serde_json::Map<String, serde_json::Value>,
 }
@@ -96,6 +102,21 @@ impl BaseInterface {
 
     pub fn can_have_ip(&self) -> bool {
         self.controller == None
+    }
+
+    pub(crate) fn is_up_priority_valid(&self) -> bool {
+        if self.controller.is_some() {
+            self.up_priority != 0
+        } else {
+            true
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            state: InterfaceState::Up,
+            ..Default::default()
+        }
     }
 }
 

--- a/rust/src/lib/ifaces/dummy.rs
+++ b/rust/src/lib/ifaces/dummy.rs
@@ -10,12 +10,9 @@ pub struct DummyInterface {
 
 impl Default for DummyInterface {
     fn default() -> Self {
-        Self {
-            base: BaseInterface {
-                iface_type: InterfaceType::Dummy,
-                ..Default::default()
-            },
-        }
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::Dummy;
+        Self { base }
     }
 }
 

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -14,11 +14,10 @@ pub struct EthernetInterface {
 
 impl Default for EthernetInterface {
     fn default() -> Self {
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::Ethernet;
         Self {
-            base: BaseInterface {
-                iface_type: InterfaceType::Ethernet,
-                ..Default::default()
-            },
+            base,
             ethernet: None,
             veth: None,
         }
@@ -44,6 +43,10 @@ impl EthernetInterface {
 
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.base.pre_verify_cleanup();
+    }
+
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -1,0 +1,322 @@
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
+
+use log::{debug, error, info};
+
+use crate::{
+    ErrorKind, InterfaceState, InterfaceType, Interfaces, NmstateError,
+};
+
+pub(crate) fn handle_changed_ports(
+    ifaces: &mut Interfaces,
+    cur_ifaces: &Interfaces,
+) -> Result<(), NmstateError> {
+    let mut pending_changes: HashMap<
+        String,
+        (Option<String>, Option<InterfaceType>),
+    > = HashMap::new();
+    for (iface_name, iface) in ifaces.kernel_ifaces.iter() {
+        if !iface.is_up() {
+            continue;
+        }
+        let desire_port_names = match iface.ports() {
+            Some(p) => HashSet::from_iter(p.iter().cloned()),
+            None => continue,
+        };
+        let current_port_names = match cur_ifaces.kernel_ifaces.get(iface_name)
+        {
+            Some(cur_iface) => match cur_iface.ports() {
+                Some(p) => HashSet::from_iter(p.iter().cloned()),
+                None => HashSet::new(),
+            },
+            None => HashSet::new(),
+        };
+
+        // Attaching new port to controller
+        for port_name in desire_port_names.difference(&current_port_names) {
+            pending_changes.insert(
+                port_name.to_string(),
+                (Some(iface_name.to_string()), Some(iface.iface_type())),
+            );
+        }
+
+        // Detaching port from current controller
+        for port_name in current_port_names.difference(&desire_port_names) {
+            pending_changes.insert(port_name.to_string(), (None, None));
+        }
+
+        // Set controller property if port in desire
+        for port_name in current_port_names.intersection(&desire_port_names) {
+            if ifaces.kernel_ifaces.contains_key(&port_name.to_string()) {
+                pending_changes.insert(
+                    port_name.to_string(),
+                    (Some(iface_name.to_string()), Some(iface.iface_type())),
+                );
+            }
+        }
+    }
+
+    for (iface_name, (ctrl_name, ctrl_type)) in pending_changes.drain() {
+        match ifaces.kernel_ifaces.get_mut(&iface_name) {
+            Some(iface) => {
+                iface.base_iface_mut().controller = ctrl_name;
+                iface.base_iface_mut().controller_type = ctrl_type;
+            }
+            None => {
+                // Port not found in desired state
+                if let Some(cur_iface) =
+                    cur_ifaces.kernel_ifaces.get(&iface_name)
+                {
+                    if cur_iface.base_iface().controller != ctrl_name
+                        || cur_iface.base_iface().controller_type != ctrl_type
+                    {
+                        let mut iface = cur_iface.clone();
+                        iface.base_iface_mut().state = InterfaceState::Up;
+                        iface.base_iface_mut().controller = ctrl_name;
+                        iface.base_iface_mut().controller_type = ctrl_type;
+                        info!(
+                            "Include interface {} to edit as its \
+                            controller required so",
+                            iface_name
+                        );
+                        ifaces.push(iface);
+                    }
+                } else {
+                    // Do not raise error if detach port
+                    if let Some(ctrl_name) = ctrl_name {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Interface {} is holding unknown port {}",
+                                ctrl_name, iface_name
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// TODO: user space interfaces
+pub(crate) fn set_ifaces_up_priority(ifaces: &mut Interfaces) -> bool {
+    // Return true when all interface has correct priority.
+    let mut ret = true;
+    let mut pending_changes: HashMap<String, u32> = HashMap::new();
+    // Use the push order to allow user providing help on dependency order
+    for (iface_name, _) in &ifaces.insert_order {
+        let iface = match ifaces.kernel_ifaces.get(iface_name) {
+            Some(i) => i,
+            None => continue,
+        };
+        if !iface.is_up() {
+            continue;
+        }
+        if iface.base_iface().is_up_priority_valid() {
+            continue;
+        }
+        if let Some(ref ctrl_name) = iface.base_iface().controller {
+            if let Some(ctrl_iface) =
+                ifaces.kernel_ifaces.get(ctrl_name.as_str())
+            {
+                if let Some(ctrl_pri) = pending_changes.remove(ctrl_name) {
+                    pending_changes.insert(ctrl_name.to_string(), ctrl_pri);
+                    pending_changes
+                        .insert(iface_name.to_string(), ctrl_pri + 1);
+                } else if ctrl_iface.base_iface().is_up_priority_valid() {
+                    pending_changes.insert(
+                        iface_name.to_string(),
+                        ctrl_iface.base_iface().up_priority + 1,
+                    );
+                } else {
+                    // Its controller does not have valid up priority yet.
+                    debug!(
+                        "Controller {} of {} is has no up priority",
+                        ctrl_name, iface_name
+                    );
+                    ret = false;
+                }
+            } else {
+                // There will be other validator check missing
+                // controller
+                error!("BUG: _set_up_priority() got port without controller");
+                continue;
+            }
+        } else {
+            continue;
+        }
+    }
+    debug!("pending kernel up priority changes {:?}", pending_changes);
+    for (iface_name, priority) in pending_changes.iter() {
+        if let Some(iface) = ifaces.kernel_ifaces.get_mut(iface_name) {
+            iface.base_iface_mut().up_priority = *priority;
+        }
+    }
+    ret
+}
+
+// Instead of placing tests in `tests` folder, we can test pub(crate) functions
+// here
+#[cfg(test)]
+mod tests {
+    use crate::{
+        ErrorKind, EthernetInterface, Interface, InterfaceType, Interfaces,
+        LinuxBridgeInterface,
+    };
+
+    #[test]
+    fn test_ifaces_up_order_no_ctrler_reserse_order() {
+        let mut ifaces = Interfaces::new();
+        ifaces.push(new_eth_iface("eth2"));
+        ifaces.push(new_eth_iface("eth1"));
+
+        let (add_ifaces, _, _) =
+            ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+        assert_eq!(ifaces.kernel_ifaces["eth1"].base_iface().up_priority, 0);
+        assert_eq!(ifaces.kernel_ifaces["eth2"].base_iface().up_priority, 0);
+
+        let ordered_ifaces = add_ifaces.to_vec();
+        assert_eq!(ordered_ifaces[0].name(), "eth1".to_string());
+        assert_eq!(ordered_ifaces[1].name(), "eth2".to_string());
+    }
+
+    #[test]
+    fn test_ifaces_up_order_nested_4_depth_worst_case() {
+        let mut ifaces = Interfaces::new();
+
+        let [br0, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+        // Push with reverse order which is the worst case
+        ifaces.push(p2);
+        ifaces.push(p1);
+        ifaces.push(br3);
+        ifaces.push(br2);
+        ifaces.push(br1);
+        ifaces.push(br0);
+
+        let (add_ifaces, _, _) =
+            ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+        assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 0);
+        assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 1);
+        assert_eq!(ifaces.kernel_ifaces["br2"].base_iface().up_priority, 2);
+        assert_eq!(ifaces.kernel_ifaces["br3"].base_iface().up_priority, 3);
+        assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().up_priority, 4);
+        assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().up_priority, 4);
+
+        let ordered_ifaces = add_ifaces.to_vec();
+
+        assert_eq!(ordered_ifaces[0].name(), "br0".to_string());
+        assert_eq!(ordered_ifaces[1].name(), "br1".to_string());
+        assert_eq!(ordered_ifaces[2].name(), "br2".to_string());
+        assert_eq!(ordered_ifaces[3].name(), "br3".to_string());
+        assert_eq!(ordered_ifaces[4].name(), "p1".to_string());
+        assert_eq!(ordered_ifaces[5].name(), "p2".to_string());
+    }
+
+    #[test]
+    fn test_ifaces_up_order_nested_5_depth_worst_case() {
+        let mut ifaces = Interfaces::new();
+        let [_, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+        let br4 = new_br_ifaces("br4");
+        let mut br0 = new_br_ifaces("br0");
+
+        br0.base_iface_mut().controller = Some("br4".to_string());
+        br0.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+        // Push with reverse order which is the worst case
+        ifaces.push(p1);
+        ifaces.push(p2);
+        ifaces.push(br3);
+        ifaces.push(br2);
+        ifaces.push(br1);
+        ifaces.push(br0);
+        ifaces.push(br4);
+
+        let result = ifaces.gen_state_for_apply(&Interfaces::new());
+        assert!(result.is_err());
+
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        }
+    }
+
+    #[test]
+    fn test_ifaces_up_order_nested_5_depth_good_case() {
+        let mut ifaces = Interfaces::new();
+        let [_, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+        let br4 = new_br_ifaces("br4");
+        let mut br0 = new_br_ifaces("br0");
+
+        br0.base_iface_mut().controller = Some("br4".to_string());
+        br0.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+        ifaces.push(br4);
+        ifaces.push(br0);
+        ifaces.push(br1);
+        ifaces.push(br2);
+        ifaces.push(br3);
+        ifaces.push(p2);
+        ifaces.push(p1);
+
+        let (add_ifaces, _, _) =
+            ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+        assert_eq!(ifaces.kernel_ifaces["br4"].base_iface().up_priority, 0);
+        assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 1);
+        assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 2);
+        assert_eq!(ifaces.kernel_ifaces["br2"].base_iface().up_priority, 3);
+        assert_eq!(ifaces.kernel_ifaces["br3"].base_iface().up_priority, 4);
+        assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().up_priority, 5);
+        assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().up_priority, 5);
+
+        let ordered_ifaces = add_ifaces.to_vec();
+
+        assert_eq!(ordered_ifaces[0].name(), "br4".to_string());
+        assert_eq!(ordered_ifaces[1].name(), "br0".to_string());
+        assert_eq!(ordered_ifaces[2].name(), "br1".to_string());
+        assert_eq!(ordered_ifaces[3].name(), "br2".to_string());
+        assert_eq!(ordered_ifaces[4].name(), "br3".to_string());
+        assert_eq!(ordered_ifaces[5].name(), "p1".to_string());
+        assert_eq!(ordered_ifaces[6].name(), "p2".to_string());
+    }
+
+    fn new_eth_iface(name: &str) -> Interface {
+        let mut iface = EthernetInterface::new();
+        iface.base.name = name.to_string();
+        Interface::Ethernet(iface)
+    }
+
+    fn new_br_ifaces(name: &str) -> Interface {
+        let mut iface = LinuxBridgeInterface::new();
+        iface.base.name = name.to_string();
+        Interface::LinuxBridge(iface)
+    }
+
+    fn new_nested_4_ifaces() -> [Interface; 6] {
+        let br0 = new_br_ifaces("br0");
+        let mut br1 = new_br_ifaces("br1");
+        let mut br2 = new_br_ifaces("br2");
+        let mut br3 = new_br_ifaces("br3");
+        let mut p1 = new_eth_iface("p1");
+        let mut p2 = new_eth_iface("p2");
+
+        br1.base_iface_mut().controller = Some("br0".to_string());
+        br1.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+        br2.base_iface_mut().controller = Some("br1".to_string());
+        br2.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+        br3.base_iface_mut().controller = Some("br2".to_string());
+        br3.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+        p1.base_iface_mut().controller = Some("br3".to_string());
+        p1.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+        p2.base_iface_mut().controller = Some("br3".to_string());
+        p2.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+        // Place the ifaces in mixed order to complex the work
+        [br0, br1, br2, br3, p1, p2]
+    }
+}

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -12,13 +12,9 @@ pub struct LinuxBridgeInterface {
 
 impl Default for LinuxBridgeInterface {
     fn default() -> Self {
-        Self {
-            base: BaseInterface {
-                iface_type: InterfaceType::LinuxBridge,
-                ..Default::default()
-            },
-            bridge: None,
-        }
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::LinuxBridge;
+        Self { base, bridge: None }
     }
 }
 
@@ -45,6 +41,10 @@ impl LinuxBridgeInterface {
 
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.base.pre_verify_cleanup();
+    }
+
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -2,6 +2,7 @@ mod base;
 mod dummy;
 mod ethernet;
 mod inter_ifaces;
+mod inter_ifaces_controller;
 mod linux_bridge;
 mod vlan;
 

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -95,14 +95,13 @@ impl NetworkState {
     }
 
     pub fn apply(&self) -> Result<(), NmstateError> {
-        let desire_state_to_edit = self.clone();
         let desire_state_to_verify = self.clone();
         let mut cur_net_state = NetworkState::new();
         cur_net_state.set_kernel_only(self.kernel_only);
         cur_net_state.retrieve()?;
 
         let (add_net_state, chg_net_state, del_net_state) =
-            desire_state_to_edit.gen_state_for_apply(&cur_net_state)?;
+            self.gen_state_for_apply(&cur_net_state)?;
 
         debug!("Adding net state {:?}", &add_net_state);
         debug!("Changing net state {:?}", &chg_net_state);
@@ -198,8 +197,10 @@ impl NetworkState {
         let mut chg_net_state = NetworkState::new();
         let mut del_net_state = NetworkState::new();
 
+        let mut ifaces = self.interfaces.clone();
+
         let (add_ifaces, chg_ifaces, del_ifaces) =
-            self.interfaces.gen_state_for_apply(&current.interfaces)?;
+            ifaces.gen_state_for_apply(&current.interfaces)?;
 
         add_net_state.interfaces = add_ifaces;
         add_net_state.prop_list = vec!["interfaces"];


### PR DESCRIPTION
When desire state contains nested interfaces, the controller should
be activated before its ports.

This patch introduce `BaseInterface.up_priority` property, the lower
value means earlier it should be activated.

We are supporting up-to 4 nested level of interfaces been placed into
desire state in any order. For more complex desire state, user should
place controller before port in desire state.

Unit test case included and enabled in github CI.