### PR TITLE
rust: linux bridge

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -227,6 +227,18 @@ function run_tests {
             test_set_vlan_iface_down or \
             test_add_new_base_iface_with_vlan' \
             ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/linux_bridge_test.py \
+            -k '\
+            not test_linux_bridge_over_bond_over_port_in_one_transaction and \
+            not test_explicitly_ignore_a_bridge_port and \
+            not test_create_linux_bridge_with_copy_mac_from and \
+            not test_linux_bridge_enable_and_disable_accept_all_mac_addresses' \
+            ${nmstate_pytest_extra_args}"
     fi
 }
 

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -14,6 +14,7 @@ nm-dbus = {path = "../libnm_dbus"}
 #nispor = "1.2"
 nispor = { git = "https://github.com/nispor/nispor", branch = "base" }
 log = "0.4.14"
+libc = "0.2.106"
 
 [dev-dependencies]
 serde_yaml = "0.8"

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -5,6 +5,7 @@ pub enum ErrorKind {
     Bug,
     VerificationError,
     NotImplementedError,
+    KernelIntegerRoundedError,
 }
 
 impl std::fmt::Display for ErrorKind {

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
+
+use log::{error, warn};
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, InterfaceType};
+use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LinuxBridgeInterface {
@@ -19,6 +22,14 @@ impl Default for LinuxBridgeInterface {
 }
 
 impl LinuxBridgeInterface {
+    pub(crate) const INTEGER_ROUNDED_OPTIONS: [&'static str; 5] = [
+        "interface.bridge.options.multicast-last-member-interval",
+        "interface.bridge.options.multicast-membership-interval",
+        "interface.bridge.options.multicast-querier-interval",
+        "interface.bridge.options.multicast-query-response-interval",
+        "interface.bridge.options.multicast-startup-query-interval",
+    ];
+
     pub(crate) fn update_bridge(&mut self, other: &LinuxBridgeInterface) {
         if let Some(br_conf) = &mut self.bridge {
             br_conf.update(other.bridge.as_ref());
@@ -27,21 +38,23 @@ impl LinuxBridgeInterface {
         }
     }
 
+    // Return None when desire state does not mentioned ports.
     pub(crate) fn ports(&self) -> Option<Vec<&str>> {
-        let mut port_names = Vec::new();
-        if let Some(br_conf) = &self.bridge {
-            if let Some(ports) = &br_conf.port {
-                for port in ports {
-                    port_names.push(port.name.as_str());
-                }
-            }
-        }
-        Some(port_names)
+        self.bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+            .map(|ports| {
+                ports.as_slice().iter().map(|p| p.name.as_str()).collect()
+            })
     }
 
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.base.pre_verify_cleanup();
-        self.sort_ports()
+        self.sort_ports();
+        self.use_upper_case_of_mac_address();
+        self.flatten_port_vlan_ranges();
+        self.sort_port_vlans();
+        self.treat_none_vlan_as_empty_dict();
     }
 
     pub fn new() -> Self {
@@ -55,6 +68,161 @@ impl LinuxBridgeInterface {
             }
         }
     }
+
+    fn use_upper_case_of_mac_address(&mut self) {
+        if let Some(address) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.options.as_mut())
+            .and_then(|br_opts| br_opts.group_addr.as_mut())
+        {
+            address.make_ascii_uppercase()
+        }
+    }
+
+    fn flatten_port_vlan_ranges(&mut self) {
+        if let Some(port_confs) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.port.as_mut())
+        {
+            for port_conf in port_confs {
+                port_conf
+                    .vlan
+                    .as_mut()
+                    .map(LinuxBridgePortVlanConfig::flatten_vlan_ranges);
+            }
+        }
+    }
+
+    fn sort_port_vlans(&mut self) {
+        if let Some(port_confs) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.port.as_mut())
+        {
+            for port_conf in port_confs {
+                port_conf
+                    .vlan
+                    .as_mut()
+                    .map(LinuxBridgePortVlanConfig::sort_trunk_tags);
+            }
+        }
+    }
+
+    fn treat_none_vlan_as_empty_dict(&mut self) {
+        if let Some(port_confs) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.port.as_mut())
+        {
+            for port_conf in port_confs {
+                if port_conf.vlan.is_none() {
+                    port_conf.vlan = Some(LinuxBridgePortVlanConfig::new());
+                }
+            }
+        }
+    }
+
+    pub(crate) fn remove_port(&mut self, port_name: &str) {
+        if let Some(index) = self.bridge.as_ref().and_then(|br_conf| {
+            br_conf.port.as_ref().and_then(|port_confs| {
+                port_confs
+                    .iter()
+                    .position(|port_conf| port_conf.name == port_name)
+            })
+        }) {
+            self.bridge
+                .as_mut()
+                .and_then(|br_conf| br_conf.port.as_mut())
+                .map(|port_confs| port_confs.remove(index));
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        self.base.validate()?;
+        self.bridge
+            .as_ref()
+            .map(LinuxBridgeConfig::validate)
+            .transpose()?;
+        Ok(())
+    }
+
+    pub(crate) fn get_port_conf(
+        &self,
+        port_name: &str,
+    ) -> Option<&LinuxBridgePortConfig> {
+        self.bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+            .and_then(|port_confs| {
+                port_confs
+                    .iter()
+                    .find(|port_conf| port_conf.name == port_name)
+            })
+    }
+
+    pub(crate) fn vlan_filtering_is_enabled(&self) -> bool {
+        self.bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+            .map(|port_confs| {
+                port_confs.iter().any(|port_conf| port_conf.vlan.is_some())
+            })
+            .unwrap_or(false)
+    }
+
+    // Port name list change is not this function's responsibility, top level
+    // code will take care of it.
+    // This function only find out those port which has changed vlan or stp
+    // configuration.
+    pub(crate) fn get_config_changed_ports(&self, current: &Self) -> Vec<&str> {
+        let mut ret: Vec<&str> = Vec::new();
+        let mut des_ports_index: HashMap<&str, &LinuxBridgePortConfig> =
+            HashMap::new();
+        let mut cur_ports_index: HashMap<&str, &LinuxBridgePortConfig> =
+            HashMap::new();
+        if let Some(port_confs) = self
+            .bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+        {
+            for port_conf in port_confs {
+                des_ports_index.insert(port_conf.name.as_str(), port_conf);
+            }
+        }
+
+        if let Some(port_confs) = current
+            .bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+        {
+            for port_conf in port_confs {
+                cur_ports_index.insert(port_conf.name.as_str(), port_conf);
+            }
+        }
+
+        for (port_name, port_conf) in des_ports_index.iter() {
+            if let Some(cur_port_conf) = cur_ports_index.get(port_name) {
+                if port_conf != cur_port_conf {
+                    ret.push(port_name);
+                }
+            }
+        }
+        ret
+    }
+
+    // With 250 kernel HZ(Ubuntu kernel) and 100 user HZ, some linux bridge
+    // kernel option value will be rounded up with 1 difference which lead to
+    // verification error.
+    pub(crate) fn is_interger_rounded_up(prop_full_name: &str) -> bool {
+        for allowed_prop_name in &Self::INTEGER_ROUNDED_OPTIONS {
+            if prop_full_name.ends_with(allowed_prop_name) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -64,6 +232,20 @@ pub struct LinuxBridgeConfig {
     pub options: Option<LinuxBridgeOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<Vec<LinuxBridgePortConfig>>,
+}
+
+impl LinuxBridgeConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        self.options
+            .as_ref()
+            .map(LinuxBridgeOptions::validate)
+            .transpose()?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -76,13 +258,78 @@ pub struct LinuxBridgePortConfig {
     pub stp_path_cost: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stp_priority: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan: Option<LinuxBridgePortVlanConfig>,
+}
+
+impl LinuxBridgePortConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct LinuxBridgeOptions {
+    // `gc_timer` is runtime status, not allowing for changing
+    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
+    pub gc_timer: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_addr: Option<String>,
+    // The group_forward_mask is the same with group_fwd_mask. The former is
+    // used by NetworkManager, the later is used by sysfs. Nmstate support
+    // both.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_forward_mask: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_fwd_mask: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash_max: Option<u32>,
+    // `hello_timer` is runtime status, not allowing for changing
+    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
+    pub hello_timer: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac_ageing_time: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_last_member_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_last_member_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_membership_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_querier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_querier_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_query_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_query_response_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_query_use_ifaddr: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_router: Option<LinuxBridgeMulticastRouterType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_snooping: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_startup_query_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multicast_startup_query_interval: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stp: Option<LinuxBridgeStpOptions>,
+}
+
+impl LinuxBridgeOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        self.stp
+            .as_ref()
+            .map(LinuxBridgeStpOptions::validate)
+            .transpose()?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -90,6 +337,84 @@ pub struct LinuxBridgeOptions {
 pub struct LinuxBridgeStpOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forward_delay: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hello_time: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u16>,
+}
+
+impl LinuxBridgeStpOptions {
+    pub const HELLO_TIME_MAX: u8 = 10;
+    pub const HELLO_TIME_MIN: u8 = 1;
+    pub const MAX_AGE_MAX: u8 = 40;
+    pub const MAX_AGE_MIN: u8 = 6;
+    pub const FORWARD_DELAY_MAX: u8 = 30;
+    pub const FORWARD_DELAY_MIN: u8 = 2;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        if let Some(hello_time) = self.hello_time {
+            if !(Self::HELLO_TIME_MIN..=Self::HELLO_TIME_MAX)
+                .contains(&hello_time)
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired STP hello time {} is not in the range \
+                        of [{},{}]",
+                        hello_time,
+                        Self::HELLO_TIME_MIN,
+                        Self::HELLO_TIME_MAX
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            }
+        }
+
+        if let Some(max_age) = self.max_age {
+            if !(Self::MAX_AGE_MIN..=Self::MAX_AGE_MAX).contains(&max_age) {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired STP max age {} is not in the range \
+                        of [{},{}]",
+                        max_age,
+                        Self::MAX_AGE_MIN,
+                        Self::MAX_AGE_MAX
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            }
+        }
+        if let Some(forward_delay) = self.forward_delay {
+            if !(Self::FORWARD_DELAY_MIN..=Self::FORWARD_DELAY_MAX)
+                .contains(&forward_delay)
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired STP forward delay {} is not in the range \
+                        of [{},{}]",
+                        forward_delay,
+                        Self::FORWARD_DELAY_MIN,
+                        Self::FORWARD_DELAY_MAX
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
 }
 
 impl LinuxBridgeConfig {
@@ -99,4 +424,123 @@ impl LinuxBridgeConfig {
             self.port = other.port.clone();
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinuxBridgeMulticastRouterType {
+    Auto,
+    Disabled,
+    Enabled,
+}
+
+impl Default for LinuxBridgeMulticastRouterType {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+impl std::fmt::Display for LinuxBridgeMulticastRouterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Auto => "auto",
+                Self::Disabled => "disabled",
+                Self::Enabled => "enabled",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct LinuxBridgePortVlanConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_native: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<LinuxBridgePortVlanMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trunk_tags: Option<Vec<LinuxBridgePortTunkTag>>,
+}
+
+impl LinuxBridgePortVlanConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn flatten_vlan_ranges(&mut self) {
+        if let Some(trunk_tags) = &self.trunk_tags {
+            let mut new_trunk_tags = Vec::new();
+            for trunk_tag in trunk_tags {
+                match trunk_tag {
+                    LinuxBridgePortTunkTag::Id(_) => {
+                        new_trunk_tags.push(trunk_tag.clone())
+                    }
+                    LinuxBridgePortTunkTag::IdRange(range) => {
+                        for i in range.min..range.max + 1 {
+                            new_trunk_tags.push(LinuxBridgePortTunkTag::Id(i));
+                        }
+                    }
+                };
+            }
+            self.trunk_tags = Some(new_trunk_tags);
+        }
+    }
+
+    pub(crate) fn sort_trunk_tags(&mut self) {
+        if let Some(trunk_tags) = self.trunk_tags.as_mut() {
+            trunk_tags.sort_unstable_by(|tag_a, tag_b| match (tag_a, tag_b) {
+                (
+                    LinuxBridgePortTunkTag::Id(a),
+                    LinuxBridgePortTunkTag::Id(b),
+                ) => a.cmp(b),
+                _ => {
+                    warn!(
+                        "Please call flatten_vlan_ranges() \
+                            before sort_port_vlans()"
+                    );
+                    std::cmp::Ordering::Equal
+                }
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinuxBridgePortVlanMode {
+    Trunk,
+    Access,
+}
+
+impl Default for LinuxBridgePortVlanMode {
+    fn default() -> Self {
+        Self::Access
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LinuxBridgePortTunkTag {
+    Id(u16),
+    IdRange(LinuxBridgePortVlanRange),
+}
+
+impl LinuxBridgePortTunkTag {
+    pub fn get_vlan_tag_range(&self) -> (u16, u16) {
+        match self {
+            Self::Id(min) => (*min, *min),
+            Self::IdRange(range) => (range.min, range.max),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct LinuxBridgePortVlanRange {
+    pub max: u16,
+    pub min: u16,
 }

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -11,7 +11,12 @@ pub use base::*;
 pub use dummy::DummyInterface;
 pub use ethernet::{EthernetConfig, EthernetInterface, VethConfig};
 pub use inter_ifaces::*;
-pub use linux_bridge::*;
+pub use linux_bridge::{
+    LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeMulticastRouterType,
+    LinuxBridgeOptions, LinuxBridgePortConfig, LinuxBridgePortTunkTag,
+    LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode,
+    LinuxBridgePortVlanRange, LinuxBridgeStpOptions,
+};
 pub use ovs::{
     OvsBridgeBondConfig, OvsBridgeBondMode, OvsBridgeBondPortConfig,
     OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -372,7 +372,7 @@ impl InterfaceIpv6 {
             self.dhcp = other.dhcp;
         }
         if other.prop_list.contains(&"autoconf") {
-            self.dhcp = other.dhcp;
+            self.autoconf = other.autoconf;
         }
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -14,8 +14,10 @@ pub use crate::iface::{
 };
 pub use crate::ifaces::{
     BaseInterface, DummyInterface, EthernetConfig, EthernetInterface,
-    Interfaces, LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeOptions,
-    LinuxBridgePortConfig, LinuxBridgeStpOptions, OvsBridgeBondConfig,
+    Interfaces, LinuxBridgeConfig, LinuxBridgeInterface,
+    LinuxBridgeMulticastRouterType, LinuxBridgeOptions, LinuxBridgePortConfig,
+    LinuxBridgePortTunkTag, LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode,
+    LinuxBridgePortVlanRange, LinuxBridgeStpOptions, OvsBridgeBondConfig,
     OvsBridgeBondMode, OvsBridgeBondPortConfig, OvsBridgeConfig,
     OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig, OvsInterface,
     VethConfig, VlanConfig, VlanInterface,

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -1,7 +1,7 @@
 use crate::{BaseInterface, EthernetInterface};
 
 pub(crate) fn np_ethernet_to_nmstate(
-    _np_iface: nispor::Iface,
+    _np_iface: &nispor::Iface,
     base_iface: BaseInterface,
 ) -> EthernetInterface {
     EthernetInterface {

--- a/rust/src/lib/nispor/linux_bridge.rs
+++ b/rust/src/lib/nispor/linux_bridge.rs
@@ -1,34 +1,70 @@
+use std::convert::TryFrom;
+
+use log::warn;
+
 use crate::{
-    BaseInterface, LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeOptions,
-    LinuxBridgePortConfig, LinuxBridgeStpOptions,
+    nispor::linux_bridge_port_vlan::parse_port_vlan_conf, BaseInterface,
+    LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeMulticastRouterType,
+    LinuxBridgeOptions, LinuxBridgePortConfig, LinuxBridgeStpOptions,
 };
 
 pub(crate) fn np_bridge_to_nmstate(
-    np_iface: nispor::Iface,
+    np_iface: &nispor::Iface,
     base_iface: BaseInterface,
 ) -> LinuxBridgeInterface {
-    LinuxBridgeInterface {
-        base: base_iface,
-        bridge: Some(LinuxBridgeConfig {
-            port: Some(np_bridge_ports_to_nmstate(&np_iface)),
-            options: Some(np_bridge_options_to_nmstate(&np_iface)),
-        }),
+    let mut br_iface = LinuxBridgeInterface::new();
+    let mut br_conf = LinuxBridgeConfig::new();
+    br_iface.base = base_iface;
+    br_conf.options = Some(np_bridge_options_to_nmstate(np_iface));
+    if let Some(np_bridge) = &np_iface.bridge {
+        br_conf.port = Some(
+            np_bridge
+                .ports
+                .as_slice()
+                .iter()
+                .map(|iface_name| {
+                    let mut port_conf = LinuxBridgePortConfig::new();
+                    port_conf.name = iface_name.to_string();
+                    port_conf
+                })
+                .collect(),
+        );
     }
+    br_iface.bridge = Some(br_conf);
+    br_iface
 }
 
-fn np_bridge_ports_to_nmstate(
+pub(crate) fn append_bridge_port_config(
+    br_iface: &mut LinuxBridgeInterface,
     np_iface: &nispor::Iface,
-) -> Vec<LinuxBridgePortConfig> {
-    let mut ports = Vec::new();
-    if let Some(np_bridge) = &np_iface.bridge {
-        for port_iface_name in &np_bridge.ports {
-            ports.push(LinuxBridgePortConfig {
-                name: port_iface_name.to_string(),
-                ..Default::default()
-            });
+    port_np_ifaces: Vec<&nispor::Iface>,
+) {
+    let mut port_confs: Vec<LinuxBridgePortConfig> = Vec::new();
+    for port_np_iface in port_np_ifaces {
+        let mut port_conf = LinuxBridgePortConfig::new();
+        port_conf.name = port_np_iface.name.to_string();
+        if let Some(np_port_info) = &port_np_iface.bridge_port {
+            port_conf.stp_hairpin_mode = Some(np_port_info.hairpin_mode);
+            port_conf.stp_path_cost = Some(np_port_info.stp_path_cost);
+            port_conf.stp_priority = Some(np_port_info.stp_priority);
+            if np_iface
+                .bridge
+                .as_ref()
+                .and_then(|br_info| br_info.vlan_filtering)
+                == Some(true)
+            {
+                port_conf.vlan = np_port_info
+                    .vlans
+                    .as_ref()
+                    .and_then(|v| parse_port_vlan_conf(v.as_slice()));
+            }
         }
+        port_confs.push(port_conf);
     }
-    ports
+
+    if let Some(mut br_conf) = br_iface.bridge.as_mut() {
+        br_conf.port = Some(port_confs);
+    }
 }
 
 fn np_bridge_options_to_nmstate(
@@ -36,15 +72,88 @@ fn np_bridge_options_to_nmstate(
 ) -> LinuxBridgeOptions {
     let mut options = LinuxBridgeOptions::default();
     if let Some(ref np_bridge) = &np_iface.bridge {
-        options.stp = Some(LinuxBridgeStpOptions {
-            enabled: Some(
-                [
-                    Some(nispor::BridgeStpState::KernelStp),
-                    Some(nispor::BridgeStpState::UserStp),
-                ]
-                .contains(&np_bridge.stp_state),
-            ),
-        });
+        options.stp = Some(get_stp_options(np_bridge));
+        options.gc_timer = np_bridge.gc_timer;
+        options.group_addr = np_bridge
+            .group_addr
+            .as_ref()
+            .map(|addr| addr.to_uppercase());
+        options.group_forward_mask = np_bridge.group_fwd_mask;
+        options.group_fwd_mask = np_bridge.group_fwd_mask;
+        options.hash_max = np_bridge.multicast_hash_max;
+        options.hello_timer = np_bridge.hello_timer;
+        options.mac_ageing_time = np_bridge.ageing_time.map(devide_by_user_hz);
+        options.multicast_last_member_count =
+            np_bridge.multicast_last_member_count;
+        options.multicast_last_member_interval =
+            np_bridge.multicast_last_member_interval;
+        options.multicast_membership_interval =
+            np_bridge.multicast_membership_interval;
+        options.multicast_querier = np_bridge.multicast_querier;
+        options.multicast_querier_interval =
+            np_bridge.multicast_querier_interval;
+        options.multicast_query_interval = np_bridge.multicast_query_interval;
+        options.multicast_query_response_interval =
+            np_bridge.multicast_query_response_interval;
+        options.multicast_query_use_ifaddr =
+            np_bridge.multicast_query_use_ifaddr;
+        options.multicast_router =
+            np_bridge.multicast_router.as_ref().and_then(|r| match r {
+                nispor::BridgePortMulticastRouterType::Disabled => {
+                    Some(LinuxBridgeMulticastRouterType::Disabled)
+                }
+                nispor::BridgePortMulticastRouterType::TempQuery => {
+                    Some(LinuxBridgeMulticastRouterType::Auto)
+                }
+                nispor::BridgePortMulticastRouterType::Perm => {
+                    Some(LinuxBridgeMulticastRouterType::Enabled)
+                }
+                _ => {
+                    warn!("Unsupported linux bridge multicast router {:?}", r);
+                    None
+                }
+            });
+        options.multicast_snooping = np_bridge.multicast_snooping;
+        options.multicast_startup_query_count =
+            np_bridge.multicast_startup_query_count;
+        options.multicast_startup_query_interval =
+            np_bridge.multicast_startup_query_interval;
     }
     options
+}
+
+// The kernel is multiplying these bridge properties by USER_HZ, we should
+// divide into seconds:
+//   * forward_delay
+//   * ageing_time
+//   * hello_time
+//   * max_age
+fn devide_by_user_hz(v: u32) -> u32 {
+    let user_hz = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u32;
+    v / user_hz
+}
+
+fn get_stp_options(np_bridge: &nispor::BridgeInfo) -> LinuxBridgeStpOptions {
+    let mut stp_opt = LinuxBridgeStpOptions::new();
+    stp_opt.enabled = Some(
+        [
+            Some(nispor::BridgeStpState::KernelStp),
+            Some(nispor::BridgeStpState::UserStp),
+        ]
+        .contains(&np_bridge.stp_state),
+    );
+    stp_opt.forward_delay = np_bridge.forward_delay.map(|v| {
+        u8::try_from(devide_by_user_hz(v))
+            .unwrap_or(LinuxBridgeStpOptions::FORWARD_DELAY_MAX)
+    });
+    stp_opt.max_age = np_bridge.max_age.map(|v| {
+        u8::try_from(devide_by_user_hz(v))
+            .unwrap_or(LinuxBridgeStpOptions::MAX_AGE_MAX)
+    });
+    stp_opt.hello_time = np_bridge.hello_time.map(|v| {
+        u8::try_from(devide_by_user_hz(v))
+            .unwrap_or(LinuxBridgeStpOptions::HELLO_TIME_MAX)
+    });
+    stp_opt.priority = np_bridge.priority;
+    stp_opt
 }

--- a/rust/src/lib/nispor/linux_bridge_port_vlan.rs
+++ b/rust/src/lib/nispor/linux_bridge_port_vlan.rs
@@ -1,0 +1,64 @@
+use crate::{
+    LinuxBridgePortTunkTag, LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode,
+    LinuxBridgePortVlanRange,
+};
+
+pub(crate) fn parse_port_vlan_conf(
+    np_vlan_entries: &[nispor::BridgeVlanEntry],
+) -> Option<LinuxBridgePortVlanConfig> {
+    let mut ret = LinuxBridgePortVlanConfig::new();
+    let mut is_native = false;
+    let mut trunk_tags = Vec::new();
+    let is_access_port = is_access_port(np_vlan_entries);
+
+    for np_vlan_entry in np_vlan_entries {
+        let (vlan_min, vlan_max) = get_vlan_tag_range(np_vlan_entry);
+        if vlan_min == 1 && vlan_max == 1 {
+            continue;
+        }
+        if is_access_port {
+            ret.tag = Some(vlan_min);
+        } else if np_vlan_entry.is_pvid && np_vlan_entry.is_egress_untagged {
+            ret.tag = Some(vlan_max);
+            is_native = true;
+        } else if vlan_min == vlan_max {
+            trunk_tags.push(LinuxBridgePortTunkTag::Id(vlan_min));
+        } else {
+            trunk_tags.push(LinuxBridgePortTunkTag::IdRange(
+                LinuxBridgePortVlanRange {
+                    max: vlan_max,
+                    min: vlan_min,
+                },
+            ));
+        }
+    }
+    if trunk_tags.is_empty() {
+        ret.mode = Some(LinuxBridgePortVlanMode::Access);
+    } else {
+        ret.mode = Some(LinuxBridgePortVlanMode::Trunk);
+        ret.enable_native = Some(is_native);
+    }
+    if ret.mode == Some(LinuxBridgePortVlanMode::Access)
+        && trunk_tags.is_empty()
+        && ret.tag.is_none()
+    {
+        None
+    } else {
+        ret.trunk_tags = Some(trunk_tags);
+
+        Some(ret)
+    }
+}
+
+fn is_access_port(np_vlan_entries: &[nispor::BridgeVlanEntry]) -> bool {
+    np_vlan_entries.len() == 1
+        && np_vlan_entries[0].is_pvid
+        && np_vlan_entries[0].is_egress_untagged
+}
+
+fn get_vlan_tag_range(np_vlan_entry: &nispor::BridgeVlanEntry) -> (u16, u16) {
+    np_vlan_entry.vid_range.unwrap_or((
+        np_vlan_entry.vid.unwrap_or(1),
+        np_vlan_entry.vid.unwrap_or(1),
+    ))
+}

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod ethernet;
 mod ip;
 mod linux_bridge;
+mod linux_bridge_port_vlan;
 mod show;
 mod veth;
 mod vlan;

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -1,15 +1,13 @@
 use crate::{BaseInterface, EthernetInterface, VethConfig};
 
 pub(crate) fn np_veth_to_nmstate(
-    np_iface: nispor::Iface,
+    np_iface: &nispor::Iface,
     base_iface: BaseInterface,
 ) -> EthernetInterface {
-    let veth_conf = match np_iface.veth {
-        Some(np_veth_info) => Some(VethConfig {
-            peer: np_veth_info.peer,
-        }),
-        None => None,
-    };
+    let veth_conf = np_iface.veth.as_ref().map(|np_veth_info| VethConfig {
+        peer: np_veth_info.peer.clone(),
+    });
+
     EthernetInterface {
         base: base_iface,
         veth: veth_conf,

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -1,16 +1,14 @@
 use crate::{BaseInterface, VlanConfig, VlanInterface};
 
 pub(crate) fn np_vlan_to_nmstate(
-    np_iface: nispor::Iface,
+    np_iface: &nispor::Iface,
     base_iface: BaseInterface,
 ) -> VlanInterface {
-    let vlan_conf = match np_iface.vlan {
-        Some(np_vlan_info) => Some(VlanConfig {
-            id: np_vlan_info.vlan_id,
-            base_iface: np_vlan_info.base_iface,
-        }),
-        None => None,
-    };
+    let vlan_conf = np_iface.vlan.as_ref().map(|np_vlan_info| VlanConfig {
+        id: np_vlan_info.vlan_id,
+        base_iface: np_vlan_info.base_iface.clone(),
+    });
+
     VlanInterface {
         base: base_iface,
         vlan: vlan_conf,

--- a/rust/src/lib/nm/bridge.rs
+++ b/rust/src/lib/nm/bridge.rs
@@ -1,5 +1,9 @@
-use crate::LinuxBridgeInterface;
-use nm_dbus::NmConnection;
+use nm_dbus::{NmConnection, NmSettingBridge, NmSettingBridgeVlanRange};
+
+use crate::{
+    LinuxBridgeInterface, LinuxBridgeOptions, LinuxBridgePortTunkTag,
+    LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode, LinuxBridgeStpOptions,
+};
 
 pub(crate) fn gen_nm_br_setting(
     br_iface: &LinuxBridgeInterface,
@@ -7,14 +11,177 @@ pub(crate) fn gen_nm_br_setting(
 ) {
     let mut nm_br_set = nm_conn.bridge.as_ref().cloned().unwrap_or_default();
 
-    if let Some(stp_enabled) = br_iface
-        .bridge
-        .as_ref()
-        .and_then(|br_conf| br_conf.options.as_ref())
-        .and_then(|br_opts| br_opts.stp.as_ref())
-        .and_then(|stp_opts| stp_opts.enabled)
-    {
-        nm_br_set.stp = Some(stp_enabled);
+    if let Some(br_conf) = br_iface.bridge.as_ref() {
+        if let Some(br_opts) = br_conf.options.as_ref() {
+            apply_br_options(&mut nm_br_set, br_opts)
+        }
+
+        if br_conf.port.is_some() {
+            nm_br_set.vlan_filtering =
+                Some(br_iface.vlan_filtering_is_enabled());
+        }
     }
+
     nm_conn.bridge = Some(nm_br_set);
+}
+
+fn apply_br_options(
+    nm_br_set: &mut NmSettingBridge,
+    br_opts: &LinuxBridgeOptions,
+) {
+    if let Some(v) = br_opts.group_addr.as_ref() {
+        nm_br_set.group_address = Some(v.to_string());
+    }
+    if let Some(v) = br_opts.group_forward_mask.as_ref() {
+        nm_br_set.group_forward_mask = Some((*v).into());
+    }
+    if let Some(v) = br_opts.group_fwd_mask.as_ref() {
+        nm_br_set.group_forward_mask = Some((*v).into());
+    }
+    if let Some(v) = br_opts.hash_max.as_ref() {
+        nm_br_set.multicast_hash_max = Some(*v);
+    }
+    if let Some(v) = br_opts.mac_ageing_time.as_ref() {
+        nm_br_set.ageing_time = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_last_member_count.as_ref() {
+        nm_br_set.multicast_last_member_count = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_last_member_interval.as_ref() {
+        nm_br_set.multicast_last_member_interval = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_membership_interval.as_ref() {
+        nm_br_set.multicast_membership_interval = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_querier.as_ref() {
+        nm_br_set.multicast_querier = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_querier_interval.as_ref() {
+        nm_br_set.multicast_querier_interval = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_query_interval.as_ref() {
+        nm_br_set.multicast_query_interval = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_query_response_interval.as_ref() {
+        nm_br_set.multicast_query_response_interval = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_query_use_ifaddr.as_ref() {
+        nm_br_set.multicast_query_use_ifaddr = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_router.as_ref() {
+        nm_br_set.multicast_router = Some(format!("{}", v));
+    }
+    if let Some(v) = br_opts.multicast_snooping.as_ref() {
+        nm_br_set.multicast_snooping = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_startup_query_count.as_ref() {
+        nm_br_set.multicast_startup_query_count = Some(*v);
+    }
+    if let Some(v) = br_opts.multicast_startup_query_interval.as_ref() {
+        nm_br_set.multicast_startup_query_interval = Some(*v);
+    }
+
+    if let Some(stp_opts) = br_opts.stp.as_ref() {
+        apply_stp_setting(nm_br_set, stp_opts);
+    }
+}
+
+fn apply_stp_setting(
+    nm_set: &mut NmSettingBridge,
+    opts: &LinuxBridgeStpOptions,
+) {
+    if let Some(v) = opts.enabled {
+        nm_set.stp = Some(v);
+    }
+    if let Some(v) = opts.forward_delay {
+        nm_set.forward_delay = Some(v.into());
+    }
+    if let Some(v) = opts.hello_time {
+        nm_set.hello_time = Some(v.into())
+    }
+    if let Some(v) = opts.max_age {
+        nm_set.max_age = Some(v.into())
+    };
+    if let Some(v) = opts.priority {
+        nm_set.priority = Some(v.into())
+    };
+}
+
+pub(crate) fn gen_nm_br_port_setting(
+    br_iface: &LinuxBridgeInterface,
+    nm_conn: &mut NmConnection,
+) {
+    let mut nm_set = nm_conn.bridge_port.as_ref().cloned().unwrap_or_default();
+    let br_port_conf = if let Some(i) = nm_conn
+        .iface_name()
+        .and_then(|iface_name| br_iface.get_port_conf(iface_name))
+    {
+        i
+    } else {
+        return;
+    };
+
+    if let Some(v) = br_port_conf.stp_hairpin_mode {
+        nm_set.hairpin_mode = Some(v);
+    }
+
+    if let Some(v) = br_port_conf.stp_path_cost {
+        nm_set.path_cost = Some(v);
+    }
+
+    if let Some(v) = br_port_conf.stp_priority {
+        nm_set.priority = Some(v.into());
+    }
+    if let Some(v) = br_port_conf.vlan.as_ref() {
+        nm_set.vlans = Some(nmstate_port_vlans_to_nm_vlan_range(v));
+    }
+
+    nm_conn.bridge_port = Some(nm_set);
+}
+
+fn nmstate_port_vlans_to_nm_vlan_range(
+    port_vlan_conf: &LinuxBridgePortVlanConfig,
+) -> Vec<NmSettingBridgeVlanRange> {
+    let mut ret = Vec::new();
+    match port_vlan_conf.mode {
+        Some(LinuxBridgePortVlanMode::Trunk) => {
+            if let Some(trunk_tags) = &port_vlan_conf.trunk_tags {
+                for trunk_tag in trunk_tags.as_slice() {
+                    ret.push(trunk_tag_to_nm_vlan_range(trunk_tag));
+                }
+            }
+            if let Some(t) = port_vlan_conf.tag {
+                ret.push(access_tag_to_nm_vlan_range(t))
+            }
+        }
+        Some(LinuxBridgePortVlanMode::Access) => {
+            if let Some(t) = port_vlan_conf.tag {
+                ret.push(access_tag_to_nm_vlan_range(t))
+            };
+        }
+        _ => (),
+    }
+
+    ret
+}
+
+fn trunk_tag_to_nm_vlan_range(
+    trunk_tag: &LinuxBridgePortTunkTag,
+) -> NmSettingBridgeVlanRange {
+    let mut ret = NmSettingBridgeVlanRange::new();
+    let (vid_min, vid_max) = trunk_tag.get_vlan_tag_range();
+    ret.vid_start = vid_min;
+    ret.vid_end = vid_max;
+    ret.pvid = false;
+    ret.untagged = false;
+    ret
+}
+
+fn access_tag_to_nm_vlan_range(tag: u16) -> NmSettingBridgeVlanRange {
+    let mut ret = NmSettingBridgeVlanRange::new();
+    ret.vid_start = tag;
+    ret.vid_end = tag;
+    ret.pvid = true;
+    ret.untagged = true;
+    ret
 }

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -209,10 +209,10 @@ fn nm_ip_setting_to_nmstate6(nm_ip_setting: &NmSettingIp) -> InterfaceIpv6 {
             NmSettingIpMethod::Disabled => (false, false, false),
             NmSettingIpMethod::LinkLocal
             | NmSettingIpMethod::Manual
-            | NmSettingIpMethod::Shared => (true, false, true),
+            | NmSettingIpMethod::Shared => (true, false, false),
             NmSettingIpMethod::Auto => (true, true, true),
             NmSettingIpMethod::Dhcp => (true, true, false),
-            NmSettingIpMethod::Ignore => (true, false, true),
+            NmSettingIpMethod::Ignore => (true, false, false),
         };
         InterfaceIpv6 {
             enabled,

--- a/rust/src/lib/state.rs
+++ b/rust/src/lib/state.rs
@@ -1,52 +1,35 @@
 use serde_json::Value;
 
-pub(crate) fn get_json_value_difference(
+pub(crate) fn get_json_value_difference<'a, 'b>(
     reference: String,
-    desire: &Value,
-    current: &Value,
-) -> Option<Value> {
+    desire: &'a Value,
+    current: &'b Value,
+) -> Option<(String, &'a Value, &'b Value)> {
     match (desire, current) {
         (Value::Bool(des), Value::Bool(cur)) => {
             if des != cur {
-                Some(Value::String(format!(
-                    "{}: desire bool: {}, current: {}",
-                    &reference, des, cur
-                )))
+                Some((reference, desire, current))
             } else {
                 None
             }
         }
         (Value::Number(des), Value::Number(cur)) => {
             if des != cur {
-                Some(Value::String(format!(
-                    "{}: desire number: {}, current: {}",
-                    &reference, des, cur
-                )))
+                Some((reference, desire, current))
             } else {
                 None
             }
         }
         (Value::String(des), Value::String(cur)) => {
             if des != cur {
-                Some(Value::String(format!(
-                    "{}: desire string: {}, current: {}",
-                    &reference, des, cur
-                )))
+                Some((reference, desire, current))
             } else {
                 None
             }
         }
         (Value::Array(des), Value::Array(cur)) => {
             if des.len() != cur.len() {
-                Some(Value::String(format!(
-                    "{} different array length {} vs {}: \
-                    desire {}, current: {}",
-                    &reference,
-                    des.len(),
-                    cur.len(),
-                    desire,
-                    current
-                )))
+                Some((reference, desire, current))
             } else {
                 for (index, des_element) in des.iter().enumerate() {
                     // The [] is safe as we already checked the length
@@ -74,18 +57,12 @@ pub(crate) fn get_json_value_difference(
                         return Some(difference);
                     }
                 } else {
-                    return Some(Value::String(format!(
-                        "{}: desire: {}, current: None",
-                        &reference, des_value
-                    )));
+                    return Some((reference, des_value, &Value::Null));
                 }
             }
             None
         }
         (Value::Null, _) => None,
-        (_, _) => Some(Value::String(format!(
-            "{}: type miss match, desire: {} current: {}",
-            &reference, desire, current
-        ))),
+        (_, _) => Some((reference, desire, current)),
     }
 }

--- a/rust/src/libnm_dbus/connection/bridge.rs
+++ b/rust/src/libnm_dbus/connection/bridge.rs
@@ -16,22 +16,155 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
+use log::error;
 use serde::Deserialize;
 
-use crate::{connection::DbusDictionary, error::NmError};
+use crate::{
+    connection::DbusDictionary,
+    convert::{
+        mac_str_to_u8_array, own_value_to_bytes_array, u8_array_to_mac_string,
+    },
+    ErrorKind, NmError,
+};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
 pub struct NmSettingBridge {
+    pub ageing_time: Option<u32>,
+    pub forward_delay: Option<u32>,
+    pub group_address: Option<String>,
+    pub group_forward_mask: Option<u32>,
+    pub hello_time: Option<u32>,
+    pub max_age: Option<u32>,
+    pub multicast_hash_max: Option<u32>,
+    pub multicast_last_member_count: Option<u32>,
+    pub multicast_last_member_interval: Option<u64>,
+    pub multicast_membership_interval: Option<u64>,
+    pub multicast_querier: Option<bool>,
+    pub multicast_querier_interval: Option<u64>,
+    pub multicast_query_interval: Option<u64>,
+    pub multicast_query_response_interval: Option<u64>,
+    pub multicast_query_use_ifaddr: Option<bool>,
+    pub multicast_router: Option<String>,
+    pub multicast_snooping: Option<bool>,
+    pub multicast_startup_query_count: Option<u32>,
+    pub multicast_startup_query_interval: Option<u64>,
+    pub priority: Option<u32>,
     pub stp: Option<bool>,
-    _other: HashMap<String, zvariant::OwnedValue>,
+    pub vlan_default_pvid: Option<u32>,
+    pub vlan_filtering: Option<bool>,
+    pub vlan_protocol: Option<NmVlanProtocol>,
+    pub vlan_stats_enabled: Option<bool>,
+    pub vlans: Option<Vec<NmSettingBridgeVlanRange>>,
+    _other: DbusDictionary,
 }
 
 impl TryFrom<DbusDictionary> for NmSettingBridge {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        // The 'interface-name' is deprecated in favor of
+        // `connection.interface-name`.
+        v.remove("interface-name");
+
         Ok(Self {
-            stp: _from_map!(v, "stp", bool::try_from)?,
+            ageing_time: _from_map!(v, "ageing-time", u32::try_from)?,
+            forward_delay: _from_map!(v, "forward-delay", u32::try_from)?,
+            group_address: _from_map!(
+                v,
+                "group-address",
+                own_value_to_bytes_array
+            )?
+            .map(u8_array_to_mac_string),
+            group_forward_mask: _from_map!(
+                v,
+                "group-forward-mask",
+                u32::try_from
+            )?,
+            hello_time: _from_map!(v, "hello-time", u32::try_from)?,
+            max_age: _from_map!(v, "max-age", u32::try_from)?,
+            multicast_hash_max: _from_map!(
+                v,
+                "multicast-hash-max",
+                u32::try_from
+            )?,
+            multicast_last_member_count: _from_map!(
+                v,
+                "multicast-last-member-count",
+                u32::try_from
+            )?,
+            multicast_last_member_interval: _from_map!(
+                v,
+                "multicast-last-member-interval",
+                u64::try_from
+            )?,
+            multicast_membership_interval: _from_map!(
+                v,
+                "multicast-membership-interval",
+                u64::try_from
+            )?,
+            multicast_querier: _from_map!(
+                v,
+                "multicast-querier",
+                bool::try_from
+            )?,
+            multicast_querier_interval: _from_map!(
+                v,
+                "multicast-querier-interval",
+                u64::try_from
+            )?,
+            multicast_query_interval: _from_map!(
+                v,
+                "multicast-query-interval",
+                u64::try_from
+            )?,
+            multicast_query_response_interval: _from_map!(
+                v,
+                "multicast-query-response-interval",
+                u64::try_from
+            )?,
+            multicast_query_use_ifaddr: _from_map!(
+                v,
+                "multicast-query-use-ifaddr",
+                bool::try_from
+            )?,
+            multicast_router: _from_map!(
+                v,
+                "multicast-router",
+                String::try_from
+            )?,
+            multicast_snooping: _from_map!(
+                v,
+                "multicast-snooping",
+                bool::try_from
+            )?,
+            multicast_startup_query_count: _from_map!(
+                v,
+                "multicast-startup-query-count",
+                u32::try_from
+            )?,
+            multicast_startup_query_interval: _from_map!(
+                v,
+                "multicast-startup-query-interval",
+                u64::try_from
+            )?,
+            priority: _from_map!(v, "priority", u32::try_from)?,
+            // Default value of STP is True
+            stp: _from_map!(v, "stp", bool::try_from)?.or(Some(true)),
+            vlan_default_pvid: _from_map!(
+                v,
+                "vlan-default-pvid",
+                u32::try_from
+            )?,
+            vlan_filtering: _from_map!(v, "vlan-filtering", bool::try_from)?,
+            vlan_protocol: _from_map!(v, "vlan-protocol", String::try_from)?
+                .map(NmVlanProtocol::try_from)
+                .transpose()?,
+            vlan_stats_enabled: _from_map!(
+                v,
+                "vlan-stats-enabled",
+                bool::try_from
+            )?,
+            vlans: _from_map!(v, "vlans", own_value_to_vlan_ranges)?,
             _other: v,
         })
     }
@@ -46,8 +179,111 @@ impl NmSettingBridge {
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
-        if let Some(v) = self.stp {
+        if let Some(v) = &self.stp {
             ret.insert("stp", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.ageing_time {
+            ret.insert("ageing-time", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.forward_delay {
+            ret.insert("forward-delay", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.group_address {
+            ret.insert(
+                "group-address",
+                zvariant::Value::new(mac_str_to_u8_array(v)),
+            );
+        }
+        if let Some(v) = &self.group_forward_mask {
+            ret.insert("group-forward-mask", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.hello_time {
+            ret.insert("hello-time", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.max_age {
+            ret.insert("max-age", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_hash_max {
+            ret.insert("multicast-hash-max", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_last_member_count {
+            ret.insert("multicast-last-member-count", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_last_member_interval {
+            ret.insert(
+                "multicast-last-member-interval",
+                zvariant::Value::new(v),
+            );
+        }
+        if let Some(v) = &self.multicast_membership_interval {
+            ret.insert(
+                "multicast-membership-interval",
+                zvariant::Value::new(v),
+            );
+        }
+        if let Some(v) = &self.multicast_querier {
+            ret.insert("multicast-querier", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_querier_interval {
+            ret.insert("multicast-querier-interval", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_query_interval {
+            ret.insert("multicast-query-interval", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_query_response_interval {
+            ret.insert(
+                "multicast-query-response-interval",
+                zvariant::Value::new(v),
+            );
+        }
+        if let Some(v) = &self.multicast_query_use_ifaddr {
+            ret.insert("multicast-query-use-ifaddr", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_router {
+            ret.insert("multicast-router", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_snooping {
+            ret.insert("multicast-snooping", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.multicast_startup_query_count {
+            ret.insert(
+                "multicast-startup-query-count",
+                zvariant::Value::new(v),
+            );
+        }
+        if let Some(v) = &self.multicast_startup_query_interval {
+            ret.insert(
+                "multicast-startup-query-interval",
+                zvariant::Value::new(v),
+            );
+        }
+        if let Some(v) = &self.priority {
+            ret.insert("priority", zvariant::Value::new(v));
+        }
+        // Default value of STP is True
+        if let Some(v) = &self.stp {
+            ret.insert("stp", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.vlan_default_pvid {
+            ret.insert("vlan-default-pvid", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.vlan_filtering {
+            ret.insert("vlan-filtering", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.vlan_protocol {
+            ret.insert("vlan-protocol", zvariant::Value::new(v.to_str()));
+        }
+        if let Some(v) = &self.vlan_stats_enabled {
+            ret.insert("vlan-stats-enabled", zvariant::Value::new(v));
+        }
+        if let Some(vlans) = &self.vlans {
+            let mut vlan_values = zvariant::Array::new(
+                zvariant::Signature::from_str_unchecked("a{sv}"),
+            );
+            for vlan in vlans {
+                vlan_values.append(vlan.to_value()?)?;
+            }
+            ret.insert("vlans", zvariant::Value::Array(vlan_values));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))
@@ -58,15 +294,78 @@ impl NmSettingBridge {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+pub struct NmSettingBridgeVlanRange {
+    pub vid_start: u16,
+    pub vid_end: u16,
+    pub pvid: bool,
+    pub untagged: bool,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingBridgeVlanRange {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vid_start: _from_map!(v, "vid-start", u16::try_from)?
+                .unwrap_or_default(),
+            vid_end: _from_map!(v, "vid-end", u16::try_from)?
+                .unwrap_or_default(),
+            pvid: _from_map!(v, "pvid", bool::try_from)?.unwrap_or_default(),
+            untagged: _from_map!(v, "untagged", bool::try_from)?
+                .unwrap_or_default(),
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingBridgeVlanRange {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+        ret.append(
+            zvariant::Value::new("vid-start"),
+            zvariant::Value::new(zvariant::Value::U16(self.vid_start)),
+        )?;
+        ret.append(
+            zvariant::Value::new("vid-end"),
+            zvariant::Value::new(zvariant::Value::U16(self.vid_end)),
+        )?;
+        ret.append(
+            zvariant::Value::new("pvid"),
+            zvariant::Value::new(zvariant::Value::Bool(self.pvid)),
+        )?;
+        ret.append(
+            zvariant::Value::new("untagged"),
+            zvariant::Value::new(zvariant::Value::Bool(self.untagged)),
+        )?;
+        Ok(zvariant::Value::Dict(ret))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct NmSettingBridgePort {
-    _other: HashMap<String, zvariant::OwnedValue>,
+    pub hairpin_mode: Option<bool>,
+    pub path_cost: Option<u32>,
+    pub priority: Option<u32>,
+    pub vlans: Option<Vec<NmSettingBridgeVlanRange>>,
+    _other: DbusDictionary,
 }
 
 impl TryFrom<DbusDictionary> for NmSettingBridgePort {
     type Error = NmError;
-    fn try_from(setting_value: DbusDictionary) -> Result<Self, Self::Error> {
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
         Ok(Self {
-            _other: setting_value,
+            hairpin_mode: _from_map!(v, "hairpin_mode", bool::try_from)?,
+            path_cost: _from_map!(v, "path-cost", u32::try_from)?,
+            priority: _from_map!(v, "priority", u32::try_from)?,
+            vlans: _from_map!(v, "vlans", own_value_to_vlan_ranges)?,
+            _other: v,
         })
     }
 }
@@ -80,9 +379,84 @@ impl NmSettingBridgePort {
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
+
+        self.hairpin_mode
+            .map(|v| ret.insert("hairpin-mode", zvariant::Value::new(v)));
+        self.path_cost
+            .map(|v| ret.insert("path-cost", zvariant::Value::new(v)));
+        self.priority
+            .map(|v| ret.insert("priority", zvariant::Value::new(v)));
+
+        if let Some(vlans) = self.vlans.as_ref() {
+            let mut vlan_values = zvariant::Array::new(
+                zvariant::Signature::from_str_unchecked("a{sv}"),
+            );
+            for vlan in vlans {
+                vlan_values.append(vlan.to_value()?)?;
+            }
+            ret.insert("vlans", zvariant::Value::Array(vlan_values));
+        }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))
         }));
         Ok(ret)
     }
+}
+
+const NM_VLAN_PROTOCOL_802_1Q: &str = "802.1Q";
+const NM_VLAN_PROTOCOL_802_1AD: &str = "802.1AD";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NmVlanProtocol {
+    Dot1Q,
+    Dot1Ad,
+}
+
+impl Default for NmVlanProtocol {
+    fn default() -> Self {
+        Self::Dot1Q
+    }
+}
+
+impl TryFrom<String> for NmVlanProtocol {
+    type Error = NmError;
+    fn try_from(vlan_protocol: String) -> Result<Self, Self::Error> {
+        match vlan_protocol.as_str() {
+            NM_VLAN_PROTOCOL_802_1Q => Ok(Self::Dot1Q),
+            NM_VLAN_PROTOCOL_802_1AD => Ok(Self::Dot1Ad),
+            _ => {
+                let e = NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Invalid VLAN protocol {}, only support: {} and {}",
+                        vlan_protocol,
+                        NM_VLAN_PROTOCOL_802_1Q,
+                        NM_VLAN_PROTOCOL_802_1AD
+                    ),
+                );
+                error!("{}", e);
+                Err(e)
+            }
+        }
+    }
+}
+
+impl NmVlanProtocol {
+    fn to_str(self) -> &'static str {
+        match self {
+            Self::Dot1Q => NM_VLAN_PROTOCOL_802_1Q,
+            Self::Dot1Ad => NM_VLAN_PROTOCOL_802_1AD,
+        }
+    }
+}
+
+fn own_value_to_vlan_ranges(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<NmSettingBridgeVlanRange>, NmError> {
+    let mut ret = Vec::new();
+    let raw_vlan_ranges = Vec::<DbusDictionary>::try_from(value)?;
+    for raw_vlan_range in raw_vlan_ranges {
+        ret.push(NmSettingBridgeVlanRange::try_from(raw_vlan_range)?);
+    }
+    Ok(ret)
 }

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -65,8 +65,8 @@ pub struct NmConnection {
     _other: HashMap<String, HashMap<String, zvariant::OwnedValue>>,
 }
 
-// The signature is the same as the NmConnectionDbusOwnedValue because we are going through the
-// try_from
+// The signature is the same as the NmConnectionDbusOwnedValue because we are
+// going through the try_from
 impl Type for NmConnection {
     fn signature() -> Signature<'static> {
         NmConnectionDbusOwnedValue::signature()

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -23,7 +23,10 @@ mod ovs;
 mod vlan;
 mod wired;
 
-pub use crate::connection::bridge::NmSettingBridge;
+pub use crate::connection::bridge::{
+    NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
+    NmVlanProtocol,
+};
 pub use crate::connection::conn::{NmConnection, NmSettingConnection};
 pub use crate::connection::ip::{NmSettingIp, NmSettingIpMethod};
 pub use crate::connection::ovs::{

--- a/rust/src/libnm_dbus/convert.rs
+++ b/rust/src/libnm_dbus/convert.rs
@@ -34,7 +34,8 @@ pub(crate) fn own_value_to_bytes_array(
 }
 
 pub(crate) fn u8_array_to_mac_string(data: Vec<u8>) -> String {
-    // TODO replace collect().join(":") with intersperse(":").collect() once it is stabilized
+    // TODO replace collect().join(":") with intersperse(":").collect() once it
+    // is stabilized
     data.iter()
         .map(|byte| format!("{:02X}", byte))
         .collect::<Vec<_>>()

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -24,9 +24,10 @@ mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
-    NmConnection, NmSettingBridge, NmSettingConnection, NmSettingIp,
-    NmSettingIpMethod, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
-    NmSettingVlan, NmSettingWired,
+    NmConnection, NmSettingBridge, NmSettingBridgeVlanRange,
+    NmSettingConnection, NmSettingIp, NmSettingIpMethod, NmSettingOvsBridge,
+    NmSettingOvsIface, NmSettingOvsPort, NmSettingVlan, NmSettingWired,
+    NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::error::{ErrorKind, NmError};

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -22,6 +22,7 @@ from .error import (
     NmstateInternalError,
     NmstatePluginError,
     NmstateNotImplementedError,
+    NmstateKernelIntegerRoundedError,
 )
 
 lib = cdll.LoadLibrary("libnmstate.so.2")
@@ -129,5 +130,7 @@ def apply_net_state(
             raise NmstatePluginError(err_msg)
         elif err_kind == "NotImplementedError":
             raise NmstateNotImplementedError(err_msg)
+        elif err_kind == "KernelIntegerRoundedError":
+            raise NmstateKernelIntegerRoundedError(err_msg)
         else:
             raise NmstateError(f"{err_kind}: {err_msg}")

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -160,7 +160,6 @@ def test_create_and_remove_linux_bridge_with_one_port(port0_up):
     port_name = port0_up[Interface.KEY][0][Interface.NAME]
     bridge_state = _create_bridge_subtree_config((port_name,))
     with linux_bridge(bridge_name, bridge_state) as desired_state:
-
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent(bridge_name)


### PR DESCRIPTION
Supporting linux bridge and also its vlan filtering.

Integration test enabled. The not enabled test cases are caused by missing
support of bond, copy_mac_from, state::ignore.

There are some cargo clippy warnings, will fix them in another patch to
minimize this one.