### PR TITLE
rust: Add support of VRF

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -22,7 +22,6 @@ import logging
 from libnmstate.error import NmstateKernelIntegerRoundedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
-from libnmstate.error import NmstateNotSupportedError
 from libnmstate.prettystate import format_desired_current_state_diff
 from libnmstate.schema import BondMode
 from libnmstate.schema import Interface
@@ -273,7 +272,6 @@ class Ifaces:
         self._bring_port_up_if_not_in_desire()
         self._validate_ovs_patch_peers()
         self._remove_unknown_type_interfaces()
-        self._validate_vrf_table_id_changes()
         self._validate_veth_peers()
 
     def _bring_port_up_if_not_in_desire(self):
@@ -419,19 +417,6 @@ class Ifaces:
                 for port_name in iface.config_changed_port(cur_iface):
                     if port_name in self._kernel_ifaces:
                         self._kernel_ifaces[port_name].mark_as_changed()
-
-    def _validate_vrf_table_id_changes(self):
-        for iface in self._kernel_ifaces.values():
-            if iface.is_desired and iface.type == InterfaceType.VRF:
-                cur_iface = self._cur_kernel_ifaces.get(iface.name)
-                if (
-                    cur_iface
-                    and cur_iface.route_table_id != iface.route_table_id
-                ):
-                    raise NmstateNotSupportedError(
-                        "Changing route table ID of existing VRF Interface "
-                        "is not supported yet"
-                    )
 
     def _validate_veth_peers(self):
         for ifname, iface in self._kernel_ifaces.items():

--- a/libnmstate/ifaces/vrf.py
+++ b/libnmstate/ifaces/vrf.py
@@ -29,6 +29,8 @@ from .base_iface import BaseIface
 
 
 class VrfIface(BaseIface):
+    TABLE_ID_CHANGED_METADATA = "_table_id_changed"
+
     def sort_port(self):
         if self.port:
             self.raw[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE].sort()

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -44,6 +44,7 @@ from .device import DeviceDelete
 from .device import DeviceReapply
 from .device import get_nm_dev
 from .translator import Api2Nm
+from .vrf import is_vrf_table_id_changed
 
 
 IMPORT_NM_DEV_TIMEOUT = 5
@@ -197,6 +198,14 @@ class NmProfile:
             # This is a workaround for NM bug:
             # https://bugzilla.redhat.com/1837254
             # https://bugzilla.redhat.com/1962551
+            self._add_action(NmProfile.ACTION_DEACTIVATE_FIRST)
+
+        if (
+            self._iface.type == InterfaceType.VRF
+            and self._nm_dev
+            and is_vrf_table_id_changed(self._iface, self._nm_dev)
+        ):
+            # NM cannot change VRF table ID online
             self._add_action(NmProfile.ACTION_DEACTIVATE_FIRST)
 
         if self._iface.is_controller and self._iface.is_up:

--- a/libnmstate/nm/vrf.py
+++ b/libnmstate/nm/vrf.py
@@ -24,3 +24,7 @@ def create_vrf_setting(vrf_iface):
     vrf_setting = NM.SettingVrf.new()
     vrf_setting.props.table = vrf_iface.route_table_id
     return vrf_setting
