### PR TITLE
rust: Add initial VLAN support

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -211,6 +211,20 @@ function run_tests {
             test_change_mtu_with_stable_link_up or \
             test_empty_state_preserve_the_old_mtu' \
             ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/vlan_test.py \
+            -k '\
+            test_add_and_remove_vlan or \
+            test_vlan_iface_uses_the_mac_of_base_iface or \
+            test_add_and_remove_two_vlans_on_same_iface or \
+            test_two_vlans_on_eth1_change_base_iface_mtu or \
+            (test_two_vlans_on_eth1_change_mtu and not test_two_vlans_on_eth1_change_mtu_rollback) or \
+            test_rollback_for_vlans' \
+            ${nmstate_pytest_extra_args}"
     fi
 }
 

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -223,7 +223,8 @@ function run_tests {
             test_add_and_remove_two_vlans_on_same_iface or \
             test_two_vlans_on_eth1_change_base_iface_mtu or \
             (test_two_vlans_on_eth1_change_mtu and not test_two_vlans_on_eth1_change_mtu_rollback) or \
-            test_rollback_for_vlans' \
+            test_rollback_for_vlans or \
+            test_set_vlan_iface_down' \
             ${nmstate_pytest_extra_args}"
     fi
 }

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -257,6 +257,10 @@ impl Interface {
         self.base_iface().state == InterfaceState::Absent
     }
 
+    pub fn is_down(&self) -> bool {
+        self.base_iface().state == InterfaceState::Down
+    }
+
     pub fn is_virtual(&self) -> bool {
         !matches!(self, Self::Ethernet(_) | Self::Unknown(_))
     }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -150,7 +150,7 @@ impl Interfaces {
 
     pub(crate) fn verify(&self, cur_ifaces: &Self) -> Result<(), NmstateError> {
         for iface in self.to_vec() {
-            if iface.is_absent() {
+            if iface.is_absent() || (iface.is_virtual() && iface.is_down()) {
                 if let Some(cur_iface) =
                     cur_ifaces.get_iface(iface.name(), iface.iface_type())
                 {

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map::Entry, HashMap};
 
-use nm_dbus::{NmApi, NmConnection, NmSettingConnection};
+use nm_dbus::{NmApi, NmConnection, NmSettingConnection, NmSettingVlan};
 
 use crate::{
     nm::bridge::gen_nm_br_setting,
@@ -90,6 +90,9 @@ pub(crate) fn iface_to_nm_connections(
             // TODO Support OVS Patch interface
             gen_nm_ovs_iface_setting(&mut nm_conn);
         }
+        Interface::Vlan(vlan_iface) => {
+            nm_conn.vlan = vlan_iface.vlan.as_ref().map(NmSettingVlan::from)
+        }
         _ => (),
     };
 
@@ -112,6 +115,7 @@ pub(crate) fn iface_type_to_nm(
         InterfaceType::Ethernet => Ok("802-3-ethernet".into()),
         InterfaceType::OvsBridge => Ok("ovs-bridge".into()),
         InterfaceType::OvsInterface => Ok("ovs-interface".into()),
+        InterfaceType::Vlan => Ok("vlan".to_string()),
         InterfaceType::Other(s) => Ok(s.to_string()),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -11,6 +11,7 @@ mod profile;
 mod show;
 #[cfg(test)]
 mod unit_tests;
+mod vlan;
 mod wired;
 
 pub(crate) use apply::nm_apply;

--- a/rust/src/lib/nm/vlan.rs
+++ b/rust/src/lib/nm/vlan.rs
@@ -1,0 +1,11 @@
+use crate::VlanConfig;
+use nm_dbus::NmSettingVlan;
+
+impl From<&VlanConfig> for NmSettingVlan {
+    fn from(config: &VlanConfig) -> Self {
+        let mut settings = NmSettingVlan::new();
+        settings.id = Some(config.id.into());
+        settings.parent = Some(config.base_iface.clone());
+        settings
+    }
+}

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -17,6 +17,7 @@ mod bridge;
 mod conn;
 mod ip;
 mod ovs;
+mod vlan;
 mod wired;
 
 pub use crate::connection::bridge::NmSettingBridge;
@@ -25,6 +26,7 @@ pub use crate::connection::ip::{NmSettingIp, NmSettingIpMethod};
 pub use crate::connection::ovs::{
     NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
 };
+pub use crate::connection::vlan::NmSettingVlan;
 pub use crate::connection::wired::NmSettingWired;
 
 pub(crate) use crate::connection::conn::{

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -1,0 +1,52 @@
+use crate::dbus_value::{own_value_to_string, own_value_to_u32};
+use crate::NmError;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmSettingVlan {
+    pub parent: Option<String>,
+    pub id: Option<u32>,
+    _other: HashMap<String, zvariant::OwnedValue>,
+}
+
+impl TryFrom<HashMap<String, zvariant::OwnedValue>> for NmSettingVlan {
+    type Error = NmError;
+    fn try_from(
+        mut setting_value: HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        let mut setting = Self::new();
+        setting.parent = setting_value
+            .remove("parent")
+            .map(own_value_to_string)
+            .transpose()?;
+        setting.id = setting_value
+            .remove("id")
+            .map(own_value_to_u32)
+            .transpose()?;
+        setting._other = setting_value;
+        Ok(setting)
+    }
+}
+
+impl NmSettingVlan {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.parent {
+            ret.insert("parent", zvariant::Value::new(v.clone()));
+        }
+        if let Some(id) = self.id {
+            ret.insert("id", zvariant::Value::new(id));
+        }
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -26,7 +26,7 @@ pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
     NmConnection, NmSettingBridge, NmSettingConnection, NmSettingIp,
     NmSettingIpMethod, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
-    NmSettingWired,
+    NmSettingVlan, NmSettingWired,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::error::{ErrorKind, NmError};


### PR DESCRIPTION
Add initial support of vlan so creating and removing
vlans should work.
