### PR TITLE
rust: Add support for dummy interfaces

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -224,7 +224,8 @@ function run_tests {
             test_two_vlans_on_eth1_change_base_iface_mtu or \
             (test_two_vlans_on_eth1_change_mtu and not test_two_vlans_on_eth1_change_mtu_rollback) or \
             test_rollback_for_vlans or \
-            test_set_vlan_iface_down' \
+            test_set_vlan_iface_down or \
+            test_add_new_base_iface_with_vlan' \
             ${nmstate_pytest_extra_args}"
     fi
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -116,6 +116,7 @@ pub(crate) fn iface_type_to_nm(
         InterfaceType::OvsBridge => Ok("ovs-bridge".into()),
         InterfaceType::OvsInterface => Ok("ovs-interface".into()),
         InterfaceType::Vlan => Ok("vlan".to_string()),
+        InterfaceType::Dummy => Ok("dummy".to_string()),
         InterfaceType::Other(s) => Ok(s.to_string()),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,


### PR DESCRIPTION
Add dummy support with one vlan test that relies on dummies. 