### PR TITLE
rust libnm_dbus: Preserve unsupported options in NmConnection

### DIFF
--- a/rust/src/lib/nm/bridge.rs
+++ b/rust/src/lib/nm/bridge.rs
@@ -1,21 +1,17 @@
-use crate::{
-    LinuxBridgeConfig, LinuxBridgeOptions, LinuxBridgeStpOptions, NmstateError,
-};
+use crate::{LinuxBridgeConfig, NmstateError};
 use nm_dbus::NmSettingBridge;
 
 pub(crate) fn linux_bridge_conf_to_nm(
     br_conf: &LinuxBridgeConfig,
 ) -> Result<NmSettingBridge, NmstateError> {
-    if let Some(LinuxBridgeOptions {
-        stp:
-            Some(LinuxBridgeStpOptions {
-                enabled: stp_enabled,
-                ..
-            }),
-        ..
-    }) = br_conf.options
+    let mut nm_setting = NmSettingBridge::new();
+    if let Some(stp_enabled) = br_conf
+        .options
+        .as_ref()
+        .and_then(|br_opts| br_opts.stp.as_ref())
+        .and_then(|stp_opts| stp_opts.enabled)
     {
-        return Ok(NmSettingBridge { stp: stp_enabled });
+        nm_setting.stp = Some(stp_enabled);
     }
-    Ok(NmSettingBridge::default())
+    Ok(nm_setting)
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -270,15 +270,14 @@ pub(crate) fn gen_nm_connection(
         iface_name.to_string()
     };
 
-    let mut nm_conn_set = NmSettingConnection {
-        id: Some(conn_name),
-        uuid: Some(uuid.to_string()),
-        iface_type: Some(nm_iface_type.to_string()),
-        iface_name: Some(iface_name.to_string()),
-        autoconnect: Some(true),
-        autoconnect_ports: if is_controller { Some(true) } else { None },
-        ..Default::default()
-    };
+    let mut nm_conn_set = NmSettingConnection::new();
+    nm_conn_set.id = Some(conn_name);
+    nm_conn_set.uuid = Some(uuid.to_string());
+    nm_conn_set.iface_type = Some(nm_iface_type.to_string());
+    nm_conn_set.iface_name = Some(iface_name.to_string());
+    nm_conn_set.autoconnect = Some(true);
+    nm_conn_set.autoconnect_ports =
+        if is_controller { Some(true) } else { None };
 
     if let Some(ctrl_name) = ctrl_name {
         if let Some(nm_ctrl_type) = nm_ctrl_type {

--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -20,10 +20,10 @@ pub(crate) fn iface_ipv4_to_nm(
     } else {
         NmSettingIpMethod::Disabled
     };
-    Ok(NmSettingIp {
-        method: Some(method),
-        addresses,
-    })
+    let mut nm_setting = NmSettingIp::new();
+    nm_setting.method = Some(method);
+    nm_setting.addresses = addresses;
+    Ok(nm_setting)
 }
 
 pub(crate) fn iface_ipv6_to_nm(
@@ -57,8 +57,8 @@ pub(crate) fn iface_ipv6_to_nm(
     } else {
         NmSettingIpMethod::Disabled
     };
-    Ok(NmSettingIp {
-        method: Some(method),
-        addresses,
-    })
+    let mut nm_setting = NmSettingIp::new();
+    nm_setting.method = Some(method);
+    nm_setting.addresses = addresses;
+    Ok(nm_setting)
 }

--- a/rust/src/libnm_dbus/dbus_value.rs
+++ b/rust/src/libnm_dbus/dbus_value.rs
@@ -22,75 +22,76 @@ const DBUS_SIGNATURE_U32: &str = "u";
 const DBUS_SIGNATURE_ARRAY: &str = "a";
 const DBUS_SIGNATURE_BYTES_ARRAY: &str = "ay";
 
-fn own_value_to_string(
-    value: &zvariant::OwnedValue,
+pub(crate) fn own_value_to_string(
+    value: zvariant::OwnedValue,
 ) -> Result<String, NmError> {
-    check_value_is_string(value)?;
-    match <&str>::try_from(value) {
-        Ok(s) => Ok(s.to_string()),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to string: {}", &value, e),
-        )),
-    }
+    check_value_is_string(&value)?;
+    let err_msg = format!("Failed to convert {:?} to string", &value);
+    <String>::try_from(value).map_err(|e| {
+        NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e))
+    })
 }
 
 // TODO: Use macro instead
