### PR TITLE
SRIOV: Add support of VLAN and QoS

### DIFF
--- a/examples/eth1_with_sriov.yml
+++ b/examples/eth1_with_sriov.yml
@@ -11,3 +11,5 @@ interfaces:
             mac-address: ee:2a:4e:8e:71:f5
             spoof-check: true
             trust: false
+            vlan-id: 102
+            qos: 5

--- a/libnmstate/nispor/ethernet.py
+++ b/libnmstate/nispor/ethernet.py
@@ -43,6 +43,8 @@ class NisporPluginEthernetIface(NisporPluginBaseIface):
                         Ethernet.SRIOV.VFS.TRUST: vf.trust,
                         Ethernet.SRIOV.VFS.MIN_TX_RATE: vf.min_tx_rate,
                         Ethernet.SRIOV.VFS.MAX_TX_RATE: vf.max_tx_rate,
+                        Ethernet.SRIOV.VFS.VLAN_ID: vf.vlan_id,
+                        Ethernet.SRIOV.VFS.QOS: vf.qos,
                     }
                 )
 

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -98,6 +98,13 @@ def _create_sriov_vfs_from_config(vfs_config, sriov_setting, vf_ids_to_add):
         for key, val in vf_config.items():
             _set_nm_attribute(vf_object, key, val)
 
+        vlan_id = vf_config.get(Ethernet.SRIOV.VFS.VLAN_ID)
+        vlan_qos = vf_config.get(Ethernet.SRIOV.VFS.QOS)
+        if vlan_id:
+            vf_object.add_vlan(vlan_id)
+            if vlan_qos:
+                vf_object.set_vlan_qos(vlan_id, vlan_qos)
+
         yield vf_object
 
 

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -253,6 +253,8 @@ class Ethernet:
             TRUST = "trust"
             MIN_TX_RATE = "min-tx-rate"
             MAX_TX_RATE = "max-tx-rate"
+            VLAN_ID = "vlan-id"
+            QOS = "qos"
 
 
 class Veth:

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -124,6 +124,10 @@ pub struct SrIovVfConfig {
     pub min_tx_rate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tx_rate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qos: Option<u32>,
 }
 
 impl SrIovVfConfig {

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -35,6 +35,8 @@ fn gen_sriov_conf(sriov_info: &nispor::SriovInfo) -> SrIovConfig {
         vf.trust = Some(vf_info.trust);
         vf.min_tx_rate = Some(vf_info.min_tx_rate);
         vf.max_tx_rate = Some(vf_info.max_tx_rate);
+        vf.vlan_id = Some(vf_info.vlan_id);
+        vf.qos = Some(vf_info.qos);
         vfs.push(vf);
     }
     ret.total_vfs = Some(vfs.len() as u32);

--- a/rust/src/lib/nm/sriov.rs
+++ b/rust/src/lib/nm/sriov.rs
@@ -1,5 +1,5 @@
 use crate::{EthernetInterface, SrIovVfConfig};
-use nm_dbus::{NmConnection, NmSettingSriovVf};
+use nm_dbus::{NmConnection, NmSettingSriovVf, NmSettingSriovVfVlan};
 
 pub(crate) fn gen_nm_sriov_setting(
     iface: &EthernetInterface,
@@ -51,6 +51,12 @@ fn gen_nm_vfs(vfs: &[SrIovVfConfig]) -> Vec<NmSettingSriovVf> {
         }
         if let Some(v) = vf.max_tx_rate {
             nm_vf.max_tx_rate = Some(v);
+        }
+        if let Some(v) = vf.vlan_id {
+            let mut nm_vf_vlan = NmSettingSriovVfVlan::new();
+            nm_vf_vlan.id = v;
+            nm_vf_vlan.qos = vf.qos.unwrap_or_default();
+            nm_vf.vlans = Some(vec![nm_vf_vlan]);
         }
         ret.push(nm_vf);
     }

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -268,3 +268,42 @@ def test_wait_sriov_vf_been_deleted_when_total_vfs_decrease():
             Interface.STATE
         ] = InterfaceState.ABSENT
         libnmstate.apply(desired_state)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for SR-IOV test",
+)
+def test_sriov_vf_vlan_id_and_qos():
+    pf_name = _test_nic_name()
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: pf_name,
+                Ethernet.CONFIG_SUBTREE: {
+                    Ethernet.SRIOV_SUBTREE: {
+                        Ethernet.SRIOV.TOTAL_VFS: 2,
+                        Ethernet.SRIOV.VFS_SUBTREE: [
+                            {
+                                Ethernet.SRIOV.VFS.ID: 0,
+                                Ethernet.SRIOV.VFS.VLAN_ID: 100,
+                                Ethernet.SRIOV.VFS.QOS: 5,
+                            },
+                            {
+                                Ethernet.SRIOV.VFS.ID: 1,
+                                Ethernet.SRIOV.VFS.VLAN_ID: 102,
+                                Ethernet.SRIOV.VFS.QOS: 6,
+                            },
+                        ],
+                    }
+                },
+            }
+        ]
+    }
+    try:
+        libnmstate.apply(desired_state)
+    finally:
+        desired_state[Interface.KEY][0][
+            Interface.STATE
+        ] = InterfaceState.ABSENT
+        libnmstate.apply(desired_state)


### PR DESCRIPTION
Including both python and rust support of SRIOV VLAN and QoS.

Example yml:

```yml
--- interfaces:
 - name: enp5s0f1
   type: ethernet
   state: up
   ethernet:
     sr-iov:
       total-vfs: 1
       vfs:
         - id: 0
           vlan-id: 102
           qos: 5
```

Integration test case included and tested on ixgbe Intel X520 card.