### PR TITLE
rust rule: Add support of IP route rule

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -253,7 +253,7 @@ function run_tests {
           pytest \
             $PYTEST_OPTIONS \
             tests/integration/route_test.py \
-            -k 'not rule' \
+            -k 'not test_route_rule_add_with_auto_route_table_id ' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 
 use env_logger::Builder;
 use log::LevelFilter;
-use nmstate::{NetworkState, Routes};
+use nmstate::{NetworkState, RouteRules, Routes};
 use serde::Serialize;
 use serde_yaml::{self, Value};
 
@@ -142,6 +142,7 @@ fn gen_conf(file_path: &str) -> Result<String, CliError> {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 struct SortedNetworkState {
     routes: Routes,
+    rules: RouteRules,
     interfaces: Vec<Value>,
 }
 
@@ -183,12 +184,14 @@ fn sort_netstate(
         return Ok(SortedNetworkState {
             interfaces: new_ifaces,
             routes: net_state.routes,
+            rules: net_state.rules,
         });
     }
 
     Ok(SortedNetworkState {
         interfaces: Vec::new(),
         routes: net_state.routes,
+        rules: net_state.rules,
     })
 }
 

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ErrorKind, InterfaceIpv4, InterfaceIpv6, InterfaceState, InterfaceType,
-    NmstateError, RouteEntry,
+    NmstateError, RouteEntry, RouteRuleEntry,
 };
 
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
@@ -39,6 +39,8 @@ pub struct BaseInterface {
     pub(crate) up_priority: u32,
     #[serde(skip)]
     pub(crate) routes: Option<Vec<RouteEntry>>,
+    #[serde(skip)]
+    pub(crate) rules: Option<Vec<RouteRuleEntry>>,
     #[serde(flatten)]
     pub _other: serde_json::Map<String, serde_json::Value>,
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -6,6 +6,7 @@ mod net_state;
 mod nispor;
 mod nm;
 mod route;
+mod route_rule;
 mod state;
 mod unit_tests;
 
@@ -29,3 +30,4 @@ pub use crate::ifaces::{
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 pub use crate::net_state::NetworkState;
 pub use crate::route::{RouteEntry, RouteState, Routes};
+pub use crate::route_rule::{RouteRuleEntry, RouteRuleState, RouteRules};

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -17,7 +17,7 @@ pub(crate) fn np_ipv4_to_nmstate(
             }
             ip.addresses.push(InterfaceIpAddr {
                 ip: np_addr.address.clone(),
-                prefix_length: np_addr.prefix_len as u32,
+                prefix_length: np_addr.prefix_len,
             });
         }
         Some(ip)
@@ -52,7 +52,7 @@ pub(crate) fn np_ipv6_to_nmstate(
             }
             ip.addresses.push(InterfaceIpAddr {
                 ip: np_addr.address.clone(),
-                prefix_length: np_addr.prefix_len as u32,
+                prefix_length: np_addr.prefix_len,
             });
         }
         Some(ip)

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -7,6 +7,7 @@ mod ip;
 mod linux_bridge;
 mod linux_bridge_port_vlan;
 mod route;
+mod route_rule;
 mod show;
 mod veth;
 mod vlan;

