### PR TITLE
rust nm: Preserve existing configurations

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -179,6 +179,7 @@ function run_tests {
           pytest \
             $PYTEST_OPTIONS \
             tests/integration/static_ip_address_test.py \
+            tests/integration/preserve_ip_config_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/nm/bridge.rs
+++ b/rust/src/lib/nm/bridge.rs
@@ -1,17 +1,20 @@
-use crate::{LinuxBridgeConfig, NmstateError};
-use nm_dbus::NmSettingBridge;
+use crate::LinuxBridgeInterface;
+use nm_dbus::NmConnection;
 
-pub(crate) fn linux_bridge_conf_to_nm(
-    br_conf: &LinuxBridgeConfig,
-) -> Result<NmSettingBridge, NmstateError> {
-    let mut nm_setting = NmSettingBridge::new();
-    if let Some(stp_enabled) = br_conf
-        .options
+pub(crate) fn gen_nm_br_setting(
+    br_iface: &LinuxBridgeInterface,
+    nm_conn: &mut NmConnection,
+) {
+    let mut nm_br_set = nm_conn.bridge.as_ref().cloned().unwrap_or_default();
+
+    if let Some(stp_enabled) = br_iface
+        .bridge
         .as_ref()
+        .and_then(|br_conf| br_conf.options.as_ref())
         .and_then(|br_opts| br_opts.stp.as_ref())
         .and_then(|stp_opts| stp_opts.enabled)
     {
-        nm_setting.stp = Some(stp_enabled);
+        nm_br_set.stp = Some(stp_enabled);
     }
-    Ok(nm_setting)
+    nm_conn.bridge = Some(nm_br_set);
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,16 +1,17 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use nm_dbus::{NmApi, NmConnection, NmSettingConnection, NmSettingWired};
+use nm_dbus::{NmApi, NmConnection, NmSettingConnection};
 
 use crate::{
-    nm::bridge::linux_bridge_conf_to_nm,
-    nm::ip::{iface_ipv4_to_nm, iface_ipv6_to_nm},
+    nm::bridge::gen_nm_br_setting,
+    nm::ip::gen_nm_ip_setting,
     nm::ovs::{
-        create_nm_ovs_br_set, create_nm_ovs_iface_set, create_ovs_port_nm_conn,
+        create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
+        gen_nm_ovs_iface_setting,
     },
     nm::profile::get_exist_profile,
-    ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6, InterfaceType,
-    NetworkState, NmstateError,
+    nm::wired::gen_nm_wired_setting,
+    ErrorKind, Interface, InterfaceType, NetworkState, NmstateError,
 };
 
 pub(crate) const NM_SETTING_BRIDGE_SETTING_NAME: &str = "bridge";
@@ -58,80 +59,47 @@ pub(crate) fn iface_to_nm_connections(
         nm_ac_uuids,
     );
 
-    let uuid = if let Some(exist_nm_conn) = exist_nm_conn {
-        if let Some(exist_uuid) = exist_nm_conn.uuid() {
-            exist_uuid.to_string()
-        } else {
-            NmApi::uuid_gen()
-        }
-    } else {
-        NmApi::uuid_gen()
-    };
-    let nm_ctrl_type = if let Some(ctrl_type) = &base_iface.controller_type {
-        Some(iface_type_to_nm(ctrl_type)?)
-    } else {
-        None
-    };
-    let nm_ctrl_type = nm_ctrl_type.as_deref();
-    let ctrl_name = base_iface.controller.as_deref();
-    let mut nm_conn = gen_nm_connection(
-        &base_iface.name,
-        &uuid,
-        &iface_type_to_nm(&base_iface.iface_type)?,
-        ctrl_name,
-        nm_ctrl_type,
-        iface.is_controller(),
-    );
+    let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
 
-    if base_iface.can_have_ip() {
-        if let Some(iface_ip) = &base_iface.ipv4 {
-            nm_conn.ipv4 = Some(iface_ipv4_to_nm(iface_ip)?);
-        } else {
-            nm_conn.ipv4 = Some(iface_ipv4_to_nm(&InterfaceIpv4 {
-                enabled: false,
-                ..Default::default()
-            })?);
+    gen_nm_conn_setting(iface, &mut nm_conn)?;
+    gen_nm_ip_setting(iface, &mut nm_conn)?;
+    gen_nm_wired_setting(iface, &mut nm_conn);
+
+    match iface {
+        Interface::OvsBridge(ovs_br_iface) => {
+            gen_nm_ovs_br_setting(ovs_br_iface, &mut nm_conn);
+            // For OVS Bridge, we should create its OVS port also
+            for ovs_port_conf in ovs_br_iface.port_confs() {
+                let exist_nm_ovs_port_conn = get_exist_profile(
+                    exist_nm_conns,
+                    &ovs_port_conf.name,
+                    &InterfaceType::Other("ovs-port".to_string()),
+                    nm_ac_uuids,
+                );
+                ret.push(create_ovs_port_nm_conn(
+                    &ovs_br_iface.base.name,
+                    ovs_port_conf,
+                    exist_nm_ovs_port_conn,
+                )?)
+            }
         }
-        if let Some(iface_ip) = &base_iface.ipv6 {
-            nm_conn.ipv6 = Some(iface_ipv6_to_nm(iface_ip)?);
-        } else {
-            nm_conn.ipv6 = Some(iface_ipv6_to_nm(&InterfaceIpv6 {
-                enabled: false,
-                ..Default::default()
-            })?);
+        Interface::LinuxBridge(br_iface) => {
+            gen_nm_br_setting(br_iface, &mut nm_conn);
         }
-    }
-    let mut nm_wired_set = NmSettingWired::new();
-    let mut flag_need_wired = false;
-    if let Some(mac) = &base_iface.mac_address {
-        flag_need_wired = true;
-        nm_wired_set.cloned_mac_address = Some(mac.to_string());
-    }
-    if flag_need_wired {
-        nm_conn.wired = Some(nm_wired_set);
+        Interface::OvsInterface(_) => {
+            // TODO Support OVS Patch interface
+            gen_nm_ovs_iface_setting(&mut nm_conn);
+        }
+        _ => (),
+    };
+
+    // When detaching a OVS system interface from OVS bridge, we should remove
+    // its NmSettingOvsIface setting
+    if base_iface.controller.is_none() {
+        nm_conn.ovs_iface = None;
     }
 
-    if let Interface::OvsBridge(ovs_br_iface) = iface {
-        nm_conn.ovs_bridge = Some(create_nm_ovs_br_set(ovs_br_iface));
-    }
-    if let Interface::LinuxBridge(br_iface) = iface {
-        if let Some(br_conf) = &br_iface.bridge {
-            nm_conn.bridge = Some(linux_bridge_conf_to_nm(br_conf)?);
-        }
-    }
-    if let Interface::OvsInterface(ovs_iface) = iface {
-        nm_conn.ovs_iface = Some(create_nm_ovs_iface_set(ovs_iface));
-    }
-    ret.push(nm_conn);
-    if let Interface::OvsBridge(ovs_br_iface) = iface {
-        // For OVS Bridge, we should create its OVS port also
-        for ovs_port_conf in ovs_br_iface.port_confs() {
-            ret.push(create_ovs_port_nm_conn(
-                &ovs_br_iface.base.name,
-                ovs_port_conf,
-            ))
-        }
-    }
+    ret.insert(0, nm_conn);
 
     Ok(ret)
 }
@@ -251,39 +219,60 @@ pub(crate) fn get_port_nm_conns<'a>(
     ret
 }
 
-pub(crate) fn gen_nm_connection(
-    iface_name: &str,
-    uuid: &str,
-    nm_iface_type: &str,
-    ctrl_name: Option<&str>,
-    nm_ctrl_type: Option<&str>,
-    is_controller: bool,
-) -> NmConnection {
-    let mut nm_conn = NmConnection::new();
-
-    // OVS port already has it own prefix
-    let conn_name = if nm_iface_type == "ovs-bridge" {
-        format!("ovs-br-{}", iface_name)
-    } else if nm_iface_type == "ovs-interface" {
-        format!("ovs-iface-{}", iface_name)
+pub(crate) fn gen_nm_conn_setting(
+    iface: &Interface,
+    nm_conn: &mut NmConnection,
+) -> Result<(), NmstateError> {
+    let mut nm_conn_set = if let Some(cur_nm_conn_set) = &nm_conn.connection {
+        cur_nm_conn_set.clone()
     } else {
-        iface_name.to_string()
+        let mut new_nm_conn_set = NmSettingConnection::new();
+        let conn_name = match iface.iface_type() {
+            InterfaceType::OvsBridge => {
+                format!("ovs-br-{}", iface.name())
+            }
+            InterfaceType::Other(ref other_type)
+                if other_type == "ovs-port" =>
+            {
+                format!("ovs-port-{}", iface.name())
+            }
+            InterfaceType::OvsInterface => {
+                format!("ovs-iface-{}", iface.name())
+            }
+            _ => iface.name().to_string(),
+        };
+
+        new_nm_conn_set.id = Some(conn_name);
+        new_nm_conn_set.uuid = Some(NmApi::uuid_gen());
+        new_nm_conn_set.iface_type =
+            Some(iface_type_to_nm(&iface.iface_type())?);
+        new_nm_conn_set
     };
 
-    let mut nm_conn_set = NmSettingConnection::new();
-    nm_conn_set.id = Some(conn_name);
-    nm_conn_set.uuid = Some(uuid.to_string());
-    nm_conn_set.iface_type = Some(nm_iface_type.to_string());
-    nm_conn_set.iface_name = Some(iface_name.to_string());
+    nm_conn_set.iface_name = Some(iface.name().to_string());
     nm_conn_set.autoconnect = Some(true);
-    nm_conn_set.autoconnect_ports =
-        if is_controller { Some(true) } else { None };
+    nm_conn_set.autoconnect_ports = if iface.is_controller() {
+        Some(true)
+    } else {
+        None
+    };
 
+    nm_conn_set.controller = None;
+    nm_conn_set.controller_type = None;
+    let nm_ctrl_type = iface
+        .base_iface()
+        .controller_type
+        .as_ref()
+        .map(iface_type_to_nm)
+        .transpose()?;
+    let nm_ctrl_type = nm_ctrl_type.as_deref();
+    let ctrl_name = iface.base_iface().controller.as_deref();
     if let Some(ctrl_name) = ctrl_name {
         if let Some(nm_ctrl_type) = nm_ctrl_type {
             nm_conn_set.controller = Some(ctrl_name.to_string());
             nm_conn_set.controller_type = if nm_ctrl_type == "ovs-bridge"
-                && nm_iface_type != "ovs-port"
+                && iface.iface_type()
+                    != InterfaceType::Other("ovs-port".to_string())
             {
                 Some("ovs-port".to_string())
             } else {
@@ -292,6 +281,5 @@ pub(crate) fn gen_nm_connection(
         }
     }
     nm_conn.connection = Some(nm_conn_set);
-
-    nm_conn
+    Ok(())
 }

--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -1,9 +1,10 @@
-use crate::{ErrorKind, InterfaceIpv4, InterfaceIpv6, NmstateError};
-use nm_dbus::{NmSettingIp, NmSettingIpMethod};
+use crate::{ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6, NmstateError};
+use nm_dbus::{NmConnection, NmSettingIpMethod};
 
-pub(crate) fn iface_ipv4_to_nm(
+fn gen_nm_ipv4_setting(
     iface_ip: &InterfaceIpv4,
-) -> Result<NmSettingIp, NmstateError> {
+    nm_conn: &mut NmConnection,
+) -> Result<(), NmstateError> {
     let mut addresses: Vec<String> = Vec::new();
     let method = if iface_ip.enabled {
         if iface_ip.dhcp {
@@ -20,15 +21,18 @@ pub(crate) fn iface_ipv4_to_nm(
     } else {
         NmSettingIpMethod::Disabled
     };
-    let mut nm_setting = NmSettingIp::new();
+
+    let mut nm_setting = nm_conn.ipv4.as_ref().cloned().unwrap_or_default();
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
-    Ok(nm_setting)
+    nm_conn.ipv4 = Some(nm_setting);
+    Ok(())
 }
 
-pub(crate) fn iface_ipv6_to_nm(
+fn gen_nm_ipv6_setting(
     iface_ip: &InterfaceIpv6,
-) -> Result<NmSettingIp, NmstateError> {
+    nm_conn: &mut NmConnection,
+) -> Result<(), NmstateError> {
     let mut addresses: Vec<String> = Vec::new();
     let method = if iface_ip.enabled {
         match (iface_ip.dhcp, iface_ip.autoconf) {
@@ -57,8 +61,38 @@ pub(crate) fn iface_ipv6_to_nm(
     } else {
         NmSettingIpMethod::Disabled
     };
-    let mut nm_setting = NmSettingIp::new();
+    let mut nm_setting = nm_conn.ipv6.as_ref().cloned().unwrap_or_default();
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
-    Ok(nm_setting)
+    nm_conn.ipv6 = Some(nm_setting);
+    Ok(())
+}
+
+pub(crate) fn gen_nm_ip_setting(
+    iface: &Interface,
+    nm_conn: &mut NmConnection,
+) -> Result<(), NmstateError> {
+    let base_iface = iface.base_iface();
+    if base_iface.can_have_ip() {
+        let ipv4_conf = if let Some(ipv4_conf) = &base_iface.ipv4 {
+            ipv4_conf.clone()
+        } else {
+            let mut ipv4_conf = InterfaceIpv4::new();
+            ipv4_conf.enabled = false;
+            ipv4_conf
+        };
+        let ipv6_conf = if let Some(ipv6_conf) = &base_iface.ipv6 {
+            ipv6_conf.clone()
+        } else {
+            let mut ipv6_conf = InterfaceIpv6::new();
+            ipv6_conf.enabled = false;
+            ipv6_conf
+        };
+        gen_nm_ipv4_setting(&ipv4_conf, nm_conn)?;
+        gen_nm_ipv6_setting(&ipv6_conf, nm_conn)?;
+    } else {
+        nm_conn.ipv4 = None;
+        nm_conn.ipv6 = None;
+    }
+    Ok(())
 }

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -11,6 +11,7 @@ mod profile;
 mod show;
 #[cfg(test)]
 mod unit_tests;
+mod wired;
 
 pub(crate) use apply::nm_apply;
 pub(crate) use checkpoint::{

--- a/rust/src/lib/nm/unit_tests/profiles.rs
+++ b/rust/src/lib/nm/unit_tests/profiles.rs
@@ -27,7 +27,7 @@ fn test_use_uuid_for_controller_reference_with_ovs_bond() {
     nm_conn_set.id = Some("ovs-port-bond1".to_string());
     nm_conn_set.uuid = Some(UUID2.to_string());
     nm_conn_set.iface_type = Some("ovs-port".to_string());
-    nm_conn_set.iface_name = Some("ovs-port-bond1".to_string());
+    nm_conn_set.iface_name = Some("bond1".to_string());
     nm_conn_set.controller = Some("br0".into());
     nm_conn_set.controller_type = Some("ovs-bridge".into());
     nm_conn.connection = Some(nm_conn_set);
@@ -97,7 +97,7 @@ fn test_use_uuid_for_controller_reference_with_ovs_bond() {
     let bond1_nm_con_set = nm_conns[1].connection.as_ref().unwrap();
     println!("bond1 {:?}", bond1_nm_con_set);
     assert!(bond1_nm_con_set.id == Some("ovs-port-bond1".to_string()));
-    assert!(bond1_nm_con_set.iface_name == Some("ovs-port-bond1".to_string()));
+    assert!(bond1_nm_con_set.iface_name == Some("bond1".to_string()));
     assert!(bond1_nm_con_set.iface_type == Some("ovs-port".to_string()));
     assert!(bond1_nm_con_set.controller == Some(UUID1.to_string()));
     assert!(bond1_nm_con_set.controller_type == Some("ovs-bridge".to_string()));

--- a/rust/src/lib/nm/wired.rs
+++ b/rust/src/lib/nm/wired.rs
@@ -1,0 +1,22 @@
+use crate::Interface;
+use nm_dbus::NmConnection;
+
+pub(crate) fn gen_nm_wired_setting(
+    iface: &Interface,
+    nm_conn: &mut NmConnection,
+) {
+    let mut nm_wired_set = nm_conn.wired.as_ref().cloned().unwrap_or_default();
+
+    let mut flag_need_wired = false;
+
+    let base_iface = iface.base_iface();
+
+    if let Some(mac) = &base_iface.mac_address {
+        nm_wired_set.cloned_mac_address = Some(mac.to_string());
+        flag_need_wired = true;
+    }
+
+    if flag_need_wired {
+        nm_conn.wired = Some(nm_wired_set);
+    }
+}


### PR DESCRIPTION
Only update user desired configure and preserving previous existing
configurations.

Enabled the integration test `test_reapply_preserve_ip_config.py` for
rust code.