### PR TITLE
gitignore: add valgrind output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _kubevirtci
 rust/Cargo.lock
 rust/target
 rust/src/clib/test/nmstate_test
+rust/src/clib/test/vgcore*


### PR DESCRIPTION
When running C bindings tests we are using valgrind to check for it is
clean of memory leaks. The output generated by valgrind must be ignored
by git.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>