--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -1,0 +1,31 @@
+use crate::{RouteRuleEntry, RouteRules};
+
+pub(crate) fn get_route_rules(np_rules: &[nispor::RouteRule]) -> RouteRules {
+    let mut ret = RouteRules::new();
+
+    let mut rules = Vec::new();
+    for np_rule in np_rules {
+        let mut rule = RouteRuleEntry::new();
+        // We only support route rules with 'table' action
+        if np_rule.action != nispor::RuleAction::Table {
+            continue;
+        }
+        // Neither ip_from or ip_to should be defeind
+        if np_rule.dst.is_none() && np_rule.src.is_none() {
+            continue;
+        }
+        if np_rule.dst.as_deref() == Some("")
+            && np_rule.src.as_deref() == Some("")
+        {
+            continue;
+        }
+        rule.ip_to = np_rule.dst.clone();
+        rule.ip_from = np_rule.src.clone();
+        rule.table_id = np_rule.table;
+        rule.priority = np_rule.priority.map(i64::from);
+        rules.push(rule);
+    }
+    ret.config = Some(rules);
+
+    ret
+}

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -8,6 +8,7 @@ use crate::{
         ethernet::np_ethernet_to_nmstate,
         linux_bridge::{append_bridge_port_config, np_bridge_to_nmstate},
         route::get_routes,
+        route_rule::get_route_rules,
         veth::np_veth_to_nmstate,
         vlan::np_vlan_to_nmstate,
     },
