### PR TITLE
rust nm vlan: Fix error when apply with vlan config

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -116,18 +116,22 @@ pub(crate) fn iface_to_nm_connections(
             gen_nm_ovs_iface_setting(&mut nm_conn);
         }
         Interface::Vlan(vlan_iface) => {
-            nm_conn.vlan = vlan_iface.vlan.as_ref().map(NmSettingVlan::from)
+            if let Some(conf) = vlan_iface.vlan.as_ref() {
+                nm_conn.vlan = Some(NmSettingVlan::from(conf))
+            }
         }
         Interface::Ethernet(eth_iface) => {
             gen_nm_sriov_setting(eth_iface, &mut nm_conn);
         }
         Interface::MacVlan(iface) => {
-            nm_conn.mac_vlan =
-                iface.mac_vlan.as_ref().map(NmSettingMacVlan::from)
+            if let Some(conf) = iface.mac_vlan.as_ref() {
+                nm_conn.mac_vlan = Some(NmSettingMacVlan::from(conf));
+            }
         }
         Interface::MacVtap(iface) => {
-            nm_conn.mac_vlan =
-                iface.mac_vtap.as_ref().map(NmSettingMacVlan::from)
+            if let Some(conf) = iface.mac_vtap.as_ref() {
+                nm_conn.mac_vlan = Some(NmSettingMacVlan::from(conf));
+            }
         }
         _ => (),
     };

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -287,3 +287,19 @@ def create_two_vlans_state():
             },
         ]
     }
+
+
+def test_preserve_existing_vlan_conf(eth1_up):
+    with vlan_interface(
+        VLAN_IFNAME, 101, eth1_up[Interface.KEY][0][Interface.NAME]
+    ) as desired_state:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: VLAN_IFNAME,
+                    }
+                ]
+            }
+        )
+        assertlib.assert_state(desired_state)


### PR DESCRIPTION
When desire state does not include vlan section, nmstate will fail even
this vlan interface already exists.

The fix is preserving existing VLAN configurations.

Also fixed mac vlan and mac vtap.

Integration test case added.