### PR TITLE
[nmstate-1.2] rust: Add deprecated API and rename ncl

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -109,7 +109,7 @@ popd
 %{_mandir}/man8/nmstate-autoconf.8*
 %{python3_sitelib}/nmstatectl
 %{_bindir}/nmstatectl
-%{_bindir}/ncl
+%{_bindir}/nmstatectl-rust
 %{_bindir}/nmstate-autoconf
 
 %files libs

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2.0.0"
+rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.1.2.0"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -2,7 +2,7 @@ include ./Makefile.inc
 
 RUST_DEBUG_BIN_DIR=./target/debug
 RUST_RELEASE_BIN_DIR=./target/release
-CLI_EXEC=ncl
+CLI_EXEC=nmstatectl-rust
 CLI_EXEC_DEBUG=$(RUST_DEBUG_BIN_DIR)/$(CLI_EXEC)
 CLIB_HEADER=nmstate.h
 CLIB_HEADER_IN=src/clib/$(CLIB_HEADER).in

--- a/rust/Makefile.inc
+++ b/rust/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=2.0.0
+CLIB_VERSION=1.2.0
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 
 [[bin]]
-name = "ncl"
+name = "nmstatectl-rust"
 path = "ncl.rs"
 
 [dependencies]

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -15,7 +15,7 @@ const SUB_CMD_SHOW: &str = "show";
 const SUB_CMD_APPLY: &str = "apply";
 
 fn main() {
-    let matches = clap::App::new("ncl")
+    let matches = clap::App::new("nmstatectl")
         .version("1.0")
         .author("Gris Ge <fge@redhat.com>")
         .about("Command line of nmstate")

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nmstate-clib"
 description = "Nmstate C binding"
-version = "2.0.0"
+version = "1.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmstate"
-version = "2.0.0"
+version = "1.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 
@@ -11,8 +11,7 @@ path = "lib.rs"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 nm-dbus = {path = "../libnm_dbus"}
-#nispor = "1.2"
-nispor = { git = "https://github.com/nispor/nispor", branch = "base" }
+nispor = "1.2.2"
 log = "0.4.14"
 libc = "0.2.106"
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -87,7 +87,11 @@ impl OvsBridgeInterface {
 pub struct OvsBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "port",
+        alias = "slaves"
+    )]
     pub ports: Option<Vec<OvsBridgePortConfig>>,
 }
 

--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -3,5 +3,5 @@ from .netapplier import apply
 from .netinfo import show
 from .prettystate import PrettyState
 
-__version__ = "2.0.0"
+__version__ = "1.2.0"
 __all__ = []

--- a/rust/src/python/setup.py
+++ b/rust/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="libnmstate",
-    version="2.0.0",
+    version="1.2.0",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of nmstate",


### PR DESCRIPTION
In version 1.x, we still support the deprecated `slaves` API.

The previous name is already taken by project http://www.ncl.ucar.edu/ , 
hence rename to `nmstate-rust`.