### PR TITLE
ovs: remove ovs-port- prefix for OVS bridge LAG ports

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -121,6 +121,8 @@ def create_new_nm_simple_conn(iface, nm_profile):
             con_name = con_name + "-br"
         elif iface.type == InterfaceType.OVS_INTERFACE:
             con_name = con_name + "-if"
+        elif iface.type == InterfaceType.OVS_PORT:
+            con_name = con_name + "-port"
 
         con_setting.create(
             con_name,

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -32,8 +32,6 @@ from libnmstate.schema import OvsDB
 from .common import NM
 
 
-PORT_PROFILE_PREFIX = "ovs-port-"
-
 CONTROLLER_TYPE_METADATA = "_controller_type"
 CONTROLLER_METADATA = "_controller"
 SETTING_OVS_EXTERNALIDS = "SettingOvsExternalIDs"
@@ -311,7 +309,7 @@ def create_iface_for_nm_ovs_port(iface):
     if ovs.is_ovs_lag_port(port_options):
         port_name = port_options[OB.Port.NAME]
     else:
-        port_name = PORT_PROFILE_PREFIX + iface_name
+        port_name = iface_name
     return OvsPortIface(
         {
             Interface.NAME: port_name,

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -59,6 +59,14 @@ def bridge_with_ports(eth1_up):
 
 
 @pytest.fixture
+def bridge_port_types():
+    yield {
+        ETH1: InterfaceType.ETHERNET,
+        IFACE0: InterfaceType.OVS_INTERFACE,
+    }
+
+
+@pytest.fixture
 def ovs_unmanaged_bridge():
     cmdlib.exec_cmd(f"ovs-vsctl add-br {BRIDGE0}".split())
     yield
@@ -118,13 +126,20 @@ class _OvsProfileStillExists(Exception):
 
 
 @pytest.mark.tier1
-def test_remove_ovs_internal_iface_got_port_profile_removed(bridge_with_ports):
+def test_remove_ovs_internal_iface_got_port_profile_removed(
+    bridge_with_ports, bridge_port_types
+):
     for ovs_iface_name in bridge_with_ports.ports_names:
         active_profile_names, active_profile_uuids = _get_nm_active_profiles()
         assert ovs_iface_name in active_profile_names
-        ovs_port_profile_uuid = _get_ovs_port_profile_uuid_of_ovs_interface(
-            ovs_iface_name
-        )
+        if bridge_port_types[ovs_iface_name] == InterfaceType.OVS_INTERFACE:
+            ovs_port_profile_uuid = (
+                _get_ovs_port_profile_uuid_of_ovs_interface(ovs_iface_name)
+            )
+        else:
+            ovs_port_profile_uuid = _get_parent_uuid_of_interface(
+                ovs_iface_name
+            )
         assert ovs_port_profile_uuid
         assert ovs_port_profile_uuid in active_profile_uuids
         libnmstate.apply(
@@ -184,15 +199,34 @@ def _get_nm_active_profiles():
 
 
 def _get_ovs_port_profile_uuid_of_ovs_interface(iface_name):
-    ovs_port_uuid = cmdlib.exec_cmd(
-        f"nmcli -g connection.master connection show {iface_name}".split(" "),
-        check=True,
-    )[1].strip()
+    ovs_iface_uuid = _get_uuid_of_ovs_interface(iface_name)
+    ovs_port_uuid = _get_parent_uuid_of_interface(ovs_iface_uuid)
     cmdlib.exec_cmd(
         f"nmcli -g connection.id connection show {ovs_port_uuid}".split(" "),
         check=True,
     )
     return ovs_port_uuid
+
+
+def _get_uuid_of_ovs_interface(iface_name):
+    conns = cmdlib.exec_cmd(
+        f"nmcli -g name,uuid,type connection show".split(" "),
+        check=True,
+    )[1].split("\n")
+    ovs_iface_conns = [
+        x for x in conns if "ovs-interface" in x and iface_name in x
+    ]
+    if len(ovs_iface_conns) == 0:
+        return ""
+    else:
+        return ovs_iface_conns[0].split(":")[1]
+
+
+def _get_parent_uuid_of_interface(iface_name):
+    return cmdlib.exec_cmd(
+        f"nmcli -g connection.master connection show {iface_name}".split(" "),
+        check=True,
+    )[1].strip()
 
 
 @pytest.fixture


### PR DESCRIPTION
The ovnkube-node pods perform health checks, and they seem to expect the port to be called the same
as the underlying interface:
https://github.com/ovn-org/ovn-kubernetes/blob/acfc09e8a7ffae73918bece102d0c520e4eb48fe/go-controller/pkg/node/healthcheck.go#L298

Renaming of the Ports causes these pods to crash.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>