### PR TITLE
go: Expose versions

### DIFF
--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -305,6 +305,31 @@ pub extern "C" fn nmstate_checkpoint_rollback(
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
+pub extern "C" fn nmstate_nm_version(
+    version_cstring: *mut *mut c_char,
+    err_kind: *mut *mut c_char,
+    err_msg: *mut *mut c_char,
+) -> c_int {
+    match nmstate::NetworkState::nm_version() {
+        Ok(version) => {
+            unsafe {
+                *version_cstring = CString::new(version).unwrap().into_raw();
+            }
+            NMSTATE_PASS
+        }
+        Err(e) => {
+            unsafe {
+                *err_msg = CString::new(e.msg()).unwrap().into_raw();
+                *err_kind =
+                    CString::new(format!("{}", &e.kind())).unwrap().into_raw();
+            }
+            NMSTATE_FAIL
+        }
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
 pub extern "C" fn nmstate_cstring_free(cstring: *mut c_char) {
     unsafe {
         if !cstring.is_null() {

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -26,6 +26,8 @@ const NMSTATE_FLAG_RUNNING_CONFIG_ONLY: u32 = 1 << 7;
 const NMSTATE_PASS: c_int = 0;
 const NMSTATE_FAIL: c_int = 1;
 
+const VERSION: Option<&str> = option_env!("CARGO_PKG_VERSION");
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn nmstate_net_state_retrieve(
@@ -325,6 +327,15 @@ pub extern "C" fn nmstate_nm_version(
             }
             NMSTATE_FAIL
         }
+    }
+}
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn nmstate_version(version_cstring: *mut *mut c_char) {
+    let version = VERSION.unwrap_or("unknown");
+    unsafe {
+        *version_cstring = CString::new(version).unwrap().into_raw();
     }
 }
 

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -213,7 +213,24 @@ int nmstate_checkpoint_rollback(const char *checkpoint, char **log, char **err_k
  *              On failure.
  */
 int nmstate_nm_version(char **version, char **err_kind, char **err_msg);
-                               
+
+/**
+ * nmstate_version - Retrieve NMState version from rust cargo pkg at clib
+ *
+ * Version:
+ *      0.1
+ *
+ * Description:
+ *      Retrieve NMState version from rust cargo pkg at clib
+ *
+ * @version:
+ *      Output pointer of char array for nmstate clib pkg version reported from 
+ *      cargo, if there is no version or compiled without cargo it returns 
+ *      unknown.
+ *      The memory should be freed by nmstate_cstring_free().
+ */
+void nmstate_version(char **version);
+
 /**
  * nmstate_cstring_free - free the c string
  *

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -185,6 +185,51 @@ int nmstate_checkpoint_commit(const char *checkpoint, char **log, char **err_kin
  */
 int nmstate_checkpoint_rollback(const char *checkpoint, char **log, char **err_kind,
                                  char **err_msg);
+/**
+ * nmstate_nm_version - Retrieve NetworkManager version from dbus
+ *
+ * Version:
+ *      0.1
+ *
+ * Description:
+ *      Retrieve NetworkManager version from dbus.
+ *
+ * @version:
+ *      Output pointer of char array for version reported from 
+ *      NetworkManager dbus.
+ *      The memory should be freed by nmstate_cstring_free().
+ * @err_kind:
+ *      Output pointer of char array for error kind.
+ *      The memory should be freed by nmstate_cstring_free().
+ * @err_msg:
+ *      Output pointer of char array for error message.
+ *      The memory should be freed by nmstate_cstring_free().
+ *
+ * Return:
+ *      Error code:
+ *          * NMSTATE_PASS
+ *              On success.
+ *          * NMSTATE_FAIL
+ *              On failure.
+ */
+int nmstate_nm_version(char **version, char **err_kind, char **err_msg);
+                               
+/**
+ * nmstate_cstring_free - free the c string
+ *
+ * Version:
+ *      0.1
+ *
+ * Description:
+ *      Free the memory of the c string
+ *
+ * @state:
+ *      Pointer of char array for c string.
+ *
+ * Return:
+ *      void
+ */
+void nmstate_cstring_free(char *state);
 
 /**
  * nmstate_generate_configurations - Generate network configurations

--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -19,6 +19,7 @@ type Nmstate struct {
 
 type Version struct {
 	NetworkManager string
+	Nmstate        string
 }
 
 const (
@@ -201,9 +202,10 @@ func (n *Nmstate) RollbackCheckpoint(checkpoint string) (string, error) {
 
 func (n *Nmstate) Version() (Version, error) {
 	var (
-		nm_version *C.char
-		err_kind   *C.char
-		err_msg    *C.char
+		nmstate_version *C.char
+		nm_version      *C.char
+		err_kind        *C.char
+		err_msg         *C.char
 	)
 	rc := C.nmstate_nm_version(&nm_version, &err_kind, &err_msg)
 	defer func() {
@@ -214,7 +216,13 @@ func (n *Nmstate) Version() (Version, error) {
 	if rc != 0 {
 		return Version{}, fmt.Errorf("failed retrieving NetworkManager versionwith rc: %d, err_msg: %s, err_kind: %s", rc, C.GoString(err_msg), C.GoString(err_kind))
 	}
-	return Version{NetworkManager: C.GoString(nm_version)}, nil
+
+	C.nmstate_version(&nmstate_version)
+
+	return Version{
+		NetworkManager: C.GoString(nm_version),
+		Nmstate:        C.GoString(nmstate_version),
+	}, nil
 }
 
 func (n *Nmstate) writeLog(log *C.char) error {

--- a/rust/src/go/nmstate/nmstate_test.go
+++ b/rust/src/go/nmstate/nmstate_test.go
@@ -59,3 +59,10 @@ func TestApplyNetStateWithCommit(t *testing.T) {
 	_, err = nms.CommitCheckpoint("")
 	assert.NoError(t, err, "must succeed commiting last active checkpoint")
 }
+
+func TestVersion(t *testing.T) {
+	nms := New()
+	version, err := nms.Version()
+	assert.NoError(t, err, "must succeed retrieving version")
+	assert.NotEmpty(t, version.NetworkManager, "NetworkManager version should not be empty")
+}

--- a/rust/src/go/nmstate/nmstate_test.go
+++ b/rust/src/go/nmstate/nmstate_test.go
@@ -65,4 +65,5 @@ func TestVersion(t *testing.T) {
 	version, err := nms.Version()
 	assert.NoError(t, err, "must succeed retrieving version")
 	assert.NotEmpty(t, version.NetworkManager, "NetworkManager version should not be empty")
+	assert.NotEmpty(t, version.Nmstate, "nmstate version should not be empty")
 }

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -13,7 +13,7 @@ use crate::{
     nm::{
         nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
         nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_gen_conf,
-        nm_retrieve,
+        nm_retrieve, version,
     },
     ovsdb::{ovsdb_apply, ovsdb_is_running, ovsdb_retrieve},
     DnsState, ErrorKind, Interface, InterfaceType, Interfaces, NmstateError,
@@ -650,6 +650,10 @@ impl NetworkState {
 
     pub fn checkpoint_commit(checkpoint: &str) -> Result<(), NmstateError> {
         nm_checkpoint_destroy(checkpoint)
+    }
+
+    pub fn nm_version() -> Result<String, NmstateError> {
+        version::nm_version()
     }
 }
 

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -22,12 +22,13 @@ mod sriov;
 #[cfg(test)]
 mod unit_tests;
 mod user;
-mod version;
 mod veth;
 mod vlan;
 mod vrf;
 mod vxlan;
 mod wired;
+
+pub mod version;
 
 pub(crate) use apply::nm_apply;
 pub(crate) use checkpoint::{


### PR DESCRIPTION
This PR expose the NetworkManager and NMState versions at the golang binding `Version` function returning an struct with all of them.
 
Depeds-on:
- https://github.com/nmstate/nmstate/pull/1795