### PR TITLE
rust: Add support of veth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           - job_type: "c8s-nm_main-integ_tier1"
           - job_type: "c8s-nm_main-integ_tier2"
           - job_type: "c8s-nm_main-integ_slow"
+          - job_type: "c8s-nm_main-integ_rust"
           - job_type: "ovs2_11-nm_stable-integ_tier1"
           - job_type: "vdsm_el8-nm_main-vdsm"
 

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -24,6 +24,7 @@ COPR_ARG=""
 
 if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
+    COPR_ARG="--copr networkmanager/NetworkManager-1.32"
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -184,6 +184,7 @@ function run_tests {
             tests/integration/mac_vlan_test.py \
             tests/integration/mac_vtap_test.py \
             tests/integration/vxlan_test.py \
+            tests/integration/veth_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -529,7 +529,13 @@ impl Interface {
     }
 
     pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
-        self.base_iface_mut().pre_edit_cleanup()
+        self.base_iface_mut().pre_edit_cleanup()?;
+        if let Interface::Ethernet(iface) = self {
+            if iface.veth.is_some() {
+                iface.base.iface_type = InterfaceType::Veth;
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -143,6 +143,10 @@ impl BaseInterface {
         if let Some(ref mut ipv6) = self.ipv6 {
             ipv6.pre_verify_cleanup()
         }
+        // Change all veth interface to ethernet for simpler verification
+        if self.iface_type == InterfaceType::Veth {
+            self.iface_type = InterfaceType::Ethernet;
+        }
     }
 
     pub fn can_have_ip(&self) -> bool {

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -85,7 +85,7 @@ pub(crate) fn handle_changed_ports(
                     if cur_iface.base_iface().controller != ctrl_name
                         || cur_iface.base_iface().controller_type != ctrl_type
                     {
-                        let mut iface = cur_iface.clone();
+                        let mut iface = cur_iface.clone_name_type_only();
                         // Some interface cannot live without controller
                         if iface.need_controller() && ctrl_name.is_none() {
                             iface.base_iface_mut().state =

--- a/rust/src/lib/nm/active_connection.rs
+++ b/rust/src/lib/nm/active_connection.rs
@@ -2,15 +2,20 @@ use std::collections::HashMap;
 
 use nm_dbus::NmActiveConnection;
 
+use crate::nm::connection::{
+    NM_SETTING_VETH_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
+};
+
 pub(crate) fn create_index_for_nm_acs_by_name_type(
     nm_acs: &[NmActiveConnection],
 ) -> HashMap<(&str, &str), &NmActiveConnection> {
     let mut ret = HashMap::new();
     for nm_ac in nm_acs {
-        ret.insert(
-            (nm_ac.iface_name.as_str(), nm_ac.iface_type.as_str()),
-            nm_ac,
-        );
+        let nm_iface_type = match nm_ac.iface_type.as_str() {
+            NM_SETTING_VETH_SETTING_NAME => NM_SETTING_WIRED_SETTING_NAME,
+            t => t,
+        };
+        ret.insert((nm_ac.iface_name.as_str(), nm_iface_type), nm_ac);
     }
     ret
 }

--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -15,6 +15,7 @@ use crate::{
         get_exist_profile, save_nm_profiles, use_uuid_for_controller_reference,
     },
     nm::route::is_route_removed,
+    nm::veth::{is_veth_peer_changed, is_veth_peer_in_desire},
     nm::vlan::is_vlan_id_changed,
     nm::vrf::is_vrf_table_id_changed,
     nm::vxlan::is_vxlan_id_changed,
@@ -165,6 +166,7 @@ fn apply_single_state(
                 ctrl_iface,
                 &exist_nm_conns,
                 &nm_ac_uuids,
+                is_veth_peer_in_desire(iface, ifaces.as_slice()),
             )? {
                 nm_conns_to_activate.push(nm_conn);
             }
@@ -311,6 +313,7 @@ fn gen_nm_conn_need_to_deactivate_first<'a>(
                     || is_vrf_table_id_changed(nm_conn, activated_nm_con)
                     || is_vlan_id_changed(nm_conn, activated_nm_con)
                     || is_vxlan_id_changed(nm_conn, activated_nm_con)
+                    || is_veth_peer_changed(nm_conn, activated_nm_con)
                 {
                     ret.push(activated_nm_con);
                 }

--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -53,6 +53,9 @@ fn gen_nm_ipv4_setting(
     if iface_ip.enabled && !iface_ip.dhcp {
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, false)?;
+            // We use above routes property for gateway also, in order
+            // to support multiple gateways.
+            nm_setting.gateway = None;
         }
     }
     if let Some(rules) = rules {

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -18,6 +18,7 @@ mod sriov;
 #[cfg(test)]
 mod unit_tests;
 mod version;
+mod veth;
 mod vlan;
 mod vrf;
 mod vxlan;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -359,7 +359,15 @@ fn get_nm_ac<'a>(
     name: &'a str,
     nm_iface_type: &'a str,
 ) -> Option<&'a NmActiveConnection> {
-    nm_acs_name_type_index.get(&(name, nm_iface_type)).copied()
+    nm_acs_name_type_index
+        .get(&(
+            name,
+            match nm_iface_type {
+                NM_SETTING_VETH_SETTING_NAME => NM_SETTING_WIRED_SETTING_NAME,
+                t => t,
+            },
+        ))
+        .copied()
 }
 
 fn set_ovs_iface_controller_info(ifaces: &mut Interfaces) {

--- a/rust/src/lib/nm/veth.rs
+++ b/rust/src/lib/nm/veth.rs
@@ -1,0 +1,70 @@
+use nm_dbus::{NmConnection, NmSettingVeth};
+
+use crate::{
+    nm::connection::gen_nm_conn_setting, nm::ip::gen_nm_ip_setting,
+    BaseInterface, EthernetInterface, Interface, InterfaceIpv4, InterfaceIpv6,
+    InterfaceState, InterfaceType, NmstateError, VethConfig,
+};
+
+impl From<&VethConfig> for NmSettingVeth {
+    fn from(config: &VethConfig) -> Self {
+        let mut settings = NmSettingVeth::new();
+        settings.peer = Some(config.peer.to_string());
+        settings
+    }
+}
+
+pub(crate) fn is_veth_peer_changed(
+    new_nm_conn: &NmConnection,
+    cur_nm_conn: &NmConnection,
+) -> bool {
+    if let (Some(new_veth_conf), Some(cur_veth_conf)) =
+        (new_nm_conn.veth.as_ref(), cur_nm_conn.veth.as_ref())
+    {
+        new_veth_conf.peer != cur_veth_conf.peer
+    } else {
+        false
+    }
+}
+
+pub(crate) fn create_veth_peer_profile_if_not_found(
+    peer_name: &str,
+    exist_nm_conns: &[NmConnection],
+) -> Result<NmConnection, NmstateError> {
+    for nm_conn in exist_nm_conns {
+        if let Some(iface_type) = nm_conn.iface_type() {
+            if nm_conn.iface_name() == Some(peer_name)
+                && ["veth", "ethernet"].contains(&iface_type)
+            {
+                return Ok(nm_conn.clone());
+            }
+        }
+    }
+    // Create new connection
+    let mut eth_iface = EthernetInterface::new();
+    eth_iface.base = BaseInterface {
+        name: peer_name.to_string(),
+        iface_type: InterfaceType::Ethernet,
+        state: InterfaceState::Up,
+        ipv4: Some(InterfaceIpv4::new()),
+        ipv6: Some(InterfaceIpv6::new()),
+        ..Default::default()
+    };
+    let iface = Interface::Ethernet(eth_iface);
+    let mut nm_conn = NmConnection::new();
+    gen_nm_conn_setting(&iface, &mut nm_conn)?;
+    gen_nm_ip_setting(&iface, None, None, &mut nm_conn)?;
+    Ok(nm_conn)
+}
+
+pub(crate) fn is_veth_peer_in_desire(
+    iface: &Interface,
+    ifaces: &[&Interface],
+) -> bool {
+    if let Interface::Ethernet(eth_iface) = iface {
+        if let Some(veth_conf) = eth_iface.veth.as_ref() {
+            return ifaces.iter().any(|i| i.name() == veth_conf.peer.as_str());
+        }
+    }
+    false
+}

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -31,6 +31,7 @@ use crate::{
         NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
     },
     connection::sriov::NmSettingSriov,
+    connection::veth::NmSettingVeth,
     connection::vlan::NmSettingVlan,
     connection::vrf::NmSettingVrf,
     connection::vxlan::NmSettingVxlan,
@@ -70,6 +71,7 @@ pub struct NmConnection {
     pub mac_vlan: Option<NmSettingMacVlan>,
     pub sriov: Option<NmSettingSriov>,
     pub vrf: Option<NmSettingVrf>,
+    pub veth: Option<NmSettingVeth>,
     #[serde(skip)]
     pub(crate) obj_path: String,
     _other: HashMap<String, HashMap<String, zvariant::OwnedValue>>,
@@ -120,6 +122,7 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
             sriov: _from_map!(v, "sriov", NmSettingSriov::try_from)?,
             mac_vlan: _from_map!(v, "macvlan", NmSettingMacVlan::try_from)?,
             vrf: _from_map!(v, "vrf", NmSettingVrf::try_from)?,
+            veth: _from_map!(v, "veth", NmSettingVeth::try_from)?,
             _other: v,
             ..Default::default()
         })
@@ -207,6 +210,9 @@ impl NmConnection {
         }
         if let Some(vrf) = &self.vrf {
             ret.insert("vrf", vrf.to_value()?);
+        }
+        if let Some(veth) = &self.veth {
+            ret.insert("veth", veth.to_value()?);
         }
         for (key, setting_value) in &self._other {
             let mut other_setting_value: HashMap<&str, zvariant::Value> =

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -107,6 +107,7 @@ pub struct NmSettingIp {
     pub route_table: Option<u32>,
     pub dhcp_client_id: Option<String>,
     pub dhcp_timeout: Option<i32>,
+    pub gateway: Option<String>,
     // IPv6 only
     pub ra_timeout: Option<i32>,
     // IPv6 only
@@ -147,6 +148,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
         setting.dhcp_duid = _from_map!(v, "dhcp-duid", String::try_from)?;
         setting.dhcp_iaid = _from_map!(v, "dhcp-iaid", String::try_from)?;
         setting.route_table = _from_map!(v, "route-table", u32::try_from)?;
+        setting.gateway = _from_map!(v, "gateway", String::try_from)?;
 
         // NM deprecated `addresses` property in the favor of `addresss-data`
         v.remove("addresses");
@@ -248,6 +250,9 @@ impl NmSettingIp {
         }
         if let Some(v) = &self.route_table {
             ret.insert("route-table", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.gateway {
+            ret.insert("gateway", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -26,6 +26,7 @@ mod ovs;
 mod route;
 mod route_rule;
 mod sriov;
+mod veth;
 mod vlan;
 mod vrf;
 mod vxlan;
@@ -46,6 +47,7 @@ pub use crate::connection::route_rule::NmIpRouteRule;
 pub use crate::connection::sriov::{
     NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
 };
+pub use crate::connection::veth::NmSettingVeth;
 pub use crate::connection::vlan::{NmSettingVlan, NmVlanProtocol};
 pub use crate::connection::vrf::NmSettingVrf;
 pub use crate::connection::vxlan::NmSettingVxlan;

--- a/rust/src/libnm_dbus/connection/veth.rs
+++ b/rust/src/libnm_dbus/connection/veth.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{connection::DbusDictionary, NmError};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmSettingVeth {
+    pub peer: Option<String>,
+    _other: HashMap<String, zvariant::OwnedValue>,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingVeth {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            peer: _from_map!(v, "peer", String::try_from)?,
+            _other: v,
+        })
+    }
+}
+
+impl NmSettingVeth {
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.peer {
+            ret.insert("peer", zvariant::Value::new(v.clone()));
+        }
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -29,7 +29,7 @@ pub use crate::connection::{
     NmSettingBridgeVlanRange, NmSettingConnection, NmSettingIp,
     NmSettingIpMethod, NmSettingMacVlan, NmSettingOvsBridge, NmSettingOvsIface,
     NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingWired,
+    NmSettingVeth, NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingWired,
     NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -57,6 +57,8 @@ def assert_state_match(desired_state_data):
     desired_state, current_state = _prepare_state_for_verify(
         desired_state_data
     )
+    print(desired_state.state)
+    print(current_state.state)
     assert desired_state.match(current_state)
 
 
@@ -102,6 +104,9 @@ def _prepare_state_for_verify(desired_state_data):
     _remove_linux_bridge_read_only_options(full_desired_state)
     _cannonicalize_infiniband_pkey(current_state)
     _cannonicalize_infiniband_pkey(full_desired_state)
+    # Nmstate always show veth as ethernet to simplify the verification.
+    _use_ethernet_type_for_veth(full_desired_state)
+    _use_ethernet_type_for_veth(current_state)
 
     return full_desired_state, current_state
 
@@ -211,3 +216,9 @@ def _cannonicalize_infiniband_pkey(state):
                 ib_config[InfiniBand.PKEY] = int(original_pkey, 16)
             else:
                 ib_config[InfiniBand.PKEY] = int(original_pkey, 10)
+
+
+def _use_ethernet_type_for_veth(state):
+    for iface_state in state.state[Interface.KEY]:
+        if iface_state[Interface.TYPE] == InterfaceType.VETH:
+            iface_state[Interface.TYPE] = InterfaceType.ETHERNET


### PR DESCRIPTION
Integration test case enabled.

Included two extra patches:
 1. Downgrade NM rpm to 1.32 as the C8S NM 1.36.0.-0.3 has bug breaking our CI.
 2. Fix the CI failure on gateway not removed.
 3. Fix the failure caused by race between profile deletion and device deletion.