### PR TITLE
rust ovsdb: Enable OVSDB query support

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -4,7 +4,7 @@ use std::io::{self, Read};
 
 use env_logger::Builder;
 use log::LevelFilter;
-use nmstate::{DnsState, NetworkState, RouteRules, Routes};
+use nmstate::{DnsState, NetworkState, OvsDbGlobalConfig, RouteRules, Routes};
 use serde::Serialize;
 use serde_yaml::{self, Value};
 
@@ -208,6 +208,8 @@ struct SortedNetworkState {
     rules: RouteRules,
     routes: Routes,
     interfaces: Vec<Value>,
+    #[serde(rename = "ovs-db")]
+    ovsdb: OvsDbGlobalConfig,
 }
 
 const IFACE_TOP_PRIORTIES: [&str; 2] = ["name", "type"];
@@ -250,6 +252,7 @@ fn sort_netstate(
             routes: net_state.routes,
             rules: net_state.rules,
             dns: net_state.dns,
+            ovsdb: net_state.ovsdb,
         });
     }
 
@@ -258,6 +261,7 @@ fn sort_netstate(
         routes: net_state.routes,
         rules: net_state.rules,
         dns: net_state.dns,
+        ovsdb: net_state.ovsdb,
     })
 }
 

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for InterfaceType {
 }
 
 impl InterfaceType {
-    const USERSPACE_IFACE_TYPES: [Self; 2] = [Self::OvsBridge, Self::Unknown];
+    const USERSPACE_IFACE_TYPES: [Self; 1] = [Self::OvsBridge];
     const CONTROLLER_IFACES_TYPES: [Self; 4] =
         [Self::Bond, Self::LinuxBridge, Self::OvsBridge, Self::Vrf];
 

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ErrorKind, InterfaceIpv4, InterfaceIpv6, InterfaceState, InterfaceType,
-    NmstateError, RouteEntry, RouteRuleEntry,
+    NmstateError, OvsDbIfaceConfig, RouteEntry, RouteRuleEntry,
 };
 
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
@@ -33,6 +33,8 @@ pub struct BaseInterface {
     pub accept_all_mac_addresses: Option<bool>,
     #[serde(skip_serializing)]
     pub copy_mac_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "ovs-db")]
