### PR TITLE
rust, nm: support reapply operation when possible

### DIFF
--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -155,9 +155,12 @@ fn apply_single_state(
             TIMEOUT_SECONDS_FOR_PROFILE_ACTIVATION,
         )?;
         info!("Activating connection {}", nm_conn_uuid);
-        nm_api
-            .connection_activate(nm_conn_uuid)
-            .map_err(nm_error_to_nmstate)?;
+        if let Err(e) = nm_api.connection_reapply(nm_conn_uuid) {
+            info!("Reapply operation failed trying activation, reason: {}", e);
+            nm_api
+                .connection_activate(nm_conn_uuid)
+                .map_err(nm_error_to_nmstate)?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
When activating a connection, Nmstate should try first to reapply and in
case it is not possible, it will fallback on the activation.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>