### PR TITLE
nmstatectl: Avoid using `abort`

### DIFF
--- a/nmstatectl/nmstatectl.py
+++ b/nmstatectl/nmstatectl.py
@@ -470,7 +470,7 @@ def _run_editor(txtstate, suffix):
             return statefile.read()
 
         except subprocess.CalledProcessError:
-            sys.stderr.write("Error running editor, aborting...\n")
+            sys.stderr.write("Error running editor, exiting...\n")
             return None
 
 

--- a/tests/integration/nmstatectl_edit_test.py
+++ b/tests/integration/nmstatectl_edit_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2018-2021 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -26,7 +26,7 @@ from .testlib import cmdlib
 RC_SUCCESS = 0
 
 
-def test_edit_abort():
+def test_edit_cancel():
     runenv = dict(os.environ)
     env = {"EDITOR": "false"}
 


### PR DESCRIPTION
Follow the recommendation of the inclusive naming initiative:
https://inclusivenaming.org/word-lists/tier-1/

Signed-off-by: Till Maas <opensource@till.name>