+    pub ovsdb: Option<OvsDbIfaceConfig>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.
@@ -74,6 +76,9 @@ impl BaseInterface {
         }
         if other.prop_list.contains(&"accept_all_mac_addresses") {
             self.accept_all_mac_addresses = other.accept_all_mac_addresses;
+        }
+        if other.prop_list.contains(&"ovsdb") {
+            self.ovsdb = other.ovsdb.clone();
         }
 
         if other.prop_list.contains(&"ipv4") {

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -6,6 +6,8 @@ mod ip;
 mod net_state;
 mod nispor;
 mod nm;
+mod ovs;
+mod ovsdb;
 mod route;
 mod route_rule;
 mod state;
@@ -34,5 +36,6 @@ pub use crate::ifaces::{
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 pub use crate::net_state::NetworkState;
+pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 pub use crate::route::{RouteEntry, RouteState, Routes};
 pub use crate::route_rule::{RouteRuleEntry, RouteRuleState, RouteRules};

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -1,0 +1,17 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct OvsDbGlobalConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_ids: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub other_config: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct OvsDbIfaceConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_ids: Option<HashMap<String, String>>,
+}

--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -1,0 +1,251 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use serde_json::{Map, Value};
+
+use crate::{
+    ovsdb::json_rpc::OvsDbJsonRpc, ErrorKind, NmstateError, OvsDbGlobalConfig,
+};
+
+const OVS_DB_NAME: &str = "Open_vSwitch";
+const GLOBAL_CONFIG_TABLE: &str = "Open_vSwitch";
+const NM_RESERVED_EXTERNAL_ID: &str = "NM.connection.uuid";
+
+#[derive(Debug)]
+pub(crate) struct OvsDbConnection {
+    rpc: OvsDbJsonRpc,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct OvsDbSelect {
+    table: String,
+    conditions: Vec<OvsDbCondition>,
+    columns: Option<Vec<&'static str>>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct OvsDbCondition {
+    column: String,
+    function: String,
+    value: Value,
+}
+
+impl OvsDbCondition {
+    fn to_value(&self) -> Value {
+        Value::Array(vec![
+            Value::String(self.column.to_string()),
+            Value::String(self.function.to_string()),
+            self.value.clone(),
+        ])
+    }
+}
+
+impl OvsDbSelect {
+    fn to_value(&self) -> Value {
+        let mut ret = Map::new();
+        ret.insert("op".to_string(), Value::String("select".to_string()));
+        ret.insert("table".to_string(), Value::String(self.table.clone()));
+        let condition_values: Vec<Value> =
+            self.conditions.iter().map(|c| c.to_value()).collect();
+        ret.insert("where".to_string(), Value::Array(condition_values));
+        if let Some(columns) = self.columns.as_ref() {
+            ret.insert(
+                "columns".to_string(),
+                Value::Array(
+                    columns
+                        .as_slice()
+                        .iter()
+                        .map(|c| Value::String(c.to_string()))
+                        .collect(),
+                ),
+            );
+        }
+        Value::Object(ret)
+    }
+}
+
+impl OvsDbConnection {
+    pub(crate) fn new(socket_path: &str) -> Result<Self, NmstateError> {
+        Ok(Self {
+            rpc: OvsDbJsonRpc::connect(socket_path)?,
+        })
+    }
+
+    pub(crate) fn check_connection(&mut self) -> bool {
+        if let Ok(reply) = self.rpc.exec("list_dbs", &Value::Array(vec![])) {
+            if let Some(dbs) = reply.as_array() {
+                dbs.iter().any(|db| db.as_str() == Some(OVS_DB_NAME))
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    fn _get_ovs_ifaec(
+        &mut self,
+        table_name: &str,
+    ) -> Result<Vec<OvsDbIface>, NmstateError> {
+        let select = OvsDbSelect {
+            table: table_name.to_string(),
+            conditions: vec![],
+            columns: Some(vec!["external_ids", "name"]),
+        };
+        let mut ret: Vec<OvsDbIface> = Vec::new();
+        match self.rpc.exec(
+            "transact",
+            &Value::Array(vec![
+                Value::String(OVS_DB_NAME.to_string()),
+                select.to_value(),
+            ]),
+        )? {
+            Value::Array(reply) => {
+                if let Some(ovsdb_ifaces) = reply
+                    .get(0)
+                    .and_then(|v| v.as_object())
+                    .and_then(|v| v.get("rows"))
+                    .and_then(|v| v.as_array())
+                {
+                    for ovsdb_iface in ovsdb_ifaces {
+                        ret.push(ovsdb_iface.try_into()?);
+                    }
+                    Ok(ret)
+                } else {
+                    let e = NmstateError::new(
+                        ErrorKind::PluginFailure,
+                        format!(
+                            "Invalid reply from OVSDB for querying {} \
+                            table: {:?}",
+                            table_name, reply
+                        ),
+                    );
+                    log::error!("{}", e);
+                    Err(e)
+                }
+            }
+            reply => {
+                let e = NmstateError::new(
+                    ErrorKind::PluginFailure,
+                    format!(
+                        "Invalid reply from OVSDB for querying {} table: {:?}",
+                        table_name, reply
+                    ),
+                );
+                log::error!("{}", e);
+                Err(e)
+            }
+        }
+    }
+
+    pub(crate) fn get_ovs_ifaces(
+        &mut self,
+    ) -> Result<Vec<OvsDbIface>, NmstateError> {
+        self._get_ovs_ifaec("Interface")
+    }
+
+    pub(crate) fn get_ovs_bridges(
+        &mut self,
+    ) -> Result<Vec<OvsDbIface>, NmstateError> {
+        self._get_ovs_ifaec("Bridge")
+    }
+
+    pub(crate) fn get_ovsdb_global_conf(
+        &mut self,
+    ) -> Result<OvsDbGlobalConfig, NmstateError> {
+        let select = OvsDbSelect {
+            table: GLOBAL_CONFIG_TABLE.to_string(),
+            conditions: vec![],
+            columns: Some(vec!["external_ids", "other_config"]),
+        };
+        match self.rpc.exec(
+            "transact",
+            &Value::Array(vec![
+                Value::String(OVS_DB_NAME.to_string()),
+                select.to_value(),
+            ]),
+        )? {
+            Value::Array(reply) => {
+                if let Some(global_conf) = reply
+                    .get(0)
+                    .and_then(|v| v.as_object())
+                    .and_then(|v| v.get("rows"))
+                    .and_then(|v| v.as_array())
+                    .and_then(|v| v.get(0))
+                    .and_then(|v| v.as_object())
+                {
+                    Ok(global_conf.into())
+                } else {
+                    let e = NmstateError::new(
+                        ErrorKind::PluginFailure,
+                        format!(
+                        "Invalid reply from OVSDB for querying {} table: {:?}",
+                        GLOBAL_CONFIG_TABLE, reply
+                    ),
+                    );
+                    log::error!("{}", e);
+                    Err(e)
+                }
+            }
+            reply => {
+                let e = NmstateError::new(
+                    ErrorKind::PluginFailure,
+                    format!(
+                        "Invalid reply from OVSDB for querying {} table: {:?}",
+                        GLOBAL_CONFIG_TABLE, reply
+                    ),
+                );
+                log::error!("{}", e);
+                Err(e)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct OvsDbIface {
+    pub(crate) name: String,
+    pub(crate) external_ids: HashMap<String, String>,
+}
+
+impl TryFrom<&Value> for OvsDbIface {
+    type Error = NmstateError;
+    fn try_from(v: &Value) -> Result<OvsDbIface, Self::Error> {
+        let e = NmstateError::new(
+            ErrorKind::PluginFailure,
+            format!("Failed to parse OVS Interface info from : {:?}", v),
+        );
+        let mut ret = OvsDbIface::default();
+        if let Value::Object(v) = v {
+            if let (Some(Value::String(n)), Some(Value::Array(ids))) =
+                (v.get("name"), v.get("external_ids"))
+            {
+                ret.name = n.to_string();
+                ret.external_ids = parse_str_map(ids);
+                return Ok(ret);
+            }
+        }
+        log::error!("{}", e);
+        Err(e)
+    }
+}
+
+pub(crate) fn parse_str_map(v: &[Value]) -> HashMap<String, String> {
+    let mut ret = HashMap::new();
+    if let Some(ids) = v.get(1).and_then(|i| i.as_array()) {
+        for kv in ids {
+            if let Some(kv) = kv.as_array() {
+                if let (Some(Value::String(k)), Some(Value::String(v))) =
+                    (kv.get(0), kv.get(1))
+                {
+                    if k == NM_RESERVED_EXTERNAL_ID {
+                        continue;
+                    }
+                    ret.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+    }
+    ret
+}

--- a/rust/src/lib/ovsdb/global_conf.rs
+++ b/rust/src/lib/ovsdb/global_conf.rs
@@ -1,0 +1,16 @@
+use serde_json::{Map, Value};
+
+use crate::{ovsdb::db::parse_str_map, OvsDbGlobalConfig};
+
+impl From<&Map<std::string::String, Value>> for OvsDbGlobalConfig {
+    fn from(m: &Map<std::string::String, Value>) -> Self {
+        let mut ret = Self::default();
+        if let (Some(Value::Array(ids)), Some(Value::Array(other_cfg))) =
+            (m.get("external_ids"), m.get("other_config"))
+        {
+            ret.external_ids = Some(parse_str_map(ids));
+            ret.other_config = Some(parse_str_map(other_cfg));
+        }
+        ret
+    }
+}

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -1,0 +1,127 @@
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{ErrorKind, NmstateError};
+
+const BUFFER_SIZE: usize = 4096;
+
+#[derive(Debug)]
+pub(crate) struct OvsDbJsonRpc {
+    socket: UnixStream,
+    transaction_id: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+struct OvsDbRpcRequest {
+    method: String,
+    params: Value,
+    id: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+struct OvsDbRpcError {
+    error: String,
+    details: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub(crate) struct OvsDbRpcReply {
+    result: Value,
+    error: Option<OvsDbRpcError>,
+    id: u64,
+}
+
+impl OvsDbJsonRpc {
+    pub(crate) fn connect(socket_path: &str) -> Result<Self, NmstateError> {
+        Ok(Self {
+            socket: UnixStream::connect(socket_path).map_err(|e| {
+                NmstateError::new(ErrorKind::Bug, format!("socket error {}", e))
+            })?,
+            transaction_id: get_sec_since_epoch(),
+        })
+    }
+
+    pub(crate) fn exec(
+        &mut self,
+        method: &str,
+        params: &Value,
+    ) -> Result<Value, NmstateError> {
+        self.transaction_id += 1;
+        let req = OvsDbRpcRequest {
+            method: method.to_string(),
+            params: params.clone(),
+            id: self.transaction_id,
+        };
+        let buffer = serde_json::to_string(&req)?;
+        log::debug!("OVSDB: sending command {}", buffer);
+        self.socket
+            .write_all(buffer.as_bytes())
+            .map_err(parse_socket_io_error)?;
+        self.recv()
+    }
+
+    fn recv(&mut self) -> Result<Value, NmstateError> {
+        let mut response: Vec<u8> = Vec::new();
+        loop {
+            let mut buffer = [0u8; BUFFER_SIZE];
+            let read = self
+                .socket
+                .read(&mut buffer)
+                .map_err(parse_socket_io_error)?;
+            log::debug!("OVSDB: recv data {:?}", &buffer[..read]);
+            response.extend_from_slice(&buffer[..read]);
+            if read < BUFFER_SIZE {
+                break;
+            }
+        }
+        let reply_string =
+            String::from_utf8(response).map_err(parse_str_parse_error)?;
+        log::debug!("OVSDB: recv string {:?}", &reply_string);
+        let reply: OvsDbRpcReply = serde_json::from_str(&reply_string)?;
+        if reply.id != self.transaction_id {
+            let e = NmstateError::new(
+                ErrorKind::PluginFailure,
+                format!(
+                    "Transaction ID mismatch for OVS DB JSON RPC: {:?}",
+                    reply
+                ),
+            );
+            log::error!("{}", e);
+            Err(e)
+        } else if let Some(rpc_error) = reply.error {
+            let e = NmstateError::new(
+                ErrorKind::PluginFailure,
+                format!("OVS DB JSON RPC error: {:?}", rpc_error),
+            );
+            log::error!("{}", e);
+            Err(e)
+        } else {
+            Ok(reply.result)
+        }
+    }
+}
+
+fn get_sec_since_epoch() -> u64 {
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => d.as_secs(),
+        Err(_) => 0,
+    }
+}
+
+fn parse_str_parse_error(e: std::string::FromUtf8Error) -> NmstateError {
+    NmstateError::new(
+        ErrorKind::PluginFailure,
+        format!("Reply from OVSDB is not valid UTF-8 string: {}", e),
+    )
+}
+
+fn parse_socket_io_error(e: std::io::Error) -> NmstateError {
+    NmstateError::new(
+        ErrorKind::PluginFailure,
+        format!("OVSDB Socket error: {}", e),
+    )
+}

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -1,0 +1,7 @@
+mod db;
+mod global_conf;
+mod json_rpc;
+mod show;
+
+pub(crate) use show::ovsdb_is_running;
+pub(crate) use show::ovsdb_retrieve;

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -1,0 +1,44 @@
+use crate::{
+    ovsdb::db::OvsDbConnection, Interface, NetworkState, NmstateError,
+    OvsBridgeInterface, OvsDbIfaceConfig, UnknownInterface,
+};
+
+// TODO: support environment variable OVS_DB_UNIX_SOCKET_PATH
+const DEFAULT_OVS_DB_SOCKET_PATH: &str = "/run/openvswitch/db.sock";
+
+pub(crate) fn ovsdb_is_running() -> bool {
+    if let Ok(mut cli) = OvsDbConnection::new(DEFAULT_OVS_DB_SOCKET_PATH) {
+        cli.check_connection()
+    } else {
+        false
+    }
+}
+
+pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
+    let mut ret = NetworkState::new();
+    ret.prop_list.push("interfaces");
+    ret.prop_list.push("ovsdb");
+    let mut cli = OvsDbConnection::new(DEFAULT_OVS_DB_SOCKET_PATH)?;
+    for ovsdb_iface in cli.get_ovs_ifaces()? {
+        let mut iface = Interface::Unknown(UnknownInterface::new());
+        iface.base_iface_mut().name = ovsdb_iface.name;
+        iface.base_iface_mut().prop_list.push("ovsdb");
+        iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
+            external_ids: Some(ovsdb_iface.external_ids),
+        });
+        ret.append_interface_data(iface);
+    }
+    for ovsdb_iface in cli.get_ovs_bridges()? {
+        let mut iface = Interface::OvsBridge(OvsBridgeInterface::new());
+        iface.base_iface_mut().name = ovsdb_iface.name;
+        iface.base_iface_mut().prop_list.push("ovsdb");
+        iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
+            external_ids: Some(ovsdb_iface.external_ids),
+        });
+        ret.append_interface_data(iface);
+    }
+
+    ret.ovsdb = cli.get_ovsdb_global_conf()?;
+
+    Ok(ret)
+}


### PR DESCRIPTION
Support query on:
 * Interface level `external_ids`.
 * Global `external_ids` and `other_config`

No extra dependency added. The API of OVS based on JSON RPC v1, and
database action is defined in RFC 7047.