-fn own_value_to_bool(value: &zvariant::OwnedValue) -> Result<bool, NmError> {
-    check_value_is_bool(value)?;
+pub(crate) fn own_value_to_bool(
+    value: zvariant::OwnedValue,
+) -> Result<bool, NmError> {
+    check_value_is_bool(&value)?;
+    let err_msg = format!("Failed to convert {:?} to bool", &value);
     match <bool>::try_from(value) {
         Ok(s) => Ok(s),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to bool: {}", &value, e),
-        )),
+        Err(e) => {
+            Err(NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e)))
+        }
     }
 }
 
 // TODO: Use macro instead
-fn own_value_to_i32(value: &zvariant::OwnedValue) -> Result<i32, NmError> {
-    check_value_is_i32(value)?;
+pub(crate) fn own_value_to_i32(
+    value: zvariant::OwnedValue,
+) -> Result<i32, NmError> {
+    check_value_is_i32(&value)?;
+    let err_msg = format!("Failed to convert {:?} to i32", &value);
     match <i32>::try_from(value) {
         Ok(s) => Ok(s),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to i32: {}", &value, e),
-        )),
+        Err(e) => {
+            Err(NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e)))
+        }
     }
 }
 
 // TODO: Use macro instead
-fn own_value_to_u32(value: &zvariant::OwnedValue) -> Result<u32, NmError> {
-    check_value_is_u32(value)?;
+pub(crate) fn own_value_to_u32(
+    value: zvariant::OwnedValue,
+) -> Result<u32, NmError> {
+    check_value_is_u32(&value)?;
+    let err_msg = format!("Failed to convert {:?} to u32", &value);
     match <u32>::try_from(value) {
         Ok(s) => Ok(s),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to u32: {}", &value, e),
-        )),
+        Err(e) => {
+            Err(NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e)))
+        }
     }
 }
 
 // TODO: Use macro instead
-fn own_value_to_array(
-    value: &zvariant::OwnedValue,
-) -> Result<&zvariant::Array, NmError> {
-    check_value_is_array(value)?;
-    match <&zvariant::Array>::try_from(value) {
-        Ok(s) => Ok(s),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to array: {}", &value, e),
-        )),
-    }
+pub(crate) fn own_value_to_array(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<zvariant::OwnedValue>, NmError> {
+    check_value_is_array(&value)?;
+    let err_msg = format!("Failed to convert {:?} to array", &value);
+    <Vec<zvariant::OwnedValue>>::try_from(value).map_err(|e| {
+        NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e))
+    })
 }
 
 // TODO: Use macro instead
