### PR TITLE
rust: Support memory only apply

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -210,6 +210,7 @@ function run_tests {
             test_create_and_remove_ovs_bridge_options_specified or \
             test_create_and_remove_ovs_bridge_with_a_system_port or \
             test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac or \
+            test_create_memory_only_ovs_bridge or \
             ovsdb' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
@@ -302,6 +303,13 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/interface_common_test.py \
             -k 'test_iface_description_removal' \
+            ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/nm/profile_test.py -k memory_only \
             ${nmstate_pytest_extra_args}"
     fi
 }

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -115,6 +115,12 @@ fn main() {
                         .takes_value(false)
                         .help("Show secrets(hide by default)"),
                 )
+                .arg(
+                    clap::Arg::with_name("MEMORY_ONLY")
+                        .long("memory-only")
+                        .takes_value(false)
+                        .help("Do not make the state persistent"),
+                )
         )
         .subcommand(
             clap::SubCommand::with_name(SUB_CMD_GEN_CONF)
@@ -339,6 +345,7 @@ where
     net_state.set_verify_change(!no_verify);
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
+    net_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
     net_state.apply()?;
     if !matches.is_present("SHOW_SECRETS") {
         net_state.hide_secrets();

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -20,8 +20,7 @@ const NMSTATE_FLAG_NO_VERIFY: u32 = 1 << 2;
 const NMSTATE_FLAG_INCLUDE_STATUS_DATA: u32 = 1 << 3;
 const NMSTATE_FLAG_INCLUDE_SECRETS: u32 = 1 << 4;
 const NMSTATE_FLAG_NO_COMMIT: u32 = 1 << 5;
-// TODO
-// const NMSTATE_FLAG_MEMORY_ONLY: u32 = 1 << 6;
+const NMSTATE_FLAG_MEMORY_ONLY: u32 = 1 << 6;
 const NMSTATE_FLAG_RUNNING_CONFIG_ONLY: u32 = 1 << 7;
 
 const NMSTATE_PASS: c_int = 0;
@@ -168,6 +167,10 @@ pub extern "C" fn nmstate_net_state_apply(
 
     if (flags & NMSTATE_FLAG_NO_COMMIT) > 0 {
         net_state.set_commit(false);
+    }
+
+    if (flags & NMSTATE_FLAG_MEMORY_ONLY) > 0 {
+        net_state.set_memory_only(true);
     }
 
     net_state.set_timeout(rollback_timeout);

--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -23,6 +23,8 @@ const (
 	includeStatusData
 	includeSecrets
 	noCommit
+	memoryOnly
+	runningConfigOnly
 )
 
 func New(options ...func(*Nmstate)) *Nmstate {
@@ -72,6 +74,18 @@ func WithIncludeSecrets() func(*Nmstate) {
 func WithNoCommit() func(*Nmstate) {
 	return func(n *Nmstate) {
 		n.flags = n.flags | noCommit
+	}
+}
+
+func WithMemoryOnly() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | memoryOnly
+	}
+}
+
+func WithRunningConfigOnly() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | runningConfigOnly
 	}
 }
 

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -103,6 +103,7 @@ pub(crate) fn save_nm_profiles(
     nm_api: &nm_dbus::NmApi,
     nm_conns: &[NmConnection],
     checkpoint: &str,
+    memory_only: bool,
 ) -> Result<(), NmstateError> {
     for (index, nm_conn) in nm_conns.iter().enumerate() {
         // Only extend the timeout every
@@ -117,7 +118,7 @@ pub(crate) fn save_nm_profiles(
         }
         info!("Creating/Modifying connection {:?}", nm_conn);
         nm_api
-            .connection_add(nm_conn)
+            .connection_add(nm_conn, memory_only)
             .map_err(nm_error_to_nmstate)?;
     }
     Ok(())

--- a/rust/src/lib/nm/version.rs
+++ b/rust/src/lib/nm/version.rs
@@ -6,7 +6,8 @@ pub(crate) fn nm_version() -> Result<String, NmstateError> {
     nm_api.version().map_err(nm_error_to_nmstate)
 }
 
-// This helper function will help us to avoid introducing new dependencies to the project.
+// This helper function will help us to avoid introducing new dependencies to
+// the project.
 pub(crate) fn nm_supports_accept_all_mac_addresses_mode(
 ) -> Result<bool, NmstateError> {
     let version = nm_version()?;

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -10,7 +10,8 @@ pub struct OvsDbGlobalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     // When the value been set as None, specified key will be removed instead
     // of merging.
-    // To remove all settings of external_ids or other_config, use empty HashMap
+    // To remove all settings of external_ids or other_config, use empty
+    // HashMap
     pub external_ids: Option<HashMap<String, Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub other_config: Option<HashMap<String, Option<String>>>,

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -18,7 +18,8 @@ fn test_resolve_unknown_type_absent_eth() {
     ifaces.push(absent_iface);
 
     ifaces.resolve_unknown_ifaces(&cur_ifaces).unwrap();
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     let del_ifaces = del_ifaces.to_vec();
 
@@ -40,7 +41,8 @@ fn test_resolve_unknown_type_absent_multiple() {
     let mut ifaces = Interfaces::new();
     ifaces.push(absent_iface);
 
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     let del_ifaces = del_ifaces.to_vec();
 
@@ -63,7 +65,8 @@ fn test_mark_orphan_vlan_as_absent() {
     eth0.base_iface_mut().state = InterfaceState::Absent;
     desired.push(eth0);
 
-    let (_, _, del_ifaces) = desired.gen_state_for_apply(&current).unwrap();
+    let (_, _, del_ifaces) =
+        desired.gen_state_for_apply(&current, false).unwrap();
     assert_eq!(del_ifaces.to_vec().len(), 2);
     assert!(del_ifaces.kernel_ifaces["eth0"].is_absent());
     assert!(del_ifaces.kernel_ifaces["eth0.10"].is_absent());
@@ -83,7 +86,7 @@ fn test_check_orphan_vlan_change_parent() {
     desired.push(new_eth_iface("eth1"));
 
     let (_, chg_ifaces, del_ifaces) =
-        desired.gen_state_for_apply(&current).unwrap();
+        desired.gen_state_for_apply(&current, false).unwrap();
     assert_eq!(del_ifaces.to_vec().len(), 1);
     assert!(del_ifaces.kernel_ifaces["eth0"].is_absent());
     assert!(!chg_ifaces.kernel_ifaces["eth0.10"].is_absent());

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -14,8 +14,9 @@ fn test_ifaces_up_order_no_ctrler_reserse_order() {
     ifaces.push(new_eth_iface("eth2"));
     ifaces.push(new_eth_iface("eth1"));
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["eth1"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["eth2"].base_iface().up_priority, 0);
@@ -39,8 +40,9 @@ fn test_ifaces_up_order_nested_4_depth_worst_case() {
     ifaces.push(br1);
     ifaces.push(br0);
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 1);
@@ -79,7 +81,7 @@ fn test_ifaces_up_order_nested_5_depth_worst_case() {
     ifaces.push(br0);
     ifaces.push(br4);
 
-    let result = ifaces.gen_state_for_apply(&Interfaces::new());
+    let result = ifaces.gen_state_for_apply(&Interfaces::new(), false);
     assert!(result.is_err());
 
     if let Err(e) = result {
@@ -106,8 +108,9 @@ fn test_ifaces_up_order_nested_5_depth_good_case() {
     ifaces.push(p2);
     ifaces.push(p1);
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["br4"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 1);
@@ -133,8 +136,9 @@ fn test_auto_include_ovs_interface() {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     println!("{:?}", ifaces);
 
@@ -193,7 +197,8 @@ fn test_auto_absent_ovs_interface() {
     let mut ifaces = Interfaces::new();
     ifaces.push(Interface::OvsBridge(absent_br0));
 
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     println!("{:?}", ifaces);
 

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -155,14 +155,19 @@ impl<'a> NmApi<'a> {
     pub fn connection_add(
         &self,
         nm_conn: &NmConnection,
+        memory_only: bool,
     ) -> Result<(), NmError> {
         debug!("connection_add: {:?}", nm_conn);
         if let Some(uuid) = nm_conn.uuid() {
             if let Ok(con_obj_path) = self.dbus.get_connection_by_uuid(uuid) {
-                return self.dbus.connection_update(&con_obj_path, nm_conn);
+                return self.dbus.connection_update(
+                    &con_obj_path,
+                    nm_conn,
+                    memory_only,
+                );
             }
         };
-        self.dbus.connection_add(nm_conn)?;
+        self.dbus.connection_add(nm_conn, memory_only)?;
         Ok(())
     }
 

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -45,7 +45,7 @@ NMSTATE_FLAG_NO_VERIFY = 1 << 2
 NMSTATE_FLAG_INCLUDE_STATUS_DATA = 1 << 3
 NMSTATE_FLAG_INCLUDE_SECRETS = 1 << 4
 NMSTATE_FLAG_NO_COMMIT = 1 << 5
-# NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
+NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
 NMSTATE_FLAG_RUNNING_CONFIG_ONLY = 1 << 7
 NMSTATE_PASS = 0
 
@@ -110,6 +110,9 @@ def apply_net_state(
 
     if not commit:
         flags |= NMSTATE_FLAG_NO_COMMIT
+
+    if not save_to_disk:
+        flags |= NMSTATE_FLAG_MEMORY_ONLY
 
     rc = lib.nmstate_net_state_apply(
         flags,


### PR DESCRIPTION
Introduce `NetworkState.set_memory_only(true)` for applying network state
to memory only(not persistent after reboot).

The command line tool added the `--memory-only` option like current python
version nmstatectl.

Integration test cases enabled.