### PR TITLE
rust: Use fixed version dependency instead of git

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -11,8 +11,7 @@ path = "lib.rs"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 nm-dbus = {path = "../libnm_dbus"}
-#nispor = "1.2.2"
-nispor = {git = "https://github.com/nispor/nispor.git"}
+nispor = "1.2.3"
 log = "0.4.14"
 libc = "0.2.106"
 


### PR DESCRIPTION
Using nispor 1.2.3 as dependency instead of git path