### PR TITLE
rust: support copy-mac-from

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -236,8 +236,7 @@ function run_tests {
             tests/integration/linux_bridge_test.py \
             -k '\
             not test_linux_bridge_over_bond_over_port_in_one_transaction and \
-            not test_explicitly_ignore_a_bridge_port and \
-            not test_create_linux_bridge_with_copy_mac_from' \
+            not test_explicitly_ignore_a_bridge_port' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \
@@ -269,8 +268,6 @@ function run_tests {
             not test_bond_mac_restriction_in_desire_mac_in_current and \
             not test_bond_mac_restriction_in_current_mac_in_desire and \
             not test_create_bond_with_both_miimon_and_arp_internal and \
-            not test_create_bond_with_copy_mac_from and \
-            not test_create_bond_with_copy_mac_from_bond_port_perm_hwaddr and \
             not test_remove_mode4_bond_and_create_mode5_with_the_same_port and \
             not test_create_bond_without_mode and \
             not test_ignore_verification_error_on_invalid_bond_option and \

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -19,6 +19,8 @@ pub struct BaseInterface {
     pub state: InterfaceState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
+    #[serde(skip)]
+    pub permanent_mac_address: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,6 +31,8 @@ pub struct BaseInterface {
     pub controller: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accept_all_mac_addresses: Option<bool>,
+    #[serde(skip_serializing)]
+    pub copy_mac_from: Option<String>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.


### PR DESCRIPTION
Integration test case enabled.

Due limitation on the code design, we cannot do verification on this
property. Supporting so require massive change on workflow which is not
worthy enough for this small feature. Manual test required.