### PR TITLE
rust nm: Fix reapply function

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -192,6 +192,10 @@ impl Interface {
         false
     }
 
+    pub(crate) fn is_controller(&self) -> bool {
+        matches!(self, Self::LinuxBridge(_))
+    }
+
     pub(crate) fn set_iface_type(&mut self, iface_type: InterfaceType) {
         self.base_iface_mut().iface_type = iface_type;
     }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -61,7 +61,11 @@ pub(crate) fn iface_to_nm_connection(
         iface_type: Some(iface_type_to_nm(&base_iface.iface_type)?),
         iface_name: Some(base_iface.name.clone()),
         autoconnect: Some(true),
-        autoconnect_ports: Some(true),
+        autoconnect_ports: if iface.is_controller() {
+            Some(true)
+        } else {
+            None
+        },
         ..Default::default()
     };
     if let Some(ctrl_name) = &base_iface.controller {


### PR DESCRIPTION
* There is race when we call `self.dbus.get_connection_by_uuid()` right
   after the profile been updated. Hence we passing the new NmConnection
   to `connection_reapply()`.

 * The `autoconnect_ports` should be set to None when interface is not a
   controller.