### PR TITLE
rust ovsdb: Support changing OVSDB

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -197,7 +197,8 @@ function run_tests {
             test_create_and_save_ovs_bridge_then_remove_and_apply_again or \
             test_create_and_remove_ovs_bridge_options_specified or \
             test_create_and_remove_ovs_bridge_with_a_system_port or \
-            test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac' \
+            test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac or \
+            ovsdb' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -9,7 +9,7 @@ use crate::{
     ifaces::ethernet::handle_veth_peer_changes,
     ifaces::inter_ifaces_controller::{
         check_overbook_ports, find_unknown_type_port, handle_changed_ports,
-        set_ifaces_up_priority,
+        preserve_ctrl_cfg_if_unchanged, set_ifaces_up_priority,
     },
     ip::include_current_ip_address_if_dhcp_on_to_off,
     ErrorKind, Interface, InterfaceState, InterfaceType, NmstateError,
@@ -243,6 +243,7 @@ impl Interfaces {
 
         self.apply_copy_mac_from(current)?;
         handle_changed_ports(self, current)?;
+        preserve_ctrl_cfg_if_unchanged(self, current);
         self.set_up_priority()?;
         check_overbook_ports(self, current)?;
 

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -175,6 +175,7 @@ pub(crate) fn iface_to_nm_connections(
         nm_conn.ovs_iface = None;
     }
 
+    println!("{:?}", nm_conn);
     ret.insert(0, nm_conn);
 
     Ok(ret)

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -11,7 +11,7 @@ use crate::{
     nm::ip::gen_nm_ip_setting,
     nm::ovs::{
         create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
-        gen_nm_ovs_iface_setting,
+        gen_nm_ovs_ext_ids_setting, gen_nm_ovs_iface_setting,
     },
     nm::profile::get_exist_profile,
     nm::sriov::gen_nm_sriov_setting,
@@ -94,6 +94,7 @@ pub(crate) fn iface_to_nm_connections(
         &mut nm_conn,
     )?;
     gen_nm_wired_setting(iface, &mut nm_conn);
+    gen_nm_ovs_ext_ids_setting(iface, &mut nm_conn);
 
     match iface {
         Interface::OvsBridge(ovs_br_iface) => {
@@ -175,7 +176,6 @@ pub(crate) fn iface_to_nm_connections(
         nm_conn.ovs_iface = None;
     }
 
-    println!("{:?}", nm_conn);
     ret.insert(0, nm_conn);
 
     Ok(ret)

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -1,17 +1,177 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+use crate::{state::get_json_value_difference, ErrorKind, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct OvsDbGlobalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_ids: Option<HashMap<String, String>>,
+    // When the value been set as None, specified key will be removed instead
+    // of merging.
+    // To remove all settings of external_ids or other_config, use empty HashMap
+    pub external_ids: Option<HashMap<String, Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub other_config: Option<HashMap<String, String>>,
+    pub other_config: Option<HashMap<String, Option<String>>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+impl OvsDbGlobalConfig {
+    pub fn is_none(&self) -> bool {
+        self.external_ids.is_none() && self.other_config.is_none()
+    }
+
+    pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+        let self_value = serde_json::to_value(self)?;
+        let current_value = serde_json::to_value(current)?;
+
+        if let Some((reference, desire, current)) = get_json_value_difference(
+            "ovsdb".to_string(),
+            &self_value,
+            &current_value,
+        ) {
+            let e = NmstateError::new(
+                ErrorKind::VerificationError,
+                format!(
+                    "Verification failure: {} desire '{}', current '{}'",
+                    reference, desire, current
+                ),
+            );
+            log::error!("{}", e);
+            Err(e)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_external_ids(&self) -> HashMap<&str, &str> {
+        let mut ret = HashMap::new();
+        if let Some(eids) = self.external_ids.as_ref() {
+            for (k, v) in eids {
+                if let Some(v) = v {
+                    ret.insert(k.as_str(), v.as_str());
+                }
+            }
+        }
+        ret
+    }
+
+    pub(crate) fn get_other_config(&self) -> HashMap<&str, &str> {
+        let mut ret = HashMap::new();
+        if let Some(ocfg) = self.other_config.as_ref() {
+            for (k, v) in ocfg.iter() {
+                if let Some(v) = v {
+                    ret.insert(k.as_str(), v.as_str());
+                }
+            }
+        }
+        ret
+    }
+
+    // Currently, we only support full editing on OVSDB.
+    //  * If OVSDB setting not mentioned, preserve old configure.
+    //  * If OVSDB is set, override.
+    pub(crate) fn merge(&mut self, current: &Self) {
+        if self.external_ids.is_some() || self.other_config.is_some() {
+            if self.external_ids.is_none() {
+                self.external_ids = current.external_ids.clone();
+            }
+            if self.other_config.is_none() {
+                self.other_config = current.other_config.clone();
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OvsDbGlobalConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut ret = Self::default();
+        let v = serde_json::Value::deserialize(deserializer)?;
+        if let Some(v) = v.as_object() {
+            if let Some(v) = v.get("external_ids") {
+                ret.external_ids = Some(value_to_hash_map(v));
+            }
+            if let Some(v) = v.get("other_config") {
+                ret.other_config = Some(value_to_hash_map(v));
+            }
+        } else {
+            return Err(serde::de::Error::custom(format!(
+                "Expecting dict/HashMap, but got {:?}",
+                v
+            )));
+        }
+        Ok(ret)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct OvsDbIfaceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_ids: Option<HashMap<String, String>>,
+    pub external_ids: Option<HashMap<String, Option<String>>>,
+}
+
+impl OvsDbIfaceConfig {
+    pub(crate) fn get_external_ids(&self) -> HashMap<&str, &str> {
+        let mut ret = HashMap::new();
+        if let Some(eids) = self.external_ids.as_ref() {
+            for (k, v) in eids {
+                if let Some(v) = v {
+                    ret.insert(k.as_str(), v.as_str());
+                }
+            }
+        }
+        ret
+    }
+}
+
+impl<'de> Deserialize<'de> for OvsDbIfaceConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut ret = Self::default();
+        let v = serde_json::Value::deserialize(deserializer)?;
+        if let Some(v) = v.as_object() {
+            if let Some(v) = v.get("external_ids") {
+                ret.external_ids = Some(value_to_hash_map(v));
+            }
+        } else {
+            return Err(serde::de::Error::custom(format!(
+                "Expecting dict/HashMap, but got {:?}",
+                v
+            )));
+        }
+        Ok(ret)
+    }
+}
+
+fn value_to_hash_map(
+    value: &serde_json::Value,
+) -> HashMap<String, Option<String>> {
+    let mut ret: HashMap<String, Option<String>> = HashMap::new();
+    if let Some(value) = value.as_object() {
+        for (k, v) in value.iter() {
+            let v = match &v {
+                serde_json::Value::Number(i) => Some({
+                    if let Some(i) = i.as_i64() {
+                        format!("{}", i)
+                    } else if let Some(i) = i.as_u64() {
+                        format!("{}", i)
+                    } else if let Some(i) = i.as_f64() {
+                        format!("{}", i)
+                    } else {
+                        continue;
+                    }
+                }),
+                serde_json::Value::String(s) => Some(s.to_string()),
+                serde_json::Value::Bool(b) => Some(format!("{}", b)),
+                serde_json::Value::Null => None,
+                _ => continue,
+            };
+            ret.insert(k.to_string(), v);
+        }
+    }
+    ret
 }

--- a/rust/src/lib/ovsdb/apply.rs
+++ b/rust/src/lib/ovsdb/apply.rs
@@ -1,0 +1,17 @@
+use crate::{ovsdb::db::OvsDbConnection, NetworkState, NmstateError};
+
+pub(crate) fn ovsdb_apply(
+    desired: &NetworkState,
+    current: &NetworkState,
+) -> Result<(), NmstateError> {
+    if desired.ovsdb.external_ids.is_some()
+        || desired.ovsdb.other_config.is_some()
+    {
+        let mut cli = OvsDbConnection::new()?;
+        let mut desired = desired.ovsdb.clone();
+        desired.merge(&current.ovsdb);
+        cli.apply_global_conf(&desired)
+    } else {
+        Ok(())
+    }
+}

--- a/rust/src/lib/ovsdb/global_conf.rs
+++ b/rust/src/lib/ovsdb/global_conf.rs
@@ -1,6 +1,11 @@
+use std::collections::HashMap;
+
 use serde_json::{Map, Value};
 
-use crate::{ovsdb::db::parse_str_map, OvsDbGlobalConfig};
+use crate::{
+    ovsdb::db::{parse_str_map, OvsDbUpdate, GLOBAL_CONFIG_TABLE},
+    OvsDbGlobalConfig,
+};
 
 impl From<&Map<std::string::String, Value>> for OvsDbGlobalConfig {
     fn from(m: &Map<std::string::String, Value>) -> Self {
@@ -8,9 +13,60 @@ impl From<&Map<std::string::String, Value>> for OvsDbGlobalConfig {
         if let (Some(Value::Array(ids)), Some(Value::Array(other_cfg))) =
             (m.get("external_ids"), m.get("other_config"))
         {
-            ret.external_ids = Some(parse_str_map(ids));
-            ret.other_config = Some(parse_str_map(other_cfg));
+            ret.external_ids = Some(convert_map(parse_str_map(ids)));
+            ret.other_config = Some(convert_map(parse_str_map(other_cfg)));
         }
         ret
+    }
+}
+
+// Convert HashMap<String, String> to HashMap<String, Option<String>>
+fn convert_map(
+    mut m: HashMap<String, String>,
+) -> HashMap<String, Option<String>> {
+    let mut ret = HashMap::new();
+    for (k, v) in m.drain() {
+        ret.insert(k, Some(v));
+    }
+    ret
+}
+
+impl From<&OvsDbGlobalConfig> for OvsDbUpdate {
+    fn from(ovs_conf: &OvsDbGlobalConfig) -> Self {
+        let mut row = HashMap::new();
+        let mut value_array = Vec::new();
+        for (k, v) in ovs_conf.get_external_ids().iter() {
+            value_array.push(Value::Array(vec![
+                Value::String(k.to_string()),
+                Value::String(v.to_string()),
+            ]));
+        }
+        row.insert(
+            "external_ids".to_string(),
+            Value::Array(vec![
+                Value::String("map".to_string()),
+                Value::Array(value_array),
+            ]),
+        );
+        let mut value_array = Vec::new();
+        for (k, v) in ovs_conf.get_other_config().iter() {
+            value_array.push(Value::Array(vec![
+                Value::String(k.to_string()),
+                Value::String(v.to_string()),
+            ]));
+        }
+        row.insert(
+            "other_config".to_string(),
+            Value::Array(vec![
+                Value::String("map".to_string()),
+                Value::Array(value_array),
+            ]),
+        );
+
+        OvsDbUpdate {
+            table: GLOBAL_CONFIG_TABLE.to_string(),
+            conditions: vec![],
+            row,
+        }
     }
 }

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -1,7 +1,9 @@
+mod apply;
 mod db;
 mod global_conf;
 mod json_rpc;
 mod show;
 
+pub(crate) use apply::ovsdb_apply;
 pub(crate) use show::ovsdb_is_running;
 pub(crate) use show::ovsdb_retrieve;

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -1,13 +1,13 @@
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
 use crate::{
     ovsdb::db::OvsDbConnection, Interface, NetworkState, NmstateError,
     OvsBridgeInterface, OvsDbIfaceConfig, UnknownInterface,
 };
 
-// TODO: support environment variable OVS_DB_UNIX_SOCKET_PATH
-const DEFAULT_OVS_DB_SOCKET_PATH: &str = "/run/openvswitch/db.sock";
-
 pub(crate) fn ovsdb_is_running() -> bool {
-    if let Ok(mut cli) = OvsDbConnection::new(DEFAULT_OVS_DB_SOCKET_PATH) {
+    if let Ok(mut cli) = OvsDbConnection::new() {
         cli.check_connection()
     } else {
         false
@@ -18,22 +18,26 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
     ret.prop_list.push("interfaces");
     ret.prop_list.push("ovsdb");
-    let mut cli = OvsDbConnection::new(DEFAULT_OVS_DB_SOCKET_PATH)?;
-    for ovsdb_iface in cli.get_ovs_ifaces()? {
+    let mut cli = OvsDbConnection::new()?;
+    for mut ovsdb_iface in cli.get_ovs_ifaces()? {
         let mut iface = Interface::Unknown(UnknownInterface::new());
         iface.base_iface_mut().name = ovsdb_iface.name;
         iface.base_iface_mut().prop_list.push("ovsdb");
         iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
-            external_ids: Some(ovsdb_iface.external_ids),
+            external_ids: Some(HashMap::from_iter(
+                ovsdb_iface.external_ids.drain().map(|(k, v)| (k, Some(v))),
+            )),
         });
         ret.append_interface_data(iface);
     }
-    for ovsdb_iface in cli.get_ovs_bridges()? {
+    for mut ovsdb_iface in cli.get_ovs_bridges()? {
         let mut iface = Interface::OvsBridge(OvsBridgeInterface::new());
         iface.base_iface_mut().name = ovsdb_iface.name;
         iface.base_iface_mut().prop_list.push("ovsdb");
         iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
-            external_ids: Some(ovsdb_iface.external_ids),
+            external_ids: Some(HashMap::from_iter(
+                ovsdb_iface.external_ids.drain().map(|(k, v)| (k, Some(v))),
+            )),
         });
         ret.append_interface_data(iface);
     }

--- a/rust/src/lib/state.rs
+++ b/rust/src/lib/state.rs
@@ -56,7 +56,7 @@ pub(crate) fn get_json_value_difference<'a, 'b>(
                     ) {
                         return Some(difference);
                     }
-                } else {
+                } else if des_value != &Value::Null {
                     return Some((reference, des_value, &Value::Null));
                 }
             }

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -28,7 +28,8 @@ use crate::{
     connection::ip::NmSettingIp,
     connection::mac_vlan::NmSettingMacVlan,
     connection::ovs::{
-        NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+        NmSettingOvsBridge, NmSettingOvsExtIds, NmSettingOvsIface,
+        NmSettingOvsPort,
     },
     connection::sriov::NmSettingSriov,
     connection::veth::NmSettingVeth,
@@ -65,6 +66,7 @@ pub struct NmConnection {
     pub ovs_bridge: Option<NmSettingOvsBridge>,
     pub ovs_port: Option<NmSettingOvsPort>,
     pub ovs_iface: Option<NmSettingOvsIface>,
+    pub ovs_ext_ids: Option<NmSettingOvsExtIds>,
     pub wired: Option<NmSettingWired>,
     pub vlan: Option<NmSettingVlan>,
     pub vxlan: Option<NmSettingVxlan>,
@@ -115,6 +117,11 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
                 v,
                 "ovs-interface",
                 NmSettingOvsIface::try_from
+            )?,
+            ovs_ext_ids: _from_map!(
+                v,
+                "ovs-external-ids",
+                NmSettingOvsExtIds::try_from
             )?,
             wired: _from_map!(v, "802-3-ethernet", NmSettingWired::try_from)?,
             vlan: _from_map!(v, "vlan", NmSettingVlan::try_from)?,
@@ -192,6 +199,9 @@ impl NmConnection {
         }
         if let Some(ovs_iface_set) = &self.ovs_iface {
             ret.insert("ovs-interface", ovs_iface_set.to_value()?);
+        }
+        if let Some(ovs_ext_ids) = &self.ovs_ext_ids {
+            ret.insert("ovs-external-ids", ovs_ext_ids.to_value()?);
         }
         if let Some(wired_set) = &self.wired {
             ret.insert("802-3-ethernet", wired_set.to_value()?);

--- a/rust/src/libnm_dbus/connection/mod.rs
+++ b/rust/src/libnm_dbus/connection/mod.rs
@@ -40,7 +40,7 @@ pub use crate::connection::conn::{NmConnection, NmSettingConnection};
 pub use crate::connection::ip::{NmSettingIp, NmSettingIpMethod};
 pub use crate::connection::mac_vlan::NmSettingMacVlan;
 pub use crate::connection::ovs::{
-    NmSettingOvsBridge, NmSettingOvsIface, NmSettingOvsPort,
+    NmSettingOvsBridge, NmSettingOvsExtIds, NmSettingOvsIface, NmSettingOvsPort,
 };
 pub use crate::connection::route::NmIpRoute;
 pub use crate::connection::route_rule::NmIpRouteRule;

--- a/rust/src/libnm_dbus/convert.rs
+++ b/rust/src/libnm_dbus/convert.rs
@@ -16,7 +16,7 @@ use std::convert::TryFrom;
 
 use log::error;
 
-use crate::error::NmError;
+use crate::NmError;
 
 pub(crate) fn own_value_to_bytes_array(
     value: zvariant::OwnedValue,

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -27,10 +27,10 @@ pub use crate::active_connection::NmActiveConnection;
 pub use crate::connection::{
     NmConnection, NmIpRoute, NmIpRouteRule, NmSettingBond, NmSettingBridge,
     NmSettingBridgeVlanRange, NmSettingConnection, NmSettingIp,
-    NmSettingIpMethod, NmSettingMacVlan, NmSettingOvsBridge, NmSettingOvsIface,
-    NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingVeth, NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingWired,
-    NmVlanProtocol,
+    NmSettingIpMethod, NmSettingMacVlan, NmSettingOvsBridge,
+    NmSettingOvsExtIds, NmSettingOvsIface, NmSettingOvsPort, NmSettingSriov,
+    NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingVeth, NmSettingVlan,
+    NmSettingVrf, NmSettingVxlan, NmSettingWired, NmVlanProtocol,
 };
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::dns::NmDnsEntry;

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -888,3 +888,22 @@ def test_linux_bridge_enable_and_disable_accept_all_mac_addresses(
     desired_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_desire_port_only_should_preserve_ctrl_setting(bridge0_with_port0):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                }
+            ]
+        }
+    )
+    state = show_only((TEST_BRIDGE0,))
+    ports = state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+        LinuxBridge.PORT_SUBTREE
+    ]
+
+    assert len(ports) == 1
+    assert ports[0][LinuxBridge.Port.NAME] == "eth1"


### PR DESCRIPTION
Using NetworkManager for changing interface level OVSDB. Using OVSDB plugin
for changing global OVSDB.

The action on remove all configure is changed:
 * Old: `ovs-db: null`
 * New: `ovs-db: {}`

This is approved by current user of OVSDB -- ovirt and be consistent
with DNS configuration.


Integration test case enabled.