+
+
+def is_vrf_table_id_changed(vrf_iface, nm_dev):
+    return vrf_iface.route_table_id != nm_dev.props.table

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -148,6 +148,7 @@ impl BaseInterface {
     pub fn can_have_ip(&self) -> bool {
         self.controller == None
             || self.iface_type == InterfaceType::OvsInterface
+            || self.controller_type == Some(InterfaceType::Vrf)
     }
 
     pub(crate) fn is_up_priority_valid(&self) -> bool {

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -3,6 +3,7 @@ mod bond;
 mod dummy;
 mod ethernet;
 mod inter_ifaces;
+mod vrf;
 // The pub(crate) is only for unit test
 pub(crate) mod inter_ifaces_controller;
 mod linux_bridge;
@@ -38,3 +39,4 @@ pub use ovs::{
 };
 pub use sriov::{SrIovConfig, SrIovVfConfig};
 pub use vlan::{VlanConfig, VlanInterface};
+pub use vrf::{VrfConfig, VrfInterface};

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{BaseInterface, InterfaceType};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VrfInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vrf: Option<VrfConfig>,
+}
+
+impl Default for VrfInterface {
+    fn default() -> Self {
+        Self {
+            base: BaseInterface {
+                iface_type: InterfaceType::Vrf,
+                ..Default::default()
+            },
+            vrf: None,
+        }
+    }
+}
+
+impl VrfInterface {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn ports(&self) -> Option<Vec<&str>> {
+        self.vrf
+            .as_ref()
+            .and_then(|vrf_conf| vrf_conf.port.as_ref())
+            .map(|ports| ports.as_slice().iter().map(|p| p.as_str()).collect())
+    }
+
+    pub(crate) fn update_vrf(&mut self, other: &VrfInterface) {
+        // TODO: this should be done by Trait
+        if let Some(vrf_conf) = &mut self.vrf {
+            vrf_conf.update(other.vrf.as_ref());
+        } else {
+            self.vrf = other.vrf.clone();
+        }
+    }
+
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        self.base.mac_address = None;
+        if self.base.accept_all_mac_addresses == Some(false) {
+            self.base.accept_all_mac_addresses = None;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct VrfConfig {
+    pub port: Option<Vec<String>>,
+    #[serde(rename = "route-table-id")]
+    pub table_id: u32,
+}
+
+impl VrfConfig {
+    fn update(&mut self, other: Option<&Self>) {
+        if let Some(other) = other {
+            self.port = other.port.clone();
+            self.table_id = other.table_id;
+        }
+    }
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -29,7 +29,8 @@ pub use crate::ifaces::{
     MacVtapMode, OvsBridgeBondConfig, OvsBridgeBondMode,
     OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
     OvsBridgeOptions, OvsBridgePortConfig, OvsInterface, SrIovConfig,
-    SrIovVfConfig, VethConfig, VlanConfig, VlanInterface,
+    SrIovVfConfig, VethConfig, VlanConfig, VlanInterface, VrfConfig,
+    VrfInterface,
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 pub use crate::net_state::NetworkState;

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -12,6 +12,7 @@ mod route_rule;
 mod show;
 mod veth;
 mod vlan;
+mod vrf;
 
 pub(crate) use apply::nispor_apply;
 pub(crate) use show::nispor_retrieve;

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -12,6 +12,7 @@ use crate::{
         route_rule::get_route_rules,
         veth::np_veth_to_nmstate,
         vlan::np_vlan_to_nmstate,
+        vrf::np_vrf_to_nmstate,
     },
     DummyInterface, Interface, InterfaceType, NetworkState, NmstateError,
     OvsInterface, UnknownInterface,
@@ -79,6 +80,9 @@ pub(crate) fn nispor_retrieve() -> Result<NetworkState, NmstateError> {
             }
             InterfaceType::MacVtap => {
                 Interface::MacVtap(np_mac_vtap_to_nmstate(np_iface, base_iface))
+            }
+            InterfaceType::Vrf => {
+                Interface::Vrf(np_vrf_to_nmstate(np_iface, base_iface))
             }
             _ => {
                 warn!(

--- a/rust/src/lib/nispor/vrf.rs
+++ b/rust/src/lib/nispor/vrf.rs
@@ -1,0 +1,16 @@
+use crate::{BaseInterface, VrfConfig, VrfInterface};
+
+pub(crate) fn np_vrf_to_nmstate(
+    np_iface: &nispor::Iface,
+    base_iface: BaseInterface,
+) -> VrfInterface {
+    let vrf_conf = np_iface.vrf.as_ref().map(|np_vrf_info| VrfConfig {
+        table_id: np_vrf_info.table_id,
+        port: Some(np_vrf_info.subordinates.clone()),
+    });
+
+    VrfInterface {
+        base: base_iface,
+        vrf: vrf_conf,
+    }
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -2,6 +2,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use nm_dbus::{
     NmApi, NmConnection, NmSettingConnection, NmSettingMacVlan, NmSettingVlan,
+    NmSettingVrf,
 };
 
 use crate::{
@@ -27,6 +28,7 @@ pub(crate) const NM_SETTING_VETH_SETTING_NAME: &str = "veth";
 pub(crate) const NM_SETTING_BOND_SETTING_NAME: &str = "bond";
 pub(crate) const NM_SETTING_DUMMY_SETTING_NAME: &str = "dummy";
 pub(crate) const NM_SETTING_MACVLAN_SETTING_NAME: &str = "macvlan";
+pub(crate) const NM_SETTING_VRF_SETTING_NAME: &str = "vrf";
 
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
@@ -133,6 +135,11 @@ pub(crate) fn iface_to_nm_connections(
                 nm_conn.mac_vlan = Some(NmSettingMacVlan::from(conf));
             }
         }
+        Interface::Vrf(iface) => {
+            if let Some(vrf_conf) = iface.vrf.as_ref() {
+                nm_conn.vrf = Some(NmSettingVrf::from(vrf_conf));
+            }
+        }
         _ => (),
     };
 
@@ -164,6 +171,7 @@ pub(crate) fn iface_type_to_nm(
         InterfaceType::Dummy => Ok("dummy".to_string()),
         InterfaceType::MacVlan => Ok("macvlan".to_string()),
         InterfaceType::MacVtap => Ok("macvlan".to_string()),
+        InterfaceType::Vrf => Ok("vrf".to_string()),
         InterfaceType::Other(s) => Ok(s.to_string()),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -19,6 +19,7 @@ mod sriov;
 mod unit_tests;
 mod version;
 mod vlan;
+mod vrf;
 mod wired;
 
 pub(crate) use apply::nm_apply;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -13,7 +13,8 @@ use crate::{
         NM_SETTING_BOND_SETTING_NAME, NM_SETTING_BRIDGE_SETTING_NAME,
         NM_SETTING_DUMMY_SETTING_NAME, NM_SETTING_MACVLAN_SETTING_NAME,
         NM_SETTING_OVS_BRIDGE_SETTING_NAME, NM_SETTING_OVS_IFACE_SETTING_NAME,
-        NM_SETTING_VETH_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
+        NM_SETTING_VETH_SETTING_NAME, NM_SETTING_VRF_SETTING_NAME,
+        NM_SETTING_WIRED_SETTING_NAME,
     },
     nm::dns::retrieve_dns_info,
     nm::error::nm_error_to_nmstate,
@@ -22,7 +23,7 @@ use crate::{
     BaseInterface, BondInterface, DummyInterface, EthernetInterface, Interface,
     InterfaceState, InterfaceType, Interfaces, LinuxBridgeInterface,
     MacVlanInterface, MacVtapInterface, NetworkState, NmstateError,
-    OvsBridgeInterface, OvsInterface, UnknownInterface,
+    OvsBridgeInterface, OvsInterface, UnknownInterface, VrfInterface,
 };
 
 pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
@@ -98,6 +99,11 @@ pub(crate) fn nm_retrieve() -> Result<NetworkState, NmstateError> {
                     }),
                     InterfaceType::MacVtap => Interface::MacVtap({
                         let mut iface = MacVtapInterface::new();
+                        iface.base = base_iface;
+                        iface
+                    }),
+                    InterfaceType::Vrf => Interface::Vrf({
+                        let mut iface = VrfInterface::new();
                         iface.base = base_iface;
                         iface
                     }),
@@ -177,6 +183,7 @@ fn nm_dev_iface_type_to_nmstate(nm_dev: &NmDevice) -> InterfaceType {
         NM_SETTING_BRIDGE_SETTING_NAME => InterfaceType::LinuxBridge,
         NM_SETTING_OVS_BRIDGE_SETTING_NAME => InterfaceType::OvsBridge,
         NM_SETTING_OVS_IFACE_SETTING_NAME => InterfaceType::OvsInterface,
+        NM_SETTING_VRF_SETTING_NAME => InterfaceType::Vrf,
         NM_SETTING_MACVLAN_SETTING_NAME => {
             if nm_dev.is_mac_vtap {
                 InterfaceType::MacVtap
@@ -252,6 +259,11 @@ fn iface_get(
             }),
             InterfaceType::MacVtap => Interface::MacVtap({
                 let mut iface = MacVtapInterface::new();
+                iface.base = base_iface;
+                iface
+            }),
+            InterfaceType::Vrf => Interface::Vrf({
+                let mut iface = VrfInterface::new();
                 iface.base = base_iface;
                 iface
             }),

--- a/rust/src/lib/nm/vrf.rs
+++ b/rust/src/lib/nm/vrf.rs
@@ -1,0 +1,24 @@
+use nm_dbus::{NmConnection, NmSettingVrf};
+
+use crate::VrfConfig;
+
+impl From<&VrfConfig> for NmSettingVrf {
+    fn from(config: &VrfConfig) -> Self {
+        let mut settings = NmSettingVrf::new();
+        settings.table = Some(config.table_id);
+        settings
+    }
+}
+
+pub(crate) fn is_vrf_table_id_changed(
+    new_nm_conn: &NmConnection,
+    cur_nm_conn: &NmConnection,
+) -> bool {
+    if let (Some(new_vrf_conf), Some(cur_vrf_conf)) =
+        (new_nm_conn.vrf.as_ref(), cur_nm_conn.vrf.as_ref())
+    {
+        new_vrf_conf.table != cur_vrf_conf.table
+    } else {
+        false
+    }
+}

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -32,6 +32,7 @@ use crate::{
     },
     connection::sriov::NmSettingSriov,
     connection::vlan::NmSettingVlan,
+    connection::vrf::NmSettingVrf,
     connection::wired::NmSettingWired,
     dbus::{NM_DBUS_INTERFACE_ROOT, NM_DBUS_INTERFACE_SETTING},
     keyfile::zvariant_value_to_keyfile,
@@ -66,6 +67,7 @@ pub struct NmConnection {
     pub vlan: Option<NmSettingVlan>,
     pub mac_vlan: Option<NmSettingMacVlan>,
     pub sriov: Option<NmSettingSriov>,
+    pub vrf: Option<NmSettingVrf>,
     #[serde(skip)]
     pub(crate) obj_path: String,
     _other: HashMap<String, HashMap<String, zvariant::OwnedValue>>,
@@ -114,6 +116,7 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
             vlan: _from_map!(v, "vlan", NmSettingVlan::try_from)?,
             sriov: _from_map!(v, "sriov", NmSettingSriov::try_from)?,
             mac_vlan: _from_map!(v, "macvlan", NmSettingMacVlan::try_from)?,
+            vrf: _from_map!(v, "vrf", NmSettingVrf::try_from)?,
             _other: v,
             ..Default::default()
         })
@@ -195,6 +198,9 @@ impl NmConnection {
         }
         if let Some(mac_vlan) = &self.mac_vlan {
             ret.insert("macvlan", mac_vlan.to_value()?);
+        }
+        if let Some(vrf) = &self.vrf {
+            ret.insert("vrf", vrf.to_value()?);
         }
         for (key, setting_value) in &self._other {
             let mut other_setting_value: HashMap<&str, zvariant::Value> =

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -27,6 +27,7 @@ mod route;
 mod route_rule;
 mod sriov;
 mod vlan;
+mod vrf;
 mod wired;
 
 pub use crate::connection::bond::NmSettingBond;
@@ -45,6 +46,7 @@ pub use crate::connection::sriov::{
     NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
 };
 pub use crate::connection::vlan::{NmSettingVlan, NmVlanProtocol};
+pub use crate::connection::vrf::NmSettingVrf;
 pub use crate::connection::wired::NmSettingWired;
 
 pub(crate) use crate::connection::conn::{

--- a/rust/src/libnm_dbus/connection/vrf.rs
+++ b/rust/src/libnm_dbus/connection/vrf.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{connection::DbusDictionary, NmError};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingVrf {
+    pub table: Option<u32>,
+    _other: HashMap<String, zvariant::OwnedValue>,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingVrf {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            table: _from_map!(v, "table", u32::try_from)?,
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingVrf {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.table {
+            ret.insert("table", zvariant::Value::new(v));
+        }
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -29,7 +29,7 @@ pub use crate::connection::{
     NmSettingBridgeVlanRange, NmSettingConnection, NmSettingIp,
     NmSettingIpMethod, NmSettingMacVlan, NmSettingOvsBridge, NmSettingOvsIface,
     NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingVlan, NmSettingWired, NmVlanProtocol,
+    NmSettingVlan, NmSettingVrf, NmSettingWired, NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::dns::NmDnsEntry;

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -23,7 +23,6 @@ import pytest
 
 import libnmstate
 
-from libnmstate.error import NmstateNotSupportedError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -154,9 +153,8 @@ class TestVrf:
         iface_info = vrf0_with_port0
         iface_info[VRF.CONFIG_SUBTREE][VRF.ROUTE_TABLE_ID] += 1
         desired_state = {Interface.KEY: [iface_info]}
-        with pytest.raises(NmstateNotSupportedError):
-            libnmstate.apply(desired_state)
-            assertlib.assert_state_match(desired_state)
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)
 
     def test_create_with_empty_ports(self):
         desired_state = {


### PR DESCRIPTION
Also add support of changing VRF table ID both in rust and python.

Integration test case enabled.