### PR TITLE
sriov: New way to wait VF been created

### DIFF
--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -17,10 +17,9 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Ethernet
-from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
-from libnmstate.schema import InterfaceState
 from libnmstate.validator import validate_boolean
 from libnmstate.validator import validate_integer
 from libnmstate.validator import validate_string
@@ -34,7 +33,7 @@ DUPLEX_VALID_VALUES = ["full", "half"]
 
 
 class EthernetIface(BaseIface):
-    IS_GENERATED_VF_METADATA = "_is_generated_vf"
+    VF_IFACE_NAME_METADATA = "_vf_iface_name"
 
     def __init__(self, info, save_to_disk=True):
         super().__init__(info, save_to_disk)
@@ -60,10 +59,6 @@ class EthernetIface(BaseIface):
         state = super().state_for_verify()
         _capitalize_sriov_vf_mac(state)
         EthernetIface._canonicalize(state)
-        if self.is_generated_vf:
-            # The VF state is unpredictable when PF is changing total_vfs count
-            # Just don't verify generated VF state.
-            state.pop(Interface.STATE, None)
         return state
 
     @property
@@ -144,54 +139,6 @@ class EthernetIface(BaseIface):
                 minimum=0,
             )
 
-    def create_sriov_vf_ifaces(self):
-        # Currently there is not a way to see the relation between a SR-IOV PF
-        # and its VFs. Broadcom BCM57416 follows a different name pattern for
-        # PF and VF, therefore it needs to be parsed if present.
-        #
-        # PF name: ens2f0np0
-        # VF name: ens2f0v0
-        #
-        # The different name pattern is due to:
-        #  1. The `n` is for `multi-port PCI device` support.
-        #  2. The `p*` is `phys_port_name` provided by the BCM driver
-        #  `bnxt_en`.
-        #
-        # If the NIC is following the standard pattern "pfname+v+vfid", this
-        # split will not touch it and the vf_pattern will be the PF name.
-        # Ref: https://bugzilla.redhat.com/1959679
-        vf_pattern = self.name
-        multiport_pattern = (
-            MULTIPORT_PCI_DEVICE_PREFIX + BNXT_DRIVER_PHYS_PORT_PREFIX
-        )
-        if len(self.name.split(multiport_pattern)) == 2:
-            vf_pattern = self.name.split(multiport_pattern)[0]
-
-        vf_ifaces = [
-            EthernetIface(
-                {
-                    # According to manpage of systemd.net-naming-scheme(7),
-                    # SRIOV VF interface will have v{slot} in device name.
-                    # Currently, nmstate has no intention to support
-                    # user-defined udev rule on SRIOV interface naming policy.
-                    Interface.NAME: f"{vf_pattern}v{i}",
-                    Interface.TYPE: InterfaceType.ETHERNET,
-                    # VF will be in DOWN state initialy
-                    Interface.STATE: InterfaceState.DOWN,
-                }
-            )
-            for i in range(0, self.sriov_total_vfs)
-        ]
-        # The generated vf metadata cannot be part of the original dict.
-        for vf in vf_ifaces:
-            vf._info[EthernetIface.IS_GENERATED_VF_METADATA] = True
-
-        return vf_ifaces
-
-    @property
-    def is_generated_vf(self):
-        return self._info.get(EthernetIface.IS_GENERATED_VF_METADATA) is True
-
     def remove_vfs_entry_when_total_vfs_decreased(self):
         vfs_count = len(
             self._info[Ethernet.CONFIG_SUBTREE]
@@ -215,6 +162,16 @@ class EthernetIface(BaseIface):
     def check_total_vfs_matches_vf_list(self, total_vfs):
         return total_vfs == len(self.sriov_vfs)
 
+    def to_dict(self):
+        info = super().to_dict()
+        for vf_info in (
+            info.get(Ethernet.CONFIG_SUBTREE, {})
+            .get(Ethernet.SRIOV_SUBTREE, {})
+            .get(Ethernet.SRIOV.VFS_SUBTREE, [])
+        ):
+            vf_info.pop(EthernetIface.VF_IFACE_NAME_METADATA, None)
+        return info
+
 
 def _capitalize_sriov_vf_mac(state):
     vfs = (
@@ -226,3 +183,36 @@ def _capitalize_sriov_vf_mac(state):
         vf_mac = vf.get(Ethernet.SRIOV.VFS.MAC_ADDRESS)
         if vf_mac:
             vf[Ethernet.SRIOV.VFS.MAC_ADDRESS] = vf_mac.upper()
+
+
+def verify_sriov_vf(iface, cur_ifaces):
+    """
+    Checking whether VF interface is been created
+    """
+    if not (
+        iface.is_up
+        and (iface.is_desired or iface.is_changed)
+        and iface.type == InterfaceType.ETHERNET
+        and iface.sriov_total_vfs > 0
+    ):
+        return
+    cur_iface = cur_ifaces.get_iface(iface.name, iface.type)
+    if not cur_iface:
+        # Other verification will raise proper exception when current interface
+        # is missing
+        return
+    cur_vf_names = []
+    for sriov_vf in cur_iface.sriov_vfs:
+        if sriov_vf.get(EthernetIface.VF_IFACE_NAME_METADATA):
+            cur_vf_names.append(sriov_vf[EthernetIface.VF_IFACE_NAME_METADATA])
+
+    if len(cur_vf_names) != iface.sriov_total_vfs:
+        raise NmstateVerificationError(
+            f"Found VF ports count does not match desired "
+            f"{iface.sriov_total_vfs}, current is: {','.join(cur_vf_names)}"
+        )
+    for cur_vf_name in cur_vf_names:
+        if not cur_ifaces.get_iface(cur_vf_name, InterfaceType.ETHERNET):
+            raise NmstateVerificationError(
+                f"VF interface {cur_vf_name} of PF {iface.name} not found"
+            )

--- a/libnmstate/nispor/ethernet.py
+++ b/libnmstate/nispor/ethernet.py
@@ -21,6 +21,7 @@ from libnmstate.schema import Ethernet
 from libnmstate.schema import InterfaceType
 
 from .base_iface import NisporPluginBaseIface
+from libnmstate.ifaces.ethernet import EthernetIface
 
 
 class NisporPluginEthernetIface(NisporPluginBaseIface):
@@ -35,6 +36,7 @@ class NisporPluginEthernetIface(NisporPluginBaseIface):
             for vf in self.np_iface.sr_iov.vfs:
                 vf_infos.append(
                     {
+                        EthernetIface.VF_IFACE_NAME_METADATA: vf.iface_name,
                         Ethernet.SRIOV.VFS.ID: vf.vf_id,
                         Ethernet.SRIOV.VFS.MAC_ADDRESS: vf.mac.upper(),
                         Ethernet.SRIOV.VFS.SPOOF_CHECK: vf.spoof_check,

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -71,7 +71,6 @@ class NmProfiles:
             for iface in sorted(
                 list(net_state.ifaces.all_ifaces()), key=attrgetter("name")
             )
-            if not getattr(iface, "is_generated_vf", None)
         ]
 
         for profile in all_profiles:

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -102,8 +102,9 @@ def _create_sriov_vfs_from_config(vfs_config, sriov_setting, vf_ids_to_add):
 
 
 def _set_nm_attribute(vf_object, key, value):
-    nm_attr, nm_variant = SRIOV_NMSTATE_TO_NM_MAP[key]
-    vf_object.set_attribute(nm_attr, nm_variant(value))
+    if key in SRIOV_NMSTATE_TO_NM_MAP:
+        nm_attr, nm_variant = SRIOV_NMSTATE_TO_NM_MAP[key]
+        vf_object.set_attribute(nm_attr, nm_variant(value))
 
 
 def _remove_sriov_vfs_in_setting(vfs_config, sriov_setting, vf_ids_to_remove):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@
 PyGObject
 PyYAML
 setuptools
-nispor>=1.1.0
+nispor>=1.2.1

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -21,7 +21,6 @@ from copy import deepcopy
 
 import pytest
 
-from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Ethernet
@@ -502,21 +501,6 @@ class TestIfaces:
 
 
 class TestIfacesSriov:
-    def test_vf_been_auto_include_as_desired(self):
-        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
-        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
-        des_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
-            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
-        }
-        ifaces = Ifaces(des_iface_infos, [])
-        assert len(list(ifaces.all_ifaces())) == 3
-        assert ifaces.get_iface(
-            f"{FOO1_IFACE_NAME}v0", InterfaceType.ETHERNET
-        ).is_desired
-        assert ifaces.get_iface(
-            f"{FOO1_IFACE_NAME}v1", InterfaceType.ETHERNET
-        ).is_desired
-
     def test_ignore_vf_when_pf_is_down(self):
         des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
         des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
@@ -605,20 +589,3 @@ class TestIfacesSriov:
             )
             == 2
         )
-
-    def test_not_support_changing_pf_along_with_vfs_in_single_desire(self):
-        cur_iface_infos = [
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-        ]
-        cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
-        cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
-            Ethernet.SRIOV_SUBTREE: {
-                Ethernet.SRIOV.TOTAL_VFS: 1,
-            }
-        }
-        cur_iface_infos[1][Interface.NAME] = f"{FOO1_IFACE_NAME}v0"
-
-        des_iface_infos = deepcopy(cur_iface_infos)
-        with pytest.raises(NmstateNotSupportedError):
-            Ifaces(des_iface_infos, cur_iface_infos)


### PR DESCRIPTION
The nispor 1.2.1 has include VF interface name as
`NisporSriovVf.iface_name` which will be used to check whether VF
interface been created.

The old VF name guessing method is removed. The `verify_sriov_vf()` is
created to collect all VF interfaces name, then comparing it with
`total_vfs` count and check whether they exists in current state.