-fn own_value_to_bytes_array(
-    value: &zvariant::OwnedValue,
+pub(crate) fn own_value_to_bytes_array(
+    value: zvariant::OwnedValue,
 ) -> Result<Vec<u8>, NmError> {
-    check_value_is_bytes_array(value)?;
-    match <&zvariant::Array>::try_from(value) {
+    check_value_is_bytes_array(&value)?;
+    let err_msg = format!("Failed to convert {:?} to bytes array", &value);
+    match <zvariant::Array>::try_from(value) {
         Ok(s) => {
             let mut bytes_array: Vec<u8> = Vec::new();
             for item in s.iter() {
@@ -100,10 +101,9 @@ fn own_value_to_bytes_array(
             }
             Ok(bytes_array)
         }
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to convert {:?} to bytes array: {}", &value, e),
-        )),
+        Err(e) => {
+            Err(NmError::new(ErrorKind::Bug, format!("{}: {}", err_msg, e)))
+        }
     }
 }
 
@@ -180,111 +180,5 @@ fn check_value_is_bytes_array(
         ))
     } else {
         Ok(())
-    }
-}
-
-pub(crate) fn value_hash_get_string(
-    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<String>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_string(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_hash_get_bool(
-    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<bool>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_bool(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_hash_get_i32(
-    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<i32>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_i32(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_hash_get_u32(
-    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<u32>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_u32(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_hash_get_array<'a>(
-    value_hashmap: &'a std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<&'a zvariant::Array<'a>>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_array(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_dict_get_string(
-    value_dict: &zvariant::Dict,
-    key: &str,
-) -> Result<Option<String>, NmError> {
-    match value_dict.get::<str, zvariant::Value>(key) {
-        Ok(Some(value)) => match <&str>::try_from(value) {
-            Ok(v) => Ok(Some(v.to_string())),
-            Err(e) => Err(NmError::new(
-                ErrorKind::Bug,
-                format!("Failed to convert {:?} to string: {}", &value, e),
-            )),
-        },
-        Ok(None) => Ok(None),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to get {} from {:?}: {}", key, value_dict, e),
-        )),
-    }
-}
-
-pub(crate) fn value_hash_get_bytes_array(
-    value_hashmap: &std::collections::HashMap<String, zvariant::OwnedValue>,
-    key: &str,
-) -> Result<Option<Vec<u8>>, NmError> {
-    if let Some(value) = value_hashmap.get(key) {
-        Ok(Some(own_value_to_bytes_array(value)?))
-    } else {
-        Ok(None)
-    }
-}
-
-pub(crate) fn value_dict_get_u32(
-    value_dict: &zvariant::Dict,
-    key: &str,
-) -> Result<Option<u32>, NmError> {
-    match value_dict.get::<str, zvariant::Value>(key) {
-        Ok(Some(value)) => match <u32>::try_from(value) {
-            Ok(v) => Ok(Some(v)),
-            Err(e) => Err(NmError::new(
-                ErrorKind::Bug,
-                format!("Failed to convert {:?} to u32: {}", &value, e),
-            )),
-        },
-        Ok(None) => Ok(None),
-        Err(e) => Err(NmError::new(
-            ErrorKind::Bug,
-            format!("Failed to get {} from {:?}: {}", key, value_dict, e),
-        )),
     }
 }

--- a/rust/src/libnm_dbus/keyfile.rs
+++ b/rust/src/libnm_dbus/keyfile.rs
@@ -1,0 +1,185 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use log::error;
+
+use crate::{ErrorKind, NmError};
+
+pub(crate) fn zvariant_value_to_keyfile(
+    value: &zvariant::Value,
+    section_name: &str,
+) -> Result<String, NmError> {
+    match value {
+        zvariant::Value::Bool(b) => Ok(if *b {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }),
+        zvariant::Value::I32(d) => Ok(format!("{}", d)),
+        zvariant::Value::U32(d) => Ok(format!("{}", d)),
+        zvariant::Value::U8(d) => Ok(format!("{}", d)),
+        zvariant::Value::U16(d) => Ok(format!("{}", d)),
+        zvariant::Value::I16(d) => Ok(format!("{}", d)),
+        zvariant::Value::U64(d) => Ok(format!("{}", d)),
+        zvariant::Value::I64(d) => Ok(format!("{}", d)),
+        zvariant::Value::Dict(d) => {
+            let data: HashMap<String, zvariant::Value> =
+                HashMap::try_from(d.clone())?;
+            if data.is_empty() {
+                return Ok("".to_string());
+            }
+            let mut ret = String::new();
+
+            let mut names: Vec<String> = data.keys().cloned().collect();
+            if section_name.is_empty() {
+                // Only sort the top level sections
+                names.sort_unstable();
+            } else {
+                // place the sub-section at the end of section_names.
+                names.sort_unstable_by(|a, b| {
+                    let a_is_subsection =
+                        matches!(data.get(a), Some(zvariant::Value::Dict(_)));
+                    let b_is_subsection =
+                        matches!(data.get(b), Some(zvariant::Value::Dict(_)));
+                    a_is_subsection.cmp(&b_is_subsection)
+                });
+            }
+
+            for key in &names {
+                let key = if section_name == "ipv4" || section_name == "ipv6" {
+                    if key == "addresses" || key == "routes" {
+                        // Ignore deprecated 'addresses' in favor of
+                        // 'address-data'.
+                        // Ignore deprecated 'routes' in favor of 'route-data'
+                        continue;
+                    } else if key == "dhcp-client-id" {
+                        "dhcp-iaid".to_string()
+                    } else {
+                        key.to_string()
+                    }
+                } else {
+                    key.to_string()
+                };
+
+                if let Some(section_value) = data.get(&key) {
+                    if key == "mac-address" {
+                        ret += &format!(
+                            "mac-address={}\n",
+                            mac_address_value_to_string(section_value)
+                        );
+                    } else if key == "type" && section_name == "connection" {
+                        let iface_type = zvariant_value_to_keyfile(
+                            section_value,
+                            section_name,
+                        )?;
+                        ret += &format!(
+                            "type={}\n",
+                            if iface_type == "802-3-ethernet" {
+                                "ethernet".to_string()
+                            } else {
+                                iface_type
+                            }
+                        );
+                    } else if key == "address-data" {
+                        ret += &ip_address_value_to_string(section_value);
+                    } else if let zvariant::Value::Dict(_) = section_value {
+                        let sub_section: HashMap<String, zvariant::Value> =
+                            HashMap::try_from(section_value.clone())?;
+                        if sub_section.is_empty() {
+                            continue;
+                        }
+
+                        let sub_section_name = if section_name.is_empty() {
+                            key.to_string()
+                        } else {
+                            format!("{}-{}", section_name, key)
+                        };
+                        ret += &format!("\n[{}]\n", sub_section_name);
+                        ret += &zvariant_value_to_keyfile(
+                            section_value,
+                            &sub_section_name,
+                        )?;
+                    } else {
+                        ret += &format!(
+                            "{}={}\n",
+                            key,
+                            zvariant_value_to_keyfile(
+                                section_value,
+                                section_name
+                            )?
+                        );
+                    }
+                }
+            }
+            Ok(ret)
+        }
+        zvariant::Value::Array(a) => {
+            let mut ret = String::new();
+            for item in a.get() {
+                ret += &zvariant_value_to_keyfile(item, section_name)?;
+                ret += ";";
+            }
+            ret.pop();
+            Ok(ret)
+        }
+        zvariant::Value::Str(s) => Ok(s.as_str().to_string()),
+        _ => {
+            let e = NmError::new(
+                ErrorKind::Bug,
+                format!(
+                    "BUG: Unknown value type in section {}: {:?}",
+                    section_name, value
+                ),
+            );
+            error!("{}", e);
+            Err(e)
+        }
+    }
+}
+
+fn mac_address_value_to_string(value: &zvariant::Value) -> String {
+    let mut ret = String::new();
+    if let zvariant::Value::Array(a) = value {
+        for item in a.get() {
+            if let Ok(s) = zvariant_value_to_keyfile(item, "") {
+                ret += &s;
+                ret += ":";
+            }
+        }
+        ret.pop();
+    }
+    ret
+}
+
+fn ip_address_value_to_string(value: &zvariant::Value) -> String {
+    let mut ret = String::new();
+    let mut index = 0u32;
+    if let zvariant::Value::Array(ip_addrs) = value {
+        for ip_addr_value in ip_addrs.get() {
+            let ip_addr_value = if let zvariant::Value::Dict(i) = ip_addr_value
+            {
+                i
+            } else {
+                continue;
+            };
+            let address = if let Ok(Some(s)) = ip_addr_value.get("address") {
+                zvariant_value_to_keyfile(s, "")
+            } else {
+                continue;
+            };
+            let prefix = if let Ok(Some(p)) = ip_addr_value.get("prefix") {
+                zvariant_value_to_keyfile(p, "")
+            } else {
+                continue;
+            };
+            if let Ok(address) = address {
+                if let Ok(prefix) = prefix {
+                    ret +=
+                        &format!("address{}={}/{}\n", index, address, prefix);
+                    index += 1;
+                }
+            }
+        }
+    }
+    ret
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -19,6 +19,7 @@ mod dbus_proxy;
 mod dbus_value;
 mod device;
 mod error;
+mod keyfile;
 mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;


### PR DESCRIPTION
When serializing/deserializing, we should also include unsupported
options in NmConnection and its subordinates(NmSettingXxx).

We use `_other` property to hold unknown data in NmConnection and
NmSettingXxx.