### PR TITLE
python route: Add support of multipath route

### DIFF
--- a/libnmstate/nispor/route.py
+++ b/libnmstate/nispor/route.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from copy import deepcopy
+
 from libnmstate.schema import Route
 
 
@@ -30,24 +32,24 @@ LOCAL_ROUTE_TABLE = 255
 
 
 def nispor_route_state_to_nmstate(np_routes):
-    return [
-        _nispor_route_to_nmstate(rt)
-        for rt in np_routes
-        if rt.scope in ["universe", "link"]
-        and rt.oif != "lo"
-        and rt.table != LOCAL_ROUTE_TABLE
-    ]
+    ret = []
+    for np_route in np_routes:
+        if np_route.oif != "lo" and np_route.table != LOCAL_ROUTE_TABLE:
+            ret.extend(_nispor_route_to_nmstate(np_route))
+    return ret
 
 
 def nispor_route_state_to_nmstate_static(np_routes):
-    return [
-        _nispor_route_to_nmstate(rt)
-        for rt in np_routes
-        if rt.scope in ["universe", "link"]
-        and rt.protocol in ["static", "boot"]
-        and rt.oif != "lo"
-        and rt.table != LOCAL_ROUTE_TABLE
-    ]
+    ret = []
+    for np_route in np_routes:
+        if (
+            np_route.oif != "lo"
+            and np_route.table != LOCAL_ROUTE_TABLE
+            and np_route.scope in ["universe", "link"]
+            and np_route.protocol in ["static", "boot"]
+        ):
+            ret.extend(_nispor_route_to_nmstate(np_route))
+    return ret
 
 
 def _nispor_route_to_nmstate(np_rt):
@@ -71,10 +73,27 @@ def _nispor_route_to_nmstate(np_rt):
             else IPV4_EMPTY_NEXT_HOP_ADDRESS
         )
 
-    return {
+    nm_route = {
         Route.TABLE_ID: np_rt.table,
         Route.DESTINATION: destination,
         Route.NEXT_HOP_INTERFACE: np_rt.oif if np_rt.oif else "",
         Route.NEXT_HOP_ADDRESS: next_hop,
         Route.METRIC: np_rt.metric if np_rt.metric else 0,
     }
+    np_mp_rts = get_multipath_routes(np_rt)
+    if np_mp_rts:
+        ret = []
+        for np_mp_rt in np_mp_rts:
+            nm_route_clone = deepcopy(nm_route)
+            nm_route_clone[Route.NEXT_HOP_INTERFACE] = np_mp_rt["iface"]
+            nm_route_clone[Route.NEXT_HOP_ADDRESS] = np_mp_rt["via"]
+            ret.append(nm_route_clone)
+        return ret
+    else:
+        return [nm_route]
+
+
+# Instead of bumping nispor dependency version, we just use nispor private
+# property temporarily
+def get_multipath_routes(np_route):
+    return np_route._info.get("multipath")

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019-2021 Red Hat, Inc.
+# Copyright (c) 2019-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -42,12 +42,16 @@ IPV4_ROUTE_TABLE_ID1 = 50
 IPV4_ROUTE_TABLE_ID2 = 51
 IPV4_EMPTY_ADDRESS = "0.0.0.0"
 IPV4_DEFAULT_GATEWAY = "0.0.0.0/0"
+IPV4_TEST_NET1 = "203.0.113.0/24"
 
 IPV6_ADDRESS1 = "2001:db8:1::1"
+IPV6_ADDRESS2 = "2001:db8:1::2"
+IPV6_ADDRESS3 = "2001:db8:1::3"
 IPV6_EMPTY_ADDRESS = "::"
 IPV6_DEFAULT_GATEWAY = "::/0"
 IPV6_ROUTE_TABLE_ID1 = 50
 IPV6_ROUTE_TABLE_ID2 = 51
+IPV6_TEST_NET1 = "2001:db8:e::/64"
 
 IPV4_DNS_NAMESERVER = "8.8.8.8"
 IPV6_DNS_NAMESERVER = "2001:4860:4860::8888"
@@ -912,3 +916,71 @@ def test_route_change_metric(eth1_static_gateway_dns):
     ipv6_route = _get_ipv6_gateways()[0]
     ipv6_route[Route.METRIC] += 2
     libnmstate.apply({Route.KEY: {Route.CONFIG: [ipv6_route, ipv4_route]}})
+
+
+@pytest.fixture
+def eth1_with_multipath_route(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+        }
+    )
+    cmdlib.exec_cmd(
+        f"ip route add {IPV4_TEST_NET1} metric 500 "
+        f"nexthop via {IPV4_ADDRESS2} dev eth1 onlink "
+        f"nexthop via {IPV4_ADDRESS3} dev eth1 onlink".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        f"ip -6 route add {IPV6_TEST_NET1} metric 501 "
+        f"nexthop via {IPV6_ADDRESS2} dev eth1 onlink "
+        f"nexthop via {IPV6_ADDRESS3} dev eth1 onlink".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd(
+        f"ip route del {IPV4_TEST_NET1} metric 500 "
+        f"nexthop via {IPV4_ADDRESS2} dev eth1 onlink "
+        f"nexthop via {IPV4_ADDRESS3} dev eth1 onlink".split()
+    )
+    cmdlib.exec_cmd(
+        f"ip -6 route del {IPV6_TEST_NET1} metric 501 "
+        f"nexthop via {IPV6_ADDRESS2} dev eth1 onlink "
+        f"nexthop via {IPV6_ADDRESS3} dev eth1 onlink".split()
+    )
+
+
+def test_support_query_multipath_route(eth1_with_multipath_route):
+    cur_state = libnmstate.show()
+    expected_routes = [
+        {
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.METRIC: 500,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.METRIC: 500,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS3,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.METRIC: 501,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.METRIC: 501,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.TABLE_ID: 254,
+        },
+    ]
+    cur_state = libnmstate.show()
+    _assert_routes(expected_routes, cur_state)


### PR DESCRIPTION
Supporting the rout created by below command:

    sudo ip -6 route add 2001:db8:e::/64 proto static \
        nexthop via 2001:db8:f::254 dev eth1 weight 1 onlink \
        nexthop via 2001:db8:f::253 dev eth1 weight 256 onlink

Integration test case included.