### PR TITLE
rust, bond: add support to bond interfaces

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -255,6 +255,26 @@ function run_tests {
             tests/integration/route_test.py \
             -k 'not rule' \
             ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/bond_test.py \
+            -k '\
+            not test_preserve_bond_after_bridge_removal and \
+            not test_bond_mac_restriction_without_mac_in_desire and \
+            not test_bond_mac_restriction_with_mac_in_desire and \
+            not test_bond_mac_restriction_in_desire_mac_in_current and \
+            not test_bond_mac_restriction_in_current_mac_in_desire and \
+            not test_create_bond_with_both_miimon_and_arp_internal and \
+            not test_create_bond_with_copy_mac_from and \
+            not test_create_bond_with_copy_mac_from_bond_port_perm_hwaddr and \
+            not test_remove_mode4_bond_and_create_mode5_with_the_same_port and \
+            not test_create_bond_without_mode and \
+            not test_ignore_verification_error_on_invalid_bond_option and \
+            not test_bond_ad_actor_system_with_multicast_mac_address' \
+            ${nmstate_pytest_extra_args}"
     fi
 }
 

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -6,6 +6,7 @@ pub enum ErrorKind {
     VerificationError,
     NotImplementedError,
     KernelIntegerRoundedError,
+    ValueError,
 }
 
 impl std::fmt::Display for ErrorKind {

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -2,9 +2,9 @@ use log::{error, warn};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
-    state::get_json_value_difference, BaseInterface, DummyInterface, ErrorKind,
-    EthernetInterface, LinuxBridgeInterface, NmstateError, OvsBridgeInterface,
-    OvsInterface, VlanInterface,
+    state::get_json_value_difference, BaseInterface, BondInterface,
+    DummyInterface, ErrorKind, EthernetInterface, LinuxBridgeInterface,
+    NmstateError, OvsBridgeInterface, OvsInterface, VlanInterface,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -144,6 +144,7 @@ impl UnknownInterface {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Interface {
+    Bond(BondInterface),
     Dummy(DummyInterface),
     Ethernet(EthernetInterface),
     LinuxBridge(LinuxBridgeInterface),
@@ -171,6 +172,11 @@ impl<'de> Deserialize<'de> for Interface {
                 let inner = LinuxBridgeInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
                 Ok(Interface::LinuxBridge(inner))
+            }
+            Some(InterfaceType::Bond) => {
+                let inner = BondInterface::deserialize(v)
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Interface::Bond(inner))
             }
             Some(InterfaceType::Veth) => {
                 let inner = EthernetInterface::deserialize(v)
@@ -216,6 +222,7 @@ impl Interface {
     pub fn name(&self) -> &str {
         match self {
             Self::LinuxBridge(iface) => iface.base.name.as_str(),
+            Self::Bond(iface) => iface.base.name.as_str(),
             Self::Ethernet(iface) => iface.base.name.as_str(),
             Self::Vlan(iface) => iface.base.name.as_str(),
             Self::Dummy(iface) => iface.base.name.as_str(),
@@ -240,6 +247,7 @@ impl Interface {
     pub fn iface_type(&self) -> InterfaceType {
         match self {
             Self::LinuxBridge(iface) => iface.base.iface_type.clone(),
+            Self::Bond(iface) => iface.base.iface_type.clone(),
             Self::Ethernet(iface) => iface.base.iface_type.clone(),
             Self::Vlan(iface) => iface.base.iface_type.clone(),
             Self::Dummy(iface) => iface.base.iface_type.clone(),
@@ -281,6 +289,11 @@ impl Interface {
                 new_iface.base = iface.base.clone_name_type_only();
                 Self::OvsBridge(new_iface)
             }
+            Self::Bond(iface) => {
+                let mut new_iface = BondInterface::new();
+                new_iface.base = iface.base.clone_name_type_only();
+                Self::Bond(new_iface)
+            }
             Self::Unknown(iface) => {
                 let mut new_iface = UnknownInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
@@ -313,6 +326,7 @@ impl Interface {
     pub fn base_iface(&self) -> &BaseInterface {
         match self {
             Self::LinuxBridge(iface) => &iface.base,
+            Self::Bond(iface) => &iface.base,
             Self::Ethernet(iface) => &iface.base,
             Self::Vlan(iface) => &iface.base,
             Self::Dummy(iface) => &iface.base,
@@ -325,6 +339,7 @@ impl Interface {
     pub(crate) fn base_iface_mut(&mut self) -> &mut BaseInterface {
         match self {
             Self::LinuxBridge(iface) => &mut iface.base,
+            Self::Bond(iface) => &mut iface.base,
             Self::Ethernet(iface) => &mut iface.base,
             Self::Vlan(iface) => &mut iface.base,
             Self::Dummy(iface) => &mut iface.base,
@@ -340,12 +355,14 @@ impl Interface {
             match self {
                 Self::LinuxBridge(_) => Some(Vec::new()),
                 Self::OvsBridge(_) => Some(Vec::new()),
+                Self::Bond(_) => Some(Vec::new()),
                 _ => None,
             }
         } else {
             match self {
                 Self::LinuxBridge(iface) => iface.ports(),
                 Self::OvsBridge(iface) => iface.ports(),
+                Self::Bond(iface) => iface.ports(),
                 _ => None,
             }
         }
@@ -360,6 +377,16 @@ impl Interface {
             Self::LinuxBridge(iface) => {
                 if let Self::LinuxBridge(other_iface) = other {
                     iface.update_bridge(other_iface);
+                } else {
+                    warn!(
+                        "Don't know how to update iface {:?} with {:?}",
+                        iface, other
+                    );
+                }
+            }
+            Self::Bond(iface) => {
+                if let Self::Bond(other_iface) = other {
+                    iface.update_bond(other_iface);
                 } else {
                     warn!(
                         "Don't know how to update iface {:?} with {:?}",
@@ -405,6 +432,9 @@ impl Interface {
     pub(crate) fn pre_verify_cleanup(&mut self) {
         match self {
             Self::LinuxBridge(ref mut iface) => {
+                iface.pre_verify_cleanup();
+            }
+            Self::Bond(ref mut iface) => {
                 iface.pre_verify_cleanup();
             }
             Self::Ethernet(ref mut iface) => {
@@ -476,6 +506,10 @@ impl Interface {
                 }
             }
 
+            if reference.contains("link-aggregation.options") {
+                return Ok(());
+            }
+
             Err(NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(
@@ -491,6 +525,8 @@ impl Interface {
     pub(crate) fn validate(&self) -> Result<(), NmstateError> {
         if let Interface::LinuxBridge(iface) = self {
             iface.validate()?;
+        } else if let Interface::Bond(iface) = self {
+            iface.validate()?;
         }
         Ok(())
     }
@@ -498,6 +534,8 @@ impl Interface {
     pub(crate) fn remove_port(&mut self, port_name: &str) {
         if let Interface::LinuxBridge(br_iface) = self {
             br_iface.remove_port(port_name);
+        } else if let Interface::Bond(iface) = self {
+            iface.remove_port(port_name);
         }
     }
 

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1,0 +1,571 @@
+use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct BondInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "link-aggregation"
+    )]
+    pub bond: Option<BondConfig>,
+}
+
+impl Default for BondInterface {
+    fn default() -> Self {
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::Bond;
+        Self { base, bond: None }
+    }
+}
+
+impl BondInterface {
+    pub(crate) fn update_bond(&mut self, other: &BondInterface) {
+        if let Some(bond_conf) = &mut self.bond {
+            bond_conf.update(other.bond.as_ref());
+        } else {
+            self.bond = other.bond.clone();
+        }
+    }
+
+    // Return None when desire state does not mention ports
+    pub(crate) fn ports(&self) -> Option<Vec<&str>> {
+        self.bond
+            .as_ref()
+            .and_then(|bond_conf| bond_conf.port.as_ref())
+            .map(|ports| ports.as_slice().iter().map(|p| p.as_str()).collect())
+    }
+
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        self.base.pre_verify_cleanup();
+        self.drop_empty_arp_ip_target();
+        self.sort_ports();
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn sort_ports(&mut self) {
+        if let Some(ref mut bond_conf) = self.bond {
+            if let Some(ref mut port_conf) = &mut bond_conf.port {
+                port_conf.sort_unstable_by_key(|p| p.clone())
+            }
+        }
+    }
+
+    fn drop_empty_arp_ip_target(&mut self) {
+        if let Some(ref mut bond_conf) = self.bond {
+            if let Some(ref mut bond_opts) = &mut bond_conf.options {
+                if let Some(ref mut arp_ip_target) = bond_opts.arp_ip_target {
+                    if arp_ip_target.is_empty() {
+                        bond_opts.arp_ip_target = None;
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        self.base.validate()?;
+        if let Some(bond_conf) = &self.bond {
+            bond_conf.validate(&self.base)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn remove_port(&mut self, port_to_remove: &str) {
+        if let Some(index) = self.bond.as_ref().and_then(|bond_conf| {
+            bond_conf.port.as_ref().and_then(|ports| {
+                ports
+                    .iter()
+                    .position(|port_name| port_name == port_to_remove)
+            })
+        }) {
+            self.bond
+                .as_mut()
+                .and_then(|bond_conf| bond_conf.port.as_mut())
+                .map(|ports| ports.remove(index));
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum BondMode {
+    #[serde(rename = "balance-rr")]
+    RoundRobin,
+    #[serde(rename = "active-backup")]
+    ActiveBackup,
+    #[serde(rename = "balance-xor")]
+    XOR,
+    #[serde(rename = "broadcast")]
+    Broadcast,
+    #[serde(rename = "802.3ad")]
+    LACP,
+    #[serde(rename = "balance-tlb")]
+    TLB,
+    #[serde(rename = "balance-alb")]
+    ALB,
+    Unknown,
+}
+
+impl Default for BondMode {
+    fn default() -> Self {
+        Self::RoundRobin
+    }
+}
+
+impl std::fmt::Display for BondMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BondMode::RoundRobin => "balance-rr",
+                BondMode::ActiveBackup => "active-backup",
+                BondMode::XOR => "balance-xor",
+                BondMode::Broadcast => "broadcast",
+                BondMode::LACP => "802.3ad",
+                BondMode::TLB => "balance-tlb",
+                BondMode::ALB => "balance-alb",
+                BondMode::Unknown => "unknown",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BondConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<BondMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<BondOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<Vec<String>>,
+}
+
+impl BondConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(
+        &self,
+        base: &BaseInterface,
+    ) -> Result<(), NmstateError> {
+        if let Some(opts) = &self.options {
+            if let Some(mode) = &self.mode {
+                opts.validate(mode, base)?;
+            } else {
+                return Err(NmstateError::new(
+                    ErrorKind::ValueError,
+                    "Bond mode is mandatory".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn update(&mut self, other: Option<&BondConfig>) {
+        if let Some(other) = other {
+            self.mode = other.mode.clone();
+            self.options = other.options.clone();
+            self.port = other.port.clone();
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondAdSelect {
+    #[serde(alias = "0")]
+    Stable,
+    #[serde(alias = "1")]
+    Bandwidth,
+    #[serde(alias = "2")]
+    Count,
+}
+
+impl BondAdSelect {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::Stable => 0,
+            Self::Bandwidth => 1,
+            Self::Count => 2,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondLacpRate {
+    #[serde(alias = "0")]
+    Slow,
+    #[serde(alias = "1")]
+    Fast,
+}
+
+impl BondLacpRate {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::Slow => 0,
+            Self::Fast => 1,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondAllPortsActive {
+    #[serde(alias = "0")]
+    Dropped,
+    #[serde(alias = "1")]
+    Delivered,
+}
+
+impl BondAllPortsActive {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::Dropped => 0,
+            Self::Delivered => 1,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondArpAllTargets {
+    #[serde(alias = "0")]
+    Any,
+    #[serde(alias = "1")]
+    All,
+}
+
+impl BondArpAllTargets {
+    pub fn to_u32(&self) -> u32 {
+        match self {
+            Self::Any => 0,
+            Self::All => 1,
+        }
+    }
+}
+
+const BOND_STATE_ACTIVE: u8 = 0;
+const BOND_STATE_BACKUP: u8 = 1;
+
+const BOND_ARP_VALIDATE_NONE: u32 = 0;
+const BOND_ARP_VALIDATE_ACTIVE: u32 = 1 << BOND_STATE_ACTIVE as u32;
+const BOND_ARP_VALIDATE_BACKUP: u32 = 1 << BOND_STATE_BACKUP as u32;
+const BOND_ARP_VALIDATE_ALL: u32 =
+    BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_VALIDATE_BACKUP;
+const BOND_ARP_FILTER: u32 = BOND_ARP_VALIDATE_ALL + 1;
+const BOND_ARP_FILTER_ACTIVE: u32 = BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_FILTER;
+const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondArpValidate {
+    None,
+    Active,
+    Backup,
+    All,
+    Filter,
+    #[serde(rename = "filter_active")]
+    FilterActive,
+    #[serde(rename = "filter_backup")]
+    FilterBackup,
+}
+
+impl BondArpValidate {
+    pub fn to_u32(&self) -> u32 {
+        match self {
+            Self::None => BOND_ARP_VALIDATE_NONE,
+            Self::Active => BOND_ARP_VALIDATE_ACTIVE,
+            Self::Backup => BOND_ARP_VALIDATE_BACKUP,
+            Self::All => BOND_ARP_VALIDATE_ALL,
+            Self::Filter => BOND_ARP_FILTER,
+            Self::FilterActive => BOND_ARP_FILTER_ACTIVE,
+            Self::FilterBackup => BOND_ARP_FILTER_BACKUP,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondFailOverMac {
+    #[serde(alias = "0")]
+    None,
+    #[serde(alias = "1")]
+    Active,
+    #[serde(alias = "2")]
+    Follow,
+}
+
+impl BondFailOverMac {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::Active => 1,
+            Self::Follow => 2,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub enum BondPrimaryReselect {
+    #[serde(alias = "0")]
+    Always,
+    #[serde(alias = "1")]
+    Better,
+    #[serde(alias = "2")]
+    Failure,
+}
+
+impl BondPrimaryReselect {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::Always => 0,
+            Self::Better => 1,
+            Self::Failure => 2,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum BondXmitHashPolicy {
+    #[serde(rename = "layer2")]
+    #[serde(alias = "0")]
+    Layer2,
+    #[serde(rename = "layer3+4")]
+    #[serde(alias = "1")]
+    Layer34,
+    #[serde(rename = "layer2+3")]
+    #[serde(alias = "2")]
+    Layer23,
+    #[serde(rename = "encap2+3")]
+    #[serde(alias = "3")]
+    Encap23,
+    #[serde(rename = "encap3+4")]
+    #[serde(alias = "4")]
+    Encap34,
+    #[serde(rename = "vlan+srcmac")]
+    #[serde(alias = "5")]
+    VlanSrcMac,
+}
+
+impl BondXmitHashPolicy {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            Self::Layer2 => 0,
+            Self::Layer34 => 1,
+            Self::Layer23 => 2,
+            Self::Encap23 => 3,
+            Self::Encap34 => 4,
+            Self::VlanSrcMac => 5,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+pub struct BondOptions {
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u16",
+        default
+    )]
+    pub ad_actor_sys_prio: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_actor_system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_select: Option<BondAdSelect>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u16",
+        default
+    )]
+    pub ad_user_port_key: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_slaves_active: Option<BondAllPortsActive>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_all_targets: Option<BondArpAllTargets>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub arp_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_ip_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_validate: Option<BondArpValidate>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub downdelay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_over_mac: Option<BondFailOverMac>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lacp_rate: Option<BondLacpRate>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub lp_interval: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub miimon: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub min_links: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u8",
+        default
+    )]
+    pub num_grat_arp: Option<u8>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u8",
+        default
+    )]
+    pub num_unsol_na: Option<u8>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub packets_per_slave: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_reselect: Option<BondPrimaryReselect>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub resend_igmp: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tlb_dynamic_lb: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "json_to_u32",
+        default
+    )]
+    pub updelay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_carrier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub xmit_hash_policy: Option<BondXmitHashPolicy>,
+}
+
+fn json_to_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let json_value: serde_json::Value = Deserialize::deserialize(deserializer)?;
+    let u32_value: u32 = match json_value.as_u64() {
+        None => {
+            if let Some(str_value) = json_value.as_str() {
+                if str_value.chars().all(char::is_numeric) {
+                    str_value.parse::<u32>().map_err(D::Error::custom)?
+                } else {
+                    return Err(NmstateError::new(
+                            ErrorKind::ValueError,
+                            format!("Property value: {} is not valid, only numeric values are allowed.", str_value)))
+                    .map_err(D::Error::custom);
+                }
+            } else {
+                return Err(NmstateError::new(
+                        ErrorKind::ValueError,
+                        format!("Property value: {} is not valid, only numeric values are allowed.", json_value)))
+                .map_err(D::Error::custom);
+            }
+        }
+        Some(u64_value) => u64_value as u32,
+    };
+
+    Ok(Some(u32_value))
+}
+
+fn json_to_u16<'de, D>(deserializer: D) -> Result<Option<u16>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(u32_value) = json_to_u32(deserializer)? {
+        Ok(Some(u32_value as u16))
+    } else {
+        Ok(None)
+    }
+}
+
+fn json_to_u8<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(u32_value) = json_to_u32(deserializer)? {
+        Ok(Some(u32_value as u8))
+    } else {
+        Ok(None)
+    }
+}
+
+impl BondOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(
+        &self,
+        mode: &BondMode,
+        base: &BaseInterface,
+    ) -> Result<(), NmstateError> {
+        self.fix_mac_restricted_mode(mode, base)?;
+        self.validate_ad_actor_system_mac_address()?;
+        Ok(())
+    }
+
+    fn fix_mac_restricted_mode(
+        &self,
+        mode: &BondMode,
+        base: &BaseInterface,
+    ) -> Result<(), NmstateError> {
+        if let Some(fail_over_mac) = &self.fail_over_mac {
+            if *mode == BondMode::ActiveBackup
+                && *fail_over_mac == BondFailOverMac::Active
+                && base.mac_address.is_some()
+            {
+                return Err(NmstateError::new(
+                        ErrorKind::ValueError,
+                            "MAC address cannot be specified in bond interface along with fail_over_mac active on active backup mode".to_string()
+                    ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_ad_actor_system_mac_address(&self) -> Result<(), NmstateError> {
+        if let Some(ad_actor_system) = &self.ad_actor_system {
+            if ad_actor_system.to_uppercase().starts_with("01:00:5E") {
+                return Err(NmstateError::new(
+                        ErrorKind::ValueError,
+                            "The ad_actor_system bond option cannot be an IANA multicast address(prefix with 01:00:5E)".to_string()
+                    ));
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -1,4 +1,5 @@
 mod base;
+mod bond;
 mod dummy;
 mod ethernet;
 mod inter_ifaces;
@@ -9,6 +10,11 @@ mod sriov;
 mod vlan;
 
 pub use base::*;
+pub use bond::{
+    BondAdSelect, BondAllPortsActive, BondArpAllTargets, BondArpValidate,
+    BondConfig, BondFailOverMac, BondInterface, BondLacpRate, BondMode,
+    BondOptions, BondPrimaryReselect, BondXmitHashPolicy,
+};
 pub use dummy::DummyInterface;
 pub use ethernet::{EthernetConfig, EthernetInterface, VethConfig};
 pub use inter_ifaces::*;

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -14,10 +14,13 @@ pub use crate::iface::{
     Interface, InterfaceState, InterfaceType, UnknownInterface,
 };
 pub use crate::ifaces::{
-    BaseInterface, DummyInterface, EthernetConfig, EthernetInterface,
-    Interfaces, LinuxBridgeConfig, LinuxBridgeInterface,
-    LinuxBridgeMulticastRouterType, LinuxBridgeOptions, LinuxBridgePortConfig,
-    LinuxBridgePortTunkTag, LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode,
+    BaseInterface, BondAdSelect, BondAllPortsActive, BondArpAllTargets,
+    BondArpValidate, BondConfig, BondFailOverMac, BondInterface, BondLacpRate,
+    BondMode, BondOptions, BondPrimaryReselect, BondXmitHashPolicy,
+    DummyInterface, EthernetConfig, EthernetInterface, Interfaces,
+    LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeMulticastRouterType,
+    LinuxBridgeOptions, LinuxBridgePortConfig, LinuxBridgePortTunkTag,
+    LinuxBridgePortVlanConfig, LinuxBridgePortVlanMode,
     LinuxBridgePortVlanRange, LinuxBridgeStpOptions, OvsBridgeBondConfig,
     OvsBridgeBondMode, OvsBridgeBondPortConfig, OvsBridgeConfig,
     OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig, OvsInterface,

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -58,6 +58,7 @@ fn nmstate_iface_type_to_np(
 ) -> nispor::IfaceType {
     match nms_iface_type {
         InterfaceType::LinuxBridge => nispor::IfaceType::Bridge,
+        InterfaceType::Bond => nispor::IfaceType::Bond,
         InterfaceType::Ethernet => nispor::IfaceType::Ethernet,
         InterfaceType::Veth => nispor::IfaceType::Veth,
         InterfaceType::Vlan => nispor::IfaceType::Vlan,

--- a/rust/src/lib/nispor/bond.rs
+++ b/rust/src/lib/nispor/bond.rs
@@ -1,0 +1,188 @@
+use log::warn;
+
+use crate::{
+    BaseInterface, BondAdSelect, BondAllPortsActive, BondArpAllTargets,
+    BondArpValidate, BondConfig, BondFailOverMac, BondInterface, BondLacpRate,
+    BondMode, BondOptions, BondPrimaryReselect, BondXmitHashPolicy,
+};
+
+pub(crate) fn np_bond_to_nmstate(
+    np_iface: &nispor::Iface,
+    base_iface: BaseInterface,
+) -> BondInterface {
+    let mut bond_iface = BondInterface::new();
+    let mut bond_conf = BondConfig::new();
+
+    bond_iface.base = base_iface;
+    bond_conf.options = Some(np_bond_options_to_nmstate(np_iface));
+    if let Some(np_bond) = &np_iface.bond {
+        bond_conf.port = Some(
+            np_bond
+                .subordinates
+                .as_slice()
+                .iter()
+                .map(|iface_name| iface_name.to_string())
+                .collect(),
+        );
+        bond_conf.mode = match np_bond.mode {
+            nispor::BondMode::BalanceRoundRobin => Some(BondMode::RoundRobin),
+            nispor::BondMode::ActiveBackup => Some(BondMode::ActiveBackup),
+            nispor::BondMode::BalanceXor => Some(BondMode::XOR),
+            nispor::BondMode::Broadcast => Some(BondMode::Broadcast),
+            nispor::BondMode::Ieee8021AD => Some(BondMode::LACP),
+            nispor::BondMode::BalanceTlb => Some(BondMode::TLB),
+            nispor::BondMode::BalanceAlb => Some(BondMode::ALB),
+            _ => {
+                warn!("Unsupported bond mode");
+                Some(BondMode::Unknown)
+            }
+        };
+    }
+    bond_iface.bond = Some(bond_conf);
+    bond_iface
+}
+
+fn np_bond_options_to_nmstate(np_iface: &nispor::Iface) -> BondOptions {
+    let mut options = BondOptions::default();
+    if let Some(ref np_bond) = &np_iface.bond {
+        options.ad_actor_sys_prio = np_bond.ad_actor_sys_prio;
+        options.ad_actor_system = np_bond.ad_actor_system.clone();
+        options.ad_select = np_bond.ad_select.as_ref().and_then(|r| match r {
+            nispor::BondAdSelect::Stable => Some(BondAdSelect::Stable),
+            nispor::BondAdSelect::Bandwidth => Some(BondAdSelect::Bandwidth),
+            nispor::BondAdSelect::Count => Some(BondAdSelect::Count),
+            _ => {
+                warn!("Unsupported bond ad_select option {:?}", r);
+                None
+            }
+        });
+        options.ad_user_port_key = np_bond.ad_user_port_key;
+        options.all_slaves_active = np_bond
+            .all_subordinates_active
+            .as_ref()
+            .and_then(|r| match r {
+                nispor::BondAllSubordinatesActive::Dropped => {
+                    Some(BondAllPortsActive::Dropped)
+                }
+                nispor::BondAllSubordinatesActive::Delivered => {
+                    Some(BondAllPortsActive::Delivered)
+                }
+                _ => {
+                    warn!("Unsupported bond all ports active options {:?}", r);
+                    None
+                }
+            });
+        options.arp_all_targets =
+            np_bond.arp_all_targets.as_ref().and_then(|r| match r {
+                nispor::BondModeArpAllTargets::Any => {
+                    Some(BondArpAllTargets::Any)
+                }
+                nispor::BondModeArpAllTargets::All => {
+                    Some(BondArpAllTargets::All)
+                }
+                _ => {
+                    warn!("Unsupported bond arp_all_targets option {:?}", r);
+                    None
+                }
+            });
+        options.arp_interval = np_bond.arp_interval;
+        options.arp_ip_target = np_bond.arp_ip_target.clone();
+        options.arp_validate =
+            np_bond.arp_validate.as_ref().and_then(|r| match r {
+                nispor::BondArpValidate::None => Some(BondArpValidate::None),
+                nispor::BondArpValidate::Active => {
+                    Some(BondArpValidate::Active)
+                }
+                nispor::BondArpValidate::Backup => {
+                    Some(BondArpValidate::Backup)
+                }
+                nispor::BondArpValidate::All => Some(BondArpValidate::All),
+                nispor::BondArpValidate::FilterActive => {
+                    Some(BondArpValidate::FilterActive)
+                }
+                nispor::BondArpValidate::FilterBackup => {
+                    Some(BondArpValidate::FilterBackup)
+                }
+                _ => {
+                    warn!("Unsupported bond arp_validate options {:?}", r);
+                    None
+                }
+            });
+        options.downdelay = np_bond.downdelay;
+        options.fail_over_mac =
+            np_bond.fail_over_mac.as_ref().and_then(|r| match r {
+                nispor::BondFailOverMac::None => Some(BondFailOverMac::None),
+                nispor::BondFailOverMac::Active => {
+                    Some(BondFailOverMac::Active)
+                }
+                nispor::BondFailOverMac::Follow => {
+                    Some(BondFailOverMac::Follow)
+                }
+                _ => {
+                    warn!("Unsupported bond fail_over_mac options {:?}", r);
+                    None
+                }
+            });
+        options.lacp_rate = np_bond.lacp_rate.as_ref().and_then(|r| match r {
+            nispor::BondLacpRate::Slow => Some(BondLacpRate::Slow),
+            nispor::BondLacpRate::Fast => Some(BondLacpRate::Fast),
+            _ => {
+                warn!("Unsupported bond lacp_rate options {:?}", r);
+                None
+            }
+        });
+        options.lp_interval = np_bond.lp_interval;
+        options.miimon = np_bond.miimon;
+        options.min_links = np_bond.min_links;
+        options.num_grat_arp = np_bond.num_grat_arp;
+        options.num_unsol_na = np_bond.num_unsol_na;
+        options.packets_per_slave = np_bond.packets_per_subordinate;
+        options.primary = np_bond.primary.clone();
+        options.primary_reselect =
+            np_bond.primary_reselect.as_ref().and_then(|r| match r {
+                nispor::BondPrimaryReselect::Always => {
+                    Some(BondPrimaryReselect::Always)
+                }
+                nispor::BondPrimaryReselect::Better => {
+                    Some(BondPrimaryReselect::Better)
+                }
+                nispor::BondPrimaryReselect::Failure => {
+                    Some(BondPrimaryReselect::Failure)
+                }
+                _ => {
+                    warn!("Unsupported bond primary_reselect options {:?}", r);
+                    None
+                }
+            });
+        options.resend_igmp = np_bond.resend_igmp;
+        options.tlb_dynamic_lb = np_bond.tlb_dynamic_lb;
+        options.updelay = np_bond.updelay;
+        options.use_carrier = np_bond.use_carrier;
+        options.xmit_hash_policy =
+            np_bond.xmit_hash_policy.as_ref().and_then(|r| match r {
+                nispor::BondXmitHashPolicy::Layer2 => {
+                    Some(BondXmitHashPolicy::Layer2)
+                }
+                nispor::BondXmitHashPolicy::Layer34 => {
+                    Some(BondXmitHashPolicy::Layer34)
+                }
+                nispor::BondXmitHashPolicy::Layer23 => {
+                    Some(BondXmitHashPolicy::Layer23)
+                }
+                nispor::BondXmitHashPolicy::Encap23 => {
+                    Some(BondXmitHashPolicy::Encap23)
+                }
+                nispor::BondXmitHashPolicy::Encap34 => {
+                    Some(BondXmitHashPolicy::Encap34)
+                }
+                nispor::BondXmitHashPolicy::VlanSrcMac => {
+                    Some(BondXmitHashPolicy::VlanSrcMac)
+                }
+                _ => {
+                    warn!("Unsupported bond xmit_hash_policy options {:?}", r);
+                    None
+                }
+            });
+    }
+    options
+}

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -1,5 +1,6 @@
 mod apply;
 mod base_iface;
+mod bond;
 mod error;
 mod ethernet;
 mod ip;

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -3,6 +3,7 @@ use log::{debug, warn};
 use crate::{
     nispor::{
         base_iface::np_iface_to_base_iface,
+        bond::np_bond_to_nmstate,
         error::np_error_to_nmstate,
         ethernet::np_ethernet_to_nmstate,
         linux_bridge::{append_bridge_port_config, np_bridge_to_nmstate},
@@ -42,6 +43,9 @@ pub(crate) fn nispor_retrieve() -> Result<NetworkState, NmstateError> {
                     port_np_ifaces,
                 );
                 Interface::LinuxBridge(br_iface)
+            }
+            InterfaceType::Bond => {
+                Interface::Bond(np_bond_to_nmstate(np_iface, base_iface))
             }
             InterfaceType::Ethernet => Interface::Ethernet(
                 np_ethernet_to_nmstate(np_iface, base_iface),

--- a/rust/src/lib/nm/bond.rs
+++ b/rust/src/lib/nm/bond.rs
@@ -1,0 +1,171 @@
+use nm_dbus::{NmConnection, NmSettingBond};
+
+use crate::{BondConfig, BondInterface, BondMode, BondOptions};
+
+pub(crate) fn gen_nm_bond_setting(
+    bond_iface: &BondInterface,
+    nm_conn: &mut NmConnection,
+) {
+    let mut nm_bond_setting =
+        nm_conn.bond.as_ref().cloned().unwrap_or_default();
+
+    if let Some(bond_conf) = bond_iface.bond.as_ref() {
+        apply_bond_config(&mut nm_bond_setting, bond_conf);
+        if let Some(bond_opts) = bond_conf.options.as_ref() {
+            nm_bond_setting.options.clear();
+            apply_bond_options(&mut nm_bond_setting, bond_opts);
+            if nm_bond_setting.options.is_empty() {
+                nm_bond_setting.clear_existing_opts();
+            }
+        }
+    }
+
+    nm_conn.bond = Some(nm_bond_setting);
+}
+
+fn apply_bond_config(nm_bond_set: &mut NmSettingBond, bond_conf: &BondConfig) {
+    if let Some(mode) = &bond_conf.mode {
+        if bond_mode_changed(nm_bond_set, mode) {
+            nm_bond_set.clear_existing_opts();
+        }
+        nm_bond_set.mode = mode.to_string();
+    }
+}
+
+fn bond_mode_changed(nm_bond_set: &mut NmSettingBond, mode: &BondMode) -> bool {
+    if let Some(current_mode) = nm_bond_set.get_current_mode() {
+        return !current_mode.eq(&mode.to_string());
+    }
+    false
+}
+
+fn apply_bond_options(
+    nm_bond_set: &mut NmSettingBond,
+    bond_opts: &BondOptions,
+) {
+    if let Some(v) = bond_opts.ad_actor_sys_prio.as_ref() {
+        nm_bond_set
+            .options
+            .insert("ad_actor_sys_prio".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.ad_actor_system.as_ref() {
+        nm_bond_set
+            .options
+            .insert("ad_actor_system".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.ad_select.as_ref() {
+        nm_bond_set
+            .options
+            .insert("ad_select".to_string(), v.to_u8().to_string());
+    }
+    if let Some(v) = bond_opts.ad_user_port_key.as_ref() {
+        nm_bond_set
+            .options
+            .insert("ad_user_port_key".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.all_slaves_active.as_ref() {
+        nm_bond_set
+            .options
+            .insert("all_slaves_active".to_string(), v.to_u8().to_string());
+    }
+    if let Some(v) = bond_opts.arp_all_targets.as_ref() {
+        nm_bond_set
+            .options
+            .insert("arp_all_targets".to_string(), v.to_u32().to_string());
+    }
+    if let Some(v) = bond_opts.arp_interval.as_ref() {
+        nm_bond_set
+            .options
+            .insert("arp_interval".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.arp_ip_target.as_ref() {
+        nm_bond_set
+            .options
+            .insert("arp_ip_target".to_string(), v.clone());
+    }
+    if let Some(v) = bond_opts.arp_validate.as_ref() {
+        nm_bond_set
+            .options
+            .insert("arp_validate".to_string(), v.to_u32().to_string());
+    }
+    if let Some(v) = bond_opts.downdelay.as_ref() {
+        nm_bond_set
+            .options
+            .insert("downdelay".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.fail_over_mac.as_ref() {
+        nm_bond_set
+            .options
+            .insert("fail_over_mac".to_string(), v.to_u8().to_string());
+    }
+    if let Some(v) = bond_opts.lacp_rate.as_ref() {
+        nm_bond_set
+            .options
+            .insert("lacp_rate".to_string(), v.to_u8().to_string());
+    }
+    if let Some(v) = bond_opts.lp_interval.as_ref() {
+        nm_bond_set
+            .options
+            .insert("lp_interval".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.miimon.as_ref() {
+        nm_bond_set
+            .options
+            .insert("miimon".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.min_links.as_ref() {
+        nm_bond_set
+            .options
+            .insert("min_links".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.num_grat_arp.as_ref() {
+        nm_bond_set
+            .options
+            .insert("num_grat_arp".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.num_unsol_na.as_ref() {
+        nm_bond_set
+            .options
+            .insert("num_unsol_na".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.packets_per_slave.as_ref() {
+        nm_bond_set
+            .options
+            .insert("packets_per_slave".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.primary.as_ref() {
+        nm_bond_set.options.insert("primary".to_string(), v.clone());
+    }
+    if let Some(v) = bond_opts.primary_reselect.as_ref() {
+        nm_bond_set
+            .options
+            .insert("primary_reselect".to_string(), v.to_u8().to_string());
+    }
+    if let Some(v) = bond_opts.resend_igmp.as_ref() {
+        nm_bond_set
+            .options
+            .insert("resend_igmp".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.tlb_dynamic_lb.as_ref() {
+        let v_parsed: u8 = (*v).into();
+        nm_bond_set
+            .options
+            .insert("tlb_dynamic_lb".to_string(), v_parsed.to_string());
+    }
+    if let Some(v) = bond_opts.updelay.as_ref() {
+        nm_bond_set
+            .options
+            .insert("updelay".to_string(), v.to_string());
+    }
+    if let Some(v) = bond_opts.use_carrier.as_ref() {
+        let v_parsed: u8 = (*v).into();
+        nm_bond_set
+            .options
+            .insert("use_carrier".to_string(), v_parsed.to_string());
+    }
+    if let Some(v) = bond_opts.xmit_hash_policy.as_ref() {
+        nm_bond_set
+            .options
+            .insert("xmit_hash_policy".to_string(), v.to_u8().to_string());
+    }
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -3,6 +3,7 @@ use std::collections::{hash_map::Entry, HashMap};
 use nm_dbus::{NmApi, NmConnection, NmSettingConnection, NmSettingVlan};
 
 use crate::{
+    nm::bond::gen_nm_bond_setting,
     nm::bridge::{gen_nm_br_port_setting, gen_nm_br_setting},
     nm::ip::gen_nm_ip_setting,
     nm::ovs::{
@@ -101,6 +102,9 @@ pub(crate) fn iface_to_nm_connections(
         Interface::LinuxBridge(br_iface) => {
             gen_nm_br_setting(br_iface, &mut nm_conn);
         }
+        Interface::Bond(bond_iface) => {
+            gen_nm_bond_setting(bond_iface, &mut nm_conn);
+        }
         Interface::OvsInterface(_) => {
             // TODO Support OVS Patch interface
             gen_nm_ovs_iface_setting(&mut nm_conn);
@@ -134,6 +138,7 @@ pub(crate) fn iface_type_to_nm(
 ) -> Result<String, NmstateError> {
     match iface_type {
         InterfaceType::LinuxBridge => Ok("bridge".into()),
+        InterfaceType::Bond => Ok("bond".into()),
         InterfaceType::Ethernet => Ok("802-3-ethernet".into()),
         InterfaceType::OvsBridge => Ok("ovs-bridge".into()),
         InterfaceType::OvsInterface => Ok("ovs-interface".into()),

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -1,5 +1,6 @@
 mod active_connection;
 mod apply;
+mod bond;
 mod bridge;
 mod checkpoint;
 mod connection;

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -1,0 +1,75 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{connection::DbusDictionary, NmError};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingBond {
+    pub mode: String,
+    pub options: HashMap<String, String>,
+    _other: HashMap<String, String>,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingBond {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        let mut options = HashMap::<String, String>::new();
+        let mut other = HashMap::<String, String>::new();
+
+        if let Some(value) = _from_map!(v, "options", HashMap::try_from)? {
+            options = value.clone();
+            other = value;
+        }
+        Ok(Self {
+            mode: String::new(),
+            options,
+            _other: other,
+        })
+    }
+}
+
+impl NmSettingBond {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut merged_opts = self.options.clone();
+        let mut ret = HashMap::new();
+
+        // Do not merge existing options if the user specified empty options
+        merged_opts.extend(
+            self._other
+                .iter()
+                .filter(|(k, _)| !self.options.contains_key(*k))
+                .map(|(k, v)| (k.to_string(), v.to_string())),
+        );
+        if let Some(arp_ip_target) = self.options.get("arp_ip_target") {
+            if arp_ip_target.is_empty() {
+                merged_opts.remove("arp_ip_target");
+            }
+        }
+
+        if !self.mode.is_empty() {
+            merged_opts.insert("mode".to_string(), self.mode.clone());
+        }
+
+        if !merged_opts.is_empty() {
+            ret.insert("options", zvariant::Value::from(merged_opts.clone()));
+        }
+        Ok(ret)
+    }
+
+    pub fn clear_existing_opts(&mut self) {
+        self._other.clear();
+    }
+
+    pub fn get_current_mode(&self) -> Option<&String> {
+        self._other.get(&String::from("mode"))
+    }
+}

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -23,6 +23,7 @@ use zbus::export::zvariant::Signature;
 use zvariant::Type;
 
 use crate::{
+    connection::bond::NmSettingBond,
     connection::bridge::{NmSettingBridge, NmSettingBridgePort},
     connection::ip::NmSettingIp,
     connection::ovs::{
@@ -52,6 +53,7 @@ pub(crate) type NmConnectionDbusValue<'a> =
 #[serde(try_from = "NmConnectionDbusOwnedValue")]
 pub struct NmConnection {
     pub connection: Option<NmSettingConnection>,
+    pub bond: Option<NmSettingBond>,
     pub bridge: Option<NmSettingBridge>,
     pub bridge_port: Option<NmSettingBridgePort>,
     pub ipv4: Option<NmSettingIp>,
@@ -88,6 +90,7 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
             )?,
             ipv4: _from_map!(v, "ipv4", NmSettingIp::try_from)?,
             ipv6: _from_map!(v, "ipv6", NmSettingIp::try_from)?,
+            bond: _from_map!(v, "bond", NmSettingBond::try_from)?,
             bridge: _from_map!(v, "bridge", NmSettingBridge::try_from)?,
             bridge_port: _from_map!(
                 v,
@@ -153,6 +156,9 @@ impl NmConnection {
         let mut ret = HashMap::new();
         if let Some(con_set) = &self.connection {
             ret.insert("connection", con_set.to_value()?);
+        }
+        if let Some(bond_set) = &self.bond {
+            ret.insert("bond", bond_set.to_value()?);
         }
         if let Some(br_set) = &self.bridge {
             ret.insert("bridge", br_set.to_value()?);

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -16,6 +16,7 @@
 #[macro_use]
 mod macros;
 
+mod bond;
 mod bridge;
 mod conn;
 mod ip;
@@ -25,6 +26,7 @@ mod sriov;
 mod vlan;
 mod wired;
 
+pub use crate::connection::bond::NmSettingBond;
 pub use crate::connection::bridge::{
     NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
 };

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -24,10 +24,11 @@ mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
-    NmConnection, NmIpRoute, NmSettingBridge, NmSettingBridgeVlanRange,
-    NmSettingConnection, NmSettingIp, NmSettingIpMethod, NmSettingOvsBridge,
-    NmSettingOvsIface, NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf,
-    NmSettingSriovVfVlan, NmSettingVlan, NmSettingWired, NmVlanProtocol,
+    NmConnection, NmIpRoute, NmSettingBond, NmSettingBridge,
+    NmSettingBridgeVlanRange, NmSettingConnection, NmSettingIp,
+    NmSettingIpMethod, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+    NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingVlan,
+    NmSettingWired, NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::error::{ErrorKind, NmError};

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -942,7 +942,10 @@ def test_reset_bond_options_back_to_default(bond99_with_2_port):
             Interface.KEY: [
                 {
                     Interface.NAME: BOND99,
-                    Bond.CONFIG_SUBTREE: {Bond.OPTIONS_SUBTREE: {}},
+                    Bond.CONFIG_SUBTREE: {
+                        Bond.MODE: BondMode.ROUND_ROBIN,
+                        Bond.OPTIONS_SUBTREE: {},
+                    },
                 }
             ]
         }


### PR DESCRIPTION
This is adding support to bond interfaces in rust.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>