### PR TITLE
rust, base: support accept-all-mac-addresses mode

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -236,8 +236,16 @@ function run_tests {
             -k '\
             not test_linux_bridge_over_bond_over_port_in_one_transaction and \
             not test_explicitly_ignore_a_bridge_port and \
-            not test_create_linux_bridge_with_copy_mac_from and \
-            not test_linux_bridge_enable_and_disable_accept_all_mac_addresses' \
+            not test_create_linux_bridge_with_copy_mac_from' \
+            ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/interface_common_test.py \
+            -k '\
+            test_enable_and_disable_accept_all_mac_addresses' \
             ${nmstate_pytest_extra_args}"
     fi
 }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -27,6 +27,8 @@ pub struct BaseInterface {
     pub ipv6: Option<InterfaceIpv6>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accept_all_mac_addresses: Option<bool>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.
@@ -61,6 +63,9 @@ impl BaseInterface {
         }
         if other.prop_list.contains(&"controller_type") {
             self.controller_type = other.controller_type.clone();
+        }
+        if other.prop_list.contains(&"accept_all_mac_addresses") {
+            self.accept_all_mac_addresses = other.accept_all_mac_addresses;
         }
 
         if other.prop_list.contains(&"ipv4") {

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -56,6 +56,14 @@ pub(crate) fn np_iface_to_base_iface(
         } else {
             Some(0u64)
         },
+        accept_all_mac_addresses: if np_iface
+            .flags
+            .contains(&nispor::IfaceFlags::Promisc)
+        {
+            Some(true)
+        } else {
+            Some(false)
+        },
         prop_list: vec![
             "name",
             "state",
@@ -65,6 +73,7 @@ pub(crate) fn np_iface_to_base_iface(
             "mac_address",
             "controller",
             "mtu",
+            "accept_all_mac_addresses",
         ],
         ..Default::default()
     };

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -12,6 +12,7 @@ mod show;
 mod sriov;
 #[cfg(test)]
 mod unit_tests;
+mod version;
 mod vlan;
 mod wired;
 

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -30,7 +30,7 @@ pub(crate) fn get_exist_profile<'a>(
         } else {
             continue;
         };
-        if exist_nm_conn.iface_name() == Some(&iface_name.to_string())
+        if exist_nm_conn.iface_name() == Some(iface_name)
             && exist_nm_conn.iface_type() == Some(&nm_iface_type)
         {
             if let Some(uuid) = exist_nm_conn.uuid() {

--- a/rust/src/lib/nm/version.rs
+++ b/rust/src/lib/nm/version.rs
@@ -1,0 +1,30 @@
+use crate::{nm::error::nm_error_to_nmstate, NmstateError};
+use nm_dbus::NmApi;
+
+pub(crate) fn nm_version() -> Result<String, NmstateError> {
+    let nm_api = NmApi::new().map_err(nm_error_to_nmstate)?;
+    nm_api.version().map_err(nm_error_to_nmstate)
+}
+
+// This helper function will help us to avoid introducing new dependencies to the project.
+pub(crate) fn nm_supports_accept_all_mac_addresses_mode(
+) -> Result<bool, NmstateError> {
+    let version = nm_version()?;
+    let version_split = version.split('.');
+    let supported_version = Vec::<u32>::from([1, 32]);
+    let mut supported_elem = supported_version.iter();
+
+    for v_elem in version_split {
+        if v_elem.chars().all(char::is_numeric) {
+            if let Some(supported_v) = supported_elem.next() {
+                if v_elem.parse::<u32>().unwrap_or_default() < *supported_v {
+                    return Ok(false);
+                }
+            } else {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/rust/src/lib/nm/wired.rs
+++ b/rust/src/lib/nm/wired.rs
@@ -1,3 +1,4 @@
+use crate::nm::version::nm_supports_accept_all_mac_addresses_mode;
 use crate::Interface;
 use nm_dbus::NmConnection;
 
@@ -18,6 +19,14 @@ pub(crate) fn gen_nm_wired_setting(
     if let Some(mtu) = &base_iface.mtu {
         nm_wired_set.mtu = Some(*mtu as u32);
         flag_need_wired = true;
+    }
+    if let Some(accept_all_mac_addresses) = &base_iface.accept_all_mac_addresses
+    {
+        if nm_supports_accept_all_mac_addresses_mode().unwrap_or_default() {
+            nm_wired_set.accept_all_mac_addresses =
+                Some(i32::from(*accept_all_mac_addresses));
+            flag_need_wired = true;
+        }
     }
 
     if flag_need_wired {

--- a/rust/src/libnm_dbus/connection/wired.rs
+++ b/rust/src/libnm_dbus/connection/wired.rs
@@ -30,6 +30,7 @@ use crate::{
 pub struct NmSettingWired {
     pub cloned_mac_address: Option<String>,
     pub mtu: Option<u32>,
+    pub accept_all_mac_addresses: Option<i32>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -44,6 +45,11 @@ impl TryFrom<DbusDictionary> for NmSettingWired {
             )?
             .map(u8_array_to_mac_string),
             mtu: _from_map!(v, "mtu", u32::try_from)?,
+            accept_all_mac_addresses: _from_map!(
+                v,
+                "accept-all-mac-addresses",
+                i32::try_from
+            )?,
             _other: v,
         })
     }
@@ -62,6 +68,9 @@ impl NmSettingWired {
         }
         if let Some(v) = &self.mtu {
             ret.insert("mtu", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.accept_all_mac_addresses {
+            ret.insert("accept-all-mac-addresses", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))


### PR DESCRIPTION
Please, notice that `accept-all-mac-addresses` DBus property is a i32
because it uses `NM_TERNARY` values. In Nmstate we consider it as
boolean so we need to convert the value.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>