### PR TITLE
rust: Fix problem when controller not mentioned in desire

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -414,11 +414,6 @@ impl Interfaces {
                 if let Some(cur_iface) =
                     current.kernel_ifaces.get(src_iface_name)
                 {
-                    println!(
-                        "per {:?} mac {:?}",
-                        cur_iface.base_iface().permanent_mac_address,
-                        cur_iface.base_iface().mac_address
-                    );
                     if !is_opt_str_empty(
                         &cur_iface.base_iface().permanent_mac_address,
                     ) {

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -9,7 +9,7 @@ use crate::{
     ifaces::ethernet::handle_veth_peer_changes,
     ifaces::inter_ifaces_controller::{
         check_overbook_ports, find_unknown_type_port, handle_changed_ports,
-        set_ifaces_up_priority,
+        preserve_ctrl_cfg_if_unchanged, set_ifaces_up_priority,
     },
     ip::include_current_ip_address_if_dhcp_on_to_off,
     ErrorKind, Interface, InterfaceState, InterfaceType, NmstateError,
@@ -243,6 +243,7 @@ impl Interfaces {
 
         self.apply_copy_mac_from(current)?;
         handle_changed_ports(self, current)?;
+        preserve_ctrl_cfg_if_unchanged(self, current);
         self.set_up_priority()?;
         check_overbook_ports(self, current)?;
 

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -47,7 +47,6 @@ fn net_state_to_nispor(
             }
             np_ifaces.push(nmstate_iface_to_np(iface, np_iface_type)?);
         } else if iface.is_absent() {
-            println!("del {:?} {:?}", iface.name(), iface.iface_type());
             np_ifaces.push(nispor::IfaceConf {
                 name: iface.name().to_string(),
                 iface_type: Some(nmstate_iface_type_to_np(&iface.iface_type())),

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -175,6 +175,7 @@ pub(crate) fn iface_to_nm_connections(
         nm_conn.ovs_iface = None;
     }
 
+    println!("{:?}", nm_conn);
     ret.insert(0, nm_conn);
 
     Ok(ret)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -888,3 +888,22 @@ def test_linux_bridge_enable_and_disable_accept_all_mac_addresses(
     desired_state[Interface.KEY][0][Interface.ACCEPT_ALL_MAC_ADDRESSES] = False
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_desire_port_only_should_preserve_ctrl_setting(bridge0_with_port0):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                }
+            ]
+        }
+    )
+    state = show_only((TEST_BRIDGE0,))
+    ports = state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+        LinuxBridge.PORT_SUBTREE
+    ]
+
+    assert len(ports) == 1
+    assert ports[0][LinuxBridge.Port.NAME] == "eth1"


### PR DESCRIPTION
When desire state contains subordinate interface without its controller,
backend code will detach it from controller.
To fix that, we copy current controller information when this interface
has no controller changes.

Integration test case included.