### PR TITLE
rust IP: Preserving existing IP setting

### DIFF
--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -271,9 +271,9 @@ impl RouteEntry {
     }
 
     // Return tuple of (no_absent, is_ipv4, table_id, next_hop_iface,
-    // destination, next_hop_addr)
+    // destination, next_hop_addr, metric)
     // The metric difference is ignored
-    fn sort_key(&self) -> (bool, bool, u32, &str, &str, &str) {
+    fn sort_key(&self) -> (bool, bool, u32, &str, &str, &str, i64) {
         (
             !matches!(self.state, Some(RouteState::Absent)),
             !self
@@ -285,6 +285,7 @@ impl RouteEntry {
             self.next_hop_iface.as_deref().unwrap_or(""),
             self.destination.as_deref().unwrap_or(""),
             self.next_hop_addr.as_deref().unwrap_or(""),
+            self.metric.unwrap_or(RouteEntry::USE_DEFAULT_METRIC),
         )
     }
 }

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -18,16 +18,16 @@ fn test_sort_uniqe_routes() {
     let mut test_routes = gen_test_route_entries();
     test_routes.reverse();
     test_routes.extend(gen_test_route_entries());
-    // Insert a route with different metric but others are the same.
-    // Only the route with bigger metric should be removed.
-    let mut dup_route6 =
-        gen_route_entry(TEST_IPV6_NET1, TEST_NIC, TEST_IPV6_ADDR1);
-    dup_route6.metric = Some(TEST_ROUTE_METRIC + 1);
-    test_routes.push(dup_route6.clone());
-    let mut dup_route4 =
-        gen_route_entry(TEST_IPV4_NET1, TEST_NIC, TEST_IPV4_ADDR1);
-    dup_route4.metric = Some(TEST_ROUTE_METRIC + 1);
-    test_routes.push(dup_route4.clone());
+    test_routes.push(gen_route_entry(
+        TEST_IPV6_NET1,
+        TEST_NIC,
+        TEST_IPV6_ADDR1,
+    ));
+    test_routes.push(gen_route_entry(
+        TEST_IPV4_NET1,
+        TEST_NIC,
+        TEST_IPV4_ADDR1,
+    ));
 
     test_routes.sort_unstable();
     test_routes.dedup();

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -904,3 +904,11 @@ def _check_ip_rules(rules):
             rule.get(RouteRule.PRIORITY),
             rule.get(RouteRule.ROUTE_TABLE),
         )
+
+
+def test_route_change_metric(eth1_static_gateway_dns):
+    ipv4_route = _get_ipv4_gateways()[0]
+    ipv4_route[Route.METRIC] += 1
+    ipv6_route = _get_ipv6_gateways()[0]
+    ipv6_route[Route.METRIC] += 2
+    libnmstate.apply({Route.KEY: {Route.CONFIG: [ipv6_route, ipv4_route]}})

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -98,6 +98,40 @@ def setup_eth1_ipv6(eth1_up):
 
 
 @pytest.fixture
+def setup_eth1_static_ip(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    return desired_state
+
+
+@pytest.fixture
 def setup_eth1_ipv6_disable(eth1_up):
     desired_state = {
         Interface.KEY: [
@@ -675,3 +709,18 @@ def test_ignore_invalid_ip_on_absent_interface(eth1_up):
             ]
         }
     )
+
+
+@pytest.mark.tier1
+def test_preserve_ip_conf_if_not_mentioned(setup_eth1_static_ip):
+    desired_state = setup_eth1_static_ip
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                }
+            ]
+        }
+    )
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
If IP config not mentioned, we should preserving existing IP setting.