### PR TITLE
rust cli: Rename to nmstatectl-rust

### DIFF
--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -100,7 +100,7 @@ popd
 %{_mandir}/man8/nmstate-autoconf.8*
 %{python3_sitelib}/nmstatectl
 %{_bindir}/nmstatectl
-%{_bindir}/ncl
+%{_bindir}/nmstatectl-rust
 %{_bindir}/nmstate-autoconf
 
 %files libs

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -2,7 +2,7 @@ include ./Makefile.inc
 
 RUST_DEBUG_BIN_DIR=./target/debug
 RUST_RELEASE_BIN_DIR=./target/release
-CLI_EXEC=ncl
+CLI_EXEC=nmstatectl-rust
 CLI_EXEC_DEBUG=$(RUST_DEBUG_BIN_DIR)/$(CLI_EXEC)
 CLIB_HEADER=nmstate.h
 CLIB_HEADER_IN=src/clib/$(CLIB_HEADER).in

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 
 [[bin]]
-name = "ncl"
+name = "nmstatectl-rust"
 path = "ncl.rs"
 
 [dependencies]

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -15,7 +15,7 @@ const SUB_CMD_SHOW: &str = "show";
 const SUB_CMD_APPLY: &str = "apply";
 
 fn main() {
-    let matches = clap::App::new("ncl")
+    let matches = clap::App::new("nmstatectl")
         .version("1.0")
         .author("Gris Ge <fge@redhat.com>")
         .about("Command line of nmstate")

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -11,7 +11,7 @@ path = "lib.rs"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 nm-dbus = {path = "../libnm_dbus"}
-nispor = "1.2.1"
+nispor = "1.2.2"
 log = "0.4.14"
 libc = "0.2.106"
 


### PR DESCRIPTION
The previous name is already taken by project http://www.ncl.ucar.edu/ ,
hence rename to `nmstate-rust`