### PR TITLE
rust, bond: drop ValueError and use InvalidArgument instead

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -266,12 +266,8 @@ function run_tests {
             not test_bond_mac_restriction_without_mac_in_desire and \
             not test_bond_mac_restriction_with_mac_in_desire and \
             not test_bond_mac_restriction_in_desire_mac_in_current and \
-            not test_bond_mac_restriction_in_current_mac_in_desire and \
-            not test_create_bond_with_both_miimon_and_arp_internal and \
             not test_remove_mode4_bond_and_create_mode5_with_the_same_port and \
-            not test_create_bond_without_mode and \
-            not test_ignore_verification_error_on_invalid_bond_option and \
-            not test_bond_ad_actor_system_with_multicast_mac_address' \
+            not test_bond_mac_restriction_in_current_mac_in_desire' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -6,7 +6,6 @@ pub enum ErrorKind {
     VerificationError,
     NotImplementedError,
     KernelIntegerRoundedError,
-    ValueError,
 }
 
 impl std::fmt::Display for ErrorKind {

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -166,6 +166,14 @@ impl BondConfig {
                 ));
             }
         }
+
+        if self.mode.is_none() {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Bond mode is mandatory".to_string(),
+            ));
+        }
+
         Ok(())
     }
 
@@ -535,6 +543,7 @@ impl BondOptions {
     ) -> Result<(), NmstateError> {
         self.fix_mac_restricted_mode(mode, base)?;
         self.validate_ad_actor_system_mac_address()?;
+        self.validate_miimon_and_arp_interval()?;
         Ok(())
     }
 
@@ -564,6 +573,20 @@ impl BondOptions {
                         ErrorKind::InvalidArgument,
                             "The ad_actor_system bond option cannot be an IANA multicast address(prefix with 01:00:5E)".to_string()
                     ));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_miimon_and_arp_interval(&self) -> Result<(), NmstateError> {
+        if let Some(miimon) = &self.miimon {
+            if let Some(arp_interval) = &self.arp_interval {
+                if miimon > &0 && arp_interval > &0 {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                            "The ad_actor_system bond option cannot be an IANA multicast address(prefix with 01:00:5E)".to_string()
+                    ));
+                }
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -161,7 +161,7 @@ impl BondConfig {
                 opts.validate(mode, base)?;
             } else {
                 return Err(NmstateError::new(
-                    ErrorKind::ValueError,
+                    ErrorKind::InvalidArgument,
                     "Bond mode is mandatory".to_string(),
                 ));
             }
@@ -484,13 +484,13 @@ where
                     str_value.parse::<u32>().map_err(D::Error::custom)?
                 } else {
                     return Err(NmstateError::new(
-                            ErrorKind::ValueError,
+                            ErrorKind::InvalidArgument,
                             format!("Property value: {} is not valid, only numeric values are allowed.", str_value)))
                     .map_err(D::Error::custom);
                 }
             } else {
                 return Err(NmstateError::new(
-                        ErrorKind::ValueError,
+                        ErrorKind::InvalidArgument,
                         format!("Property value: {} is not valid, only numeric values are allowed.", json_value)))
                 .map_err(D::Error::custom);
             }
@@ -549,7 +549,7 @@ impl BondOptions {
                 && base.mac_address.is_some()
             {
                 return Err(NmstateError::new(
-                        ErrorKind::ValueError,
+                        ErrorKind::InvalidArgument,
                             "MAC address cannot be specified in bond interface along with fail_over_mac active on active backup mode".to_string()
                     ));
             }
@@ -561,7 +561,7 @@ impl BondOptions {
         if let Some(ad_actor_system) = &self.ad_actor_system {
             if ad_actor_system.to_uppercase().starts_with("01:00:5E") {
                 return Err(NmstateError::new(
-                        ErrorKind::ValueError,
+                        ErrorKind::InvalidArgument,
                             "The ad_actor_system bond option cannot be an IANA multicast address(prefix with 01:00:5E)".to_string()
                     ));
             }


### PR DESCRIPTION
The integration test for nmstate-rust have been adjusted.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>