### PR TITLE
rust: Mark all public struct/enum as `non_exhaustive`

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -10,6 +10,7 @@ use crate::{
 const DEFAULT_DNS_PRIORITY: i32 = 40;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DnsState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running: Option<DnsClientState>,
@@ -133,6 +134,7 @@ impl DnsState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DnsClientState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server: Option<Vec<String>>,

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     InvalidArgument,
     PluginFailure,
@@ -21,6 +22,7 @@ impl std::fmt::Display for NmstateError {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct NmstateError {
     kind: ErrorKind,
     msg: String,

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -10,6 +10,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum InterfaceType {
     Bond,
     LinuxBridge,
@@ -106,6 +107,7 @@ impl InterfaceType {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum InterfaceState {
     Up,
     Down,
@@ -131,6 +133,7 @@ impl From<&str> for InterfaceState {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub struct UnknownInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -144,6 +147,7 @@ impl UnknownInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case", untagged)]
+#[non_exhaustive]
 pub enum Interface {
     Bond(BondInterface),
     Dummy(DummyInterface),

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -9,6 +9,7 @@ use crate::{
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct BaseInterface {
     pub name: String,
     #[serde(skip)]

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -3,6 +3,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct BondInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -92,6 +93,7 @@ impl BondInterface {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum BondMode {
     #[serde(rename = "balance-rr")]
     RoundRobin,
@@ -137,6 +139,7 @@ impl std::fmt::Display for BondMode {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct BondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<BondMode>,
@@ -187,6 +190,7 @@ impl BondConfig {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondAdSelect {
     #[serde(alias = "0")]
     Stable,
@@ -208,6 +212,7 @@ impl BondAdSelect {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondLacpRate {
     #[serde(alias = "0")]
     Slow,
@@ -226,6 +231,7 @@ impl BondLacpRate {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondAllPortsActive {
     #[serde(alias = "0")]
     Dropped,
@@ -244,6 +250,7 @@ impl BondAllPortsActive {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondArpAllTargets {
     #[serde(alias = "0")]
     Any,
@@ -274,6 +281,7 @@ const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondArpValidate {
     None,
     Active,
@@ -302,6 +310,7 @@ impl BondArpValidate {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondFailOverMac {
     #[serde(alias = "0")]
     None,
@@ -323,6 +332,7 @@ impl BondFailOverMac {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BondPrimaryReselect {
     #[serde(alias = "0")]
     Always,
@@ -343,6 +353,7 @@ impl BondPrimaryReselect {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum BondXmitHashPolicy {
     #[serde(rename = "layer2")]
     #[serde(alias = "0")]
@@ -378,6 +389,7 @@ impl BondXmitHashPolicy {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct BondOptions {
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/dummy.rs
+++ b/rust/src/lib/ifaces/dummy.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, InterfaceType};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DummyInterface {
     #[serde(flatten)]
     pub base: BaseInterface,

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct EthernetInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -93,6 +94,7 @@ impl EthernetInterface {
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum EthernetDuplex {
     Full,
     Half,
@@ -113,6 +115,7 @@ impl std::fmt::Display for EthernetDuplex {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct EthernetConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sr_iov: Option<SrIovConfig>,
@@ -154,6 +157,7 @@ impl EthernetConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub struct VethConfig {
     pub peer: String,
 }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -28,6 +28,7 @@ const COPY_MAC_ALLOWED_IFACE_TYPES: [InterfaceType; 3] = [
 ];
 
 #[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
 pub struct Interfaces {
     pub(crate) kernel_ifaces: HashMap<String, Interface>,
     pub(crate) user_ifaces: HashMap<(String, InterfaceType), Interface>,

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct LinuxBridgeInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -226,6 +227,7 @@ impl LinuxBridgeInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<LinuxBridgeOptions>,
@@ -249,6 +251,7 @@ impl LinuxBridgeConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct LinuxBridgePortConfig {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -285,6 +288,7 @@ impl LinuxBridgePortConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct LinuxBridgeOptions {
     // `gc_timer` is runtime status, not allowing for changing
     #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
@@ -349,6 +353,7 @@ impl LinuxBridgeOptions {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct LinuxBridgeStpOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
@@ -443,6 +448,7 @@ impl LinuxBridgeConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum LinuxBridgeMulticastRouterType {
     Auto,
     Disabled,
@@ -471,6 +477,7 @@ impl std::fmt::Display for LinuxBridgeMulticastRouterType {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct LinuxBridgePortVlanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_native: Option<bool>,
@@ -536,6 +543,7 @@ impl LinuxBridgePortVlanConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum LinuxBridgePortVlanMode {
     Trunk,
     Access,
@@ -549,6 +557,7 @@ impl Default for LinuxBridgePortVlanMode {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum LinuxBridgePortTunkTag {
     Id(u16),
     IdRange(LinuxBridgePortVlanRange),
@@ -564,6 +573,7 @@ impl LinuxBridgePortTunkTag {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub struct LinuxBridgePortVlanRange {
     pub max: u16,
     pub min: u16,

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MacVlanInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -61,6 +62,7 @@ impl MacVlanInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct MacVlanConfig {
     pub base_iface: String,
     pub mode: MacVlanMode,
@@ -80,6 +82,7 @@ impl MacVlanConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum MacVlanMode {
     Vepa,
     Bridge,

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MacVtapInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -61,6 +62,7 @@ impl MacVtapInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct MacVtapConfig {
     pub base_iface: String,
     pub mode: MacVtapMode,
@@ -80,6 +82,7 @@ impl MacVtapConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum MacVtapMode {
     Vepa,
     Bridge,

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct OvsBridgeInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -83,6 +84,7 @@ impl OvsBridgeInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct OvsBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
@@ -104,6 +106,7 @@ impl OvsBridgeConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct OvsBridgeOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stp: Option<bool>,
@@ -123,6 +126,7 @@ impl OvsBridgeOptions {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct OvsBridgePortConfig {
     pub name: String,
     #[serde(
@@ -139,6 +143,7 @@ impl OvsBridgePortConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct OvsInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -164,6 +169,7 @@ impl OvsInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct OvsBridgeBondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<OvsBridgeBondMode>,
@@ -198,6 +204,7 @@ impl OvsBridgeBondConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct OvsBridgeBondPortConfig {
     pub name: String,
 }
@@ -210,6 +217,7 @@ impl OvsBridgeBondPortConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum OvsBridgeBondMode {
     ActiveBackup,
     BalanceSlb,

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -5,6 +5,7 @@ use crate::{ErrorKind, Interface, InterfaceType, Interfaces, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct SrIovConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_vfs: Option<u32>,
@@ -110,6 +111,7 @@ impl SrIovConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct SrIovVfConfig {
     pub id: u32,
     #[serde(skip)]

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, InterfaceType};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct VlanInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -43,6 +44,7 @@ impl VlanInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct VlanConfig {
     pub base_iface: String,
     pub id: u16,

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, InterfaceType};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct VrfInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -52,6 +53,7 @@ impl VrfInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub struct VrfConfig {
     pub port: Option<Vec<String>>,
     #[serde(rename = "route-table-id")]

--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{BaseInterface, InterfaceType};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct VxlanInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -43,6 +44,7 @@ impl VxlanInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct VxlanConfig {
     pub base_iface: String,
     pub id: u32,

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -8,6 +8,7 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use crate::{DnsClientState, ErrorKind, Interfaces, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct InterfaceIpv4 {
     pub enabled: bool,
     pub prop_list: Vec<&'static str>,
@@ -344,6 +345,7 @@ impl InterfaceIpv4 {
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct InterfaceIpv6 {
     pub enabled: bool,
     pub prop_list: Vec<&'static str>,
@@ -721,6 +723,7 @@ impl InterfaceIpv6 {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct InterfaceIpAddr {
     pub ip: String,
     pub prefix_length: u8,

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -28,6 +28,7 @@ const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
 
 #[derive(Clone, Debug, Serialize, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct NetworkState {
     #[serde(rename = "dns-resolver", default)]
     pub dns: DnsState,

--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -230,6 +230,10 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             NmSettingIpMethod::Auto => (true, true, true),
             NmSettingIpMethod::Dhcp => (true, true, false),
             NmSettingIpMethod::Ignore => (true, false, false),
+            _ => {
+                log::warn!("Unknown NM IP method {:?}", nm_ip_method);
+                (false, false, false)
+            }
         };
         let (auto_dns, auto_gateway, auto_routes, auto_table_id) =
             parse_dhcp_opts(nm_ip_setting);

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{state::get_json_value_difference, ErrorKind, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[non_exhaustive]
 pub struct OvsDbGlobalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     // When the value been set as None, specified key will be removed instead
@@ -107,6 +108,7 @@ impl<'de> Deserialize<'de> for OvsDbGlobalConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[non_exhaustive]
 pub struct OvsDbIfaceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_ids: Option<HashMap<String, Option<String>>>,

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ip::is_ipv6_addr, ErrorKind, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Routes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running: Option<Vec<RouteEntry>>,
@@ -193,6 +194,7 @@ impl Routes {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum RouteState {
     Absent,
 }
@@ -205,6 +207,7 @@ impl Default for RouteState {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct RouteEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<RouteState>,

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ip::is_ipv6_addr, ErrorKind, InterfaceIpAddr, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RouteRules {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Vec<RouteRuleEntry>>,
@@ -177,6 +178,7 @@ impl RouteRules {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum RouteRuleState {
     Absent,
 }
@@ -189,6 +191,7 @@ impl Default for RouteRuleState {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub struct RouteRuleEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<RouteRuleState>,

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -7,6 +7,7 @@ use crate::{connection::DbusDictionary, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingBond {
     pub mode: String,
     pub options: HashMap<String, String>,

--- a/rust/src/libnm_dbus/connection/bridge.rs
+++ b/rust/src/libnm_dbus/connection/bridge.rs
@@ -28,6 +28,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingBridge {
     pub ageing_time: Option<u32>,
     pub forward_delay: Option<u32>,
@@ -293,6 +294,7 @@ impl NmSettingBridge {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingBridgeVlanRange {
     pub vid_start: u16,
     pub vid_end: u16,
@@ -348,6 +350,7 @@ impl NmSettingBridgeVlanRange {
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct NmSettingBridgePort {
     pub hairpin_mode: Option<bool>,
     pub path_cost: Option<u32>,

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -56,6 +56,7 @@ pub(crate) type NmConnectionDbusValue<'a> =
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "NmConnectionDbusOwnedValue")]
+#[non_exhaustive]
 pub struct NmConnection {
     pub connection: Option<NmSettingConnection>,
     pub bond: Option<NmSettingBond>,
@@ -250,6 +251,7 @@ impl NmConnection {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingConnection {
     pub id: Option<String>,
     pub uuid: Option<String>,

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -37,6 +37,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(try_from = "zvariant::OwnedValue")]
+#[non_exhaustive]
 pub enum NmSettingIpMethod {
     Auto,
     Disabled,
@@ -93,6 +94,7 @@ impl TryFrom<zvariant::OwnedValue> for NmSettingIpMethod {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingIp {
     pub method: Option<NmSettingIpMethod>,
     pub addresses: Vec<String>,

--- a/rust/src/libnm_dbus/connection/mac_vlan.rs
+++ b/rust/src/libnm_dbus/connection/mac_vlan.rs
@@ -7,6 +7,7 @@ use crate::{connection::DbusDictionary, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingMacVlan {
     pub parent: Option<String>,
     pub mode: Option<u32>,

--- a/rust/src/libnm_dbus/connection/ovs.rs
+++ b/rust/src/libnm_dbus/connection/ovs.rs
@@ -22,6 +22,7 @@ use crate::{connection::DbusDictionary, error::NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingOvsBridge {
     pub stp: Option<bool>,
     pub mcast_snooping_enable: Option<bool>,
@@ -77,6 +78,7 @@ impl NmSettingOvsBridge {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingOvsPort {
     pub mode: Option<String>,
     pub up_delay: Option<u32>,
@@ -123,6 +125,7 @@ impl NmSettingOvsPort {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingOvsIface {
     pub iface_type: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
@@ -159,6 +162,7 @@ impl NmSettingOvsIface {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingOvsExtIds {
     pub data: Option<HashMap<String, String>>,
     _other: HashMap<String, zvariant::OwnedValue>,

--- a/rust/src/libnm_dbus/connection/route.rs
+++ b/rust/src/libnm_dbus/connection/route.rs
@@ -21,6 +21,7 @@ use crate::{connection::DbusDictionary, error::NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmIpRoute {
     pub dest: Option<String>,
     pub prefix: Option<u32>,

--- a/rust/src/libnm_dbus/connection/route_rule.rs
+++ b/rust/src/libnm_dbus/connection/route_rule.rs
@@ -21,6 +21,7 @@ use crate::{connection::DbusDictionary, error::NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmIpRouteRule {
     pub family: Option<i32>,
     pub priority: Option<u32>,

--- a/rust/src/libnm_dbus/connection/sriov.rs
+++ b/rust/src/libnm_dbus/connection/sriov.rs
@@ -27,6 +27,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingSriov {
     pub autoprobe_drivers: Option<bool>,
     pub total_vfs: Option<u32>,
@@ -94,6 +95,7 @@ impl NmSettingSriov {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingSriovVf {
     pub index: Option<u32>,
     pub mac: Option<String>,
@@ -193,6 +195,7 @@ impl NmSettingSriovVf {
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingSriovVfVlan {
     pub id: u32,
     pub qos: u32,

--- a/rust/src/libnm_dbus/connection/veth.rs
+++ b/rust/src/libnm_dbus/connection/veth.rs
@@ -7,6 +7,7 @@ use crate::{connection::DbusDictionary, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingVeth {
     pub peer: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -8,6 +8,7 @@ use crate::{connection::DbusDictionary, ErrorKind, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingVlan {
     pub parent: Option<String>,
     pub id: Option<u32>,
@@ -51,6 +52,7 @@ const NM_VLAN_PROTOCOL_802_1Q: &str = "802.1Q";
 const NM_VLAN_PROTOCOL_802_1AD: &str = "802.1AD";
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum NmVlanProtocol {
     Dot1Q,
     Dot1Ad,

--- a/rust/src/libnm_dbus/connection/vrf.rs
+++ b/rust/src/libnm_dbus/connection/vrf.rs
@@ -7,6 +7,7 @@ use crate::{connection::DbusDictionary, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingVrf {
     pub table: Option<u32>,
     _other: HashMap<String, zvariant::OwnedValue>,

--- a/rust/src/libnm_dbus/connection/vxlan.rs
+++ b/rust/src/libnm_dbus/connection/vxlan.rs
@@ -7,6 +7,7 @@ use crate::{connection::DbusDictionary, NmError};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingVxlan {
     pub parent: Option<String>,
     pub id: Option<u32>,

--- a/rust/src/libnm_dbus/connection/wired.rs
+++ b/rust/src/libnm_dbus/connection/wired.rs
@@ -27,6 +27,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingWired {
     pub cloned_mac_address: Option<String>,
     pub mtu: Option<u32>,

--- a/rust/src/libnm_dbus/device.rs
+++ b/rust/src/libnm_dbus/device.rs
@@ -53,6 +53,7 @@ const NM_DEVICE_STATE_DEACTIVATING: u32 = 110;
 const NM_DEVICE_STATE_FAILED: u32 = 120;
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum NmDeviceState {
     Unknown,
     Unmanaged,
@@ -169,6 +170,7 @@ const NM_DEVICE_STATE_REASON_SRIOV_CONFIGURATION_FAILED: u32 = 66;
 const NM_DEVICE_STATE_REASON_PEER_NOT_FOUND: u32 = 67;
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum NmDeviceStateReason {
     Null,
     Unknown,

--- a/rust/src/libnm_dbus/error.rs
+++ b/rust/src/libnm_dbus/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     DbusConnectionError,
     CheckpointConflict,


### PR DESCRIPTION
All the public struct/enum in nmstate might add members/type, hence
marking them as `non_exhaustive` which will prevent API user from
in-compatibility usage.

Please refer to https://doc.rust-lang.org/reference/attributes/type_system.html
for more detail.