### PR TITLE
rust: Add dns support

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -180,6 +180,7 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/static_ip_address_test.py \
             tests/integration/preserve_ip_config_test.py \
+            tests/integration/dns_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 
 use env_logger::Builder;
 use log::LevelFilter;
-use nmstate::{NetworkState, RouteRules, Routes};
+use nmstate::{DnsState, NetworkState, RouteRules, Routes};
 use serde::Serialize;
 use serde_yaml::{self, Value};
 
@@ -141,8 +141,9 @@ fn gen_conf(file_path: &str) -> Result<String, CliError> {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 struct SortedNetworkState {
-    routes: Routes,
+    dns: DnsState,
     rules: RouteRules,
+    routes: Routes,
     interfaces: Vec<Value>,
 }
 
@@ -185,6 +186,7 @@ fn sort_netstate(
             interfaces: new_ifaces,
             routes: net_state.routes,
             rules: net_state.rules,
+            dns: net_state.dns,
         });
     }
 
@@ -192,6 +194,7 @@ fn sort_netstate(
         interfaces: Vec::new(),
         routes: net_state.routes,
         rules: net_state.rules,
+        dns: net_state.dns,
     })
 }
 

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -1,0 +1,551 @@
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ip::is_ipv6_addr, ErrorKind, Interface, Interfaces, NetworkState,
+    NmstateError,
+};
+
+const DEFAULT_DNS_PRIORITY: i32 = 40;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct DnsState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub running: Option<DnsClientState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<DnsClientState>,
+}
+
+impl DnsState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+        if let Some(dns_conf) = self.config.as_ref() {
+            if let Some(config_srvs) = dns_conf.server.as_ref() {
+                if config_srvs.len() > 2
+                    && is_mixed_dns_servers(config_srvs.as_slice())
+                {
+                    let e = NmstateError::new(
+                    ErrorKind::NotImplementedError,
+                    "Placing IPv4/IPv6 nameserver in the middle of IPv6/IPv4 \
+                    nameservers is not supported yet"
+                        .to_string(),
+                );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+        if let Some(conf) = self.config.as_ref() {
+            if let Some(srvs) = conf.server.as_ref() {
+                let cur_conf = current.config.as_ref().ok_or_else(|| {
+                    // Do not log verification error as we have fail-retry
+                    NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Failed to apply DNS config: desire {:?} got {:?}",
+                            self, current
+                        ),
+                    )
+                })?;
+                let mut canonicalized_srvs = Vec::new();
+                for srv in srvs {
+                    if is_ipv6_addr(srv) {
+                        if let Ok(ip_addr) = srv.parse::<Ipv6Addr>() {
+                            canonicalized_srvs.push(ip_addr.to_string());
+                        }
+                    } else if let Ok(ip_addr) = srv.parse::<Ipv4Addr>() {
+                        canonicalized_srvs.push(ip_addr.to_string());
+                    }
+                }
+
+                if cur_conf.server != Some(canonicalized_srvs)
+                    && !(cur_conf.server.is_none() && srvs.is_empty())
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Failed to apply DNS config: desire name servers \
+                            {:?}, got {:?}",
+                            srvs,
+                            cur_conf.server.as_ref()
+                        ),
+                    ));
+                }
+            }
+            if let Some(schs) = conf.search.as_ref() {
+                let cur_conf = current.config.as_ref().ok_or_else(|| {
+                    NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Failed to apply DNS config: desire {:?} got {:?}",
+                            self, current
+                        ),
+                    )
+                })?;
+                if cur_conf.search != Some(schs.to_vec())
+                    && !(cur_conf.search.is_none() && schs.is_empty())
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::VerificationError,
+                        format!(
+                            "Failed to apply DNS config: desire searches \
+                            {:?}, got {:?}",
+                            schs,
+                            cur_conf.search.as_ref()
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn merge_current(&mut self, current: &Self) {
+        if let Some(conf) = self.config.as_mut() {
+            if conf.is_purge() {
+                self.config = Some(DnsClientState {
+                    server: Some(Vec::new()),
+                    search: Some(Vec::new()),
+                    priority: None,
+                });
+            } else if let Some(cur_conf) = current.config.as_ref() {
+                if conf.server.is_none() {
+                    conf.server =
+                        Some(cur_conf.server.clone().unwrap_or_default());
+                }
+                if conf.search.is_none() {
+                    conf.search =
+                        Some(cur_conf.search.clone().unwrap_or_default());
+                }
+            }
+        } else {
+            self.config = current.config.clone();
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct DnsClientState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub server: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search: Option<Vec<String>>,
+    #[serde(skip)]
+    // Lower is better
+    pub(crate) priority: Option<i32>,
+}
+
+impl DnsClientState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // Whether user want to purge all DNS settings
+    pub(crate) fn is_purge(&self) -> bool {
+        match (&self.server, &self.search) {
+            (Some(srvs), Some(schs)) => srvs.is_empty() && schs.is_empty(),
+            (Some(srvs), None) => srvs.is_empty(),
+            (None, Some(schs)) => schs.is_empty(),
+            (None, None) => true,
+        }
+    }
+
+    pub(crate) fn is_null(&self) -> bool {
+        self.server.as_ref().map(|s| s.len()).unwrap_or_default() == 0
+            && self.search.as_ref().map(|s| s.len()).unwrap_or_default() == 0
+    }
+
+    pub(crate) fn save_dns_to_iface(
+        &self,
+        v4_iface_name: &str,
+        v6_iface_name: &str,
+        add_net_state: &mut NetworkState,
+        chg_net_state: &mut NetworkState,
+        current: &NetworkState,
+    ) -> Result<(), NmstateError> {
+        let servers = if let Some(srvs) = self.server.as_ref() {
+            srvs.clone()
+        } else {
+            Vec::new()
+        };
+        let searches = if let Some(schs) = self.search.as_ref() {
+            schs.clone()
+        } else {
+            Vec::new()
+        };
+        let mut v4_servers = Vec::new();
+        let mut v6_servers = Vec::new();
+        let prefer_ipv6_srv = servers
+            .get(0)
+            .map(|s| is_ipv6_addr(s.as_str()))
+            .unwrap_or_default();
+        for srv in servers {
+            if is_ipv6_addr(&srv) {
+                v6_servers.push(srv.to_string())
+            } else {
+                v4_servers.push(srv.to_string())
+            }
+        }
+        if !v6_servers.is_empty() {
+            _save_dns_to_iface(
+                true,
+                v6_iface_name,
+                (v6_servers, searches.clone()),
+                add_net_state,
+                chg_net_state,
+                current,
+                prefer_ipv6_srv,
+            )?;
+        }
+        if !v4_servers.is_empty() {
+            _save_dns_to_iface(
+                false,
+                v4_iface_name,
+                (v4_servers, searches),
+                add_net_state,
+                chg_net_state,
+                current,
+                !prefer_ipv6_srv,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn is_dns_changed(
+    desired: &NetworkState,
+    current: &NetworkState,
+) -> bool {
+    match (desired.dns.config.as_ref(), current.dns.config.as_ref()) {
+        (None, None) => false,
+        (Some(des_config), Some(cur_config)) => {
+            if des_config == cur_config {
+                // DNS configure not changed, but we need to check whether
+                // interface holding DNS still valid to hold DNS config
+                !current_dns_ifaces_are_still_valid(desired, current)
+            } else {
+                true
+            }
+        }
+        (Some(_), None) => true,
+        (None, Some(_)) => {
+            // DNS configure not changed, but we need to check whether
+            // interface holding DNS still valid to hold DNS config
+            !current_dns_ifaces_are_still_valid(desired, current)
+        }
+    }
+}
+
+// Return interfaces to hold IPv4 and IPv6 DNS configuration.
+pub(crate) fn reselect_dns_ifaces(
+    desired: &NetworkState,
+    current: &NetworkState,
+) -> (String, String) {
+    (
+        find_ifaces_in_desire(false, &desired.interfaces)
+            .or_else(|| {
+                find_ifaces_with_static_gateways(
+                    false,
+                    &desired.interfaces,
+                    &current.interfaces,
+                )
+            })
+            .unwrap_or_default(),
+        find_ifaces_in_desire(true, &desired.interfaces)
+            .or_else(|| {
+                find_ifaces_with_static_gateways(
+                    true,
+                    &desired.interfaces,
+                    &current.interfaces,
+                )
+            })
+            .unwrap_or_default(),
+    )
+}
+
+// Return None if specified interface has IP configuration as None.
+// TODO: support auto_dns: false
+fn is_iface_valid_for_dns(is_ipv6: bool, iface: &Interface) -> Option<bool> {
+    if is_ipv6 {
+        iface.base_iface().ipv6.as_ref().map(|ip_conf| {
+            ip_conf.enabled && !ip_conf.dhcp && !ip_conf.autoconf
+        })
+    } else {
+        iface
+            .base_iface()
+            .ipv4
+            .as_ref()
+            .map(|ip_conf| ip_conf.enabled && !ip_conf.dhcp)
+    }
+}
+
+// Return false when desired state disabled the IP of dns interface.
+fn current_dns_ifaces_are_still_valid(
+    desired: &NetworkState,
+    current: &NetworkState,
+) -> bool {
+    for (iface_name, cur_iface) in current.interfaces.kernel_ifaces.iter() {
+        if let Some(ipv4) = &cur_iface.base_iface().ipv4 {
+            if ipv4.enabled && ipv4.dns.is_some() {
+                if let Some(des_iface) =
+                    desired.interfaces.kernel_ifaces.get(iface_name)
+                {
+                    if is_iface_valid_for_dns(false, des_iface) == Some(false) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if let Some(ipv6) = &cur_iface.base_iface().ipv6 {
+            if ipv6.enabled && ipv6.dns.is_some() {
+                if let Some(des_iface) =
+                    desired.interfaces.kernel_ifaces.get(iface_name)
+                {
+                    if is_iface_valid_for_dns(true, des_iface) == Some(false) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+// Find interface with DHCP disabled and IP enabled from desired interfaces.
+fn find_ifaces_in_desire(
+    is_ipv6: bool,
+    desired: &Interfaces,
+) -> Option<String> {
+    for (iface_name, iface) in desired.kernel_ifaces.iter() {
+        if is_iface_valid_for_dns(is_ipv6, iface) == Some(true) {
+            return Some(iface_name.to_string());
+        }
+    }
+    None
+}
+
+fn find_ifaces_with_static_gateways(
+    is_ipv6: bool,
+    desired: &Interfaces,
+    current: &Interfaces,
+) -> Option<String> {
+    for (iface_name, iface) in desired
+        .kernel_ifaces
+        .iter()
+        .chain(current.kernel_ifaces.iter())
+    {
+        if is_iface_valid_for_dns(is_ipv6, iface) == Some(true) {
+            let des_iface = desired.kernel_ifaces.get(iface_name);
+            if let Some(des_iface) = des_iface {
+                if is_iface_valid_for_dns(is_ipv6, des_iface) != Some(false) {
+                    return Some(iface_name.to_string());
+                }
+            } else {
+                return Some(iface_name.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn is_mixed_dns_servers(srvs: &[String]) -> bool {
+    let mut pattern = String::new();
+    for srv in srvs {
+        let cur_char = if is_ipv6_addr(srv) { '6' } else { '4' };
+        if !pattern.ends_with(cur_char) {
+            pattern.push(cur_char);
+        }
+    }
+    pattern.contains("464") || pattern.contains("646")
+}
+
+// Return a list of interfaces hold DNS configurations
+pub(crate) fn get_cur_dns_ifaces(
+    current: &Interfaces,
+) -> (Vec<String>, Vec<String>) {
+    let mut v4_ifaces = Vec::new();
+    let mut v6_ifaces = Vec::new();
+    for (iface_name, cur_iface) in current.kernel_ifaces.iter() {
+        if let Some(ipv4) = &cur_iface.base_iface().ipv4 {
+            if ipv4.enabled {
+                if let Some(dns_conf) = &ipv4.dns {
+                    if !dns_conf.is_null() && !v4_ifaces.contains(iface_name) {
+                        v4_ifaces.push(iface_name.to_string())
+                    }
+                }
+            }
+        }
+        if let Some(ipv6) = &cur_iface.base_iface().ipv6 {
+            if ipv6.enabled {
+                if let Some(dns_conf) = &ipv6.dns {
+                    if !dns_conf.is_null() && !v6_ifaces.contains(iface_name) {
+                        v6_ifaces.push(iface_name.to_string())
+                    }
+                }
+            }
+        }
+    }
+    (v4_ifaces, v6_ifaces)
+}
+
+fn set_iface_dns_conf(
+    is_ipv6: bool,
+    iface: &mut Interface,
+    servers: Vec<String>,
+    searches: Vec<String>,
+    priority: Option<i32>,
+) {
+    let dns_conf = DnsClientState {
+        server: Some(servers),
+        search: Some(searches),
+        priority,
+    };
+    if is_ipv6 {
+        if let Some(ip_conf) = iface.base_iface_mut().ipv6.as_mut() {
+            ip_conf.dns = Some(dns_conf);
+        } else {
+            // Should never happen
+            log::error!("BUG: The dns interface is hold None IP {:?}", iface);
+        }
+    } else if let Some(ip_conf) = iface.base_iface_mut().ipv4.as_mut() {
+        ip_conf.dns = Some(dns_conf);
+    } else {
+        // Should never happen
+        log::error!("BUG: The dns interface is hold None IP {:?}", iface);
+    }
+}
+
+pub(crate) fn purge_dns_config(
+    is_ipv6: bool,
+    ifaces: &[String],
+    chg_net_state: &mut NetworkState,
+    current: &NetworkState,
+) {
+    for iface_name in ifaces {
+        if let Some(iface) =
+            chg_net_state.interfaces.kernel_ifaces.get_mut(iface_name)
+        {
+            set_iface_dns_conf(is_ipv6, iface, Vec::new(), Vec::new(), None);
+        } else {
+            // Include interface to chg_net_state
+            if let Some(cur_iface) =
+                current.interfaces.kernel_ifaces.get(iface_name)
+            {
+                let mut new_iface = cur_iface.clone_name_type_only();
+                new_iface
+                    .base_iface_mut()
+                    .copy_ip_config_if_none(cur_iface.base_iface());
+                set_iface_dns_conf(
+                    is_ipv6,
+                    &mut new_iface,
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                );
+                chg_net_state.append_interface_data(new_iface);
+            }
+        }
+    }
+}
+
+// Only preferred: true will save the searches
+fn _save_dns_to_iface(
+    is_ipv6: bool,
+    iface_name: &str,
+    dns_conf: (Vec<String>, Vec<String>),
+    add_net_state: &mut NetworkState,
+    chg_net_state: &mut NetworkState,
+    current: &NetworkState,
+    preferred: bool,
+) -> Result<(), NmstateError> {
+    let (servers, searches) = dns_conf;
+    if iface_name.is_empty() {
+        let e = NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Failed to find suitable(IP enabled with DHCP off \
+                or auto-dns: false) interface for DNS server {:?}",
+                servers
+            ),
+        );
+        log::error!("{}", e);
+        return Err(e);
+    }
+    let cur_iface = current.interfaces.kernel_ifaces.get(iface_name);
+    if let Some(iface) = add_net_state
+        .interfaces
+        .kernel_ifaces
+        .get_mut(iface_name)
+        .or_else(|| chg_net_state.interfaces.kernel_ifaces.get_mut(iface_name))
+    {
+        if let Some(cur_iface) = cur_iface {
+            iface
+                .base_iface_mut()
+                .copy_ip_config_if_none(cur_iface.base_iface());
+        }
+        if preferred {
+            set_iface_dns_conf(
+                is_ipv6,
+                iface,
+                servers,
+                searches,
+                Some(DEFAULT_DNS_PRIORITY),
+            );
+        } else {
+            set_iface_dns_conf(
+                is_ipv6,
+                iface,
+                servers,
+                Vec::new(),
+                Some(DEFAULT_DNS_PRIORITY + 10),
+            );
+        }
+    } else {
+        // Copy interface from current
+        if let Some(cur_iface) = cur_iface {
+            let mut new_iface = cur_iface.clone_name_type_only();
+            new_iface
+                .base_iface_mut()
+                .copy_ip_config_if_none(cur_iface.base_iface());
+            // We just append the interface, below unwrap() will never fail
+            if preferred {
+                set_iface_dns_conf(
+                    is_ipv6,
+                    &mut new_iface,
+                    servers,
+                    searches,
+                    Some(DEFAULT_DNS_PRIORITY),
+                );
+            } else {
+                set_iface_dns_conf(
+                    is_ipv6,
+                    &mut new_iface,
+                    servers,
+                    Vec::new(),
+                    Some(DEFAULT_DNS_PRIORITY + 10),
+                );
+            }
+            chg_net_state.append_interface_data(new_iface);
+        } else {
+            let e = NmstateError::new(
+                ErrorKind::Bug,
+                format!(
+                    "Selected interface {} for dns, but not found it",
+                    iface_name
+                ),
+            );
+            log::error!("{}", e);
+            return Err(e);
+        }
+    }
+
+    Ok(())
+}

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -5,7 +5,7 @@ use log::{debug, warn};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
-use crate::{ErrorKind, NmstateError};
+use crate::{DnsClientState, ErrorKind, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct InterfaceIpv4 {
@@ -13,6 +13,7 @@ pub struct InterfaceIpv4 {
     pub prop_list: Vec<&'static str>,
     pub dhcp: bool,
     pub addresses: Vec<InterfaceIpAddr>,
+    pub(crate) dns: Option<DnsClientState>,
 }
 
 impl Serialize for InterfaceIpv4 {
@@ -137,6 +138,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                     prop_list,
                     dhcp,
                     addresses,
+                    dns: None,
                 })
             }
         }
@@ -163,6 +165,9 @@ impl InterfaceIpv4 {
         }
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();
+        }
+        if other.prop_list.contains(&"dns") {
+            self.dns = other.dns.clone();
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
@@ -205,6 +210,7 @@ pub struct InterfaceIpv6 {
     pub dhcp: bool,
     pub autoconf: bool,
     pub addresses: Vec<InterfaceIpAddr>,
+    pub(crate) dns: Option<DnsClientState>,
 }
 
 impl Serialize for InterfaceIpv6 {
@@ -347,6 +353,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                     dhcp,
                     autoconf,
                     addresses,
+                    dns: None,
                 })
             }
         }
@@ -376,6 +383,9 @@ impl InterfaceIpv6 {
         }
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();
+        }
+        if other.prop_list.contains(&"dns") {
+            self.dns = other.dns.clone();
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -1,3 +1,4 @@
+mod dns;
 mod error;
 mod iface;
 mod ifaces;
@@ -10,6 +11,7 @@ mod route_rule;
 mod state;
 mod unit_tests;
 
+pub use crate::dns::{DnsClientState, DnsState};
 pub use crate::error::{ErrorKind, NmstateError};
 pub use crate::iface::{
     Interface, InterfaceState, InterfaceType, UnknownInterface,

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -1,0 +1,85 @@
+use nm_dbus::{NmApi, NmSettingIp};
+
+use crate::{
+    nm::error::nm_error_to_nmstate, DnsClientState, DnsState, Interfaces,
+    NmstateError,
+};
+
+pub(crate) fn nm_dns_to_nmstate(nm_ip_setting: &NmSettingIp) -> DnsClientState {
+    DnsClientState {
+        server: nm_ip_setting.dns.clone(),
+        search: nm_ip_setting.dns_search.clone(),
+        priority: nm_ip_setting.dns_priority,
+    }
+}
+
+pub(crate) fn apply_nm_dns_setting(
+    nm_ip_setting: &mut NmSettingIp,
+    dns_conf: &DnsClientState,
+) {
+    nm_ip_setting.dns = dns_conf.server.clone();
+    nm_ip_setting.dns_search = dns_conf.search.clone();
+    nm_ip_setting.dns_priority = dns_conf.priority;
+}
+
+pub(crate) fn retrieve_dns_info(
+    nm_api: &NmApi,
+    ifaces: &Interfaces,
+) -> Result<DnsState, NmstateError> {
+    let mut nm_dns_entires = nm_api
+        .get_dns_configuration()
+        .map_err(nm_error_to_nmstate)?;
+    nm_dns_entires.sort_unstable_by_key(|d| d.priority);
+    let mut running_srvs: Vec<String> = Vec::new();
+    let mut running_schs: Vec<String> = Vec::new();
+    for nm_dns_entry in nm_dns_entires {
+        running_srvs.extend_from_slice(nm_dns_entry.name_servers.as_slice());
+        running_schs.extend_from_slice(nm_dns_entry.domains.as_slice());
+    }
+
+    let mut dns_confs: Vec<&DnsClientState> = Vec::new();
+    for iface in ifaces.kernel_ifaces.values() {
+        if let Some(ip_conf) = iface.base_iface().ipv6.as_ref() {
+            if let Some(dns_conf) = ip_conf.dns.as_ref() {
+                dns_confs.push(dns_conf);
+            }
+        }
+        if let Some(ip_conf) = iface.base_iface().ipv4.as_ref() {
+            if let Some(dns_conf) = ip_conf.dns.as_ref() {
+                dns_confs.push(dns_conf);
+            }
+        }
+    }
+    dns_confs.sort_unstable_by_key(|d| d.priority.unwrap_or_default());
+    let mut config_srvs: Vec<String> = Vec::new();
+    let mut config_schs: Vec<String> = Vec::new();
+    for dns_conf in dns_confs {
+        if let Some(srvs) = dns_conf.server.as_ref() {
+            config_srvs.extend_from_slice(srvs);
+        }
+        if let Some(schs) = dns_conf.search.as_ref() {
+            config_schs.extend_from_slice(schs);
+        }
+    }
+
+    Ok(DnsState {
+        running: Some(DnsClientState {
+            server: Some(running_srvs),
+            search: Some(running_schs),
+            ..Default::default()
+        }),
+        config: Some(DnsClientState {
+            server: if config_srvs.is_empty() && config_schs.is_empty() {
+                None
+            } else {
+                Some(config_srvs.clone())
+            },
+            search: if config_srvs.is_empty() && config_schs.is_empty() {
+                None
+            } else {
+                Some(config_schs)
+            },
+            ..Default::default()
+        }),
+    })
+}

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -5,6 +5,7 @@ mod bridge;
 mod checkpoint;
 mod connection;
 mod device;
+mod dns;
 mod error;
 mod ip;
 mod ovs;

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -46,7 +46,6 @@ impl Routes {
     //   added.
     // * desired static route exists.
     pub fn verify(&self, current: &Self) -> Result<(), NmstateError> {
-        println!("desired {:?}\ncurrent {:?}", self, current);
         if let Some(config_routes) = self.config.as_ref() {
             let cur_config_routes = match current.config.as_ref() {
                 Some(c) => c.to_vec(),

--- a/rust/src/libnm_dbus/Cargo.toml
+++ b/rust/src/libnm_dbus/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 path = "lib.rs"
 
 [dependencies]
-zbus = "1.9.1"
-zvariant = "2.7.0"
-uuid = { version = "0.8", features = ["v4"] }
-serde = { version = "1.0.130", features = ["derive"] }
+zbus = "1.9.2"
+zvariant = "2.10.0"
+uuid = { version = "0.8.2", features = ["v4"] }
+serde = { version = "1.0.132", features = ["derive"] }
 log = "0.4.14"

--- a/rust/src/libnm_dbus/connection/dns.rs
+++ b/rust/src/libnm_dbus/connection/dns.rs
@@ -1,0 +1,158 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::convert::TryFrom;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+use crate::{ErrorKind, NmError};
+
+const IPV6_ADDR_LEN: usize = 16;
+
+pub(crate) fn parse_nm_dns(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<String>, NmError> {
+    let mut dns_srvs = Vec::new();
+    for nm_dns_srv in Vec::<zvariant::OwnedValue>::try_from(value)? {
+        match nm_dns_srv.value_signature().as_str() {
+            "u" => match u32::try_from(nm_dns_srv) {
+                Ok(i) => {
+                    dns_srvs.push(Ipv4Addr::from(u32::from_be(i)).to_string())
+                }
+                Err(e) => {
+                    let e = NmError::new(
+                        ErrorKind::InvalidArgument,
+                        format!("Failed to convert to IP address: {}", e),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
+            },
+            "ay" => match Vec::<u8>::try_from(nm_dns_srv) {
+                Ok(b) => {
+                    if b.len() == IPV6_ADDR_LEN {
+                        let mut bytes = [0u8; IPV6_ADDR_LEN];
+                        bytes.copy_from_slice(&b[..IPV6_ADDR_LEN]);
+                        dns_srvs.push(
+                            Ipv6Addr::from(u128::from_be_bytes(bytes))
+                                .to_string(),
+                        );
+                    } else {
+                        let e = NmError::new(
+                            ErrorKind::InvalidArgument,
+                            format!("Failed to convert {:?} to IP address", b),
+                        );
+                        log::error!("{}", e);
+                        return Err(e);
+                    }
+                }
+                Err(e) => {
+                    let e = NmError::new(
+                        ErrorKind::InvalidArgument,
+                        format!("Failed to convert to IP address: {}", e),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
+            },
+            s => {
+                let e = NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Failed to convert to IP address: \
+                        invalid signature {:?}",
+                        s
+                    ),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
+        }
+    }
+    Ok(dns_srvs)
+}
+
+pub(crate) fn parse_nm_dns_search(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<String>, NmError> {
+    Vec::<String>::try_from(value).map_err(|e| {
+        let e = NmError::new(
+            ErrorKind::InvalidArgument,
+            format!("In valid DNS search: {}", e),
+        );
+        log::error!("{}", e);
+        e
+    })
+}
+
+pub(crate) fn nm_ip_dns_to_value(
+    dns_srvs: &[String],
+) -> Result<zvariant::Value, NmError> {
+    let mut is_ipv6 = false;
+    let mut dns_values = if let Some(dns_srv) = dns_srvs.get(0) {
+        if dns_srv.contains(':') {
+            // is IPv6
+            is_ipv6 = true;
+            zvariant::Array::new(zvariant::Signature::from_str_unchecked("ay"))
+        } else {
+            zvariant::Array::new(zvariant::Signature::from_str_unchecked("u"))
+        }
+    } else {
+        let e = NmError::new(
+            ErrorKind::Bug,
+            "nm_ip_dns_to_value got unexpected empty dns_srvs".to_string(),
+        );
+        log::error!("{}", e);
+        return Err(e);
+    };
+    for dns_srv in dns_srvs {
+        if is_ipv6 {
+            let ip_addr = Ipv6Addr::from_str(dns_srv).map_err(|e| {
+                let e = NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Invalid IPv6 address: {}: {}", dns_srv, e),
+                );
+                log::error!("{}", e);
+                e
+            })?;
+            let mut bytes = [0u8; IPV6_ADDR_LEN];
+            bytes.copy_from_slice(&ip_addr.octets()[..IPV6_ADDR_LEN]);
+            dns_values.append(zvariant::Value::new(bytes.to_vec()))?;
+        } else {
+            let ip_addr = Ipv4Addr::from_str(dns_srv).map_err(|e| {
+                let e = NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Invalid IPv4 address: {}: {}", dns_srv, e),
+                );
+                log::error!("{}", e);
+                e
+            })?;
+            let ip_addr_u32 = u32::from_be_bytes(ip_addr.octets()).to_be();
+            dns_values.append(zvariant::Value::new(ip_addr_u32))?;
+        }
+    }
+    Ok(zvariant::Value::Array(dns_values))
+}
+
+pub(crate) fn nm_ip_dns_search_to_value(
+    dns_searches: &[String],
+) -> Result<zvariant::Value, NmError> {
+    let mut values =
+        zvariant::Array::new(zvariant::Signature::from_str_unchecked("s"));
+    for search in dns_searches {
+        values.append(zvariant::Value::new(search))?;
+    }
+    Ok(zvariant::Value::Array(values))
+}

--- a/rust/src/libnm_dbus/connection/macros.rs
+++ b/rust/src/libnm_dbus/connection/macros.rs
@@ -21,3 +21,5 @@ macro_rules! _from_map {
         })
     };
 }
+
+pub(crate) use _from_map;

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -19,6 +19,7 @@ mod macros;
 mod bond;
 mod bridge;
 mod conn;
+mod dns;
 mod ip;
 mod ovs;
 mod route;
@@ -47,3 +48,5 @@ pub(crate) use crate::connection::conn::{
 };
 pub use crate::connection::route::NmIpRoute;
 pub use crate::connection::route_rule::NmIpRouteRule;
+
+pub(crate) use crate::connection::macros::_from_map;

--- a/rust/src/libnm_dbus/dbus.rs
+++ b/rust/src/libnm_dbus/dbus.rs
@@ -19,7 +19,9 @@ use log::debug;
 
 use crate::{
     connection::{NmConnection, NmConnectionDbusValue},
-    dbus_proxy::{NetworkManagerProxy, NetworkManagerSettingProxy},
+    dbus_proxy::{
+        NetworkManagerDnsProxy, NetworkManagerProxy, NetworkManagerSettingProxy,
+    },
     error::{ErrorKind, NmError},
 };
 
@@ -54,6 +56,7 @@ pub(crate) struct NmDbus<'a> {
     pub(crate) connection: zbus::Connection,
     proxy: NetworkManagerProxy<'a>,
     setting_proxy: NetworkManagerSettingProxy<'a>,
+    dns_proxy: NetworkManagerDnsProxy<'a>,
 }
 
 impl<'a> NmDbus<'a> {
@@ -61,11 +64,13 @@ impl<'a> NmDbus<'a> {
         let connection = zbus::Connection::new_system()?;
         let proxy = NetworkManagerProxy::new(&connection)?;
         let setting_proxy = NetworkManagerSettingProxy::new(&connection)?;
+        let dns_proxy = NetworkManagerDnsProxy::new(&connection)?;
 
         Ok(Self {
             connection,
             proxy,
             setting_proxy,
+            dns_proxy,
         })
     }
 
@@ -337,6 +342,12 @@ impl<'a> NmDbus<'a> {
             &str_to_obj_path(checkpoint)?,
             added_time_sec,
         )?)
+    }
+
+    pub(crate) fn get_dns_configuration(
+        &self,
+    ) -> Result<Vec<HashMap<String, zvariant::OwnedValue>>, NmError> {
+        Ok(self.dns_proxy.configuration()?)
     }
 }
 

--- a/rust/src/libnm_dbus/dbus_proxy.rs
+++ b/rust/src/libnm_dbus/dbus_proxy.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use zbus::dbus_proxy;
 
 #[dbus_proxy(
@@ -46,7 +48,7 @@ trait NetworkManager {
     fn checkpoint_rollback(
         &self,
         checkpoint: &zvariant::ObjectPath,
-    ) -> zbus::Result<std::collections::HashMap<String, u32>>;
+    ) -> zbus::Result<HashMap<String, u32>>;
 
     /// ActivateConnection method
     fn activate_connection(
@@ -94,15 +96,12 @@ trait NetworkManagerSetting {
     /// AddConnection2 method
     fn add_connection2(
         &self,
-        settings: std::collections::HashMap<
-            &str,
-            std::collections::HashMap<&str, zvariant::Value>,
-        >,
+        settings: HashMap<&str, HashMap<&str, zvariant::Value>>,
         flags: u32,
-        args: std::collections::HashMap<&str, zvariant::Value>,
+        args: HashMap<&str, zvariant::Value>,
     ) -> zbus::Result<(
         zvariant::OwnedObjectPath,
-        std::collections::HashMap<String, zvariant::OwnedValue>,
+        HashMap<String, zvariant::OwnedValue>,
     )>;
 
     /// ListConnections method
@@ -110,4 +109,17 @@ trait NetworkManagerSetting {
 
     /// GetAllDevices method
     fn get_all_devices(&self) -> zbus::Result<Vec<zvariant::OwnedObjectPath>>;
+}
+
+#[dbus_proxy(
+    interface = "org.freedesktop.NetworkManager.DnsManager",
+    default_service = "org.freedesktop.NetworkManager",
+    default_path = "/org/freedesktop/NetworkManager/DnsManager"
+)]
+trait NetworkManagerDns {
+    /// Configuration property
+    #[dbus_proxy(property)]
+    fn configuration(
+        &self,
+    ) -> zbus::Result<Vec<HashMap<String, zvariant::OwnedValue>>>;
 }

--- a/rust/src/libnm_dbus/dns.rs
+++ b/rust/src/libnm_dbus/dns.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use crate::{connection::_from_map, NmError};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct NmDnsEntry {
+    pub priority: i32,
+    pub domains: Vec<String>,
+    pub name_servers: Vec<String>,
+    pub interface: String,
+    pub is_vpn: bool,
+    _other: HashMap<String, zvariant::OwnedValue>,
+}
+
+impl TryFrom<HashMap<String, zvariant::OwnedValue>> for NmDnsEntry {
+    type Error = NmError;
+    fn try_from(
+        mut v: HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            priority: _from_map!(v, "priority", i32::try_from)?
+                .unwrap_or_default(),
+            domains: _from_map!(v, "domains", Vec::<String>::try_from)?
+                .unwrap_or_default(),
+            name_servers: _from_map!(
+                v,
+                "nameservers",
+                Vec::<String>::try_from
+            )?
+            .unwrap_or_default(),
+            interface: _from_map!(v, "interface", String::try_from)?
+                .unwrap_or_default(),
+            is_vpn: _from_map!(v, "vpn", bool::try_from)?.unwrap_or_default(),
+            _other: v,
+        })
+    }
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -18,6 +18,7 @@ mod convert;
 mod dbus;
 mod dbus_proxy;
 mod device;
+mod dns;
 mod error;
 mod keyfile;
 mod nm_api;
@@ -31,5 +32,6 @@ pub use crate::connection::{
     NmSettingWired, NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
+pub use crate::dns::NmDnsEntry;
 pub use crate::error::{ErrorKind, NmError};
 pub use crate::nm_api::NmApi;

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::convert::TryFrom;
 use std::time::{Duration, Instant};
 
 use log::debug;
@@ -26,6 +27,7 @@ use crate::{
         nm_dev_delete, nm_dev_from_obj_path, NmDevice, NmDeviceState,
         NmDeviceStateReason,
     },
+    dns::NmDnsEntry,
     error::{ErrorKind, NmError},
 };
 
@@ -268,6 +270,14 @@ impl<'a> NmApi<'a> {
             ErrorKind::Timeout,
             "Timeout on waiting rollback".to_string(),
         ))
+    }
+
+    pub fn get_dns_configuration(&self) -> Result<Vec<NmDnsEntry>, NmError> {
+        let mut ret: Vec<NmDnsEntry> = Vec::new();
+        for dns_value in self.dbus.get_dns_configuration()? {
+            ret.push(NmDnsEntry::try_from(dns_value)?);
+        }
+        Ok(ret)
     }
 }
 

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -33,7 +33,7 @@ from libnmstate.schema import Route
 IPV4_DNS_NAMESERVERS = ["8.8.8.8", "1.1.1.1"]
 EXTRA_IPV4_DNS_NAMESERVER = "9.9.9.9"
 IPV6_DNS_NAMESERVERS = ["2001:4860:4860::8888", "2606:4700:4700::1111"]
-IPV6_DNS_LONG_NAMESERVER = ["0000:0000:0000:0000:0000:0000:0000:0100"]
+IPV6_DNS_LONG_NAMESERVER = ["2000:0000:0000:0000:0000:0000:0000:0100"]
 EXTRA_IPV6_DNS_NAMESERVER = "2620:fe::9"
 EXAMPLE_SEARCHES = ["example.org", "example.com"]
 
@@ -316,7 +316,7 @@ def test_add_non_canonicalized_ipv6_nameserver():
     libnmstate.apply(desired_state)
 
     current_state = libnmstate.show()
-    assert "::100" in current_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]
+    assert "2000::100" in current_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]
 
 
 def _get_test_iface_states():


### PR DESCRIPTION
Due to lacking support of `auto_dns: false`, currently, only support using
static default gateway interface as DNS interface.

Rust code will try to use valid(ip enabled and manual dns allowed)
interface from desire state first, then search static gateway. I(Gris)
think this provides the small opportunity for user to enforce a interface
to hold the DNS configuration regardless the static gateway preference.

Integration test case enabled.

Changed one test case `test_add_non_canonicalized_ipv6_nameserver`:

    The test expect nmstate to
    compress `0000:0000:0000:0000:0000:0000:0000:0100` to `::100`.

    This IPv6 is IPv4-Compatible IPv6 Address(RFC 4291), so it is also
    legal to show as `::0.0.1.0` which is used by rust `std::net::Ipv6Addr`.

    Hence change the test IP to 2000::100 which is not ambiguous.