### PR TITLE
route: The config route should only include static routes and boot routes

### DIFF
--- a/libnmstate/nispor/route.py
+++ b/libnmstate/nispor/route.py
@@ -44,7 +44,7 @@ def nispor_route_state_to_nmstate_static(np_routes):
         _nispor_route_to_nmstate(rt)
         for rt in np_routes
         if rt.scope in ["universe", "link"]
-        and rt.protocol not in ["kernel", "ra", "dhcp"]
+        and rt.protocol in ["static", "boot"]
         and rt.oif != "lo"
         and rt.table != LOCAL_ROUTE_TABLE
     ]

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -5,6 +5,9 @@ use crate::{RouteEntry, Routes};
 const SUPPORTED_ROUTE_SCOPE: [nispor::RouteScope; 2] =
     [nispor::RouteScope::Universe, nispor::RouteScope::Link];
 
+const SUPPORTED_STATIC_ROUTE_PROTOCOL: [nispor::RouteProtocol; 2] =
+    [nispor::RouteProtocol::Boot, nispor::RouteProtocol::Static];
+
 const LOCAL_ROUTE_TABLE: u32 = 255;
 const IPV4_DEFAULT_GATEWAY: &str = "0.0.0.0/0";
 const IPV6_DEFAULT_GATEWAY: &str = "::/0";
@@ -31,7 +34,8 @@ pub(crate) fn get_routes(np_routes: &[nispor::Route]) -> Routes {
             .iter()
             .filter(|np_route| {
                 SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope)
-                    && np_route.protocol == nispor::RouteProtocol::Static
+                    && SUPPORTED_STATIC_ROUTE_PROTOCOL
+                        .contains(&np_route.protocol)
                     && np_route.table != LOCAL_ROUTE_TABLE
                     && np_route.oif.as_ref() != Some(&"lo".to_string())
             })


### PR DESCRIPTION
The ip command created route is boot protocol, we should include it
in route.config also.

Both python and rust code are updated.