### PR TITLE
rust ovs: Support OpenvSwitch

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -180,6 +180,19 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/static_ip_address_test.py \
             ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/ovs_test.py \
+            -k '\
+            test_create_and_remove_ovs_bridge_with_min_desired_state or \
+            test_create_and_save_ovs_bridge_then_remove_and_apply_again or \
+            test_create_and_remove_ovs_bridge_options_specified or \
+            test_create_and_remove_ovs_bridge_with_a_system_port or \
+            test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac' \
+            ${nmstate_pytest_extra_args}"
     fi
 }
 

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -48,10 +48,14 @@ impl BaseInterface {
         {
             self.iface_type = other.iface_type.clone();
         }
-        if other.prop_list.contains(&"iface_type")
-            && other.state != InterfaceState::Unknown
-        {
+        if other.prop_list.contains(&"state") {
             self.state = other.state.clone();
+        }
+        if other.prop_list.contains(&"controller") {
+            self.controller = other.controller.clone();
+        }
+        if other.prop_list.contains(&"controller_type") {
+            self.controller_type = other.controller_type.clone();
         }
 
         if other.prop_list.contains(&"ipv4") {
@@ -102,6 +106,7 @@ impl BaseInterface {
 
     pub fn can_have_ip(&self) -> bool {
         self.controller == None
+            || self.iface_type == InterfaceType::OvsInterface
     }
 
     pub(crate) fn is_up_priority_valid(&self) -> bool {

--- a/rust/src/lib/ifaces/dummy.rs
+++ b/rust/src/lib/ifaces/dummy.rs
@@ -17,7 +17,7 @@ impl Default for DummyInterface {
 }
 
 impl DummyInterface {
-    pub fn new(base: BaseInterface) -> Self {
-        Self { base }
+    pub fn new() -> Self {
+        Self::default()
     }
 }

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -4,6 +4,7 @@ mod ethernet;
 mod inter_ifaces;
 mod inter_ifaces_controller;
 mod linux_bridge;
+mod ovs;
 mod vlan;
 
 pub use base::*;
@@ -11,4 +12,9 @@ pub use dummy::DummyInterface;
 pub use ethernet::{EthernetConfig, EthernetInterface, VethConfig};
 pub use inter_ifaces::*;
 pub use linux_bridge::*;
+pub use ovs::{
+    OvsBridgeBondConfig, OvsBridgeBondMode, OvsBridgeBondPortConfig,
+    OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
+    OvsInterface,
+};
 pub use vlan::{VlanConfig, VlanInterface};

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -1,0 +1,252 @@
+use std::convert::TryFrom;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OvsBridgeInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge: Option<OvsBridgeConfig>,
+}
+
+impl Default for OvsBridgeInterface {
+    fn default() -> Self {
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::OvsBridge;
+        Self { base, bridge: None }
+    }
+}
+
+impl OvsBridgeInterface {
+    pub(crate) fn update_ovs_bridge(&mut self, other: &OvsBridgeInterface) {
+        if let Some(br_conf) = &mut self.bridge {
+            br_conf.update(other.bridge.as_ref());
+        } else {
+            self.bridge = other.bridge.clone();
+        }
+    }
+
+    pub(crate) fn ports(&self) -> Option<Vec<&str>> {
+        let mut port_names = Vec::new();
+        if let Some(br_conf) = &self.bridge {
+            if let Some(port_confs) = &br_conf.ports {
+                for port_conf in port_confs {
+                    if let Some(bond_conf) = &port_conf.bond {
+                        for port_name in bond_conf.ports() {
+                            port_names.push(port_name);
+                        }
+                    } else {
+                        port_names.push(port_conf.name.as_str());
+                    }
+                }
+            }
+        }
+        Some(port_names)
+    }
+
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        self.base.pre_verify_cleanup();
+        self.sort_ports()
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn sort_ports(&mut self) {
+        if let Some(ref mut br_conf) = self.bridge {
+            if let Some(ref mut port_confs) = &mut br_conf.ports {
+                port_confs.sort_unstable_by_key(|p| p.name.clone());
+                for port_conf in port_confs {
+                    if let Some(ref mut bond_conf) = port_conf.bond {
+                        bond_conf.sort_ports();
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn port_confs(&self) -> Vec<&OvsBridgePortConfig> {
+        let mut ret: Vec<&OvsBridgePortConfig> = Vec::new();
+        if let Some(br_conf) = &self.bridge {
+            if let Some(port_confs) = &br_conf.ports {
+                for port_conf in port_confs {
+                    ret.push(port_conf)
+                }
+            }
+        }
+        ret
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct OvsBridgeConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<OvsBridgeOptions>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    pub ports: Option<Vec<OvsBridgePortConfig>>,
+}
+
+impl OvsBridgeConfig {
+    pub(crate) fn update(&mut self, other: Option<&OvsBridgeConfig>) {
+        if let Some(other) = other {
+            self.ports = other.ports.clone();
+        }
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct OvsBridgeOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stp: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rstp: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_snooping_enable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_mode: Option<String>,
+}
+
+impl OvsBridgeOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct OvsBridgePortConfig {
+    pub name: String,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "link-aggregation"
+    )]
+    pub bond: Option<OvsBridgeBondConfig>,
+}
+
+impl OvsBridgePortConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OvsInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+}
+
+impl Default for OvsInterface {
+    fn default() -> Self {
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::OvsInterface;
+        Self { base }
+    }
+}
+
+impl OvsInterface {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct OvsBridgeBondConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<OvsBridgeBondMode>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bond_downdelay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bond_updelay: Option<u32>,
+}
+
+impl OvsBridgeBondConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn ports(&self) -> Vec<&str> {
+        let mut port_names: Vec<&str> = Vec::new();
+        if let Some(ports) = &self.ports {
+            for port in ports {
+                port_names.push(&port.name);
+            }
+        }
+        port_names
+    }
+    pub(crate) fn sort_ports(&mut self) {
+        if let Some(ref mut bond_ports) = self.ports {
+            bond_ports.sort_unstable_by_key(|p| p.name.clone())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct OvsBridgeBondPortConfig {
+    pub name: String,
+}
+
+impl OvsBridgeBondPortConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OvsBridgeBondMode {
+    ActiveBackup,
+    BalanceSlb,
+    BalanceTcp,
+    Lacp,
+}
+
+impl Default for OvsBridgeBondMode {
+    fn default() -> Self {
+        Self::BalanceSlb
+    }
+}
+
+impl TryFrom<&str> for OvsBridgeBondMode {
+    type Error = NmstateError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "active-backup" => Ok(Self::ActiveBackup),
+            "balance-slb" => Ok(Self::BalanceSlb),
+            "balance-tcp" => Ok(Self::BalanceTcp),
+            "lacp" => Ok(Self::Lacp),
+            _ => Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!("Unsupported OVS Bond mode {}", value),
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for OvsBridgeBondMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::ActiveBackup => "active-backup",
+                Self::BalanceSlb => "balance-slb",
+                Self::BalanceTcp => "balance-tcp",
+                Self::Lacp => "lacp",
+            }
+        )
+    }
+}

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -150,6 +150,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
 }
 
 impl InterfaceIpv4 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;
@@ -356,6 +360,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
 }
 
 impl InterfaceIpv6 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -6,6 +6,7 @@ mod net_state;
 mod nispor;
 mod nm;
 mod state;
+mod unit_tests;
 
 pub use crate::error::{ErrorKind, NmstateError};
 pub use crate::iface::{
@@ -14,8 +15,10 @@ pub use crate::iface::{
 pub use crate::ifaces::{
     BaseInterface, DummyInterface, EthernetConfig, EthernetInterface,
     Interfaces, LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeOptions,
-    LinuxBridgePortConfig, LinuxBridgeStpOptions, VethConfig, VlanConfig,
-    VlanInterface,
+    LinuxBridgePortConfig, LinuxBridgeStpOptions, OvsBridgeBondConfig,
+    OvsBridgeBondMode, OvsBridgeBondPortConfig, OvsBridgeConfig,
+    OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig, OvsInterface,
+    VethConfig, VlanConfig, VlanInterface,
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 pub use crate::net_state::NetworkState;

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -13,7 +13,7 @@ pub(crate) fn nispor_apply(
     add_net_state: &NetworkState,
     chg_net_state: &NetworkState,
     del_net_state: &NetworkState,
-    _cur_net_state: &NetworkState,
+    _full_net_state: &NetworkState,
 ) -> Result<(), NmstateError> {
     apply_single_state(del_net_state)?;
     apply_single_state(add_net_state)?;

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -43,7 +43,7 @@ pub(crate) fn np_iface_to_base_iface(
         iface_type: np_iface_type_to_nmstate(&np_iface.iface_type),
         ipv4: np_ipv4_to_nmstate(np_iface),
         ipv6: np_ipv6_to_nmstate(np_iface),
-        mac_address: Some(np_iface.mac_address.to_string()),
+        mac_address: Some(np_iface.mac_address.to_uppercase()),
         controller: np_iface.controller.as_ref().map(|c| c.to_string()),
         mtu: if np_iface.mtu >= 0 {
             Some(np_iface.mtu as u64)

--- a/rust/src/lib/nm/active_connection.rs
+++ b/rust/src/lib/nm/active_connection.rs
@@ -1,0 +1,16 @@
+use std::collections::HashMap;
+
+use nm_dbus::NmActiveConnection;
+
+pub(crate) fn create_index_for_nm_acs_by_name_type(
+    nm_acs: &[NmActiveConnection],
+) -> HashMap<(&str, &str), &NmActiveConnection> {
+    let mut ret = HashMap::new();
+    for nm_ac in nm_acs {
+        ret.insert(
+            (nm_ac.iface_name.as_str(), nm_ac.iface_type.as_str()),
+            nm_ac,
+        );
+    }
+    ret
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,14 +1,24 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use nm_dbus::{NmApi, NmConnection, NmSettingConnection};
+use nm_dbus::{NmApi, NmConnection, NmSettingConnection, NmSettingWired};
 
 use crate::{
     nm::bridge::linux_bridge_conf_to_nm,
     nm::ip::{iface_ipv4_to_nm, iface_ipv6_to_nm},
+    nm::ovs::{
+        create_nm_ovs_br_set, create_nm_ovs_iface_set, create_ovs_port_nm_conn,
+    },
     nm::profile::get_exist_profile,
     ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6, InterfaceType,
     NetworkState, NmstateError,
 };
+
+pub(crate) const NM_SETTING_BRIDGE_SETTING_NAME: &str = "bridge";
+pub(crate) const NM_SETTING_WIRED_SETTING_NAME: &str = "802-3-ethernet";
+pub(crate) const NM_SETTING_OVS_BRIDGE_SETTING_NAME: &str = "ovs-bridge";
+pub(crate) const NM_SETTING_OVS_PORT_SETTING_NAME: &str = "ovs-port";
+pub(crate) const NM_SETTING_OVS_IFACE_SETTING_NAME: &str = "ovs-interface";
+pub(crate) const NM_SETTING_VETH_SETTING_NAME: &str = "veth";
 
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
@@ -16,28 +26,30 @@ pub(crate) fn nm_gen_conf(
     let mut ret = Vec::new();
     let ifaces = net_state.interfaces.to_vec();
     for iface in &ifaces {
-        let (_, nm_conn) = iface_to_nm_connection(iface, &[], &[])?;
-        ret.push(match nm_conn.to_keyfile() {
-            Ok(s) => s,
-            Err(e) => {
-                return Err(NmstateError::new(
-                    ErrorKind::PluginFailure,
-                    format!(
+        for nm_conn in iface_to_nm_connections(iface, &[], &[])? {
+            ret.push(match nm_conn.to_keyfile() {
+                Ok(s) => s,
+                Err(e) => {
+                    return Err(NmstateError::new(
+                        ErrorKind::PluginFailure,
+                        format!(
                         "Bug in NM plugin, failed to generate configure: {}",
                         e
                     ),
-                ));
-            }
-        })
+                    ));
+                }
+            })
+        }
     }
     Ok(ret)
 }
 
-pub(crate) fn iface_to_nm_connection(
+pub(crate) fn iface_to_nm_connections(
     iface: &Interface,
     exist_nm_conns: &[NmConnection],
     nm_ac_uuids: &[&str],
-) -> Result<(String, NmConnection), NmstateError> {
+) -> Result<Vec<NmConnection>, NmstateError> {
+    let mut ret: Vec<NmConnection> = Vec::new();
     let base_iface = iface.base_iface();
     let exist_nm_conn = get_exist_profile(
         exist_nm_conns,
@@ -55,27 +67,22 @@ pub(crate) fn iface_to_nm_connection(
     } else {
         NmApi::uuid_gen()
     };
-    let mut nm_conn_set = NmSettingConnection {
-        id: Some(base_iface.name.clone()),
-        uuid: Some(uuid.clone()),
-        iface_type: Some(iface_type_to_nm(&base_iface.iface_type)?),
-        iface_name: Some(base_iface.name.clone()),
-        autoconnect: Some(true),
-        autoconnect_ports: if iface.is_controller() {
-            Some(true)
-        } else {
-            None
-        },
-        ..Default::default()
+    let nm_ctrl_type = if let Some(ctrl_type) = &base_iface.controller_type {
+        Some(iface_type_to_nm(ctrl_type)?)
+    } else {
+        None
     };
-    if let Some(ctrl_name) = &base_iface.controller {
-        if let Some(ctrl_type) = &base_iface.controller_type {
-            nm_conn_set.controller = Some(ctrl_name.to_string());
-            nm_conn_set.controller_type = Some(iface_type_to_nm(ctrl_type)?);
-        }
-    }
-    let mut nm_conn = NmConnection::new();
-    nm_conn.connection = Some(nm_conn_set);
+    let nm_ctrl_type = nm_ctrl_type.as_deref();
+    let ctrl_name = base_iface.controller.as_deref();
+    let mut nm_conn = gen_nm_connection(
+        &base_iface.name,
+        &uuid,
+        &iface_type_to_nm(&base_iface.iface_type)?,
+        ctrl_name,
+        nm_ctrl_type,
+        iface.is_controller(),
+    );
+
     if base_iface.can_have_ip() {
         if let Some(iface_ip) = &base_iface.ipv4 {
             nm_conn.ipv4 = Some(iface_ipv4_to_nm(iface_ip)?);
@@ -94,12 +101,39 @@ pub(crate) fn iface_to_nm_connection(
             })?);
         }
     }
+    let mut nm_wired_set = NmSettingWired::new();
+    let mut flag_need_wired = false;
+    if let Some(mac) = &base_iface.mac_address {
+        flag_need_wired = true;
+        nm_wired_set.cloned_mac_address = Some(mac.to_string());
+    }
+    if flag_need_wired {
+        nm_conn.wired = Some(nm_wired_set);
+    }
+
+    if let Interface::OvsBridge(ovs_br_iface) = iface {
+        nm_conn.ovs_bridge = Some(create_nm_ovs_br_set(ovs_br_iface));
+    }
     if let Interface::LinuxBridge(br_iface) = iface {
         if let Some(br_conf) = &br_iface.bridge {
             nm_conn.bridge = Some(linux_bridge_conf_to_nm(br_conf)?);
         }
     }
-    Ok((uuid, nm_conn))
+    if let Interface::OvsInterface(ovs_iface) = iface {
+        nm_conn.ovs_iface = Some(create_nm_ovs_iface_set(ovs_iface));
+    }
+    ret.push(nm_conn);
+    if let Interface::OvsBridge(ovs_br_iface) = iface {
+        // For OVS Bridge, we should create its OVS port also
+        for ovs_port_conf in ovs_br_iface.port_confs() {
+            ret.push(create_ovs_port_nm_conn(
+                &ovs_br_iface.base.name,
+                ovs_port_conf,
+            ))
+        }
+    }
+
+    Ok(ret)
 }
 
 pub(crate) fn iface_type_to_nm(
@@ -108,6 +142,9 @@ pub(crate) fn iface_type_to_nm(
     match iface_type {
         InterfaceType::LinuxBridge => Ok("bridge".into()),
         InterfaceType::Ethernet => Ok("802-3-ethernet".into()),
+        InterfaceType::OvsBridge => Ok("ovs-bridge".into()),
+        InterfaceType::OvsInterface => Ok("ovs-interface".into()),
+        InterfaceType::Other(s) => Ok(s.to_string()),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,
             format!("Does not support iface type: {:?} yet", iface_type),
@@ -115,16 +152,17 @@ pub(crate) fn iface_type_to_nm(
     }
 }
 
-pub(crate) fn create_index_for_nm_conns(
+pub(crate) fn create_index_for_nm_conns_by_name_type(
     nm_conns: &[NmConnection],
-) -> HashMap<(String, String), Vec<&NmConnection>> {
-    let mut ret: HashMap<(String, String), Vec<&NmConnection>> = HashMap::new();
+) -> HashMap<(&str, &str), Vec<&NmConnection>> {
+    let mut ret: HashMap<(&str, &str), Vec<&NmConnection>> = HashMap::new();
     for nm_conn in nm_conns {
         if let Some(iface_name) = nm_conn.iface_name() {
-            if let Some(nm_iface_type) = nm_conn.iface_type() {
-                match ret
-                    .entry((iface_name.to_string(), nm_iface_type.to_string()))
-                {
+            if let Some(mut nm_iface_type) = nm_conn.iface_type() {
+                if nm_iface_type == NM_SETTING_VETH_SETTING_NAME {
+                    nm_iface_type = NM_SETTING_WIRED_SETTING_NAME;
+                }
+                match ret.entry((iface_name, nm_iface_type)) {
                     Entry::Occupied(o) => {
                         o.into_mut().push(nm_conn);
                     }
@@ -136,4 +174,125 @@ pub(crate) fn create_index_for_nm_conns(
         }
     }
     ret
+}
+
+pub(crate) fn create_index_for_nm_conns_by_ctrler_type(
+    nm_conns: &[NmConnection],
+) -> HashMap<(&str, &str), Vec<&NmConnection>> {
+    let mut ret: HashMap<(&str, &str), Vec<&NmConnection>> = HashMap::new();
+    for nm_conn in nm_conns {
+        let ctrl_name = if let Some(c) = nm_conn.controller() {
+            c
+        } else {
+            continue;
+        };
+        let nm_ctrl_type = if let Some(c) = nm_conn.controller_type() {
+            c
+        } else {
+            continue;
+        };
+        match ret.entry((ctrl_name, nm_ctrl_type)) {
+            Entry::Occupied(o) => {
+                o.into_mut().push(nm_conn);
+            }
+            Entry::Vacant(v) => {
+                v.insert(vec![nm_conn]);
+            }
+        };
+    }
+    ret
+}
+
+pub(crate) fn get_port_nm_conns<'a>(
+    nm_conn: &'a NmConnection,
+    nm_conns_ctrler_type_index: &HashMap<
+        (&'a str, &'a str),
+        Vec<&'a NmConnection>,
+    >,
+) -> Vec<&'a NmConnection> {
+    let mut ret: Vec<&NmConnection> = Vec::new();
+    if let Some(nm_iface_type) = nm_conn.iface_type() {
+        if let Some(uuid) = nm_conn.uuid() {
+            if let Some(port_nm_conns) =
+                nm_conns_ctrler_type_index.get(&(uuid, nm_iface_type))
+            {
+                for port_nm_conn in port_nm_conns {
+                    ret.push(port_nm_conn);
+                    if port_nm_conn.iface_type() == Some("ovs-port") {
+                        for ovs_iface_nm_conn in get_port_nm_conns(
+                            port_nm_conn,
+                            nm_conns_ctrler_type_index,
+                        ) {
+                            ret.push(ovs_iface_nm_conn)
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(name) = nm_conn.iface_name() {
+            if let Some(port_nm_conns) =
+                nm_conns_ctrler_type_index.get(&(name, nm_iface_type))
+            {
+                for port_nm_conn in port_nm_conns {
+                    ret.push(port_nm_conn);
+                    if port_nm_conn.iface_type() == Some("ovs-port") {
+                        for ovs_iface_nm_conn in get_port_nm_conns(
+                            port_nm_conn,
+                            nm_conns_ctrler_type_index,
+                        ) {
+                            ret.push(ovs_iface_nm_conn)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ret
+}
+
+pub(crate) fn gen_nm_connection(
+    iface_name: &str,
+    uuid: &str,
+    nm_iface_type: &str,
+    ctrl_name: Option<&str>,
+    nm_ctrl_type: Option<&str>,
+    is_controller: bool,
+) -> NmConnection {
+    let mut nm_conn = NmConnection::new();
+
+    // OVS port already has it own prefix
+    let conn_name = if nm_iface_type == "ovs-bridge" {
+        format!("ovs-br-{}", iface_name)
+    } else if nm_iface_type == "ovs-interface" {
+        format!("ovs-iface-{}", iface_name)
+    } else {
+        iface_name.to_string()
+    };
+
+    let mut nm_conn_set = NmSettingConnection {
+        id: Some(conn_name),
+        uuid: Some(uuid.to_string()),
+        iface_type: Some(nm_iface_type.to_string()),
+        iface_name: Some(iface_name.to_string()),
+        autoconnect: Some(true),
+        autoconnect_ports: if is_controller { Some(true) } else { None },
+        ..Default::default()
+    };
+
+    if let Some(ctrl_name) = ctrl_name {
+        if let Some(nm_ctrl_type) = nm_ctrl_type {
+            nm_conn_set.controller = Some(ctrl_name.to_string());
+            nm_conn_set.controller_type = if nm_ctrl_type == "ovs-bridge"
+                && nm_iface_type != "ovs-port"
+            {
+                Some("ovs-port".to_string())
+            } else {
+                Some(nm_ctrl_type.to_string())
+            };
+        }
+    }
+    nm_conn.connection = Some(nm_conn_set);
+
+    nm_conn
 }

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -1,3 +1,4 @@
+mod active_connection;
 mod apply;
 mod bridge;
 mod checkpoint;
@@ -5,10 +6,16 @@ mod connection;
 mod device;
 mod error;
 mod ip;
+mod ovs;
 mod profile;
 mod show;
+#[cfg(test)]
+mod unit_tests;
 
-pub(crate) use apply::*;
-pub(crate) use checkpoint::*;
+pub(crate) use apply::nm_apply;
+pub(crate) use checkpoint::{
+    nm_checkpoint_create, nm_checkpoint_destroy, nm_checkpoint_rollback,
+    nm_checkpoint_timeout_extend,
+};
 pub(crate) use connection::nm_gen_conf;
-pub(crate) use show::*;
+pub(crate) use show::nm_retrieve;

--- a/rust/src/lib/nm/ovs.rs
+++ b/rust/src/lib/nm/ovs.rs
@@ -1,0 +1,250 @@
+use std::convert::TryFrom;
+
+use log::warn;
+use nm_dbus::{
+    NmConnection, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+};
+
+use crate::{
+    nm::connection::gen_nm_connection, NmstateError, OvsBridgeBondConfig,
+    OvsBridgeBondMode, OvsBridgeBondPortConfig, OvsBridgeConfig,
+    OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig, OvsInterface,
+};
+
+pub(crate) const OVS_PORT_PREFIX: &str = "ovs-port-";
+
+pub(crate) fn nm_ovs_bridge_conf_get(
+    nm_conn: &NmConnection,
+    port_nm_conns: Option<&[&NmConnection]>,
+) -> Result<OvsBridgeConfig, NmstateError> {
+    let mut ovs_br_conf = OvsBridgeConfig::new();
+    if let Some(nm_ovs_setting) = &nm_conn.ovs_bridge {
+        let mut br_opts = OvsBridgeOptions::new();
+        // The DBUS interface of NM does not return default values
+        // We set default values to be consistent with old nmstate behavior
+        br_opts.stp = match nm_ovs_setting.stp {
+            Some(n) => Some(n),
+            None => Some(false),
+        };
+        br_opts.rstp = match nm_ovs_setting.rstp {
+            Some(n) => Some(n),
+            None => Some(false),
+        };
+        br_opts.mcast_snooping_enable =
+            match nm_ovs_setting.mcast_snooping_enable {
+                Some(n) => Some(n),
+                None => Some(false),
+            };
+        br_opts.fail_mode = match nm_ovs_setting.fail_mode.as_ref() {
+            Some(m) => Some(m.to_string()),
+            None => Some("".to_string()),
+        };
+        ovs_br_conf.options = Some(br_opts);
+        if let Some(port_nm_conns) = port_nm_conns {
+            ovs_br_conf.ports =
+                Some(nm_ovs_bridge_conf_port_get(port_nm_conns));
+        }
+    }
+    Ok(ovs_br_conf)
+}
+
+fn nm_ovs_bridge_conf_port_get(
+    nm_conns: &[&NmConnection],
+) -> Vec<OvsBridgePortConfig> {
+    let mut ret = Vec::new();
+    for nm_conn in nm_conns {
+        if nm_conn.iface_type() == Some("ovs-port") {
+            let nm_ovs_iface_conns = get_nm_ovs_iface_conns(nm_conn, nm_conns);
+            match nm_ovs_iface_conns.len() {
+                d if d > 1 => {
+                    if let Some(p) = get_ovs_port_config_for_bond(
+                        nm_conn,
+                        &nm_ovs_iface_conns,
+                    ) {
+                        ret.push(p);
+                    }
+                }
+                1 => {
+                    if let Some(p) =
+                        get_ovs_port_config_for_iface(nm_ovs_iface_conns[0])
+                    {
+                        ret.push(p);
+                    }
+                }
+                _ => (),
+            };
+        }
+    }
+    ret
+}
+
+fn get_ovs_port_config_for_bond(
+    nm_ovs_port_conn: &NmConnection,
+    nm_ovs_iface_conns: &[&NmConnection],
+) -> Option<OvsBridgePortConfig> {
+    let mut port_conf = OvsBridgePortConfig::new();
+    if let Some(n) = nm_ovs_port_conn.iface_name() {
+        port_conf.name = remove_ovs_port_name_prefix(n).to_string();
+    } else {
+        return None;
+    }
+    let mut ovs_bond_conf = OvsBridgeBondConfig::new();
+
+    let nm_port_set = if let Some(s) = &nm_ovs_port_conn.ovs_port {
+        s
+    } else {
+        return None;
+    };
+
+    ovs_bond_conf.mode = nm_port_set.mode.as_ref().and_then(|nm_mode| {
+        if let Ok(m) = OvsBridgeBondMode::try_from(nm_mode.as_str()) {
+            Some(m)
+        } else {
+            warn!("Unsupported OVS bond mode {}", nm_mode);
+            None
+        }
+    });
+
+    ovs_bond_conf.bond_downdelay = nm_port_set.down_delay;
+    ovs_bond_conf.bond_updelay = nm_port_set.up_delay;
+    let mut ovs_iface_confs = Vec::new();
+
+    for nm_ovs_iface_conn in nm_ovs_iface_conns {
+        if let Some(name) = nm_ovs_iface_conn.iface_name() {
+            ovs_iface_confs.push(OvsBridgeBondPortConfig {
+                name: name.to_string(),
+            })
+        }
+    }
+
+    ovs_bond_conf.ports = Some(ovs_iface_confs);
+    port_conf.bond = Some(ovs_bond_conf);
+
+    Some(port_conf)
+}
+
+fn get_ovs_port_config_for_iface(
+    nm_conn: &NmConnection,
+) -> Option<OvsBridgePortConfig> {
+    if let Some(name) = nm_conn.iface_name() {
+        let mut port_conf = OvsBridgePortConfig::new();
+        port_conf.name = name.to_string();
+        Some(port_conf)
+    } else {
+        None
+    }
+}
+
+fn get_nm_ovs_iface_conns<'a>(
+    nm_ovs_port_conn: &'a NmConnection,
+    nm_conns: &'a [&'a NmConnection],
+) -> Vec<&'a NmConnection> {
+    let mut ret = Vec::new();
+    let uuid = if let Some(n) = nm_ovs_port_conn.uuid() {
+        n
+    } else {
+        return ret;
+    };
+    let name = if let Some(n) = nm_ovs_port_conn.iface_name() {
+        n
+    } else {
+        return ret;
+    };
+    for nm_conn in nm_conns {
+        if nm_conn.controller_type() == Some("ovs-port")
+            && (nm_conn.controller() == Some(uuid)
+                || nm_conn.controller() == Some(name))
+        {
+            ret.push(nm_conn)
+        }
+    }
+    ret
+}
+
+pub(crate) fn gen_ovs_port_name(port_name: &str) -> String {
+    format!("{}{}", OVS_PORT_PREFIX, port_name)
+}
+
+fn remove_ovs_port_name_prefix(nm_port_name: &str) -> &str {
+    if nm_port_name.len() > OVS_PORT_PREFIX.len() {
+        &nm_port_name[OVS_PORT_PREFIX.len()..]
+    } else {
+        nm_port_name
+    }
+}
+
+pub(crate) fn create_ovs_port_nm_conn(
+    br_name: &str,
+    port_conf: &OvsBridgePortConfig,
+) -> NmConnection {
+    let port_name = gen_ovs_port_name(&port_conf.name);
+    let mut nm_conn = gen_nm_connection(
+        &port_name,
+        &nm_dbus::NmApi::uuid_gen(),
+        "ovs-port",
+        Some(br_name),
+        Some("ovs-bridge"),
+        true, // is controller
+    );
+    let mut nm_ovs_port_set = NmSettingOvsPort::new();
+    if let Some(bond_conf) = &port_conf.bond {
+        if let Some(bond_mode) = &bond_conf.mode {
+            nm_ovs_port_set.mode = Some(format!("{}", bond_mode));
+        }
+
+        if let Some(bond_downdelay) = bond_conf.bond_downdelay {
+            nm_ovs_port_set.down_delay = Some(bond_downdelay);
+        }
+
+        if let Some(bond_updelay) = bond_conf.bond_updelay {
+            nm_ovs_port_set.up_delay = Some(bond_updelay);
+        }
+    }
+    nm_conn.ovs_port = Some(nm_ovs_port_set);
+    nm_conn
+}
+
+pub(crate) fn get_ovs_port_name(
+    ovs_br_iface: &OvsBridgeInterface,
+    ovs_iface_name: &str,
+) -> Option<String> {
+    for port_conf in ovs_br_iface.port_confs() {
+        if let Some(bond_conf) = &port_conf.bond {
+            for bond_port_name in bond_conf.ports() {
+                if bond_port_name == ovs_iface_name {
+                    return Some(gen_ovs_port_name(&port_conf.name));
+                }
+            }
+        } else if ovs_iface_name == port_conf.name {
+            return Some(gen_ovs_port_name(ovs_iface_name));
+        }
+    }
+    None
+}
+
+pub(crate) fn create_nm_ovs_br_set(
+    ovs_br_iface: &OvsBridgeInterface,
+) -> NmSettingOvsBridge {
+    let mut nm_ovs_br_set = NmSettingOvsBridge::new();
+    if let Some(br_conf) = &ovs_br_iface.bridge {
+        if let Some(br_opts) = &br_conf.options {
+            nm_ovs_br_set.stp = br_opts.stp;
+            nm_ovs_br_set.rstp = br_opts.rstp;
+            nm_ovs_br_set.mcast_snooping_enable = br_opts.mcast_snooping_enable;
+            if let Some(fail_mode) = &br_opts.fail_mode {
+                if !fail_mode.is_empty() {
+                    nm_ovs_br_set.fail_mode = Some(fail_mode.to_string());
+                }
+            }
+        }
+    }
+    nm_ovs_br_set
+}
+
+pub(crate) fn create_nm_ovs_iface_set(
+    _ovs_iface: &OvsInterface,
+) -> NmSettingOvsIface {
+    let mut nm_ovs_iface_set = NmSettingOvsIface::new();
+    nm_ovs_iface_set.iface_type = Some("internal".to_string());
+    nm_ovs_iface_set
+}

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -1,10 +1,19 @@
-use log::{info, warn};
+use std::collections::{hash_map::Entry, HashMap};
+
+use log::{error, info};
 use nm_dbus::{NmApi, NmConnection};
 
 use crate::{
+    nm::checkpoint::nm_checkpoint_timeout_extend,
     nm::connection::iface_type_to_nm, nm::error::nm_error_to_nmstate,
-    InterfaceType, NmstateError,
+    nm::ovs::get_ovs_port_name, ErrorKind, Interface, InterfaceType,
+    NmstateError,
 };
+
+// We only adjust timeout for every 20 profile additions.
+const TIMEOUT_ADJUST_PROFILE_ADDTION_GROUP_SIZE: usize = 20;
+const TIMEOUT_SECONDS_FOR_PROFILE_ADDTION: u32 = 60;
+const TIMEOUT_SECONDS_FOR_PROFILE_ACTIVATION: u32 = 60;
 
 // Found existing profile, prefer the activated one
 pub(crate) fn get_exist_profile<'a>(
@@ -15,8 +24,16 @@ pub(crate) fn get_exist_profile<'a>(
 ) -> Option<&'a NmConnection> {
     let mut found_nm_conns: Vec<&NmConnection> = Vec::new();
     for exist_nm_conn in exist_nm_conns {
-        if nm_connection_matches(exist_nm_conn, iface_name, iface_type) {
+        let nm_iface_type = if let Ok(t) = iface_type_to_nm(iface_type) {
+            t
+        } else {
+            continue;
+        };
+        if exist_nm_conn.iface_name() == Some(&iface_name.to_string())
+            && exist_nm_conn.iface_type() == Some(&nm_iface_type)
+        {
             if let Some(uuid) = exist_nm_conn.uuid() {
+                // Prefer activated connection
                 if nm_ac_uuids.contains(&uuid) {
                     return Some(exist_nm_conn);
                 }
@@ -30,18 +47,97 @@ pub(crate) fn get_exist_profile<'a>(
 pub(crate) fn delete_exist_profiles(
     nm_api: &NmApi,
     exist_nm_conns: &[NmConnection],
-    iface_name: &str,
-    iface_type: &InterfaceType,
-    excluded_uuid: &str,
+    nm_conns: &[NmConnection],
 ) -> Result<(), NmstateError> {
+    let mut excluded_uuids: Vec<&str> = Vec::new();
+    let mut changed_iface_name_types: Vec<(&str, &str)> = Vec::new();
+    for nm_conn in nm_conns {
+        if let Some(uuid) = nm_conn.uuid() {
+            excluded_uuids.push(uuid);
+        }
+        if let Some(name) = nm_conn.iface_name() {
+            if let Some(nm_iface_type) = nm_conn.iface_type() {
+                changed_iface_name_types.push((name, nm_iface_type));
+            }
+        }
+    }
     for exist_nm_conn in exist_nm_conns {
-        if let Some(uuid) = exist_nm_conn.uuid() {
-            if uuid != excluded_uuid
-                && nm_connection_matches(exist_nm_conn, iface_name, iface_type)
-            {
-                info!("Deleting connection {:?}", exist_nm_conn);
+        let uuid = if let Some(u) = exist_nm_conn.uuid() {
+            u
+        } else {
+            continue;
+        };
+        let iface_name = if let Some(i) = exist_nm_conn.iface_name() {
+            i
+        } else {
+            continue;
+        };
+        let nm_iface_type = if let Some(t) = exist_nm_conn.iface_type() {
+            t
+        } else {
+            continue;
+        };
+        if !excluded_uuids.contains(&uuid)
+            && changed_iface_name_types.contains(&(iface_name, nm_iface_type))
+        {
+            info!("Deleting existing connection {:?}", exist_nm_conn);
+            nm_api
+                .connection_delete(uuid)
+                .map_err(nm_error_to_nmstate)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn save_nm_profiles(
+    nm_api: &nm_dbus::NmApi,
+    nm_conns: &[NmConnection],
+    checkpoint: &str,
+) -> Result<(), NmstateError> {
+    for (index, nm_conn) in nm_conns.iter().enumerate() {
+        // Only extend the timeout every
+        // TIMEOUT_ADJUST_PROFILE_ADDTION_GROUP_SIZE profile addition.
+        if index % TIMEOUT_ADJUST_PROFILE_ADDTION_GROUP_SIZE
+            == TIMEOUT_ADJUST_PROFILE_ADDTION_GROUP_SIZE - 1
+        {
+            nm_checkpoint_timeout_extend(
+                checkpoint,
+                TIMEOUT_SECONDS_FOR_PROFILE_ADDTION,
+            )?;
+        }
+        info!("Creating/Modifying connection {:?}", nm_conn);
+        nm_api
+            .connection_add(nm_conn)
+            .map_err(nm_error_to_nmstate)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn activate_nm_profiles(
+    nm_api: &nm_dbus::NmApi,
+    nm_conns: &[NmConnection],
+    checkpoint: &str,
+) -> Result<(), NmstateError> {
+    for nm_conn in nm_conns {
+        nm_checkpoint_timeout_extend(
+            checkpoint,
+            TIMEOUT_SECONDS_FOR_PROFILE_ACTIVATION,
+        )?;
+        if let Some(uuid) = nm_conn.uuid() {
+            info!(
+                "Activating connection {}: {}/{}",
+                uuid,
+                nm_conn.iface_name().unwrap_or(""),
+                nm_conn.iface_type().unwrap_or("")
+            );
+            if let Err(e) = nm_api.connection_reapply(nm_conn) {
+                info!(
+                    "Reapply operation failed trying activation, reason: {}, \
+                    retry on normal activation",
+                    e
+                );
                 nm_api
-                    .connection_delete(uuid)
+                    .connection_activate(uuid)
                     .map_err(nm_error_to_nmstate)?;
             }
         }
@@ -49,23 +145,134 @@ pub(crate) fn delete_exist_profiles(
     Ok(())
 }
 
-fn nm_connection_matches(
-    nm_conn: &NmConnection,
-    iface_name: &str,
-    iface_type: &InterfaceType,
-) -> bool {
-    // TODO Need to handle veth/ethernet
-    let nm_iface_type = match iface_type_to_nm(iface_type) {
-        Ok(i) => i,
-        Err(e) => {
-            warn!(
-                "Failed to convert iface_type {:?} to network \
-                manager type: {}",
-                iface_type, e
-            );
-            return false;
+pub(crate) fn use_uuid_for_controller_reference(
+    nm_conns: &mut [NmConnection],
+    des_user_space_ifaces: &HashMap<(String, InterfaceType), Interface>,
+    cur_user_space_ifaces: &HashMap<(String, InterfaceType), Interface>,
+    exist_nm_conns: &[NmConnection],
+) -> Result<(), NmstateError> {
+    let mut name_type_2_uuid_index: HashMap<(String, String), String> =
+        HashMap::new();
+
+    // This block does not need nm_conn to be mutable, using iter_mut()
+    // just to suppress the rust clippy warning message
+    for nm_conn in nm_conns.iter_mut() {
+        let iface_type = if let Some(i) = nm_conn.iface_type() {
+            i
+        } else {
+            continue;
+        };
+        if let Some(uuid) = nm_conn.uuid() {
+            if let Some(iface_name) = nm_conn.iface_name() {
+                name_type_2_uuid_index.insert(
+                    (iface_name.to_string(), iface_type.to_string()),
+                    uuid.to_string(),
+                );
+            }
         }
-    };
-    nm_conn.iface_name() == Some(iface_name)
-        && nm_conn.iface_type() == Some(&nm_iface_type)
+    }
+
+    for nm_conn in exist_nm_conns {
+        let iface_type = if let Some(i) = nm_conn.iface_type() {
+            i
+        } else {
+            continue;
+        };
+        if let Some(uuid) = nm_conn.uuid() {
+            if let Some(iface_name) = nm_conn.iface_name() {
+                match name_type_2_uuid_index
+                    .entry((iface_name.to_string(), iface_type.to_string()))
+                {
+                    // Prefer newly created NmConnection over existing one
+                    Entry::Occupied(_) => {
+                        continue;
+                    }
+                    Entry::Vacant(v) => {
+                        v.insert(uuid.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    let mut pending_changes: Vec<(&mut NmConnection, String)> = Vec::new();
+
+    for nm_conn in nm_conns.iter_mut() {
+        let ctrl_type = if let Some(t) = nm_conn.controller_type() {
+            t
+        } else {
+            continue;
+        };
+        let mut ctrl_name = if let Some(n) = nm_conn.controller() {
+            n.to_string()
+        } else {
+            continue;
+        };
+
+        if ctrl_type == "ovs-port" {
+            if let Some(Interface::OvsBridge(ovs_br_iface)) =
+                des_user_space_ifaces
+                    .get(&(ctrl_name.to_string(), InterfaceType::OvsBridge))
+                    .or_else(|| {
+                        cur_user_space_ifaces.get(&(
+                            ctrl_name.to_string(),
+                            InterfaceType::OvsBridge,
+                        ))
+                    })
+            {
+                if let Some(iface_name) = nm_conn.iface_name() {
+                    if let Some(ovs_port_name) =
+                        get_ovs_port_name(ovs_br_iface, iface_name)
+                    {
+                        ctrl_name = ovs_port_name.to_string();
+                    } else {
+                        let e = NmstateError::new(
+                            ErrorKind::Bug,
+                            format!(
+                                "Failed to find OVS port name for \
+                                NmConnection {:?}",
+                                nm_conn
+                            ),
+                        );
+                        error!("{}", e);
+                        return Err(e);
+                    }
+                }
+            } else {
+                let e = NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "Failed to find OVS Bridge interface for \
+                        NmConnection {:?}",
+                        nm_conn
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            }
+        }
+
+        if let Some(uuid) = name_type_2_uuid_index
+            .get(&(ctrl_name.clone(), ctrl_type.to_string()))
+        {
+            pending_changes.push((nm_conn, uuid.to_string()));
+        } else {
+            let e = NmstateError::new(
+                ErrorKind::Bug,
+                format!(
+                    "BUG: Failed to find UUID of controller connection: \
+                {}, {}",
+                    ctrl_name, ctrl_type
+                ),
+            );
+            error!("{}", e);
+            return Err(e);
+        }
+    }
+    for (nm_conn, uuid) in pending_changes {
+        if let Some(ref mut nm_conn_set) = &mut nm_conn.connection {
+            nm_conn_set.controller = Some(uuid.to_string());
+        }
+    }
+    Ok(())
 }

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -1,17 +1,27 @@
+use std::collections::HashMap;
+
 use log::{debug, warn};
 use nm_dbus::{
-    NmApi, NmConnection, NmDeviceState, NmSettingIp, NmSettingIpMethod,
+    NmActiveConnection, NmApi, NmConnection, NmDeviceState, NmSettingIp,
+    NmSettingIpMethod,
 };
 
 use crate::{
-    nm::connection::create_index_for_nm_conns, nm::error::nm_error_to_nmstate,
+    nm::active_connection::create_index_for_nm_acs_by_name_type,
+    nm::connection::{
+        create_index_for_nm_conns_by_ctrler_type,
+        create_index_for_nm_conns_by_name_type, get_port_nm_conns,
+        NM_SETTING_BRIDGE_SETTING_NAME, NM_SETTING_OVS_BRIDGE_SETTING_NAME,
+        NM_SETTING_OVS_IFACE_SETTING_NAME, NM_SETTING_VETH_SETTING_NAME,
+        NM_SETTING_WIRED_SETTING_NAME,
+    },
+    nm::error::nm_error_to_nmstate,
+    nm::ovs::nm_ovs_bridge_conf_get,
     BaseInterface, EthernetInterface, Interface, InterfaceIpv4, InterfaceIpv6,
-    InterfaceState, InterfaceType, LinuxBridgeInterface, NetworkState,
-    NmstateError, UnknownInterface,
+    InterfaceState, InterfaceType, Interfaces, LinuxBridgeInterface,
+    NetworkState, NmstateError, OvsBridgeInterface, OvsInterface,
+    UnknownInterface,
 };
-
-const NM_SETTING_BRIDGE_SETTING_NAME: &str = "bridge";
-const NM_SETTING_WIRED_SETTING_NAME: &str = "802-3-ethernet";
 
 pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
     let mut net_state = NetworkState::new();
@@ -21,77 +31,114 @@ pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
         .applied_connections_get()
         .map_err(nm_error_to_nmstate)?;
     let nm_devs = nm_api.devices_get().map_err(nm_error_to_nmstate)?;
+    let nm_saved_conns =
+        nm_api.connections_get().map_err(nm_error_to_nmstate)?;
+    let nm_acs = nm_api
+        .active_connections_get()
+        .map_err(nm_error_to_nmstate)?;
 
-    let nm_conn_indexed = create_index_for_nm_conns(nm_conns.as_slice());
+    let nm_conns_name_type_index =
+        create_index_for_nm_conns_by_name_type(nm_conns.as_slice());
+    let mut nm_saved_conn_uuid_index: HashMap<&str, &NmConnection> =
+        HashMap::new();
+    for nm_saved_conn in nm_saved_conns.as_slice() {
+        if let Some(uuid) = nm_saved_conn.uuid() {
+            nm_saved_conn_uuid_index.insert(uuid, nm_saved_conn);
+        }
+    }
+    let nm_saved_conns_ctrler_type_index =
+        create_index_for_nm_conns_by_ctrler_type(nm_saved_conns.as_slice());
+    let nm_acs_name_type_index =
+        create_index_for_nm_acs_by_name_type(nm_acs.as_slice());
 
     // Include disconnected interface as state:down
     // This is used for verify on `state: absent`
     for nm_dev in &nm_devs {
+        let iface_type = nm_iface_type_to_nmstate(&nm_dev.iface_type);
         match nm_dev.state {
             NmDeviceState::Unmanaged => continue,
             NmDeviceState::Disconnected => {
-                let iface_type = nm_iface_type_to_nmstate(&nm_dev.iface_type);
-                let base_iface = BaseInterface {
-                    name: nm_dev.name.clone(),
-                    prop_list: vec!["name", "iface_type", "state"],
-                    state: InterfaceState::Down,
-                    iface_type,
-                    ..Default::default()
-                };
+                let mut base_iface = BaseInterface::new();
+                base_iface.name = nm_dev.name.clone();
+                base_iface.prop_list = vec!["name", "iface_type", "state"];
+                base_iface.state = InterfaceState::Down;
+                base_iface.iface_type = iface_type;
                 let iface = match &base_iface.iface_type {
-                    InterfaceType::Ethernet => {
-                        Interface::Ethernet(EthernetInterface {
-                            base: base_iface,
-                            ..Default::default()
-                        })
-                    }
-                    InterfaceType::LinuxBridge => {
-                        Interface::LinuxBridge(LinuxBridgeInterface {
-                            base: base_iface,
-                            ..Default::default()
-                        })
-                    }
-                    _ => Interface::Unknown(UnknownInterface::new(base_iface)),
+                    InterfaceType::Ethernet => Interface::Ethernet({
+                        let mut iface = EthernetInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
+                    InterfaceType::LinuxBridge => Interface::LinuxBridge({
+                        let mut iface = LinuxBridgeInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
+                    InterfaceType::OvsInterface => Interface::OvsInterface({
+                        let mut iface = OvsInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
+                    _ => Interface::Unknown({
+                        let mut iface = UnknownInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
                 };
                 debug!("Found disconnected interface {:?}", iface);
                 net_state.append_interface_data(iface);
             }
             _ => {
-                if let Some(nm_conns) = nm_conn_indexed
-                    .get(&(nm_dev.name.clone(), nm_dev.iface_type.clone()))
-                {
-                    // There is only single applied connection for each device
-                    let nm_conn = if nm_conns.is_empty() {
-                        continue;
-                    } else {
-                        nm_conns[0]
-                    };
+                let nm_conn = if let Some(c) = get_first_nm_conn(
+                    &nm_conns_name_type_index,
+                    &nm_dev.name,
+                    &nm_dev.iface_type,
+                ) {
+                    c
+                } else {
+                    warn!(
+                        "Failed to find applied NmConnection for interface \
+                        {} {}",
+                        nm_dev.name, nm_dev.iface_type
+                    );
 
-                    if let Some(base_iface) = nm_conn_to_base_iface(nm_conn) {
-                        let iface = match &base_iface.iface_type {
-                            InterfaceType::LinuxBridge => {
-                                Interface::LinuxBridge(LinuxBridgeInterface {
-                                    base: base_iface,
-                                    ..Default::default()
-                                })
-                            }
-                            InterfaceType::Ethernet => {
-                                Interface::Ethernet(EthernetInterface {
-                                    base: base_iface,
-                                    ..Default::default()
-                                })
-                            }
-                            _ => Interface::Unknown(UnknownInterface::new(
-                                base_iface,
-                            )),
-                        };
-                        debug!("Found interface {:?}", iface);
-                        net_state.append_interface_data(iface);
-                    }
+                    continue;
+                };
+                let nm_ac = get_nm_ac(
+                    &nm_acs_name_type_index,
+                    &nm_dev.name,
+                    &nm_dev.iface_type,
+                );
+
+                // NM developer confirmed NmActiveConnection UUID is the
+                // UUID of NmConnection associated
+                let nm_saved_conn = if let Some(nm_ac) = nm_ac {
+                    nm_saved_conn_uuid_index.get(nm_ac.uuid.as_str()).copied()
+                } else {
+                    None
+                };
+                let port_saved_nm_conns = if iface_type.is_controller() {
+                    Some(get_port_nm_conns(
+                        nm_conn,
+                        &nm_saved_conns_ctrler_type_index,
+                    ))
+                } else {
+                    None
+                };
+
+                if let Some(iface) = iface_get(
+                    nm_conn,
+                    nm_saved_conn,
+                    port_saved_nm_conns.as_ref().map(Vec::as_ref),
+                ) {
+                    debug!("Found interface {:?}", iface);
+                    net_state.append_interface_data(iface);
                 }
             }
         }
     }
+
+    set_ovs_iface_controller_info(&mut net_state.interfaces);
 
     Ok(net_state)
 }
@@ -99,8 +146,11 @@ pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
 fn nm_iface_type_to_nmstate(nm_iface_type: &str) -> InterfaceType {
     match nm_iface_type {
         NM_SETTING_WIRED_SETTING_NAME => InterfaceType::Ethernet,
+        NM_SETTING_VETH_SETTING_NAME => InterfaceType::Ethernet,
         NM_SETTING_BRIDGE_SETTING_NAME => InterfaceType::LinuxBridge,
-        _ => InterfaceType::Unknown,
+        NM_SETTING_OVS_BRIDGE_SETTING_NAME => InterfaceType::OvsBridge,
+        NM_SETTING_OVS_IFACE_SETTING_NAME => InterfaceType::OvsInterface,
+        _ => InterfaceType::Other(nm_iface_type.to_string()),
     }
 }
 
@@ -114,15 +164,16 @@ fn nm_conn_to_base_iface(nm_conn: &NmConnection) -> Option<BaseInterface> {
                 nm_ip_setting_to_nmstate6(nm_ipv6_setting)
             });
 
-            return Some(BaseInterface {
-                name: iface_name.to_string(),
-                prop_list: vec!["name", "state", "iface_type", "ipv4", "ipv6"],
-                state: InterfaceState::Up,
-                iface_type: nm_iface_type_to_nmstate(iface_type),
-                ipv4,
-                ipv6,
-                ..Default::default()
-            });
+            let mut base_iface = BaseInterface::new();
+            base_iface.name = iface_name.to_string();
+            base_iface.prop_list =
+                vec!["name", "state", "iface_type", "ipv4", "ipv6"];
+            base_iface.state = InterfaceState::Up;
+            base_iface.iface_type = nm_iface_type_to_nmstate(iface_type);
+            base_iface.ipv4 = ipv4;
+            base_iface.ipv6 = ipv6;
+            base_iface.controller = nm_conn.controller().map(|c| c.to_string());
+            return Some(base_iface);
         }
     }
     None
@@ -172,5 +223,122 @@ fn nm_ip_setting_to_nmstate6(nm_ip_setting: &NmSettingIp) -> InterfaceIpv6 {
         }
     } else {
         InterfaceIpv6::default()
+    }
+}
+
+// Applied connection does not hold OVS config, we need the NmConnection
+// used by `NmActiveConnection` also.
+fn iface_get(
+    nm_conn: &NmConnection,
+    nm_saved_conn: Option<&NmConnection>,
+    port_saved_nm_conns: Option<&[&NmConnection]>,
+) -> Option<Interface> {
+    if let Some(base_iface) = nm_conn_to_base_iface(nm_conn) {
+        let iface = match &base_iface.iface_type {
+            InterfaceType::LinuxBridge => Interface::LinuxBridge({
+                let mut iface = LinuxBridgeInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
+            InterfaceType::Ethernet => Interface::Ethernet({
+                let mut iface = EthernetInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
+            InterfaceType::OvsInterface => Interface::OvsInterface({
+                let mut iface = OvsInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
+            InterfaceType::OvsBridge => {
+                // NetworkManager applied connection does not
+                // have ovs configure
+                if let Some(nm_saved_conn) = nm_saved_conn {
+                    let mut br_iface = OvsBridgeInterface::new();
+                    br_iface.base = base_iface;
+                    br_iface.bridge = nm_ovs_bridge_conf_get(
+                        nm_saved_conn,
+                        port_saved_nm_conns,
+                    )
+                    .ok();
+                    Interface::OvsBridge(br_iface)
+                } else {
+                    warn!(
+                        "Failed to get active connection of interface \
+                        {} {}",
+                        base_iface.name, base_iface.iface_type
+                    );
+                    return None;
+                }
+            }
+            _ => {
+                debug!("Skip unsupported interface {:?}", base_iface);
+                return None;
+            }
+        };
+        debug!("Found interface {:?}", iface);
+        Some(iface)
+    } else {
+        // NmConnection has no interface name
+        None
+    }
+}
+
+fn get_first_nm_conn<'a>(
+    nm_conns_name_type_index: &'a HashMap<
+        (&'a str, &'a str),
+        Vec<&'a NmConnection>,
+    >,
+    name: &'a str,
+    nm_iface_type: &'a str,
+) -> Option<&'a NmConnection> {
+    // Treating veth as ethernet
+    let nm_iface_type = if nm_iface_type == NM_SETTING_VETH_SETTING_NAME {
+        NM_SETTING_WIRED_SETTING_NAME
+    } else {
+        nm_iface_type
+    };
+    if let Some(nm_conns) = nm_conns_name_type_index.get(&(name, nm_iface_type))
+    {
+        if nm_conns.is_empty() {
+            None
+        } else {
+            Some(nm_conns[0])
+        }
+    } else {
+        None
+    }
+}
+
+fn get_nm_ac<'a>(
+    nm_acs_name_type_index: &'a HashMap<
+        (&'a str, &'a str),
+        &'a NmActiveConnection,
+    >,
+    name: &'a str,
+    nm_iface_type: &'a str,
+) -> Option<&'a NmActiveConnection> {
+    nm_acs_name_type_index.get(&(name, nm_iface_type)).copied()
+}
+
+fn set_ovs_iface_controller_info(ifaces: &mut Interfaces) {
+    let mut pending_changes: Vec<(&str, &str)> = Vec::new();
+    for iface in ifaces.user_ifaces.values() {
+        if iface.iface_type() == InterfaceType::OvsBridge {
+            if let Some(port_names) = iface.ports() {
+                for port_name in port_names {
+                    pending_changes.push((port_name, iface.name()));
+                }
+            }
+        }
+    }
+    for (iface_name, ctrl_name) in pending_changes {
+        if let Some(ref mut iface) = ifaces.kernel_ifaces.get_mut(iface_name) {
+            iface.base_iface_mut().prop_list.push("controller");
+            iface.base_iface_mut().prop_list.push("controller_type");
+            iface.base_iface_mut().controller = Some(ctrl_name.to_string());
+            iface.base_iface_mut().controller_type =
+                Some(InterfaceType::OvsBridge);
+        }
     }
 }

--- a/rust/src/lib/nm/unit_tests/mod.rs
+++ b/rust/src/lib/nm/unit_tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod profiles;

--- a/rust/src/lib/nm/unit_tests/profiles.rs
+++ b/rust/src/lib/nm/unit_tests/profiles.rs
@@ -1,0 +1,120 @@
+use crate::{
+    nm::profile::use_uuid_for_controller_reference, Interface, InterfaceType,
+    OvsBridgeBondConfig, OvsBridgeBondPortConfig, OvsBridgeConfig,
+    OvsBridgeInterface, OvsBridgePortConfig,
+};
+use nm_dbus::{NmConnection, NmSettingConnection};
+use std::collections::HashMap;
+const UUID1: &str = "8aca0200-accc-4d13-a62f-3c89a6da53c5";
+const UUID2: &str = "1c646761-efcc-4d33-a0d9-cb3c1c2d3309";
+const UUID3: &str = "06935474-b8d3-4e7c-be52-48e2e6e6b3b9";
+const UUID4: &str = "3c80d8de-a6d7-47da-b0b3-47d2b1052fe5";
+
+#[test]
+fn test_use_uuid_for_controller_reference_with_ovs_bond() {
+    let mut nm_conns: Vec<NmConnection> = Vec::new();
+    let mut nm_conn = NmConnection::new();
+    let mut nm_conn_set = NmSettingConnection::new();
+    nm_conn_set.id = Some("ovs-br-br0".to_string());
+    nm_conn_set.uuid = Some(UUID1.to_string());
+    nm_conn_set.iface_type = Some("ovs-bridge".to_string());
+    nm_conn_set.iface_name = Some("br0".to_string());
+    nm_conn.connection = Some(nm_conn_set);
+    nm_conns.push(nm_conn);
+
+    let mut nm_conn = NmConnection::new();
+    let mut nm_conn_set = NmSettingConnection::new();
+    nm_conn_set.id = Some("ovs-port-bond1".to_string());
+    nm_conn_set.uuid = Some(UUID2.to_string());
+    nm_conn_set.iface_type = Some("ovs-port".to_string());
+    nm_conn_set.iface_name = Some("ovs-port-bond1".to_string());
+    nm_conn_set.controller = Some("br0".into());
+    nm_conn_set.controller_type = Some("ovs-bridge".into());
+    nm_conn.connection = Some(nm_conn_set);
+    nm_conns.push(nm_conn);
+
+    let mut nm_conn = NmConnection::new();
+    let mut nm_conn_set = NmSettingConnection::new();
+    nm_conn_set.id = Some("ovs-iface-p1".to_string());
+    nm_conn_set.uuid = Some(UUID3.to_string());
+    nm_conn_set.iface_type = Some("ovs-interface".to_string());
+    nm_conn_set.iface_name = Some("p1".to_string());
+    nm_conn_set.controller = Some("br0".into());
+    nm_conn_set.controller_type = Some("ovs-port".into());
+    nm_conn.connection = Some(nm_conn_set);
+    nm_conns.push(nm_conn);
+
+    let mut nm_conn = NmConnection::new();
+    let mut nm_conn_set = NmSettingConnection::new();
+    nm_conn_set.id = Some("ovs-iface-p2".to_string());
+    nm_conn_set.uuid = Some(UUID4.to_string());
+    nm_conn_set.iface_type = Some("ovs-interface".to_string());
+    nm_conn_set.iface_name = Some("p2".to_string());
+    nm_conn_set.controller = Some("br0".into());
+    nm_conn_set.controller_type = Some("ovs-port".into());
+    nm_conn.connection = Some(nm_conn_set);
+    nm_conns.push(nm_conn);
+
+    let mut br0 = OvsBridgeInterface::new();
+    br0.base.iface_type = InterfaceType::OvsBridge;
+    br0.base.name = "br0".to_string();
+    let mut br_conf = OvsBridgeConfig::new();
+    let mut p1_port_conf = OvsBridgeBondPortConfig::new();
+    p1_port_conf.name = "p1".to_string();
+    let mut p2_port_conf = OvsBridgeBondPortConfig::new();
+    p2_port_conf.name = "p2".to_string();
+    let mut bond_conf = OvsBridgeBondConfig::new();
+    bond_conf.ports = Some(vec![p1_port_conf, p2_port_conf]);
+    let mut port_conf = OvsBridgePortConfig::new();
+    port_conf.name = "bond1".to_string();
+    port_conf.bond = Some(bond_conf);
+    br_conf.ports = Some(vec![port_conf]);
+    br0.bridge = Some(br_conf);
+
+    let mut user_ifaces: HashMap<(String, InterfaceType), Interface> =
+        HashMap::new();
+
+    user_ifaces.insert(
+        ("br0".to_string(), InterfaceType::OvsBridge),
+        Interface::OvsBridge(br0),
+    );
+
+    use_uuid_for_controller_reference(
+        &mut nm_conns,
+        &user_ifaces,
+        &HashMap::new(),
+        &vec![],
+    )
+    .unwrap();
+
+    println!("nm_conns {:?}", nm_conns);
+
+    let br0_nm_con_set = nm_conns[0].connection.as_ref().unwrap();
+    println!("br0 {:?}", br0_nm_con_set);
+    assert!(br0_nm_con_set.iface_name == Some("br0".to_string()));
+    assert!(br0_nm_con_set.id == Some("ovs-br-br0".to_string()));
+
+    let bond1_nm_con_set = nm_conns[1].connection.as_ref().unwrap();
+    println!("bond1 {:?}", bond1_nm_con_set);
+    assert!(bond1_nm_con_set.id == Some("ovs-port-bond1".to_string()));
+    assert!(bond1_nm_con_set.iface_name == Some("ovs-port-bond1".to_string()));
+    assert!(bond1_nm_con_set.iface_type == Some("ovs-port".to_string()));
+    assert!(bond1_nm_con_set.controller == Some(UUID1.to_string()));
+    assert!(bond1_nm_con_set.controller_type == Some("ovs-bridge".to_string()));
+
+    let p1_nm_con_set = nm_conns[2].connection.as_ref().unwrap();
+    println!("p1 {:?}", p1_nm_con_set);
+    assert!(p1_nm_con_set.id == Some("ovs-iface-p1".to_string()));
+    assert!(p1_nm_con_set.iface_name == Some("p1".to_string()));
+    assert!(p1_nm_con_set.iface_type == Some("ovs-interface".to_string()));
+    assert!(p1_nm_con_set.controller == Some(UUID2.to_string()));
+    assert!(p1_nm_con_set.controller_type == Some("ovs-port".to_string()));
+
+    let p2_nm_con_set = nm_conns[3].connection.as_ref().unwrap();
+    println!("p2 {:?}", p2_nm_con_set);
+    assert!(p2_nm_con_set.id == Some("ovs-iface-p2".to_string()));
+    assert!(p2_nm_con_set.iface_name == Some("p2".to_string()));
+    assert!(p2_nm_con_set.iface_type == Some("ovs-interface".to_string()));
+    assert!(p2_nm_con_set.controller == Some(UUID2.to_string()));
+    assert!(p2_nm_con_set.controller_type == Some("ovs-port".to_string()));
+}

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -1,0 +1,51 @@
+use crate::{
+    unit_tests::testlib::{
+        new_eth_iface, new_ovs_br_iface, new_ovs_iface, new_unknown_iface,
+    },
+    InterfaceState, InterfaceType, Interfaces,
+};
+
+#[test]
+fn test_resolve_unknown_type_absent_eth() {
+    let mut cur_ifaces = Interfaces::new();
+    cur_ifaces.push(new_eth_iface("eth2"));
+    cur_ifaces.push(new_eth_iface("eth1"));
+
+    let mut absent_iface = new_unknown_iface("eth1");
+    absent_iface.base_iface_mut().state = InterfaceState::Absent;
+    let mut ifaces = Interfaces::new();
+    ifaces.push(absent_iface);
+
+    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+
+    let del_ifaces = del_ifaces.to_vec();
+
+    assert_eq!(del_ifaces[0].name(), "eth1");
+    assert_eq!(del_ifaces[0].iface_type(), InterfaceType::Ethernet);
+    assert!(del_ifaces[0].is_absent());
+    assert!(ifaces.user_ifaces.is_empty());
+}
+
+#[test]
+fn test_resolve_unknown_type_absent_multiple() {
+    let mut cur_ifaces = Interfaces::new();
+    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_iface("br0", "br0"));
+    cur_ifaces.push(new_ovs_iface("p1", "br0"));
+
+    let mut absent_iface = new_unknown_iface("br0");
+    absent_iface.base_iface_mut().state = InterfaceState::Absent;
+    let mut ifaces = Interfaces::new();
+    ifaces.push(absent_iface);
+
+    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+
+    let del_ifaces = del_ifaces.to_vec();
+
+    assert_eq!(del_ifaces[0].name(), "br0");
+    assert_eq!(del_ifaces[0].iface_type(), InterfaceType::OvsInterface);
+    assert!(del_ifaces[0].is_absent());
+    assert_eq!(del_ifaces[1].name(), "br0");
+    assert_eq!(del_ifaces[1].iface_type(), InterfaceType::OvsBridge);
+    assert!(del_ifaces[1].is_absent());
+}

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -1,0 +1,229 @@
+use crate::{
+    unit_tests::testlib::{
+        new_br_iface, new_eth_iface, new_nested_4_ifaces, new_ovs_br_iface,
+        new_ovs_iface,
+    },
+    ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
+    OvsBridgeInterface,
+};
+
+#[test]
+fn test_ifaces_up_order_no_ctrler_reserse_order() {
+    let mut ifaces = Interfaces::new();
+    ifaces.push(new_eth_iface("eth2"));
+    ifaces.push(new_eth_iface("eth1"));
+
+    let (add_ifaces, _, _) =
+        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+    assert_eq!(ifaces.kernel_ifaces["eth1"].base_iface().up_priority, 0);
+    assert_eq!(ifaces.kernel_ifaces["eth2"].base_iface().up_priority, 0);
+
+    let ordered_ifaces = add_ifaces.to_vec();
+    assert_eq!(ordered_ifaces[0].name(), "eth1".to_string());
+    assert_eq!(ordered_ifaces[1].name(), "eth2".to_string());
+}
+
+#[test]
+fn test_ifaces_up_order_nested_4_depth_worst_case() {
+    let mut ifaces = Interfaces::new();
+
+    let [br0, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+    // Push with reverse order which is the worst case
+    ifaces.push(p2);
+    ifaces.push(p1);
+    ifaces.push(br3);
+    ifaces.push(br2);
+    ifaces.push(br1);
+    ifaces.push(br0);
+
+    let (add_ifaces, _, _) =
+        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+    assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 0);
+    assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 1);
+    assert_eq!(ifaces.kernel_ifaces["br2"].base_iface().up_priority, 2);
+    assert_eq!(ifaces.kernel_ifaces["br3"].base_iface().up_priority, 3);
+    assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().up_priority, 4);
+    assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().up_priority, 4);
+
+    let ordered_ifaces = add_ifaces.to_vec();
+
+    assert_eq!(ordered_ifaces[0].name(), "br0".to_string());
+    assert_eq!(ordered_ifaces[1].name(), "br1".to_string());
+    assert_eq!(ordered_ifaces[2].name(), "br2".to_string());
+    assert_eq!(ordered_ifaces[3].name(), "br3".to_string());
+    assert_eq!(ordered_ifaces[4].name(), "p1".to_string());
+    assert_eq!(ordered_ifaces[5].name(), "p2".to_string());
+}
+
+#[test]
+fn test_ifaces_up_order_nested_5_depth_worst_case() {
+    let mut ifaces = Interfaces::new();
+    let [_, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+    let br4 = new_br_iface("br4");
+    let mut br0 = new_br_iface("br0");
+
+    br0.base_iface_mut().controller = Some("br4".to_string());
+    br0.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+    // Push with reverse order which is the worst case
+    ifaces.push(p1);
+    ifaces.push(p2);
+    ifaces.push(br3);
+    ifaces.push(br2);
+    ifaces.push(br1);
+    ifaces.push(br0);
+    ifaces.push(br4);
+
+    let result = ifaces.gen_state_for_apply(&Interfaces::new());
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_ifaces_up_order_nested_5_depth_good_case() {
+    let mut ifaces = Interfaces::new();
+    let [_, br1, br2, br3, p1, p2] = new_nested_4_ifaces();
+
+    let br4 = new_br_iface("br4");
+    let mut br0 = new_br_iface("br0");
+
+    br0.base_iface_mut().controller = Some("br4".to_string());
+    br0.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+    ifaces.push(br4);
+    ifaces.push(br0);
+    ifaces.push(br1);
+    ifaces.push(br2);
+    ifaces.push(br3);
+    ifaces.push(p2);
+    ifaces.push(p1);
+
+    let (add_ifaces, _, _) =
+        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+    assert_eq!(ifaces.kernel_ifaces["br4"].base_iface().up_priority, 0);
+    assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 1);
+    assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 2);
+    assert_eq!(ifaces.kernel_ifaces["br2"].base_iface().up_priority, 3);
+    assert_eq!(ifaces.kernel_ifaces["br3"].base_iface().up_priority, 4);
+    assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().up_priority, 5);
+    assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().up_priority, 5);
+
+    let ordered_ifaces = add_ifaces.to_vec();
+
+    assert_eq!(ordered_ifaces[0].name(), "br4".to_string());
+    assert_eq!(ordered_ifaces[1].name(), "br0".to_string());
+    assert_eq!(ordered_ifaces[2].name(), "br1".to_string());
+    assert_eq!(ordered_ifaces[3].name(), "br2".to_string());
+    assert_eq!(ordered_ifaces[4].name(), "br3".to_string());
+    assert_eq!(ordered_ifaces[5].name(), "p1".to_string());
+    assert_eq!(ordered_ifaces[6].name(), "p2".to_string());
+}
+
+#[test]
+fn test_auto_include_ovs_interface() {
+    let mut ifaces = Interfaces::new();
+    ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+
+    let (add_ifaces, _, _) =
+        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+
+    println!("{:?}", ifaces);
+
+    assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().up_priority, 1);
+    assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().name, "p1");
+    assert_eq!(
+        ifaces.kernel_ifaces["p1"].base_iface().iface_type,
+        InterfaceType::OvsInterface
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p1"].base_iface().controller,
+        Some("br0".to_string())
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p1"].base_iface().controller_type,
+        Some(InterfaceType::OvsBridge)
+    );
+    assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().up_priority, 1);
+    assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().name, "p2");
+    assert_eq!(
+        ifaces.kernel_ifaces["p2"].base_iface().iface_type,
+        InterfaceType::OvsInterface
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p2"].base_iface().controller,
+        Some("br0".to_string())
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p2"].base_iface().controller_type,
+        Some(InterfaceType::OvsBridge)
+    );
+    assert_eq!(
+        ifaces.user_ifaces[&("br0".to_string(), InterfaceType::OvsBridge)]
+            .base_iface()
+            .up_priority,
+        0
+    );
+
+    let ordered_ifaces = add_ifaces.to_vec();
+
+    assert_eq!(ordered_ifaces[0].name(), "br0".to_string());
+    assert_eq!(ordered_ifaces[1].name(), "p1".to_string());
+    assert_eq!(ordered_ifaces[2].name(), "p2".to_string());
+}
+
+#[test]
+fn test_auto_absent_ovs_interface() {
+    let mut cur_ifaces = Interfaces::new();
+    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_iface("p1", "br0"));
+    cur_ifaces.push(new_ovs_iface("p2", "br0"));
+
+    let mut absent_br0 = OvsBridgeInterface::new();
+    absent_br0.base.name = "br0".to_string();
+    absent_br0.base.state = InterfaceState::Absent;
+    let mut ifaces = Interfaces::new();
+    ifaces.push(Interface::OvsBridge(absent_br0));
+
+    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+
+    println!("{:?}", ifaces);
+
+    assert_eq!(ifaces.kernel_ifaces["p1"].base_iface().name, "p1");
+    assert_eq!(
+        ifaces.kernel_ifaces["p1"].base_iface().iface_type,
+        InterfaceType::OvsInterface
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p1"].base_iface().state,
+        InterfaceState::Absent
+    );
+
+    assert_eq!(ifaces.kernel_ifaces["p2"].base_iface().name, "p2");
+    assert_eq!(
+        ifaces.kernel_ifaces["p2"].base_iface().iface_type,
+        InterfaceType::OvsInterface
+    );
+    assert_eq!(
+        ifaces.kernel_ifaces["p2"].base_iface().state,
+        InterfaceState::Absent
+    );
+    assert_eq!(
+        ifaces.user_ifaces[&("br0".to_string(), InterfaceType::OvsBridge)]
+            .base_iface()
+            .state,
+        InterfaceState::Absent
+    );
+
+    let del_ifaces = del_ifaces.to_vec();
+    assert_eq!(del_ifaces[0].base_iface().name, "br0");
+    assert_eq!(del_ifaces[1].base_iface().name, "p1");
+    assert_eq!(del_ifaces[2].base_iface().name, "p2");
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod ifaces_ctrller;
+
+#[cfg(test)]
+mod ifaces;
+
+#[cfg(test)]
+mod testlib;

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -1,0 +1,71 @@
+use crate::{
+    EthernetInterface, Interface, InterfaceType, LinuxBridgeInterface,
+    OvsBridgeConfig, OvsBridgeInterface, OvsBridgePortConfig, OvsInterface,
+    UnknownInterface,
+};
+
+pub(crate) fn new_eth_iface(name: &str) -> Interface {
+    let mut iface = EthernetInterface::new();
+    iface.base.name = name.to_string();
+    Interface::Ethernet(iface)
+}
+
+pub(crate) fn new_unknown_iface(name: &str) -> Interface {
+    let mut iface = UnknownInterface::new();
+    iface.base.name = name.to_string();
+    Interface::Unknown(iface)
+}
+
+pub(crate) fn new_br_iface(name: &str) -> Interface {
+    let mut iface = LinuxBridgeInterface::new();
+    iface.base.name = name.to_string();
+    Interface::LinuxBridge(iface)
+}
+
+pub(crate) fn new_ovs_br_iface(name: &str, port_names: &[&str]) -> Interface {
+    let mut br0 = OvsBridgeInterface::new();
+    br0.base.iface_type = InterfaceType::OvsBridge;
+    br0.base.name = name.to_string();
+    let mut br_conf = OvsBridgeConfig::new();
+    let mut br_port_confs = Vec::new();
+    for port_name in port_names {
+        let mut br_port_conf = OvsBridgePortConfig::new();
+        br_port_conf.name = port_name.to_string();
+        br_port_confs.push(br_port_conf);
+    }
+    br_conf.ports = Some(br_port_confs);
+    br0.bridge = Some(br_conf);
+    Interface::OvsBridge(br0)
+}
+
+pub(crate) fn new_ovs_iface(name: &str, ctrl_name: &str) -> Interface {
+    let mut iface = OvsInterface::new();
+    iface.base.iface_type = InterfaceType::OvsInterface;
+    iface.base.name = name.to_string();
+    iface.base.controller = Some(ctrl_name.to_string());
+    iface.base.controller_type = Some(InterfaceType::OvsBridge);
+    Interface::OvsInterface(iface)
+}
+
+pub(crate) fn new_nested_4_ifaces() -> [Interface; 6] {
+    let br0 = new_br_iface("br0");
+    let mut br1 = new_br_iface("br1");
+    let mut br2 = new_br_iface("br2");
+    let mut br3 = new_br_iface("br3");
+    let mut p1 = new_eth_iface("p1");
+    let mut p2 = new_eth_iface("p2");
+
+    br1.base_iface_mut().controller = Some("br0".to_string());
+    br1.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+    br2.base_iface_mut().controller = Some("br1".to_string());
+    br2.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+    br3.base_iface_mut().controller = Some("br2".to_string());
+    br3.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+    p1.base_iface_mut().controller = Some("br3".to_string());
+    p1.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+    p2.base_iface_mut().controller = Some("br3".to_string());
+    p2.base_iface_mut().controller_type = Some(InterfaceType::LinuxBridge);
+
+    // Place the ifaces in mixed order to complex the work
+    [br0, br1, br2, br3, p1, p2]
+}

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -16,10 +16,16 @@
 mod bridge;
 mod conn;
 mod ip;
+mod ovs;
+mod wired;
 
 pub use crate::connection::bridge::NmSettingBridge;
 pub use crate::connection::conn::{NmConnection, NmSettingConnection};
 pub use crate::connection::ip::{NmSettingIp, NmSettingIpMethod};
+pub use crate::connection::ovs::{
+    NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+};
+pub use crate::connection::wired::NmSettingWired;
 
 pub(crate) use crate::connection::conn::{
     nm_con_get_from_obj_path, NmConnectionDbusOwnedValue, NmConnectionDbusValue,

--- a/rust/src/libnm_dbus/connection/ovs.rs
+++ b/rust/src/libnm_dbus/connection/ovs.rs
@@ -1,0 +1,148 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use crate::{
+    dbus_value::{
+        value_hash_get_bool, value_hash_get_string, value_hash_get_u32,
+    },
+    error::NmError,
+};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmSettingOvsBridge {
+    pub stp: Option<bool>,
+    pub mcast_snooping_enable: Option<bool>,
+    pub rstp: Option<bool>,
+    pub fail_mode: Option<String>,
+}
+
+impl TryFrom<&HashMap<String, zvariant::OwnedValue>> for NmSettingOvsBridge {
+    type Error = NmError;
+    fn try_from(
+        value: &HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            stp: value_hash_get_bool(value, "stp-enable")?,
+            mcast_snooping_enable: value_hash_get_bool(
+                value,
+                "mcast-snooping-enable",
+            )?,
+            rstp: value_hash_get_bool(value, "rstp-enable")?,
+            fail_mode: value_hash_get_string(value, "fail-mode")?,
+        })
+    }
+}
+
+impl NmSettingOvsBridge {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = self.stp {
+            ret.insert("stp-enable", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.mcast_snooping_enable {
+            ret.insert("mcast-snooping-enable", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.rstp {
+            ret.insert("rstp-enable", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.fail_mode {
+            ret.insert("fail-mode", zvariant::Value::new(v));
+        }
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmSettingOvsPort {
+    pub mode: Option<String>,
+    pub up_delay: Option<u32>,
+    pub down_delay: Option<u32>,
+}
+
+impl TryFrom<&HashMap<String, zvariant::OwnedValue>> for NmSettingOvsPort {
+    type Error = NmError;
+    fn try_from(
+        value: &HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            mode: value_hash_get_string(value, "bond-mode")?,
+            up_delay: value_hash_get_u32(value, "bond-updelay")?,
+            down_delay: value_hash_get_u32(value, "bond-downdelay")?,
+        })
+    }
+}
+
+impl NmSettingOvsPort {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.mode {
+            ret.insert("bond-mode", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.up_delay {
+            ret.insert("bond-updelay", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.down_delay {
+            ret.insert("bond-downdelay", zvariant::Value::new(v));
+        }
+        Ok(ret)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmSettingOvsIface {
+    pub iface_type: Option<String>,
+}
+
+impl TryFrom<&HashMap<String, zvariant::OwnedValue>> for NmSettingOvsIface {
+    type Error = NmError;
+    fn try_from(
+        value: &HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            iface_type: value_hash_get_string(value, "type")?,
+        })
+    }
+}
+
+impl NmSettingOvsIface {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.iface_type {
+            ret.insert("type", zvariant::Value::new(v));
+        }
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/libnm_dbus/connection/wired.rs
+++ b/rust/src/libnm_dbus/connection/wired.rs
@@ -1,0 +1,93 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt::Write;
+
+use log::error;
+
+use crate::{dbus_value::value_hash_get_bytes_array, error::NmError};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmSettingWired {
+    pub cloned_mac_address: Option<String>,
+}
+
+impl TryFrom<&HashMap<String, zvariant::OwnedValue>> for NmSettingWired {
+    type Error = NmError;
+    fn try_from(
+        value: &HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            cloned_mac_address: value_hash_get_bytes_array(
+                value,
+                "cloned-mac-address",
+            )?
+            .map(|s| u8_array_to_mac_string(&s)),
+        })
+    }
+}
+
+impl NmSettingWired {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.cloned_mac_address {
+            ret.insert(
+                "cloned-mac-address",
+                zvariant::Value::new(mac_str_to_u8_array(v)),
+            );
+        }
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn u8_array_to_mac_string(data: &[u8]) -> String {
+    let mut mac_addr = String::new();
+    for byte in data {
+        if let Err(e) = write!(&mut mac_addr, "{:02X}:", byte) {
+            error!(
+                "Failed to convert bytes array to MAC address {:?}: {}",
+                data, e
+            );
+            return "".to_string();
+        }
+    }
+    mac_addr.pop();
+    mac_addr
+}
+
+fn mac_str_to_u8_array(mac: &str) -> Vec<u8> {
+    let mut mac_bytes = Vec::new();
+    for item in mac.split(':') {
+        match u8::from_str_radix(item, 16) {
+            Ok(i) => mac_bytes.push(i),
+            Err(e) => {
+                error!(
+                    "Failed to convert to MAC address to bytes {:?}: {}",
+                    mac, e
+                );
+                return Vec::new();
+            }
+        }
+    }
+    mac_bytes
+}

--- a/rust/src/libnm_dbus/dbus_value.rs
+++ b/rust/src/libnm_dbus/dbus_value.rs
@@ -18,7 +18,9 @@ use std::convert::TryFrom;
 const DBUS_SIGNATURE_STRING: &str = "s";
 const DBUS_SIGNATURE_BOOL: &str = "b";
 const DBUS_SIGNATURE_I32: &str = "i";
+const DBUS_SIGNATURE_U32: &str = "u";
 const DBUS_SIGNATURE_ARRAY: &str = "a";
+const DBUS_SIGNATURE_BYTES_ARRAY: &str = "ay";
 
 fn own_value_to_string(
     value: &zvariant::OwnedValue,
@@ -52,7 +54,19 @@ fn own_value_to_i32(value: &zvariant::OwnedValue) -> Result<i32, NmError> {
         Ok(s) => Ok(s),
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
-            format!("Failed to convert {:?} to bool: {}", &value, e),
+            format!("Failed to convert {:?} to i32: {}", &value, e),
+        )),
+    }
+}
+
+// TODO: Use macro instead
+fn own_value_to_u32(value: &zvariant::OwnedValue) -> Result<u32, NmError> {
+    check_value_is_u32(value)?;
+    match <u32>::try_from(value) {
+        Ok(s) => Ok(s),
+        Err(e) => Err(NmError::new(
+            ErrorKind::Bug,
+            format!("Failed to convert {:?} to u32: {}", &value, e),
         )),
     }
 }
@@ -67,6 +81,28 @@ fn own_value_to_array(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!("Failed to convert {:?} to array: {}", &value, e),
+        )),
+    }
+}
+
+// TODO: Use macro instead
+fn own_value_to_bytes_array(
+    value: &zvariant::OwnedValue,
+) -> Result<Vec<u8>, NmError> {
+    check_value_is_bytes_array(value)?;
+    match <&zvariant::Array>::try_from(value) {
+        Ok(s) => {
+            let mut bytes_array: Vec<u8> = Vec::new();
+            for item in s.iter() {
+                if let zvariant::Value::U8(i) = item {
+                    bytes_array.push(*i);
+                }
+            }
+            Ok(bytes_array)
+        }
+        Err(e) => Err(NmError::new(
+            ErrorKind::Bug,
+            format!("Failed to convert {:?} to bytes array: {}", &value, e),
         )),
     }
 }
@@ -104,6 +140,17 @@ fn check_value_is_i32(value: &zvariant::OwnedValue) -> Result<(), NmError> {
     }
 }
 
+fn check_value_is_u32(value: &zvariant::OwnedValue) -> Result<(), NmError> {
+    if value.value_signature().as_str() != DBUS_SIGNATURE_U32 {
+        Err(NmError::new(
+            ErrorKind::Bug,
+            format!("OwnedValue {:?} is not u32", &value),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 fn check_value_is_array(value: &zvariant::OwnedValue) -> Result<(), NmError> {
     if !value
         .value_signature()
@@ -113,6 +160,23 @@ fn check_value_is_array(value: &zvariant::OwnedValue) -> Result<(), NmError> {
         Err(NmError::new(
             ErrorKind::Bug,
             format!("OwnedValue {:?} is not array", &value),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_value_is_bytes_array(
+    value: &zvariant::OwnedValue,
+) -> Result<(), NmError> {
+    if !value
+        .value_signature()
+        .as_str()
+        .starts_with(DBUS_SIGNATURE_BYTES_ARRAY)
+    {
+        Err(NmError::new(
+            ErrorKind::Bug,
+            format!("OwnedValue {:?} is not bytes array", &value),
         ))
     } else {
         Ok(())
@@ -152,6 +216,17 @@ pub(crate) fn value_hash_get_i32(
     }
 }
 
+pub(crate) fn value_hash_get_u32(
+    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
+    key: &str,
+) -> Result<Option<u32>, NmError> {
+    if let Some(value) = value_hashmap.get(key) {
+        Ok(Some(own_value_to_u32(value)?))
+    } else {
+        Ok(None)
+    }
+}
+
 pub(crate) fn value_hash_get_array<'a>(
     value_hashmap: &'a std::collections::HashMap<String, zvariant::OwnedValue>,
     key: &str,
@@ -180,6 +255,17 @@ pub(crate) fn value_dict_get_string(
             ErrorKind::Bug,
             format!("Failed to get {} from {:?}: {}", key, value_dict, e),
         )),
+    }
+}
+
+pub(crate) fn value_hash_get_bytes_array(
+    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
+    key: &str,
+) -> Result<Option<Vec<u8>>, NmError> {
+    if let Some(value) = value_hashmap.get(key) {
+        Ok(Some(own_value_to_bytes_array(value)?))
+    } else {
+        Ok(None)
     }
 }
 

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -24,7 +24,8 @@ mod nm_api;
 pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
     NmConnection, NmSettingBridge, NmSettingConnection, NmSettingIp,
-    NmSettingIpMethod,
+    NmSettingIpMethod, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+    NmSettingWired,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::error::{ErrorKind, NmError};

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -211,10 +211,20 @@ impl<'a> NmApi<'a> {
         debug!("devices_get");
         let mut ret = Vec::new();
         for nm_dev_obj_path in &self.dbus.nm_dev_obj_paths_get()? {
-            let nm_dev =
-                nm_dev_from_obj_path(&self.dbus.connection, nm_dev_obj_path)?;
-            debug!("Got Device {:?}", nm_dev);
-            ret.push(nm_dev);
+            match nm_dev_from_obj_path(&self.dbus.connection, nm_dev_obj_path) {
+                Ok(nm_dev) => {
+                    debug!("Got Device {:?}", nm_dev);
+                    ret.push(nm_dev);
+                }
+                Err(e) => {
+                    // We might have race when relieve device list along with
+                    // deleting device
+                    debug!(
+                        "Failed to retrieve device {} {}",
+                        nm_dev_obj_path, e
+                    )
+                }
+            }
         }
         Ok(ret)
     }

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -35,7 +35,6 @@ from libnmstate.schema import OvsDB
 from libnmstate.schema import RouteRule
 from libnmstate.schema import VLAN
 from libnmstate.schema import VXLAN
-from libnmstate.state import state_match
 from libnmstate.error import NmstateDependencyError
 from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateValueError
@@ -47,6 +46,7 @@ from .testlib import statelib
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.nmplugin import mount_devnull_to_path
+from .testlib.statelib import state_match
 from .testlib.ovslib import Bridge
 from .testlib.vlan import vlan_interface
 


### PR DESCRIPTION
Done:
 * User space interface support. Unknown and other interface type are
   treated as user space interface also.
 * Query support.
 * Apply support of OVS and OVS bond.

Extra:
 * Support MAC address
 * Support desire state without interface type.
 * Isolate unit test cases to `unit_tests` folder.

Test:
 * Changed to OVS integration test case code to use `testlib.statelib.state_match` instead of `libnmstate.state.state_match`.
 * Unit test cases included.
 * Enabled CI for below integration tests:
     * `test_create_and_remove_ovs_bridge_with_min_desired_state`
     * `test_create_and_save_ovs_bridge_then_remove_and_apply_again`
     * `test_create_and_remove_ovs_bridge_options_specified`
     * `test_create_and_remove_ovs_bridge_with_a_system_port`
     * `test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac`