### PR TITLE
rust dhcp: Support DHCP options

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -276,6 +276,14 @@ function run_tests {
             not test_ignore_verification_error_on_invalid_bond_option and \
             not test_bond_ad_actor_system_with_multicast_mac_address' \
             ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/dynamic_ip_test.py \
+            -k 'not test_show_running_config_does_not_include_auto_config' \
+            ${nmstate_pytest_extra_args}"
     fi
 }
 

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -125,6 +125,13 @@ impl BaseInterface {
     }
 
     pub(crate) fn pre_verify_cleanup(&mut self) {
+        // * If cannot have IP, set ip: none
+        if !self.can_have_ip() {
+            self.ipv4 = None;
+            self.ipv6 = None;
+            self.prop_list.retain(|p| p != &"ipv4" && p != &"ipv6");
+        }
+
         if let Some(ref mut ipv4) = self.ipv4 {
             ipv4.pre_verify_cleanup();
         }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -9,6 +9,7 @@ use crate::{
     ifaces::inter_ifaces_controller::{
         find_unknown_type_port, handle_changed_ports, set_ifaces_up_priority,
     },
+    ip::include_current_ip_address_if_dhcp_on_to_off,
     ErrorKind, Interface, InterfaceState, InterfaceType, NmstateError,
 };
 
@@ -260,6 +261,12 @@ impl Interfaces {
                 }
             }
         }
+
+        // Normally, we expect backend to preserve configuration which not
+        // mentioned in desire, but when DHCP switch from ON to OFF, the design
+        // of nmstate is expecting dynamic IP address goes static. This should
+        // be done by top level code.
+        include_current_ip_address_if_dhcp_on_to_off(&mut chg_ifaces, current);
 
         Ok((add_ifaces, chg_ifaces, del_ifaces))
     }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -5,7 +5,7 @@ use log::{debug, warn};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 
