### PR TITLE
[nmstate-1.0] sriov: New way to wait VF been created

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -33,6 +33,7 @@ from .base_iface import BaseIface
 from .bond import BondIface
 from .dummy import DummyIface
 from .ethernet import EthernetIface
+from .ethernet import verify_sriov_vf
 from .infiniband import InfiniBandIface
 from .linux_bridge import LinuxBridgeIface
 from .macvlan import MacVlanIface
@@ -151,7 +152,6 @@ class Ifaces:
                     self._kernel_ifaces[iface.name] = iface
 
             self._create_virtual_port()
-            self._create_sriov_vfs_when_changed()
             self._mark_vf_interface_as_absent_when_sriov_vf_decrease()
             self._validate_unknown_port()
             self._validate_unknown_parent()
@@ -217,30 +217,6 @@ class Ifaces:
                             new_ifaces.append(new_port)
         for iface in new_ifaces:
             self._kernel_ifaces[iface.name] = iface
-
-    def _create_sriov_vfs_when_changed(self):
-        """
-        When plugin set the TOTAL_VFS of PF, it might take 1 seconds or
-        more to have the VFs to be ready.
-        Nmstate should use verification retry to make sure VFs are full ready.
-        To do that, we include VFs into desire state.
-        """
-        new_ifaces = []
-        for iface in self.all_ifaces():
-            if (
-                iface.is_up
-                and (iface.is_desired or iface.is_changed)
-                and iface.type == InterfaceType.ETHERNET
-                and iface.sriov_total_vfs > 0
-            ):
-                for new_iface in iface.create_sriov_vf_ifaces():
-                    if new_iface.name not in self._kernel_ifaces:
-                        new_iface.mark_as_desired()
-                        new_ifaces.append(new_iface)
-                    else:
-                        self._kernel_ifaces[new_iface.name].mark_as_desired()
-        for new_iface in new_ifaces:
-            self._kernel_ifaces[new_iface.name] = new_iface
 
     def _mark_vf_interface_as_absent_when_sriov_vf_decrease(self):
         """
@@ -605,6 +581,7 @@ class Ifaces:
         cur_ifaces._remove_ignore_interfaces(self._ignored_ifaces)
         self._remove_ignore_interfaces(self._ignored_ifaces)
         for iface in self.all_ifaces():
+            verify_sriov_vf(iface, cur_ifaces)
             if iface.is_desired:
                 if (
                     iface.is_virtual
@@ -658,18 +635,6 @@ class Ifaces:
                                 cur_iface.state_for_verify(),
                             )
                         )
-                    elif (
-                        iface.type == InterfaceType.ETHERNET and iface.is_sriov
-                    ):
-                        if not cur_iface.check_total_vfs_matches_vf_list(
-                            iface.sriov_total_vfs
-                        ):
-                            raise NmstateVerificationError(
-                                "The NIC exceeded the waiting time for "
-                                "verification and it is failing because "
-                                "the `total_vfs` does not match the VF "
-                                "list length."
-                            )
 
     def gen_dns_metadata(self, dns_state, route_state):
         iface_metadata = dns_state.gen_metadata(self, route_state)

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -40,9 +40,6 @@ from .veth import create_iface_for_nm_veth_peer
 from .veth import is_nm_veth_supported
 
 
-IS_GENERATED_VF_METADATA = "_is_generated_vf"
-
-
 class NmProfiles:
     def __init__(self, context):
         self._ctx = context
@@ -66,7 +63,6 @@ class NmProfiles:
         all_profiles = [
             NmProfile(self._ctx, iface)
             for iface in net_state.ifaces.all_ifaces()
-            if not _is_only_for_verify(iface)
         ]
 
         for profile in all_profiles:
@@ -413,7 +409,3 @@ def _nm_ovs_port_has_child(nm_profile, ovs_bridge_iface, net_state):
         ):
             return True
     return False
-
-
-def _is_only_for_verify(iface):
-    return iface.to_dict().get(IS_GENERATED_VF_METADATA)

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -102,8 +102,9 @@ def _create_sriov_vfs_from_config(vfs_config, sriov_setting, vf_ids_to_add):
 
 
 def _set_nm_attribute(vf_object, key, value):
-    nm_attr, nm_variant = SRIOV_NMSTATE_TO_NM_MAP[key]
-    vf_object.set_attribute(nm_attr, nm_variant(value))
+    if key in SRIOV_NMSTATE_TO_NM_MAP:
+        nm_attr, nm_variant = SRIOV_NMSTATE_TO_NM_MAP[key]
+        vf_object.set_attribute(nm_attr, nm_variant(value))
 
 
 def _remove_sriov_vfs_in_setting(vfs_config, sriov_setting, vf_ids_to_remove):

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -456,21 +456,6 @@ class TestIfaces:
 
 
 class TestIfacesSriov:
-    def test_vf_been_auto_include_as_desired(self):
-        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
-        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
-        des_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
-            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
-        }
-        ifaces = Ifaces(des_iface_infos, [])
-        assert len(list(ifaces.all_ifaces())) == 3
-        assert ifaces.get_iface(
-            f"{FOO1_IFACE_NAME}v0", InterfaceType.ETHERNET
-        ).is_desired
-        assert ifaces.get_iface(
-            f"{FOO1_IFACE_NAME}v1", InterfaceType.ETHERNET
-        ).is_desired
-
     def test_ignore_vf_when_pf_is_down(self):
         des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
         des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
@@ -524,38 +509,3 @@ class TestIfacesSriov:
         )
         assert absent_iface.is_desired
         assert absent_iface.is_absent
-
-    def test_vfs_been_updated_according_to_decreased_total_vfs(self):
-        cur_iface_infos = [
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-            gen_foo_iface_info(InterfaceType.ETHERNET),
-        ]
-        cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
-        cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
-            Ethernet.SRIOV_SUBTREE: {
-                Ethernet.SRIOV.TOTAL_VFS: 3,
-                Ethernet.SRIOV.VFS_SUBTREE: [1, 2, 3],
-            }
-        }
-        cur_iface_infos[1][Interface.NAME] = f"{FOO1_IFACE_NAME}v0"
-        cur_iface_infos[2][Interface.NAME] = f"{FOO1_IFACE_NAME}v1"
-        cur_iface_infos[3][Interface.NAME] = f"{FOO1_IFACE_NAME}v2"
-
-        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
-        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
-        des_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
-            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2}
-        }
-        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
-
-        pf_iface = ifaces.get_iface(FOO1_IFACE_NAME, InterfaceType.ETHERNET)
-        assert (
-            len(
-                pf_iface.to_dict()[Ethernet.CONFIG_SUBTREE][
-                    Ethernet.SRIOV_SUBTREE
-                ][Ethernet.SRIOV.VFS_SUBTREE]
-            )
-            == 2
-        )


### PR DESCRIPTION
By checking `/sys/class/net/<pf_name>/device/virtfn<sriov_id>/net/`
we could tell the interface name of VF.

The old VF name guessing method is removed. The `verify_sriov_vf()` is
created to collect all VF interfaces name, then comparing it with
`total_vfs` count and check whether they exists in current state.

The test indicate kernel/udev does not require extra time to remove VF
interface when decreasing SR-IOV VF count.