### PR TITLE
rust, clib: expose missing NMSTATE_FLAG_*

### DIFF
--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -36,8 +36,11 @@ extern "C" {
 #define NMSTATE_PASS                 0
 #define NMSTATE_FAIL                 1
 
-#define NMSTATE_FLAG_NONE            0
-#define NMSTATE_FLAG_KERNEL_ONLY     1 << 1
+#define NMSTATE_FLAG_NONE                   0
+#define NMSTATE_FLAG_KERNEL_ONLY            1 << 1
+#define NMSTATE_FLAG_NO_VERIFY              1 << 2
+#define NMSTATE_FLAG_INCLUDE_STATUS_DATA    1 << 3
+#define NMSTATE_FLAG_INCLUDE_SECRETS        1 << 4
 
 /**
  * nmstate_net_state_retrieve - Retrieve network state


### PR DESCRIPTION
The following nmstate flags were missing on clib:
  * NMSTATE_FLAG_NO_VERIFY
  * NMSTATE_FLAG_INCLUDE_STATUS_DATA
  * NMSTATE_FLAG_INCLUDE_SECRETS

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>