-use crate::{DnsClientState, ErrorKind, NmstateError};
+use crate::{DnsClientState, ErrorKind, Interfaces, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct InterfaceIpv4 {
@@ -14,6 +14,10 @@ pub struct InterfaceIpv4 {
     pub dhcp: bool,
     pub addresses: Vec<InterfaceIpAddr>,
     pub(crate) dns: Option<DnsClientState>,
+    pub auto_dns: Option<bool>,
+    pub auto_gateway: Option<bool>,
+    pub auto_routes: Option<bool>,
+    pub auto_table_id: Option<u32>,
 }
 
 impl Serialize for InterfaceIpv4 {
@@ -24,7 +28,11 @@ impl Serialize for InterfaceIpv4 {
         let mut serial_struct = serializer.serialize_struct(
             "ipv4",
             if self.enabled {
-                self.prop_list.len()
+                if self.dhcp {
+                    self.prop_list.len()
+                } else {
+                    std::cmp::min(3, self.prop_list.len())
+                }
             } else {
                 1
             },
@@ -33,6 +41,26 @@ impl Serialize for InterfaceIpv4 {
         if self.enabled {
             if self.prop_list.contains(&"dhcp") {
                 serial_struct.serialize_field("dhcp", &self.dhcp)?;
+            }
+            if self.dhcp {
+                if self.prop_list.contains(&"auto_dns") {
+                    serial_struct
+                        .serialize_field("auto-dns", &self.auto_dns)?;
+                }
+                if self.prop_list.contains(&"auto_gateway") {
+                    serial_struct
+                        .serialize_field("auto-gateway", &self.auto_gateway)?;
+                }
+                if self.prop_list.contains(&"auto_routes") {
+                    serial_struct
+                        .serialize_field("auto-routes", &self.auto_routes)?;
+                }
+                if self.prop_list.contains(&"auto_table_id") {
+                    serial_struct.serialize_field(
+                        "auto-route-table-id",
+                        &self.auto_table_id,
+                    )?;
+                }
             }
             if self.prop_list.contains(&"addresses") {
                 serial_struct.serialize_field("address", &self.addresses)?;
@@ -51,6 +79,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
             Enabled,
             Dhcp,
             Address,
+            AutoDns,
+            AutoGateway,
+            AutoRoutes,
+            AutoRouteTableId,
         }
 
         impl<'de> Deserialize<'de> for Field {
@@ -67,7 +99,11 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                         &self,
                         formatter: &mut fmt::Formatter,
                     ) -> fmt::Result {
-                        formatter.write_str("`enabled`, `dhcp` or `address`")
+                        formatter.write_str(
+                            "`enabled`, `dhcp`, `address`\
+                            `auto-dns`, `auto-gateway`, `auto-routes` or \
+                            `auto-route-table-id`",
+                        )
                     }
 
                     fn visit_str<E>(self, value: &str) -> Result<Field, E>
@@ -78,6 +114,12 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                             "enabled" => Ok(Field::Enabled),
                             "dhcp" => Ok(Field::Dhcp),
                             "address" => Ok(Field::Address),
+                            "auto-dns" => Ok(Field::AutoDns),
+                            "auto-gateway" => Ok(Field::AutoGateway),
+                            "auto-routes" => Ok(Field::AutoRoutes),
+                            "auto-route-table-id" => {
+                                Ok(Field::AutoRouteTableId)
+                            }
                             _ => Err(de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -103,6 +145,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                 let mut dhcp = false;
                 let mut prop_list: Vec<&'static str> = Vec::new();
                 let mut addresses: Vec<InterfaceIpAddr> = Vec::new();
+                let mut auto_dns = None;
+                let mut auto_routes = None;
+                let mut auto_gateway = None;
+                let mut auto_table_id = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -131,6 +177,42 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                             addresses = map.next_value()?;
                             prop_list.push("addresses");
                         }
+                        Field::AutoDns => {
+                            if prop_list.contains(&"auto_dns") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_dns = map.next_value()?;
+                            prop_list.push("auto_dns");
+                        }
+                        Field::AutoGateway => {
+                            if prop_list.contains(&"auto_gateway") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_gateway = map.next_value()?;
+                            prop_list.push("auto_gateway");
+                        }
+                        Field::AutoRoutes => {
+                            if prop_list.contains(&"auto_routes") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_routes = map.next_value()?;
+                            prop_list.push("auto_routes");
+                        }
+                        Field::AutoRouteTableId => {
+                            if prop_list.contains(&"auto_table_id") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_table_id = map.next_value()?;
+                            prop_list.push("auto_table_id");
+                        }
                     }
                 }
                 Ok(InterfaceIpv4 {
@@ -138,11 +220,23 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                     prop_list,
                     dhcp,
                     addresses,
+                    auto_dns,
+                    auto_gateway,
+                    auto_routes,
+                    auto_table_id,
                     dns: None,
                 })
             }
         }
-        const FIELDS: &[&str] = &["enabled", "dhcp", "address"];
+        const FIELDS: &[&str] = &[
+            "enabled",
+            "dhcp",
+            "address",
+            "auto-dns",
+            "auto-gateway",
+            "auto-routes",
+            "auto-route-table-id",
+        ];
         deserializer.deserialize_struct(
             "InterfaceIpv4",
             FIELDS,
@@ -169,6 +263,18 @@ impl InterfaceIpv4 {
         if other.prop_list.contains(&"dns") {
             self.dns = other.dns.clone();
         }
+        if other.prop_list.contains(&"auto_dns") {
+            self.auto_dns = other.auto_dns;
+        }
+        if other.prop_list.contains(&"auto_gateway") {
+            self.auto_gateway = other.auto_gateway;
+        }
+        if other.prop_list.contains(&"auto_routes") {
+            self.auto_routes = other.auto_routes;
+        }
+        if other.prop_list.contains(&"auto_table_id") {
+            self.auto_table_id = other.auto_table_id;
+        }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
                 self.prop_list.push(other_prop_name);
@@ -178,9 +284,31 @@ impl InterfaceIpv4 {
 
     // Clean up before sending to plugin for applying
     // * Convert expanded IP address to compacted
+    // * Set auto_dns, auto_gateway and auto_routes to true if DHCP enabled and
+    //   those options is None
+    // * Remove static IP address when DHCP enabled.
     pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
         for addr in &mut self.addresses {
             addr.sanitize()?;
+        }
+        if self.enabled && self.dhcp {
+            if self.auto_dns.is_none() {
+                self.auto_dns = Some(true);
+            }
+            if self.auto_routes.is_none() {
+                self.auto_routes = Some(true);
+            }
+            if self.auto_gateway.is_none() {
+                self.auto_gateway = Some(true);
+            }
+            if !self.addresses.is_empty() {
+                log::warn!(
+                    "Static addresses {:?} are ignored when dynamic \
+                    IP is enabled",
+                    self.addresses.as_slice()
+                );
+                self.addresses = Vec::new();
+            }
         }
         Ok(())
     }
@@ -189,6 +317,9 @@ impl InterfaceIpv4 {
     // * Sort IP address
     // * Convert expanded IP address to compacted
     // * Add optional properties to prop_list
+    // * Ignore DHCP options if DHCP disabled
+    // * Ignore address if DHCP enabled
+    // * Set DHCP as off if enabled and dhcp is None
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.addresses.sort_unstable_by(|a, b| {
             (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
@@ -200,6 +331,15 @@ impl InterfaceIpv4 {
         }
         debug!("IPv4 after pre_verify_cleanup: {:?}", self);
         self.prop_list.push("dhcp");
+        if !self.enabled || !self.dhcp {
+            self.prop_list.retain(|p| {
+                !["auto_dns", "auto_routes", "auto_gateway", "auto_table_id"]
+                    .contains(p)
+            });
+        }
+        if self.enabled && self.dhcp && self.prop_list.contains(&"addresses") {
+            self.prop_list.retain(|p| p != &"addresses")
+        }
     }
 }
 
@@ -211,6 +351,10 @@ pub struct InterfaceIpv6 {
     pub autoconf: bool,
     pub addresses: Vec<InterfaceIpAddr>,
     pub(crate) dns: Option<DnsClientState>,
+    pub auto_dns: Option<bool>,
+    pub auto_gateway: Option<bool>,
+    pub auto_routes: Option<bool>,
+    pub auto_table_id: Option<u32>,
 }
 
 impl Serialize for InterfaceIpv6 {
@@ -221,9 +365,14 @@ impl Serialize for InterfaceIpv6 {
         let mut serial_struct = serializer.serialize_struct(
             "ipv6",
             if self.enabled {
-                1
+                if self.dhcp || self.autoconf {
+                    self.prop_list.len()
+                } else {
+                    // If DHCP disabled, we can only show
+                    std::cmp::min(4, self.prop_list.len())
+                }
             } else {
-                self.prop_list.len()
+                1
             },
         )?;
         serial_struct.serialize_field("enabled", &self.enabled)?;
@@ -233,6 +382,26 @@ impl Serialize for InterfaceIpv6 {
             }
             if self.prop_list.contains(&"autoconf") {
                 serial_struct.serialize_field("autoconf", &self.autoconf)?;
+            }
+            if self.dhcp || self.autoconf {
+                if self.prop_list.contains(&"auto_dns") {
+                    serial_struct
+                        .serialize_field("auto-dns", &self.auto_dns)?;
+                }
+                if self.prop_list.contains(&"auto_gateway") {
+                    serial_struct
+                        .serialize_field("auto-gateway", &self.auto_gateway)?;
+                }
+                if self.prop_list.contains(&"auto_routes") {
+                    serial_struct
+                        .serialize_field("auto-routes", &self.auto_routes)?;
+                }
+                if self.prop_list.contains(&"auto_table_id") {
+                    serial_struct.serialize_field(
+                        "auto-route-table-id",
+                        &self.auto_table_id,
+                    )?;
+                }
             }
             if self.prop_list.contains(&"addresses") {
                 serial_struct.serialize_field("address", &self.addresses)?;
@@ -252,6 +421,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
             Dhcp,
             Autoconf,
             Address,
+            AutoDns,
+            AutoGateway,
+            AutoRoutes,
+            AutoRouteTableId,
         }
 
         impl<'de> Deserialize<'de> for Field {
@@ -269,7 +442,9 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                         formatter: &mut fmt::Formatter,
                     ) -> fmt::Result {
                         formatter.write_str(
-                            "`enabled`, `dhcp`, `autoconf` or `address`",
+                            "`enabled`, `dhcp`, `autoconf`, `address` \
+                            `auto-dns`, `auto-gateway`, `auto-routes` or \
+                            `auto-route-table-id`",
                         )
                     }
 
@@ -282,6 +457,12 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                             "dhcp" => Ok(Field::Dhcp),
                             "autoconf" => Ok(Field::Autoconf),
                             "address" => Ok(Field::Address),
+                            "auto-dns" => Ok(Field::AutoDns),
+                            "auto-gateway" => Ok(Field::AutoGateway),
+                            "auto-routes" => Ok(Field::AutoRoutes),
+                            "auto-route-table-id" => {
+                                Ok(Field::AutoRouteTableId)
+                            }
                             _ => Err(de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -308,6 +489,10 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                 let mut autoconf = false;
                 let mut prop_list: Vec<&'static str> = Vec::new();
                 let mut addresses: Vec<InterfaceIpAddr> = Vec::new();
+                let mut auto_dns = None;
+                let mut auto_routes = None;
+                let mut auto_gateway = None;
+                let mut auto_table_id = None;
 
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -345,6 +530,42 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                             addresses = map.next_value()?;
                             prop_list.push("addresses");
                         }
+                        Field::AutoDns => {
+                            if prop_list.contains(&"auto_dns") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_dns = map.next_value()?;
+                            prop_list.push("auto_dns");
+                        }
+                        Field::AutoGateway => {
+                            if prop_list.contains(&"auto_gateway") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_gateway = map.next_value()?;
+                            prop_list.push("auto_gateway");
+                        }
+                        Field::AutoRoutes => {
+                            if prop_list.contains(&"auto_routes") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_routes = map.next_value()?;
+                            prop_list.push("auto_routes");
+                        }
+                        Field::AutoRouteTableId => {
+                            if prop_list.contains(&"auto_table_id") {
+                                return Err(de::Error::duplicate_field(
+                                    "address",
+                                ));
+                            }
+                            auto_table_id = map.next_value()?;
+                            prop_list.push("auto_table_id");
+                        }
                     }
                 }
                 Ok(InterfaceIpv6 {
@@ -353,11 +574,24 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                     dhcp,
                     autoconf,
                     addresses,
+                    auto_dns,
+                    auto_gateway,
+                    auto_routes,
+                    auto_table_id,
                     dns: None,
                 })
             }
         }
-        const FIELDS: &[&str] = &["enabled", "dhcp", "autoconf", "address"];
+        const FIELDS: &[&str] = &[
+            "enabled",
+            "dhcp",
+            "autoconf",
+            "address",
+            "auto-dns",
+            "auto-gateway",
+            "auto-routes",
+            "auto-route-table-id",
+        ];
         deserializer.deserialize_struct(
             "InterfaceIpv6",
             FIELDS,
@@ -384,6 +618,18 @@ impl InterfaceIpv6 {
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();
         }
+        if other.prop_list.contains(&"auto_dns") {
+            self.auto_dns = other.auto_dns;
+        }
+        if other.prop_list.contains(&"auto_gateway") {
+            self.auto_gateway = other.auto_gateway;
+        }
+        if other.prop_list.contains(&"auto_routes") {
+            self.auto_routes = other.auto_routes;
+        }
+        if other.prop_list.contains(&"auto_table_id") {
+            self.auto_table_id = other.auto_table_id;
+        }
         if other.prop_list.contains(&"dns") {
             self.dns = other.dns.clone();
         }
@@ -398,6 +644,8 @@ impl InterfaceIpv6 {
     // * Remove link-local address
     // * Sanitize the expanded IP address
     // * Add optional properties to prop_list
+    // * Ignore DHCP options if DHCP disabled
+    // * Ignore IP address when DHCP/autoconf enabled.
     pub(crate) fn pre_verify_cleanup(&mut self) {
         self.addresses.retain(|addr| {
             !is_ipv6_unicast_link_local(&addr.ip, addr.prefix_length)
@@ -410,14 +658,29 @@ impl InterfaceIpv6 {
                 warn!("BUG: IP address sanitize failure: {}", e);
             }
         }
-        debug!("IPv6 after pre_verify_cleanup: {:?}", self);
         self.prop_list.push("dhcp");
         self.prop_list.push("autoconf");
+        if !self.enabled || (!self.dhcp && !self.autoconf) {
+            self.prop_list.retain(|p| {
+                !["auto_dns", "auto_routes", "auto_gateway", "auto_table_id"]
+                    .contains(p)
+            });
+        }
+        if self.enabled
+            && (self.dhcp || self.autoconf)
+            && self.prop_list.contains(&"addresses")
+        {
+            self.prop_list.retain(|p| p != &"addresses")
+        }
+        debug!("IPv6 after pre_verify_cleanup: {:?}", self);
     }
 
     // Clean up before Apply
     // * Remove link-local address
     // * Sanitize the expanded IP address
+    // * Set auto_dns, auto_gateway and auto_routes to true if DHCP/autoconf
+    //   enabled and those options is None
+    // * Remove static IP address when DHCP/autoconf enabled.
     pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
         self.addresses.retain(|addr| {
             if is_ipv6_unicast_link_local(&addr.ip, addr.prefix_length) {
@@ -432,6 +695,25 @@ impl InterfaceIpv6 {
         });
         for addr in &mut self.addresses {
             addr.sanitize()?;
+        }
+        if self.enabled && (self.dhcp || self.autoconf) {
+            if self.auto_dns.is_none() {
+                self.auto_dns = Some(true);
+            }
+            if self.auto_routes.is_none() {
+                self.auto_routes = Some(true);
+            }
+            if self.auto_gateway.is_none() {
+                self.auto_gateway = Some(true);
+            }
+            if !self.addresses.is_empty() {
+                log::warn!(
+                    "Static addresses {:?} are ignored when dynamic \
+                    IP is enabled",
+                    self.addresses.as_slice()
+                );
+                self.addresses = Vec::new();
+            }
         }
         Ok(())
     }
@@ -496,5 +778,47 @@ impl std::convert::TryFrom<&str> for InterfaceIpAddr {
 impl std::convert::From<&InterfaceIpAddr> for String {
     fn from(v: &InterfaceIpAddr) -> String {
         format!("{}/{}", &v.ip, v.prefix_length)
+    }
+}
+
+pub(crate) fn include_current_ip_address_if_dhcp_on_to_off(
+    chg_net_state: &mut Interfaces,
+    current: &Interfaces,
+) {
+    for (iface_name, iface) in chg_net_state.kernel_ifaces.iter_mut() {
+        let cur_iface = if let Some(c) = current.kernel_ifaces.get(iface_name) {
+            c
+        } else {
+            continue;
+        };
+        if let Some(cur_ip_conf) = cur_iface.base_iface().ipv4.as_ref() {
+            if cur_ip_conf.dhcp && !cur_ip_conf.addresses.is_empty() {
+                if let Some(ip_conf) = iface.base_iface_mut().ipv4.as_mut() {
+                    if ip_conf.enabled
+                        && !ip_conf.dhcp
+                        && !ip_conf.prop_list.contains(&"addresses")
+                    {
+                        ip_conf.addresses = cur_ip_conf.addresses.clone();
+                        ip_conf.prop_list.push("addresses");
+                    }
+                }
+            }
+        }
+        if let Some(cur_ip_conf) = cur_iface.base_iface().ipv6.as_ref() {
+            if (cur_ip_conf.dhcp || cur_ip_conf.autoconf)
+                && !cur_ip_conf.addresses.is_empty()
+            {
+                if let Some(ip_conf) = iface.base_iface_mut().ipv6.as_mut() {
+                    if ip_conf.enabled
+                        && !ip_conf.dhcp
+                        && !ip_conf.autoconf
+                        && !ip_conf.prop_list.contains(&"addresses")
+                    {
+                        ip_conf.addresses = cur_ip_conf.addresses.clone();
+                        ip_conf.prop_list.push("addresses");
+                    }
+                }
+            }
+        }
     }
 }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -22,6 +22,8 @@ pub(crate) const NM_SETTING_OVS_BRIDGE_SETTING_NAME: &str = "ovs-bridge";
 pub(crate) const NM_SETTING_OVS_PORT_SETTING_NAME: &str = "ovs-port";
 pub(crate) const NM_SETTING_OVS_IFACE_SETTING_NAME: &str = "ovs-interface";
 pub(crate) const NM_SETTING_VETH_SETTING_NAME: &str = "veth";
+pub(crate) const NM_SETTING_BOND_SETTING_NAME: &str = "bond";
+pub(crate) const NM_SETTING_DUMMY_SETTING_NAME: &str = "dummy";
 
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -8,7 +8,8 @@ use crate::{
     nm::connection::{
         create_index_for_nm_conns_by_ctrler_type,
         create_index_for_nm_conns_by_name_type, get_port_nm_conns,
-        NM_SETTING_BRIDGE_SETTING_NAME, NM_SETTING_OVS_BRIDGE_SETTING_NAME,
+        NM_SETTING_BOND_SETTING_NAME, NM_SETTING_BRIDGE_SETTING_NAME,
+        NM_SETTING_DUMMY_SETTING_NAME, NM_SETTING_OVS_BRIDGE_SETTING_NAME,
         NM_SETTING_OVS_IFACE_SETTING_NAME, NM_SETTING_VETH_SETTING_NAME,
         NM_SETTING_WIRED_SETTING_NAME,
     },
@@ -16,9 +17,10 @@ use crate::{
     nm::error::nm_error_to_nmstate,
     nm::ip::{nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6},
     nm::ovs::nm_ovs_bridge_conf_get,
-    BaseInterface, EthernetInterface, Interface, InterfaceState, InterfaceType,
-    Interfaces, LinuxBridgeInterface, NetworkState, NmstateError,
-    OvsBridgeInterface, OvsInterface, UnknownInterface,
+    BaseInterface, BondInterface, DummyInterface, EthernetInterface, Interface,
+    InterfaceState, InterfaceType, Interfaces, LinuxBridgeInterface,
+    NetworkState, NmstateError, OvsBridgeInterface, OvsInterface,
+    UnknownInterface,
 };
 
 pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
@@ -67,6 +69,11 @@ pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
                         iface.base = base_iface;
                         iface
                     }),
+                    InterfaceType::Dummy => Interface::Dummy({
+                        let mut iface = DummyInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
                     InterfaceType::LinuxBridge => Interface::LinuxBridge({
                         let mut iface = LinuxBridgeInterface::new();
                         iface.base = base_iface;
@@ -74,6 +81,11 @@ pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
                     }),
                     InterfaceType::OvsInterface => Interface::OvsInterface({
                         let mut iface = OvsInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
+                    InterfaceType::Bond => Interface::Bond({
+                        let mut iface = BondInterface::new();
                         iface.base = base_iface;
                         iface
                     }),
@@ -147,6 +159,8 @@ fn nm_iface_type_to_nmstate(nm_iface_type: &str) -> InterfaceType {
     match nm_iface_type {
         NM_SETTING_WIRED_SETTING_NAME => InterfaceType::Ethernet,
         NM_SETTING_VETH_SETTING_NAME => InterfaceType::Ethernet,
+        NM_SETTING_BOND_SETTING_NAME => InterfaceType::Bond,
+        NM_SETTING_DUMMY_SETTING_NAME => InterfaceType::Dummy,
         NM_SETTING_BRIDGE_SETTING_NAME => InterfaceType::LinuxBridge,
         NM_SETTING_OVS_BRIDGE_SETTING_NAME => InterfaceType::OvsBridge,
         NM_SETTING_OVS_IFACE_SETTING_NAME => InterfaceType::OvsInterface,
@@ -198,8 +212,18 @@ fn iface_get(
                 iface.base = base_iface;
                 iface
             }),
+            InterfaceType::Bond => Interface::Bond({
+                let mut iface = BondInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
             InterfaceType::OvsInterface => Interface::OvsInterface({
                 let mut iface = OvsInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
+            InterfaceType::Dummy => Interface::Dummy({
+                let mut iface = DummyInterface::new();
                 iface.base = base_iface;
                 iface
             }),

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -101,6 +101,20 @@ pub struct NmSettingIp {
     pub dns_priority: Option<i32>,
     pub dns_search: Option<Vec<String>>,
     pub dns: Option<Vec<String>>,
+    pub ignore_auto_dns: Option<bool>,
+    pub never_default: Option<bool>,
+    pub ignore_auto_routes: Option<bool>,
+    pub route_table: Option<u32>,
+    pub dhcp_client_id: Option<String>,
+    pub dhcp_timeout: Option<i32>,
+    // IPv6 only
+    pub ra_timeout: Option<i32>,
+    // IPv6 only
+    pub addr_gen_mode: Option<i32>,
+    // IPv6 only
+    pub dhcp_duid: Option<String>,
+    // IPv6 only
+    pub dhcp_iaid: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -120,6 +134,19 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
         setting.dns = _from_map!(v, "dns", parse_nm_dns)?;
         setting.dns_search = _from_map!(v, "dns-search", parse_nm_dns_search)?;
         setting.dns_priority = _from_map!(v, "dns-priority", i32::try_from)?;
+        setting.ignore_auto_dns =
+            _from_map!(v, "ignore-auto-dns", bool::try_from)?;
+        setting.never_default = _from_map!(v, "never-default", bool::try_from)?;
+        setting.ignore_auto_routes =
+            _from_map!(v, "ignore-auto-routes", bool::try_from)?;
+        setting.dhcp_client_id =
+            _from_map!(v, "dhcp-client-id", String::try_from)?;
+        setting.dhcp_timeout = _from_map!(v, "dhcp-timeout", i32::try_from)?;
+        setting.ra_timeout = _from_map!(v, "ra-timeout", i32::try_from)?;
+        setting.addr_gen_mode = _from_map!(v, "addr-gen-mode", i32::try_from)?;
+        setting.dhcp_duid = _from_map!(v, "dhcp-duid", String::try_from)?;
+        setting.dhcp_iaid = _from_map!(v, "dhcp-iaid", String::try_from)?;
+        setting.route_table = _from_map!(v, "route-table", u32::try_from)?;
 
         // NM deprecated `addresses` property in the favor of `addresss-data`
         v.remove("addresses");
@@ -191,6 +218,36 @@ impl NmSettingIp {
         }
         if let Some(dns_priority) = self.dns_priority {
             ret.insert("dns-priority", zvariant::Value::new(dns_priority));
+        }
+        if let Some(v) = self.ignore_auto_dns {
+            ret.insert("ignore-auto-dns", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.ignore_auto_routes {
+            ret.insert("ignore-auto-routes", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.never_default {
+            ret.insert("never-default", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_client_id {
+            ret.insert("dhcp-client-id", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.dhcp_timeout {
+            ret.insert("dhcp-timeout", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.ra_timeout {
+            ret.insert("ra-timeout", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.addr_gen_mode {
+            ret.insert("addr-gen-mode", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_duid {
+            ret.insert("dhcp-duid", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_iaid {
+            ret.insert("dhcp-iaid", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.route_table {
+            ret.insert("route-table", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -263,7 +263,7 @@ impl<'a> NmApi<'a> {
                     "Waiting rollback on these devices {:?}",
                     waiting_nm_dev
                 );
-                std::thread::sleep(Duration::from_millis(100));
+                std::thread::sleep(Duration::from_millis(500));
             }
         }
         Err(NmError::new(


### PR DESCRIPTION
Support auto-dns, auto-gateway, auto-routes, auto-route-table-id.

Also support saving DNS configuration to interface with
`auto-dns: false`.

Integration test case enabled.

extra patches:
   * rust bond dummy: Fix bond and dummy DHCP info
   * rust route: support multipath route