### PR TITLE
[nmstate-1.0] ovs: remove ovs-port prefix

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -117,8 +117,19 @@ def create_new_nm_simple_conn(iface, nm_profile):
         con_setting.import_by_profile(nm_profile, iface.is_controller)
         con_setting.set_profile_name(iface.name)
     else:
+        # OVS bridge and interfaces could sharing the same interface name, to
+        # distinguish them at NM connection level, instead of using interface
+        # name as connection name, we append a postfix.
+        con_name = iface.name
+        if iface.type == InterfaceType.OVS_BRIDGE:
+            con_name = con_name + "-br"
+        elif iface.type == InterfaceType.OVS_INTERFACE:
+            con_name = con_name + "-if"
+        elif iface.type == InterfaceType.OVS_PORT:
+            con_name = con_name + "-port"
+
         con_setting.create(
-            iface.name, iface.name, nm_iface_type, iface.is_controller
+            con_name, iface.name, nm_iface_type, iface.is_controller
         )
 
     apply_lldp_setting(con_setting, iface_info)

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -32,8 +32,6 @@ from libnmstate.schema import OvsDB
 from .common import NM
 
 
-PORT_PROFILE_PREFIX = "ovs-port-"
-
 CONTROLLER_TYPE_METADATA = "_controller_type"
 CONTROLLER_METADATA = "_controller"
 SETTING_OVS_EXTERNALIDS = "SettingOvsExternalIDs"
@@ -311,7 +309,7 @@ def create_iface_for_nm_ovs_port(iface):
     if ovs.is_ovs_lag_port(port_options):
         port_name = port_options[OB.Port.NAME]
     else:
-        port_name = PORT_PROFILE_PREFIX + iface_name
+        port_name = iface_name
     return OvsPortIface(
         {
             Interface.NAME: port_name,

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -420,7 +420,7 @@ def ovs_bridge_with_internal_port():
 def test_ovs_profile_been_delete_by_state_absent(
     ovs_bridge_with_internal_port,
 ):
-    assert _profile_exists(NM_PROFILE_DIRECTORY + "ovs0.nmconnection")
+    assert _profile_exists(NM_PROFILE_DIRECTORY + "ovs0-if.nmconnection")
     libnmstate.apply(
         {
             Interface.KEY: [
@@ -431,7 +431,7 @@ def test_ovs_profile_been_delete_by_state_absent(
             ]
         }
     )
-    assert not _profile_exists(NM_PROFILE_DIRECTORY + "ovs0.nmconnection")
+    assert not _profile_exists(NM_PROFILE_DIRECTORY + "ovs0-if.nmconnection")
 
 
 @pytest.fixture


### PR DESCRIPTION
Prepending the prefix causes ovnkube-node pods to crash.
This change adds -port postfix to ovs-interface connection instead.