@@ -19,6 +20,7 @@ pub(crate) fn nispor_retrieve() -> Result<NetworkState, NmstateError> {
     let mut net_state = NetworkState::new();
     net_state.prop_list.push("interfaces");
     net_state.prop_list.push("routes");
+    net_state.prop_list.push("rules");
     let np_state = nispor::NetState::retrieve().map_err(np_error_to_nmstate)?;
 
     for (_, np_iface) in np_state.ifaces.iter() {
@@ -87,6 +89,7 @@ pub(crate) fn nispor_retrieve() -> Result<NetworkState, NmstateError> {
         net_state.append_interface_data(iface);
     }
     net_state.routes = get_routes(&np_state.routes);
+    net_state.rules = get_route_rules(&np_state.rules);
 
     Ok(net_state)
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -77,6 +77,7 @@ pub(crate) fn iface_to_nm_connections(
     gen_nm_ip_setting(
         iface,
         iface.base_iface().routes.as_deref(),
+        iface.base_iface().rules.as_deref(),
         &mut nm_conn,
     )?;
     gen_nm_wired_setting(iface, &mut nm_conn);

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -10,6 +10,7 @@ mod ip;
 mod ovs;
 mod profile;
 mod route;
+mod route_rule;
 mod show;
 mod sriov;
 #[cfg(test)]

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -1,0 +1,59 @@
+use std::convert::TryFrom;
+
+use nm_dbus::NmIpRouteRule;
+
+use crate::{ip::is_ipv6_addr, InterfaceIpAddr, NmstateError, RouteRuleEntry};
+
+// NM require route rule priority been set explicitly, use 30,000 when
+// desire state instruct to use USE_DEFAULT_PRIORITY
+const ROUTE_RULE_DEFAULT_PRIORIRY: u32 = 30000;
+
+pub(crate) fn gen_nm_ip_rules(
+    rules: &[RouteRuleEntry],
+    is_ipv6: bool,
+) -> Result<Vec<NmIpRouteRule>, NmstateError> {
+    let mut ret = Vec::new();
+    for rule in rules {
+        let mut nm_rule = NmIpRouteRule::new();
+        nm_rule.family = Some(if is_ipv6 {
+            libc::AF_INET6
+        } else {
+            libc::AF_INET
+        });
+        if let Some(addr) = rule.ip_from.as_deref() {
+            match (is_ipv6, is_ipv6_addr(addr)) {
+                (true, true) | (false, false) => {
+                    let ip_addr = InterfaceIpAddr::try_from(addr)?;
+                    nm_rule.from_len = Some(ip_addr.prefix_length);
+                    nm_rule.from = Some(ip_addr.ip);
+                }
+                _ => continue,
+            }
+        }
+        if let Some(addr) = rule.ip_to.as_deref() {
+            match (is_ipv6, is_ipv6_addr(addr)) {
+                (true, true) | (false, false) => {
+                    let ip_addr = InterfaceIpAddr::try_from(addr)?;
+                    nm_rule.to_len = Some(ip_addr.prefix_length);
+                    nm_rule.to = Some(ip_addr.ip);
+                }
+                _ => continue,
+            }
+        }
+        nm_rule.priority = match rule.priority {
+            Some(RouteRuleEntry::USE_DEFAULT_PRIORITY) | None => {
+                Some(ROUTE_RULE_DEFAULT_PRIORIRY)
+            }
+            Some(i) => Some(i as u32),
+        };
+        nm_rule.table = match rule.table_id {
+            Some(RouteRuleEntry::USE_DEFAULT_ROUTE_TABLE) | None => {
+                Some(RouteRuleEntry::DEFAULR_ROUTE_TABLE_ID)
+            }
+            Some(i) => Some(i),
+        };
+
+        ret.push(nm_rule);
+    }
+    Ok(ret)
+}

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -46,6 +46,7 @@ impl Routes {
     //   added.
     // * desired static route exists.
     pub fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+        println!("desired {:?}\ncurrent {:?}", self, current);
         if let Some(config_routes) = self.config.as_ref() {
             let cur_config_routes = match current.config.as_ref() {
                 Some(c) => c.to_vec(),

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -1,0 +1,381 @@
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::convert::TryFrom;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ip::is_ipv6_addr, ErrorKind, InterfaceIpAddr, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct RouteRules {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<Vec<RouteRuleEntry>>,
+}
+
+impl RouteRules {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // * Neither ip_from nor ip_to should be defined
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        if let Some(rules) = self.config.as_ref() {
+            for rule in rules.iter().filter(|r| !r.is_absent()) {
+                rule.validate()?;
+            }
+        }
+        Ok(())
+    }
+
+    // * desired absent route rule is removed unless another matching rule been
+    //   added.
+    // * desired static rule exists.
+    pub fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+        if let Some(rules) = self.config.as_ref() {
+            let empty_vec: Vec<RouteRuleEntry> = Vec::new();
+            let cur_rules = match current.config.as_deref() {
+                Some(c) => c,
+                None => empty_vec.as_slice(),
+            };
+            for rule in rules.iter().filter(|r| !r.is_absent()) {
+                if !cur_rules.iter().any(|r| rule.is_match(r)) {
+                    let e = NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Desired route rule {:?} not found after apply",
+                            rule
+                        ),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
+            }
+
+            for absent_rule in rules.iter().filter(|r| r.is_absent()) {
+                // We ignore absent rule if user is replacing old rule
+                // with new one.
+                if rules
+                    .iter()
+                    .any(|r| (!r.is_absent()) && absent_rule.is_match(r))
+                {
+                    continue;
+                }
+
+                if let Some(cur_rule) =
+                    cur_rules.iter().find(|r| absent_rule.is_match(r))
+                {
+                    let e = NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Desired absent route rule {:?} still found \
+                            after apply: {:?}",
+                            absent_rule, cur_rule
+                        ),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // RouteRuleEntry been added/removed for specific table id , all(including
+    // desire and current) its rules will be included in return hash.
+    // Steps:
+    //  1. Find out all table id with desired add rules.
+    //  2. Find out all table id impacted by desired absent rules.
+    //  3. Copy all rules from current which are to changed table id.
+    //  4. Remove rules base on absent.
+    //  5. Add rules in desire.
+    //  6. Sort and remove duplicate rule.
+    pub(crate) fn gen_rule_changed_table_ids(
+        &self,
+        current: &Self,
+    ) -> HashMap<u32, Vec<RouteRuleEntry>> {
+        let mut ret: HashMap<u32, Vec<RouteRuleEntry>> = HashMap::new();
+        let cur_rules_index = current
+            .config
+            .as_ref()
+            .map(|c| create_rule_index_by_table_id(c.as_slice()))
+            .unwrap_or_default();
+        let des_rules_index = self
+            .config
+            .as_ref()
+            .map(|c| create_rule_index_by_table_id(c.as_slice()))
+            .unwrap_or_default();
+
+        let mut table_ids_in_desire: HashSet<u32> =
+            des_rules_index.keys().copied().collect();
+
+        // Convert the absent rule without table id to multiple
+        // rules with table_id define.
+        let absent_rules = flat_absent_rule(
+            self.config.as_deref().unwrap_or(&[]),
+            current.config.as_deref().unwrap_or(&[]),
+        );
+
+        // Include table id which will be impacted by absent rules
+        for absent_rule in &absent_rules {
+            if let Some(i) = absent_rule.table_id {
+                log::debug!(
+                    "Route table is impacted by absent rule {:?}",
+                    absent_rule
+                );
+                table_ids_in_desire.insert(i);
+            }
+        }
+
+        // Copy current rules of desired route table
+        for table_id in &table_ids_in_desire {
+            if let Some(cur_rules) = cur_rules_index.get(table_id) {
+                ret.insert(
+                    *table_id,
+                    cur_rules
+                        .as_slice()
+                        .iter()
+                        .map(|r| (*r).clone())
+                        .collect::<Vec<RouteRuleEntry>>(),
+                );
+            }
+        }
+
+        // Apply absent rules
+        for absent_rule in &absent_rules {
+            // All absent_rule should have table id here
+            if let Some(table_id) = absent_rule.table_id.as_ref() {
+                if let Some(rules) = ret.get_mut(table_id) {
+                    rules.retain(|r| !absent_rule.is_match(r));
+                }
+            }
+        }
+
+        // Append desire rules
+        for (table_id, desire_rules) in des_rules_index.iter() {
+            let new_rules = desire_rules
+                .iter()
+                .map(|r| (*r).clone())
+                .collect::<Vec<RouteRuleEntry>>();
+            match ret.entry(*table_id) {
+                Entry::Occupied(o) => {
+                    o.into_mut().extend(new_rules);
+                }
+                Entry::Vacant(v) => {
+                    v.insert(new_rules);
+                }
+            };
+        }
+
+        // Sort and remove the duplicated rules
+        for desire_rules in ret.values_mut() {
+            desire_rules.sort_unstable();
+            desire_rules.dedup();
+        }
+
+        ret
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RouteRuleState {
+    Absent,
+}
+
+impl Default for RouteRuleState {
+    fn default() -> Self {
+        Self::Absent
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RouteRuleEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<RouteRuleState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "route-table")]
+    pub table_id: Option<u32>,
+}
+
+impl RouteRuleEntry {
+    pub const USE_DEFAULT_PRIORITY: i64 = -1;
+    pub const USE_DEFAULT_ROUTE_TABLE: u32 = 0;
+    pub const DEFAULR_ROUTE_TABLE_ID: u32 = 254;
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // * Neither ip_from nor ip_to should be defined
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        if self.ip_from.is_none() && self.ip_to.is_none() {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Neither ip-from or ip-to is defined in route rule {:?}",
+                    self
+                ),
+            );
+            log::error!("{}", e);
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn is_absent(&self) -> bool {
+        matches!(self.state, Some(RouteRuleState::Absent))
+    }
+
+    fn is_match(&self, other: &Self) -> bool {
+        if let Some(ip_from) = self.ip_from.as_deref() {
+            let ip_from = if !ip_from.contains('/') {
+                match InterfaceIpAddr::try_from(ip_from) {
+                    Ok(ref i) => i.into(),
+                    Err(e) => {
+                        log::error!("{}", e);
+                        return false;
+                    }
+                }
+            } else {
+                ip_from.to_string()
+            };
+            if other.ip_from != Some(ip_from) {
+                return false;
+            }
+        }
+        if let Some(ip_to) = self.ip_to.as_deref() {
+            let ip_to = if !ip_to.contains('/') {
+                match InterfaceIpAddr::try_from(ip_to) {
+                    Ok(ref i) => i.into(),
+                    Err(e) => {
+                        log::error!("{}", e);
+                        return false;
+                    }
+                }
+            } else {
+                ip_to.to_string()
+            };
+            if other.ip_to != Some(ip_to) {
+                return false;
+            }
+        }
+        if self.priority.is_some()
+            && self.priority != Some(RouteRuleEntry::USE_DEFAULT_PRIORITY)
+            && self.priority != other.priority
+        {
+            return false;
+        }
+        if self.table_id.is_some()
+            && self.table_id != Some(RouteRuleEntry::USE_DEFAULT_ROUTE_TABLE)
+            && self.table_id != other.table_id
+        {
+            return false;
+        }
+        true
+    }
+
+    // Return tuple of (no_absent, is_ipv4, table_id, ip_from,
+    // ip_to, priority)
+    fn sort_key(&self) -> (bool, bool, u32, &str, &str, i64) {
+        (
+            !matches!(self.state, Some(RouteRuleState::Absent)),
+            {
+                if let Some(ip_from) = self.ip_from.as_ref() {
+                    !is_ipv6_addr(ip_from.as_str())
+                } else if let Some(ip_to) = self.ip_to.as_ref() {
+                    !is_ipv6_addr(ip_to.as_str())
+                } else {
+                    log::warn!(
+                        "Neither ip-from nor ip-to \
+                    is defined, treating it a IPv4 route rule"
+                    );
+                    true
+                }
+            },
+            self.table_id
+                .unwrap_or(RouteRuleEntry::USE_DEFAULT_ROUTE_TABLE),
+            self.ip_from.as_deref().unwrap_or(""),
+            self.ip_to.as_deref().unwrap_or(""),
+            self.priority
+                .unwrap_or(RouteRuleEntry::USE_DEFAULT_PRIORITY),
+        )
+    }
+}
+
+// For Vec::dedup()
+impl PartialEq for RouteRuleEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.sort_key() == other.sort_key()
+    }
+}
+
+// For Vec::sort_unstable()
+impl Ord for RouteRuleEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.sort_key().cmp(&other.sort_key())
+    }
+}
+
+// For ord
+impl Eq for RouteRuleEntry {}
+
+// For ord
+impl PartialOrd for RouteRuleEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Absent rule will be ignored
+fn create_rule_index_by_table_id(
+    rules: &[RouteRuleEntry],
+) -> HashMap<u32, Vec<&RouteRuleEntry>> {
+    let mut ret: HashMap<u32, Vec<&RouteRuleEntry>> = HashMap::new();
+    for rule in rules {
+        if rule.is_absent() {
+            continue;
+        }
+        let table_id = match rule.table_id {
+            Some(RouteRuleEntry::USE_DEFAULT_ROUTE_TABLE) | None => {
+                RouteRuleEntry::DEFAULR_ROUTE_TABLE_ID
+            }
+            Some(i) => i,
+        };
+        match ret.entry(table_id) {
+            Entry::Occupied(o) => {
+                o.into_mut().push(rule);
+            }
+            Entry::Vacant(v) => {
+                v.insert(vec![rule]);
+            }
+        };
+    }
+    ret
+}
+
+// All the rules sending to this function has no table id defined.
+fn flat_absent_rule(
+    desire_rules: &[RouteRuleEntry],
+    cur_rules: &[RouteRuleEntry],
+) -> Vec<RouteRuleEntry> {
+    let mut ret: Vec<RouteRuleEntry> = Vec::new();
+    for absent_rule in desire_rules.iter().filter(|r| r.is_absent()) {
+        if absent_rule.table_id.is_none() {
+            for cur_rule in cur_rules {
+                if absent_rule.is_match(cur_rule) {
+                    let mut new_absent_rule = absent_rule.clone();
+                    new_absent_rule.table_id = cur_rule.table_id;
+                    ret.push(new_absent_rule);
+                }
+            }
+        } else {
+            ret.push(absent_rule.clone());
+        }
+    }
+    ret
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -5,6 +5,8 @@ mod ifaces_ctrller;
 #[cfg(test)]
 mod route;
 #[cfg(test)]
+mod route_rule;
+#[cfg(test)]
 mod sriov;
 #[cfg(test)]
 mod testlib;

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -1,0 +1,158 @@
+use crate::{
+    unit_tests::testlib::new_eth_iface, Interfaces, NetworkState, RouteEntry,
+    RouteRuleEntry, RouteRules, Routes,
+};
+
+const TEST_NIC: &str = "eth1";
+const TEST_IPV4_NET1: &str = "192.0.2.0/24";
+const TEST_IPV4_ADDR1: &str = "198.51.100.1";
+const TEST_IPV6_NET1: &str = "2001:db8:1::/64";
+const TEST_IPV6_ADDR1: &str = "2001:db8:0::1";
+const TEST_TABLE_ID1: u32 = 101;
+const TEST_TABLE_ID2: u32 = 102;
+
+const TEST_RULE_IPV6_FROM: &str = "2001:db8:1::2";
+const TEST_RULE_IPV4_FROM: &str = "192.0.2.1";
+const TEST_RULE_IPV6_TO: &str = "2001:db8:2::2";
+const TEST_RULE_IPV4_TO: &str = "198.51.100.1";
+const TEST_RULE_PRIORITY1: i64 = 201;
+const TEST_RULE_PRIORITY2: i64 = 202;
+
+const TEST_ROUTE_METRIC: i64 = 100;
+
+#[test]
+fn test_sort_uniqe_route_rules() {
+    let mut test_routes = gen_test_rule_entries();
+    test_routes.reverse();
+    test_routes.extend(gen_test_rule_entries());
+    test_routes.sort_unstable();
+    test_routes.dedup();
+
+    assert_eq!(test_routes, gen_test_rule_entries());
+}
+
+#[test]
+fn test_add_rules_to_new_interface() {
+    let cur_net_state = NetworkState::new();
+
+    let des_iface = new_eth_iface(TEST_NIC);
+    let mut des_ifaces = Interfaces::new();
+    des_ifaces.push(des_iface);
+    let mut des_net_state = NetworkState::new();
+    des_net_state.interfaces = des_ifaces;
+    des_net_state.routes = gen_test_routes_conf();
+    des_net_state.rules = gen_test_rules_conf();
+
+    let (add_net_state, chg_net_state, del_net_state) =
+        des_net_state.gen_state_for_apply(&cur_net_state).unwrap();
+
+    assert_eq!(chg_net_state, NetworkState::new());
+    assert_eq!(del_net_state, NetworkState::new());
+
+    let add_ifaces = add_net_state.interfaces.to_vec();
+
+    assert_eq!(add_ifaces.len(), 1);
+    assert_eq!(add_ifaces[0].name(), TEST_NIC);
+    let config_rules = add_ifaces[0].base_iface().rules.as_ref().unwrap();
+
+    println!("{:?}", config_rules);
+    assert_eq!(config_rules.len(), 2);
+
+    assert_eq!(
+        config_rules[0].ip_from.as_ref().unwrap().as_str(),
+        TEST_RULE_IPV6_FROM,
+    );
+    assert_eq!(
+        config_rules[0].ip_to.as_ref().unwrap().as_str(),
+        TEST_RULE_IPV6_TO,
+    );
+    assert_eq!(config_rules[0].priority.unwrap(), TEST_RULE_PRIORITY1);
+    assert_eq!(config_rules[0].table_id.unwrap(), TEST_TABLE_ID1);
+    assert_eq!(
+        config_rules[1].ip_from.as_ref().unwrap().as_str(),
+        TEST_RULE_IPV4_FROM,
+    );
+    assert_eq!(
+        config_rules[1].ip_to.as_ref().unwrap().as_str(),
+        TEST_RULE_IPV4_TO,
+    );
+    assert_eq!(config_rules[1].priority.unwrap(), TEST_RULE_PRIORITY2);
+    assert_eq!(config_rules[1].table_id.unwrap(), TEST_TABLE_ID2);
+}
+
+fn gen_test_routes_conf() -> Routes {
+    let mut ret = Routes::new();
+    ret.running = Some(gen_test_route_entries());
+    ret.config = Some(gen_test_route_entries());
+    ret
+}
+
+fn gen_test_route_entries() -> Vec<RouteEntry> {
+    let mut routes = Vec::new();
+    routes.push(gen_route_entry(
+        TEST_IPV6_NET1,
+        TEST_NIC,
+        TEST_IPV6_ADDR1,
+        TEST_TABLE_ID1,
+    ));
+    routes.push(gen_route_entry(
+        TEST_IPV4_NET1,
+        TEST_NIC,
+        TEST_IPV4_ADDR1,
+        TEST_TABLE_ID2,
+    ));
+    routes
+}
+
+fn gen_route_entry(
+    dst: &str,
+    next_hop_iface: &str,
+    next_hop_addr: &str,
+    table_id: u32,
+) -> RouteEntry {
+    let mut ret = RouteEntry::new();
+    ret.destination = Some(dst.to_string());
+    ret.next_hop_iface = Some(next_hop_iface.to_string());
+    ret.next_hop_addr = Some(next_hop_addr.to_string());
+    ret.metric = Some(TEST_ROUTE_METRIC);
+    ret.table_id = Some(table_id);
+    ret
+}
+
+fn gen_test_rules_conf() -> RouteRules {
+    RouteRules {
+        config: Some(gen_test_rule_entries()),
+    }
+}
+
+fn gen_test_rule_entries() -> Vec<RouteRuleEntry> {
+    let mut rules = Vec::new();
+    rules.push(gen_rule_entry(
+        TEST_RULE_IPV6_FROM,
+        TEST_RULE_IPV6_TO,
+        TEST_RULE_PRIORITY1,
+        TEST_TABLE_ID1,
+    ));
+    rules.push(gen_rule_entry(
+        TEST_RULE_IPV4_FROM,
+        TEST_RULE_IPV4_TO,
+        TEST_RULE_PRIORITY2,
+        TEST_TABLE_ID2,
+    ));
+    rules
+}
+
+fn gen_rule_entry(
+    ip_from: &str,
+    ip_to: &str,
+    priority: i64,
+    table_id: u32,
+) -> RouteRuleEntry {
+    RouteRuleEntry {
+        state: None,
+        ip_from: Some(ip_from.to_string()),
+        ip_to: Some(ip_to.to_string()),
+        table_id: Some(table_id),
+        priority: Some(priority),
+    }
+}

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -24,6 +24,9 @@ use crate::{
     connection::route::{
         nm_ip_routes_to_value, parse_nm_ip_route_data, NmIpRoute,
     },
+    connection::route_rule::{
+        nm_ip_rules_to_value, parse_nm_ip_rule_data, NmIpRouteRule,
+    },
     connection::DbusDictionary,
     error::{ErrorKind, NmError},
 };
@@ -90,6 +93,7 @@ pub struct NmSettingIp {
     pub method: Option<NmSettingIpMethod>,
     pub addresses: Vec<String>,
     pub routes: Vec<NmIpRoute>,
+    pub route_rules: Vec<NmIpRouteRule>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -103,6 +107,9 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
                 .unwrap_or_default();
         setting.routes = _from_map!(v, "route-data", parse_nm_ip_route_data)?
             .unwrap_or_default();
+        setting.route_rules =
+            _from_map!(v, "routing-rules", parse_nm_ip_rule_data)?
+                .unwrap_or_default();
 
         // NM deprecated `addresses` property in the favor of `addresss-data`
         v.remove("addresses");
@@ -163,6 +170,7 @@ impl NmSettingIp {
         }
         ret.insert("address-data", zvariant::Value::Array(addresss_data));
         ret.insert("route-data", nm_ip_routes_to_value(&self.routes)?);
+        ret.insert("routing-rules", nm_ip_rules_to_value(&self.route_rules)?);
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))
         }));

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -22,6 +22,7 @@ mod conn;
 mod ip;
 mod ovs;
 mod route;
