### PR TITLE
Rust: Support SR-IOV

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -11,8 +11,7 @@ path = "lib.rs"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 nm-dbus = {path = "../libnm_dbus"}
-#nispor = "1.2"
-nispor = { git = "https://github.com/nispor/nispor", branch = "base" }
+nispor = "1.2.1"
 log = "0.4.14"
 libc = "0.2.106"
 

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, InterfaceType};
+use crate::{
+    BaseInterface, InterfaceType, Interfaces, NmstateError, SrIovConfig,
+};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EthernetInterface {
@@ -43,20 +45,65 @@ impl EthernetInterface {
 
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.base.pre_verify_cleanup();
+
+        if let Some(eth_conf) = self.ethernet.as_mut() {
+            eth_conf.pre_verify_cleanup()
+        }
         self.base.iface_type = InterfaceType::Ethernet;
     }
 
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub(crate) fn sriov_is_enabled(&self) -> bool {
+        self.ethernet
+            .as_ref()
+            .and_then(|eth_conf| {
+                eth_conf.sr_iov.as_ref().map(SrIovConfig::sriov_is_enabled)
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn verify_sriov(
+        &self,
+        cur_ifaces: &Interfaces,
+    ) -> Result<(), NmstateError> {
+        if let Some(eth_conf) = &self.ethernet {
+            if let Some(sriov_conf) = &eth_conf.sr_iov {
+                sriov_conf.verify_sriov(self.base.name.as_str(), cur_ifaces)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub struct EthernetConfig {}
+#[serde(rename_all = "kebab-case")]
+pub struct EthernetConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sr_iov: Option<SrIovConfig>,
+}
 
 impl EthernetConfig {
-    pub(crate) fn update(&mut self, _other: Option<&EthernetConfig>) {
-        // TODO
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn update(&mut self, other: Option<&EthernetConfig>) {
+        if let Some(other) = other {
+            if let Some(sr_iov_conf) = &mut self.sr_iov {
+                sr_iov_conf.update(other.sr_iov.as_ref())
+            } else {
+                self.sr_iov = other.sr_iov.clone()
+            }
+        }
+    }
+
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        if let Some(sriov_conf) = self.sr_iov.as_mut() {
+            sriov_conf.pre_verify_cleanup()
+        }
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -165,6 +165,11 @@ impl Interfaces {
                 cur_clone.get_iface(iface.name(), iface.iface_type())
             {
                 iface.verify(cur_iface)?;
+                if let Interface::Ethernet(eth_iface) = iface {
+                    if eth_iface.sriov_is_enabled() {
+                        eth_iface.verify_sriov(cur_ifaces)?;
+                    }
+                }
             } else {
                 return Err(NmstateError::new(
                     ErrorKind::VerificationError,
@@ -218,7 +223,6 @@ impl Interfaces {
         let mut chg_ifaces = Self::new();
         let mut del_ifaces = Self::new();
 
-        resolve_unknown_ifaces(self, current)?;
         handle_changed_ports(self, current)?;
         self.set_up_priority()?;
 
@@ -278,6 +282,91 @@ impl Interfaces {
             state to place controller before its ports"
                 .to_string(),
         ))
+    }
+
+    pub(crate) fn has_sriov_enabled(&self) -> bool {
+        self.kernel_ifaces.values().any(|i| {
+            if let Interface::Ethernet(eth_iface) = i {
+                eth_iface.sriov_is_enabled()
+            } else {
+                false
+            }
+        })
+    }
+
+    pub(crate) fn resolve_unknown_ifaces(
+        &mut self,
+        cur_ifaces: &Self,
+    ) -> Result<(), NmstateError> {
+        let mut resolved_ifaces: Vec<Interface> = Vec::new();
+        for ((iface_name, iface_type), iface) in self.user_ifaces.iter() {
+            if iface_type != &InterfaceType::Unknown {
+                continue;
+            }
+
+            if iface.is_absent() {
+                for cur_iface in cur_ifaces.to_vec() {
+                    if cur_iface.name() == iface_name {
+                        let mut new_iface = cur_iface.clone();
+                        new_iface.base_iface_mut().state =
+                            InterfaceState::Absent;
+                        resolved_ifaces.push(new_iface);
+                    }
+                }
+            } else {
+                let mut found_iface = Vec::new();
+                for cur_iface in cur_ifaces.to_vec() {
+                    if cur_iface.name() == iface_name {
+                        let mut new_iface = iface.clone();
+                        new_iface.base_iface_mut().iface_type =
+                            cur_iface.iface_type().clone();
+                        found_iface.push(new_iface);
+                    }
+                }
+                match found_iface.len() {
+                    0 => {
+                        let e = NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Failed to find unknown type interface {} \
+                            in current state",
+                                iface_name
+                            ),
+                        );
+                        error!("{}", e);
+                        return Err(e);
+                    }
+                    1 => {
+                        let new_iface = Interface::deserialize(
+                            serde_json::to_value(&found_iface[0])?,
+                        )?;
+
+                        resolved_ifaces.push(new_iface);
+                    }
+                    _ => {
+                        let e = NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Found 2+ interface matching desired unknown \
+                            type interface {}: {:?}",
+                                iface_name, &found_iface
+                            ),
+                        );
+                        error!("{}", e);
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        for new_iface in resolved_ifaces {
+            self.user_ifaces.remove(&(
+                new_iface.name().to_string(),
+                InterfaceType::Unknown,
+            ));
+            self.push(new_iface);
+        }
+        Ok(())
     }
 }
 
@@ -339,77 +428,4 @@ fn gen_ifaces_to_del(
         }
     }
     del_ifaces
-}
-
-fn resolve_unknown_ifaces(
-    ifaces: &mut Interfaces,
-    cur_ifaces: &Interfaces,
-) -> Result<(), NmstateError> {
-    let mut resolved_ifaces: Vec<Interface> = Vec::new();
-    for ((iface_name, iface_type), iface) in ifaces.user_ifaces.iter() {
-        if iface_type != &InterfaceType::Unknown {
-            continue;
-        }
-
-        if iface.is_absent() {
-            for cur_iface in cur_ifaces.to_vec() {
-                if cur_iface.name() == iface_name {
-                    let mut new_iface = cur_iface.clone();
-                    new_iface.base_iface_mut().state = InterfaceState::Absent;
-                    resolved_ifaces.push(new_iface);
-                }
-            }
-        } else {
-            let mut found_iface = Vec::new();
-            for cur_iface in cur_ifaces.to_vec() {
-                if cur_iface.name() == iface_name {
-                    let mut new_iface = iface.clone();
-                    new_iface.base_iface_mut().iface_type =
-                        cur_iface.iface_type().clone();
-                    found_iface.push(new_iface);
-                }
-            }
-            match found_iface.len() {
-                0 => {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Failed to find unknown type interface {} \
-                            in current state",
-                            iface_name
-                        ),
-                    );
-                    error!("{}", e);
-                    return Err(e);
-                }
-                1 => {
-                    let new_iface = Interface::deserialize(
-                        serde_json::to_value(&found_iface[0])?,
-                    )?;
-
-                    resolved_ifaces.push(new_iface);
-                }
-                _ => {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Found 2+ interface matching desired unknown \
-                            type interface {}: {:?}",
-                            iface_name, &found_iface
-                        ),
-                    );
-                    error!("{}", e);
-                    return Err(e);
-                }
-            }
-        }
-    }
-
-    for new_iface in resolved_ifaces {
-        ifaces
-            .user_ifaces
-            .remove(&(new_iface.name().to_string(), InterfaceType::Unknown));
-        ifaces.push(new_iface);
-    }
-    Ok(())
 }

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -5,6 +5,7 @@ mod inter_ifaces;
 mod inter_ifaces_controller;
 mod linux_bridge;
 mod ovs;
+mod sriov;
 mod vlan;
 
 pub use base::*;
@@ -22,4 +23,5 @@ pub use ovs::{
     OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
     OvsInterface,
 };
+pub use sriov::{SrIovConfig, SrIovVfConfig};
 pub use vlan::{VlanConfig, VlanInterface};

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -1,0 +1,133 @@
+use log::error;
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, Interface, InterfaceType, Interfaces, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct SrIovConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_vfs: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vfs: Option<Vec<SrIovVfConfig>>,
+}
+
+impl SrIovConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn update(&mut self, other: Option<&SrIovConfig>) {
+        if let Some(other) = other {
+            if let Some(total_vfs) = other.total_vfs {
+                self.total_vfs = Some(total_vfs);
+            }
+            if let Some(vfs) = other.vfs.as_ref() {
+                self.vfs = Some(vfs.clone());
+            }
+        }
+    }
+
+    // Convert VF MAC address to upper case
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        if let Some(vfs) = self.vfs.as_mut() {
+            for vf in vfs {
+                if let Some(address) = vf.mac_address.as_mut() {
+                    address.make_ascii_uppercase()
+                }
+            }
+        }
+    }
+
+    pub(crate) fn sriov_is_enabled(&self) -> bool {
+        matches!(self.total_vfs, Some(i) if i > 0)
+    }
+
+    // Many SRIOV card require extra time for kernel and udev to setup the
+    // VF interface. This function will wait VF interface been found in
+    // cur_ifaces.
+    // This function does not handle the decrease of SRIOV count(interface been
+    // removed from kernel) as our test showed kernel does not require extra
+    // time on deleting interface.
+    pub(crate) fn verify_sriov(
+        &self,
+        pf_name: &str,
+        cur_ifaces: &Interfaces,
+    ) -> Result<(), NmstateError> {
+        let cur_pf_iface =
+            match cur_ifaces.get_iface(pf_name, InterfaceType::Ethernet) {
+                Some(Interface::Ethernet(i)) => i,
+                _ => {
+                    let e = NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!("Failed to find PF interface {}", pf_name),
+                    );
+                    error!("{}", e);
+                    return Err(e);
+                }
+            };
+
+        let vfs = if let Some(vfs) = cur_pf_iface
+            .ethernet
+            .as_ref()
+            .and_then(|eth_conf| eth_conf.sr_iov.as_ref())
+            .and_then(|sriov_conf| sriov_conf.vfs.as_ref())
+        {
+            vfs
+        } else {
+            return Ok(());
+        };
+        for vf in vfs {
+            if vf.iface_name.as_str().is_empty() {
+                let e = NmstateError::new(
+                    ErrorKind::VerificationError,
+                    format!(
+                        "Failed to find VF {} interface name of PF {}",
+                        vf.id, pf_name
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            } else if cur_ifaces
+                .get_iface(vf.iface_name.as_str(), InterfaceType::Ethernet)
+                .is_none()
+            {
+                let e = NmstateError::new(
+                    ErrorKind::VerificationError,
+                    format!(
+                        "Find VF {} interface name {} of PF {} \
+                        is not exist yet",
+                        vf.id, &vf.iface_name, pf_name
+                    ),
+                );
+                error!("{}", e);
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct SrIovVfConfig {
+    pub id: u32,
+    #[serde(skip)]
+    pub(crate) iface_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spoof_check: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_tx_rate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tx_rate: Option<u32>,
+}
+
+impl SrIovVfConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -20,7 +20,7 @@ pub use crate::ifaces::{
     LinuxBridgePortVlanRange, LinuxBridgeStpOptions, OvsBridgeBondConfig,
     OvsBridgeBondMode, OvsBridgeBondPortConfig, OvsBridgeConfig,
     OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig, OvsInterface,
-    VethConfig, VlanConfig, VlanInterface,
+    SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig, VlanInterface,
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 pub use crate::net_state::NetworkState;

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -1,11 +1,43 @@
-use crate::{BaseInterface, EthernetInterface};
+use crate::{
+    BaseInterface, EthernetConfig, EthernetInterface, SrIovConfig,
+    SrIovVfConfig,
+};
 
 pub(crate) fn np_ethernet_to_nmstate(
-    _np_iface: &nispor::Iface,
+    np_iface: &nispor::Iface,
     base_iface: BaseInterface,
 ) -> EthernetInterface {
-    EthernetInterface {
-        base: base_iface,
-        ..Default::default()
+    let mut iface = EthernetInterface::new();
+    iface.base = base_iface;
+    iface.ethernet = Some(gen_eth_conf(np_iface));
+    iface
+}
+
+fn gen_eth_conf(np_iface: &nispor::Iface) -> EthernetConfig {
+    let mut eth_conf = EthernetConfig::new();
+    if let Some(sriov_info) = &np_iface.sriov {
+        eth_conf.sr_iov = Some(gen_sriov_conf(sriov_info));
     }
+
+    eth_conf
+}
+
+fn gen_sriov_conf(sriov_info: &nispor::SriovInfo) -> SrIovConfig {
+    let mut ret = SrIovConfig::new();
+    let mut vfs: Vec<SrIovVfConfig> = Vec::new();
+    for vf_info in &sriov_info.vfs {
+        let mut vf = SrIovVfConfig::new();
+        vf.id = vf_info.id;
+        vf.iface_name =
+            vf_info.iface_name.as_ref().cloned().unwrap_or_default();
+        vf.mac_address = Some(vf_info.mac.to_ascii_uppercase());
+        vf.spoof_check = Some(vf_info.spoof_check);
+        vf.trust = Some(vf_info.trust);
+        vf.min_tx_rate = Some(vf_info.min_tx_rate);
+        vf.max_tx_rate = Some(vf_info.max_tx_rate);
+        vfs.push(vf);
+    }
+    ret.total_vfs = Some(vfs.len() as u32);
+    ret.vfs = Some(vfs);
+    ret
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -10,6 +10,7 @@ use crate::{
         gen_nm_ovs_iface_setting,
     },
     nm::profile::get_exist_profile,
+    nm::sriov::gen_nm_sriov_setting,
     nm::wired::gen_nm_wired_setting,
     ErrorKind, Interface, InterfaceType, NetworkState, NmstateError,
 };
@@ -101,6 +102,9 @@ pub(crate) fn iface_to_nm_connections(
         }
         Interface::Vlan(vlan_iface) => {
             nm_conn.vlan = vlan_iface.vlan.as_ref().map(NmSettingVlan::from)
+        }
+        Interface::Ethernet(eth_iface) => {
+            gen_nm_sriov_setting(eth_iface, &mut nm_conn);
         }
         _ => (),
     };

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -9,6 +9,7 @@ mod ip;
 mod ovs;
 mod profile;
 mod show;
+mod sriov;
 #[cfg(test)]
 mod unit_tests;
 mod vlan;

--- a/rust/src/lib/nm/sriov.rs
+++ b/rust/src/lib/nm/sriov.rs
@@ -1,0 +1,58 @@
+use crate::{EthernetInterface, SrIovVfConfig};
+use nm_dbus::{NmConnection, NmSettingSriovVf};
+
+pub(crate) fn gen_nm_sriov_setting(
+    iface: &EthernetInterface,
+    nm_conn: &mut NmConnection,
+) {
+    let sriov_conf = match iface
+        .ethernet
+        .as_ref()
+        .and_then(|eth_conf| eth_conf.sr_iov.as_ref())
+    {
+        Some(c) => c,
+        None => return,
+    };
+
+    if sriov_conf.total_vfs == Some(0) {
+        nm_conn.sriov = None;
+        return;
+    }
+
+    let mut nm_sriov_set = nm_conn.sriov.as_ref().cloned().unwrap_or_default();
+
+    if let Some(v) = sriov_conf.total_vfs {
+        nm_sriov_set.total_vfs = Some(v);
+    }
+
+    if let Some(vfs) = &sriov_conf.vfs {
+        nm_sriov_set.vfs = Some(gen_nm_vfs(vfs));
+    }
+
+    nm_conn.sriov = Some(nm_sriov_set);
+}
+
+fn gen_nm_vfs(vfs: &[SrIovVfConfig]) -> Vec<NmSettingSriovVf> {
+    let mut ret: Vec<NmSettingSriovVf> = Vec::new();
+    for vf in vfs {
+        let mut nm_vf = NmSettingSriovVf::new();
+        nm_vf.index = Some(vf.id);
+        if let Some(v) = &vf.mac_address {
+            nm_vf.mac = Some(v.to_string());
+        }
+        if let Some(v) = vf.spoof_check {
+            nm_vf.spoof_check = Some(v);
+        }
+        if let Some(v) = vf.trust {
+            nm_vf.trust = Some(v);
+        }
+        if let Some(v) = vf.min_tx_rate {
+            nm_vf.min_tx_rate = Some(v);
+        }
+        if let Some(v) = vf.max_tx_rate {
+            nm_vf.max_tx_rate = Some(v);
+        }
+        ret.push(nm_vf);
+    }
+    ret
+}

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -16,6 +16,7 @@ fn test_resolve_unknown_type_absent_eth() {
     let mut ifaces = Interfaces::new();
     ifaces.push(absent_iface);
 
+    ifaces.resolve_unknown_ifaces(&cur_ifaces).unwrap();
     let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
 
     let del_ifaces = del_ifaces.to_vec();

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
-mod ifaces_ctrller;
-
-#[cfg(test)]
 mod ifaces;
-
+#[cfg(test)]
+mod ifaces_ctrller;
+#[cfg(test)]
+mod sriov;
 #[cfg(test)]
 mod testlib;

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -1,0 +1,41 @@
+use crate::{
+    unit_tests::testlib::new_eth_iface, EthernetConfig, Interface, Interfaces,
+    SrIovConfig, SrIovVfConfig,
+};
+
+#[test]
+fn test_sriov_vf_mac_mix_case() {
+    let mut cur_ifaces = Interfaces::new();
+    let mut cur_iface = new_eth_iface("eth1");
+    if let Interface::Ethernet(ref mut eth_iface) = cur_iface {
+        let mut eth_conf = EthernetConfig::new();
+        let mut sriov_conf = SrIovConfig::new();
+        let mut vf_conf = SrIovVfConfig::new();
+        vf_conf.id = 0;
+        vf_conf.mac_address = Some("00:11:22:33:44:FF".into());
+        sriov_conf.vfs = Some(vec![vf_conf]);
+        eth_conf.sr_iov = Some(sriov_conf);
+        eth_iface.ethernet = Some(eth_conf);
+    } else {
+        panic!("Should be ethernet interface");
+    }
+    cur_ifaces.push(cur_iface);
+
+    let mut des_ifaces = Interfaces::new();
+    let mut des_iface = new_eth_iface("eth1");
+    if let Interface::Ethernet(ref mut eth_iface) = des_iface {
+        let mut eth_conf = EthernetConfig::new();
+        let mut sriov_conf = SrIovConfig::new();
+        let mut vf_conf = SrIovVfConfig::new();
+        vf_conf.id = 0;
+        vf_conf.mac_address = Some("00:11:22:33:44:Ff".into());
+        sriov_conf.vfs = Some(vec![vf_conf]);
+        eth_conf.sr_iov = Some(sriov_conf);
+        eth_iface.ethernet = Some(eth_conf);
+    } else {
+        panic!("Should be ethernet interface");
+    }
+    des_ifaces.push(des_iface);
+
+    des_ifaces.verify(&cur_ifaces).unwrap();
+}

--- a/rust/src/libnm_dbus/connection/bridge.rs
+++ b/rust/src/libnm_dbus/connection/bridge.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use log::error;
 use serde::Deserialize;
 
 use crate::{
@@ -24,7 +23,7 @@ use crate::{
     convert::{
         mac_str_to_u8_array, own_value_to_bytes_array, u8_array_to_mac_string,
     },
-    ErrorKind, NmError,
+    NmError, NmVlanProtocol,
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
@@ -400,53 +399,6 @@ impl NmSettingBridgePort {
             (key.as_str(), zvariant::Value::from(value.clone()))
         }));
         Ok(ret)
-    }
-}
-
-const NM_VLAN_PROTOCOL_802_1Q: &str = "802.1Q";
-const NM_VLAN_PROTOCOL_802_1AD: &str = "802.1AD";
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum NmVlanProtocol {
-    Dot1Q,
-    Dot1Ad,
-}
-
-impl Default for NmVlanProtocol {
-    fn default() -> Self {
-        Self::Dot1Q
-    }
-}
-
-impl TryFrom<String> for NmVlanProtocol {
-    type Error = NmError;
-    fn try_from(vlan_protocol: String) -> Result<Self, Self::Error> {
-        match vlan_protocol.as_str() {
-            NM_VLAN_PROTOCOL_802_1Q => Ok(Self::Dot1Q),
-            NM_VLAN_PROTOCOL_802_1AD => Ok(Self::Dot1Ad),
-            _ => {
-                let e = NmError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Invalid VLAN protocol {}, only support: {} and {}",
-                        vlan_protocol,
-                        NM_VLAN_PROTOCOL_802_1Q,
-                        NM_VLAN_PROTOCOL_802_1AD
-                    ),
-                );
-                error!("{}", e);
-                Err(e)
-            }
-        }
-    }
-}
-
-impl NmVlanProtocol {
-    fn to_str(self) -> &'static str {
-        match self {
-            Self::Dot1Q => NM_VLAN_PROTOCOL_802_1Q,
-            Self::Dot1Ad => NM_VLAN_PROTOCOL_802_1AD,
-        }
     }
 }
 

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -28,6 +28,7 @@ use crate::{
     connection::ovs::{
         NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
     },
+    connection::sriov::NmSettingSriov,
     connection::vlan::NmSettingVlan,
     connection::wired::NmSettingWired,
     dbus::{NM_DBUS_INTERFACE_ROOT, NM_DBUS_INTERFACE_SETTING},
@@ -60,6 +61,7 @@ pub struct NmConnection {
     pub ovs_iface: Option<NmSettingOvsIface>,
     pub wired: Option<NmSettingWired>,
     pub vlan: Option<NmSettingVlan>,
+    pub sriov: Option<NmSettingSriov>,
     #[serde(skip)]
     pub(crate) obj_path: String,
     _other: HashMap<String, HashMap<String, zvariant::OwnedValue>>,
@@ -105,6 +107,7 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
             )?,
             wired: _from_map!(v, "802-3-ethernet", NmSettingWired::try_from)?,
             vlan: _from_map!(v, "vlan", NmSettingVlan::try_from)?,
+            sriov: _from_map!(v, "sriov", NmSettingSriov::try_from)?,
             _other: v,
             ..Default::default()
         })
@@ -177,6 +180,9 @@ impl NmConnection {
         }
         if let Some(vlan) = &self.vlan {
             ret.insert("vlan", vlan.to_value()?);
+        }
+        if let Some(sriov) = &self.sriov {
+            ret.insert("sriov", sriov.to_value()?);
         }
         for (key, setting_value) in &self._other {
             let mut other_setting_value: HashMap<&str, zvariant::Value> =

--- a/rust/src/libnm_dbus/connection/macros.rs
+++ b/rust/src/libnm_dbus/connection/macros.rs
@@ -10,6 +10,14 @@ macro_rules! _connection_inner_string_member {
 
 macro_rules! _from_map {
     ($map: ident, $remove: expr, $convert: expr) => {
-        $map.remove($remove).map($convert).transpose()
+        $map.remove($remove).map($convert).transpose().map_err(|e| {
+            use crate::NmError;
+
+            let e = NmError::from(e);
+            NmError::new(
+                e.kind,
+                format!("key {} fail to convert: {}", $remove, e.msg),
+            )
+        })
     };
 }

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -20,19 +20,22 @@ mod bridge;
 mod conn;
 mod ip;
 mod ovs;
+mod sriov;
 mod vlan;
 mod wired;
 
 pub use crate::connection::bridge::{
     NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
-    NmVlanProtocol,
 };
 pub use crate::connection::conn::{NmConnection, NmSettingConnection};
 pub use crate::connection::ip::{NmSettingIp, NmSettingIpMethod};
 pub use crate::connection::ovs::{
     NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
 };
-pub use crate::connection::vlan::NmSettingVlan;
+pub use crate::connection::sriov::{
+    NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
+};
+pub use crate::connection::vlan::{NmSettingVlan, NmVlanProtocol};
 pub use crate::connection::wired::NmSettingWired;
 
 pub(crate) use crate::connection::conn::{

--- a/rust/src/libnm_dbus/connection/sriov.rs
+++ b/rust/src/libnm_dbus/connection/sriov.rs
@@ -1,0 +1,267 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{
+    connection::DbusDictionary,
+    dbus::{NM_TERNARY_FALSE, NM_TERNARY_TRUE},
+    error::NmError,
+    NmVlanProtocol,
+};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingSriov {
+    pub autoprobe_drivers: Option<bool>,
+    pub total_vfs: Option<u32>,
+    pub vfs: Option<Vec<NmSettingSriovVf>>,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingSriov {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            autoprobe_drivers: match _from_map!(
+                v,
+                "autoprobe-drivers",
+                i32::try_from
+            )? {
+                Some(NM_TERNARY_TRUE) => Some(true),
+                Some(NM_TERNARY_FALSE) => Some(false),
+                _ => None,
+            },
+            total_vfs: _from_map!(v, "total-vfs", u32::try_from)?,
+            vfs: _from_map!(v, "vfs", own_value_to_vfs)?,
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingSriov {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.autoprobe_drivers {
+            ret.insert(
+                "autoprobe-drivers",
+                zvariant::Value::new(match v {
+                    true => NM_TERNARY_TRUE,
+                    false => NM_TERNARY_FALSE,
+                }),
+            );
+        }
+        if let Some(v) = &self.total_vfs {
+            ret.insert("total-vfs", zvariant::Value::new(v));
+        }
+        if let Some(vfs) = self.vfs.as_ref() {
+            let mut vf_values = zvariant::Array::new(
+                zvariant::Signature::from_str_unchecked("a{sv}"),
+            );
+            for vf in vfs {
+                vf_values.append(vf.to_value()?)?;
+            }
+            ret.insert("vfs", zvariant::Value::Array(vf_values));
+        }
+
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingSriovVf {
+    pub index: Option<u32>,
+    pub mac: Option<String>,
+    pub spoof_check: Option<bool>,
+    pub trust: Option<bool>,
+    pub min_tx_rate: Option<u32>,
+    pub max_tx_rate: Option<u32>,
+    pub vlans: Option<Vec<NmSettingSriovVfVlan>>,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingSriovVf {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            index: _from_map!(v, "index", u32::try_from)?,
+            mac: _from_map!(v, "mac", String::try_from)?,
+            spoof_check: _from_map!(v, "spoof-check", bool::try_from)?,
+            trust: _from_map!(v, "trust", bool::try_from)?,
+            min_tx_rate: _from_map!(v, "min-tx-rate", u32::try_from)?,
+            max_tx_rate: _from_map!(v, "max-tx-rate", u32::try_from)?,
+            vlans: _from_map!(v, "vlans", own_value_to_vf_vlans)?,
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingSriovVf {
+    pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+
+        if let Some(v) = &self.index {
+            ret.append(
+                zvariant::Value::new("index"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.mac {
+            ret.append(
+                zvariant::Value::new("mac"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.spoof_check {
+            ret.append(
+                zvariant::Value::new("spoof-check"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.trust {
+            ret.append(
+                zvariant::Value::new("trust"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.min_tx_rate {
+            ret.append(
+                zvariant::Value::new("min-tx-rate"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.max_tx_rate {
+            ret.append(
+                zvariant::Value::new("max-tx-rate"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(vlans) = self.vlans.as_ref() {
+            let mut vlan_values = zvariant::Array::new(
+                zvariant::Signature::from_str_unchecked("a{sv}"),
+            );
+            for vlan in vlans {
+                vlan_values.append(vlan.to_value()?)?;
+            }
+            ret.append(
+                zvariant::Value::new("vlans"),
+                zvariant::Value::new(zvariant::Value::Array(vlan_values)),
+            )?;
+        }
+        for (key, value) in self._other.iter() {
+            ret.append(
+                zvariant::Value::new(key.as_str()),
+                zvariant::Value::from(value.clone()),
+            )?;
+        }
+
+        Ok(zvariant::Value::Dict(ret))
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingSriovVfVlan {
+    pub id: u32,
+    pub qos: u32,
+    pub protocol: NmVlanProtocol,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingSriovVfVlan {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: _from_map!(v, "id", u32::try_from)?.unwrap_or_default(),
+            qos: _from_map!(v, "qos", u32::try_from)?.unwrap_or_default(),
+            protocol: match _from_map!(v, "protocol", u32::try_from)? {
+                Some(1) => NmVlanProtocol::Dot1Ad,
+                _ => NmVlanProtocol::Dot1Q,
+            },
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingSriovVfVlan {
+    pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+        ret.append(
+            zvariant::Value::new("id"),
+            zvariant::Value::new(zvariant::Value::U32(self.id)),
+        )?;
+        ret.append(
+            zvariant::Value::new("qos"),
+            zvariant::Value::new(zvariant::Value::U32(self.qos)),
+        )?;
+        ret.append(
+            zvariant::Value::new("protocol"),
+            zvariant::Value::new(zvariant::Value::U32(match self.protocol {
+                NmVlanProtocol::Dot1Q => 0,
+                NmVlanProtocol::Dot1Ad => 1,
+            })),
+        )?;
+        Ok(zvariant::Value::Dict(ret))
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn own_value_to_vfs(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<NmSettingSriovVf>, NmError> {
+    let mut ret = Vec::new();
+    let raw_vfs = Vec::<DbusDictionary>::try_from(value)?;
+    for raw_vf in raw_vfs {
+        ret.push(NmSettingSriovVf::try_from(raw_vf)?);
+    }
+    Ok(ret)
+}
+
+fn own_value_to_vf_vlans(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<NmSettingSriovVfVlan>, NmError> {
+    let mut ret = Vec::new();
+    let raw_vfs = Vec::<DbusDictionary>::try_from(value)?;
+    for raw_vf in raw_vfs {
+        ret.push(NmSettingSriovVfVlan::try_from(raw_vf)?);
+    }
+    Ok(ret)
+}

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -1,8 +1,10 @@
-use crate::connection::DbusDictionary;
-use crate::NmError;
-use serde::Deserialize;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+
+use log::error;
+use serde::Deserialize;
+
+use crate::{connection::DbusDictionary, ErrorKind, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
@@ -42,5 +44,52 @@ impl NmSettingVlan {
 
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+const NM_VLAN_PROTOCOL_802_1Q: &str = "802.1Q";
+const NM_VLAN_PROTOCOL_802_1AD: &str = "802.1AD";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NmVlanProtocol {
+    Dot1Q,
+    Dot1Ad,
+}
+
+impl Default for NmVlanProtocol {
+    fn default() -> Self {
+        Self::Dot1Q
+    }
+}
+
+impl TryFrom<String> for NmVlanProtocol {
+    type Error = NmError;
+    fn try_from(vlan_protocol: String) -> Result<Self, Self::Error> {
+        match vlan_protocol.as_str() {
+            NM_VLAN_PROTOCOL_802_1Q => Ok(Self::Dot1Q),
+            NM_VLAN_PROTOCOL_802_1AD => Ok(Self::Dot1Ad),
+            _ => {
+                let e = NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Invalid VLAN protocol {}, only support: {} and {}",
+                        vlan_protocol,
+                        NM_VLAN_PROTOCOL_802_1Q,
+                        NM_VLAN_PROTOCOL_802_1AD
+                    ),
+                );
+                error!("{}", e);
+                Err(e)
+            }
+        }
+    }
+}
+
+impl NmVlanProtocol {
+    pub fn to_str(self) -> &'static str {
+        match self {
+            Self::Dot1Q => NM_VLAN_PROTOCOL_802_1Q,
+            Self::Dot1Ad => NM_VLAN_PROTOCOL_802_1AD,
+        }
     }
 }

--- a/rust/src/libnm_dbus/dbus.rs
+++ b/rust/src/libnm_dbus/dbus.rs
@@ -26,6 +26,9 @@ use crate::{
 const NM_CHECKPOINT_CREATE_FLAG_DELETE_NEW_CONNECTIONS: u32 = 0x02;
 const NM_CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES: u32 = 0x04;
 
+pub(crate) const NM_TERNARY_TRUE: i32 = 1;
+pub(crate) const NM_TERNARY_FALSE: i32 = 0;
+
 const CHECKPOINT_TMO: u32 = 30;
 
 const OBJ_PATH_NULL_STR: &str = "/";

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -26,8 +26,8 @@ pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
     NmConnection, NmSettingBridge, NmSettingBridgeVlanRange,
     NmSettingConnection, NmSettingIp, NmSettingIpMethod, NmSettingOvsBridge,
-    NmSettingOvsIface, NmSettingOvsPort, NmSettingVlan, NmSettingWired,
-    NmVlanProtocol,
+    NmSettingOvsIface, NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf,
+    NmSettingSriovVfVlan, NmSettingVlan, NmSettingWired, NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::error::{ErrorKind, NmError};


### PR DESCRIPTION
The intergation test cases in `sriov_test.py` passed on Intel i40e
cards.

The `SrIovConfig.verify_sriov()` function is introduced to wait VF
interface been created in kernel/udev.

The test indicate kernel/udev does not require extra time to remove VF
interface when decreasing SR-IOV VF count.
