### PR TITLE
rust: rewrite the overbook and orphan check

### DIFF
--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -3,7 +3,8 @@ mod bond;
 mod dummy;
 mod ethernet;
 mod inter_ifaces;
-mod inter_ifaces_controller;
+// The pub(crate) is only for unit test
+pub(crate) mod inter_ifaces_controller;
 mod linux_bridge;
 mod mac_vlan;
 mod mac_vtap;

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -1,8 +1,9 @@
 use crate::{
-    EthernetInterface, Interface, InterfaceType, LinuxBridgeConfig,
-    LinuxBridgeInterface, LinuxBridgePortConfig, OvsBridgeConfig,
-    OvsBridgeInterface, OvsBridgePortConfig, OvsInterface, UnknownInterface,
-    VlanConfig, VlanInterface,
+    BondConfig, BondInterface, BondMode, EthernetInterface, Interface,
+    InterfaceType, LinuxBridgeConfig, LinuxBridgeInterface,
+    LinuxBridgePortConfig, OvsBridgeConfig, OvsBridgeInterface,
+    OvsBridgePortConfig, OvsInterface, UnknownInterface, VlanConfig,
+    VlanInterface,
 };
 
 pub(crate) fn new_eth_iface(name: &str) -> Interface {
@@ -21,6 +22,12 @@ pub(crate) fn new_br_iface(name: &str) -> Interface {
     let mut iface = LinuxBridgeInterface::new();
     iface.base.name = name.to_string();
     Interface::LinuxBridge(iface)
+}
+
+fn new_bond_iface(name: &str) -> Interface {
+    let mut iface = BondInterface::new();
+    iface.base.name = name.to_string();
+    Interface::Bond(iface)
 }
 
 pub(crate) fn new_ovs_br_iface(name: &str, port_names: &[&str]) -> Interface {
@@ -99,4 +106,17 @@ pub(crate) fn bridge_with_ports(name: &str, ports: &[&str]) -> Interface {
         })
     };
     br0
+}
+
+pub(crate) fn bond_with_ports(name: &str, ports: &[&str]) -> Interface {
+    let ports = ports.iter().map(|p| p.to_string()).collect::<Vec<String>>();
+    let mut iface = new_bond_iface(name);
+    if let Interface::Bond(bond_iface) = &mut iface {
+        bond_iface.bond = Some(BondConfig {
+            mode: Some(BondMode::RoundRobin),
+            port: Some(ports),
+            ..Default::default()
+        });
+    }
+    iface
 }


### PR DESCRIPTION
Move the code from NetworkState to Interfaces as this does not require
knowledge outside of Interfaces.

Removed `MergedInterfaces` and use dedicate function
`check_overbook_ports` and `mark_orphan_interface_as_absent`. The old
nmstate python code has shown general purpose state merging will complex
the debug work as we cannot tell whether certain information is from merged
or user desire or current.

Added the check on desire interface overbooking current controllers' port.
Added the check on orphan interface changing its parent.

Unit test cases updated.