+mod route_rule;
 mod sriov;
 mod vlan;
 mod wired;
@@ -45,3 +46,4 @@ pub(crate) use crate::connection::conn::{
     nm_con_get_from_obj_path, DbusDictionary, NmConnectionDbusValue,
 };
 pub use crate::connection::route::NmIpRoute;
+pub use crate::connection::route_rule::NmIpRouteRule;

--- a/rust/src/libnm_dbus/connection/route_rule.rs
+++ b/rust/src/libnm_dbus/connection/route_rule.rs
@@ -1,0 +1,134 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{connection::DbusDictionary, error::NmError};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmIpRouteRule {
+    pub family: Option<i32>,
+    pub priority: Option<u32>,
+    pub from: Option<String>,
+    pub from_len: Option<u8>,
+    pub to: Option<String>,
+    pub to_len: Option<u8>,
+    pub table: Option<u32>,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmIpRouteRule {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        let mut setting = Self::new();
+        setting.family = _from_map!(v, "family", i32::try_from)?;
+        setting.priority = _from_map!(v, "priority", u32::try_from)?;
+        setting.from = _from_map!(v, "from", String::try_from)?;
+        setting.from_len = _from_map!(v, "from-len", u8::try_from)?;
+        setting.to = _from_map!(v, "to", String::try_from)?;
+        setting.to_len = _from_map!(v, "to-len", u8::try_from)?;
+        setting.table = _from_map!(v, "table", u32::try_from)?;
+
+        setting._other = v;
+        Ok(setting)
+    }
+}
+
+impl NmIpRouteRule {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+        if let Some(v) = &self.family {
+            ret.append(
+                zvariant::Value::new("family"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.priority {
+            ret.append(
+                zvariant::Value::new("priority"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.from {
+            ret.append(
+                zvariant::Value::new("from"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.from_len {
+            ret.append(
+                zvariant::Value::new("from-len"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.to {
+            ret.append(
+                zvariant::Value::new("to"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.to_len {
+            ret.append(
+                zvariant::Value::new("to-len"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.table {
+            ret.append(
+                zvariant::Value::new("table"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+
+        for (key, value) in self._other.iter() {
+            ret.append(
+                zvariant::Value::new(key.as_str()),
+                zvariant::Value::from(value.clone()),
+            )?;
+        }
+        Ok(zvariant::Value::Dict(ret))
+    }
+}
+
+pub(crate) fn parse_nm_ip_rule_data(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<NmIpRouteRule>, NmError> {
+    let mut rules = Vec::new();
+    for nm_rule_value in <Vec<DbusDictionary>>::try_from(value)? {
+        rules.push(NmIpRouteRule::try_from(nm_rule_value)?);
+    }
+    Ok(rules)
+}
+
+pub(crate) fn nm_ip_rules_to_value(
+    nm_rules: &[NmIpRouteRule],
+) -> Result<zvariant::Value, NmError> {
+    let mut rule_values =
+        zvariant::Array::new(zvariant::Signature::from_str_unchecked("a{sv}"));
+    for nm_rule in nm_rules {
+        rule_values.append(nm_rule.to_value()?)?;
+    }
+    Ok(zvariant::Value::Array(rule_values))
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -24,7 +24,7 @@ mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
-    NmConnection, NmIpRoute, NmSettingBond, NmSettingBridge,
+    NmConnection, NmIpRoute, NmIpRouteRule, NmSettingBond, NmSettingBridge,
     NmSettingBridgeVlanRange, NmSettingConnection, NmSettingIp,
     NmSettingIpMethod, NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
     NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingVlan,


### PR DESCRIPTION
Integration test cases enabled except
`test_route_rule_add_with_auto_route_table_id` which require support of
DHCP option.