### PR TITLE
rust, ip: Fix deserialization/serialization of ipv4/ipv6

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -179,6 +179,7 @@ impl InterfaceIpv4 {
     // Clean up before verification
     // * Sort IP address
     // * Convert expanded IP address to compacted
+    // * Add optional properties to prop_list
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.addresses.sort_unstable_by(|a, b| {
             (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
@@ -189,6 +190,7 @@ impl InterfaceIpv4 {
             }
         }
         debug!("IPv4 after pre_verify_cleanup: {:?}", self);
+        self.prop_list.push("dhcp");
     }
 }
 
@@ -377,6 +379,7 @@ impl InterfaceIpv6 {
     // Clean up before verification
     // * Remove link-local address
     // * Sanitize the expanded IP address
+    // * Add optional properties to prop_list
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.addresses.retain(|addr| {
             !is_ipv6_unicast_link_local(&addr.ip, addr.prefix_length)
@@ -390,6 +393,8 @@ impl InterfaceIpv6 {
             }
         }
         debug!("IPv6 after pre_verify_cleanup: {:?}", self);
+        self.prop_list.push("dhcp");
+        self.prop_list.push("autoconf");
     }
 
     // Clean up before Apply


### PR DESCRIPTION
Nmstate is using a custom serializer for ipv4 and ipv6. We are relying
in `prop_list` to serialize the values but when creating a NetState
struct and doing `serde::to_string(net_state)` the `prop_list` is not
populated. Therefore it will not show the properties.

For example if we generate a NetState from the following file:

```yaml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      enabled: true
      address:
        - ip: 192.168.100.200
          prefix-length: 24
```

And we use the `serde::to_string()` method, it will show:

```yaml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      enabled: true
```

In order to fix this, we must implement our deserializer in which we
populate `prop_list`. This must be done on each struct that relies on
`prop_list` to serialize.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>