### PR TITLE
Fixing CI

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -24,7 +24,6 @@ COPR_ARG=""
 
 if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
-    COPR_ARG="--copr networkmanager/NetworkManager-1.32"
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -52,6 +52,8 @@ RUN dnf update -y && \
 
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
+COPY network_manager_keyfile.conf \
+     /etc/NetworkManager/conf.d/96-keyfile.conf
 
 RUN systemctl enable dbus systemd-udevd NetworkManager
 

--- a/packaging/network_manager_keyfile.conf
+++ b/packaging/network_manager_keyfile.conf
@@ -1,0 +1,2 @@
+[main]
+plugins=keyfile

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -333,8 +333,8 @@ impl Interfaces {
         cur_ifaces: &Self,
     ) -> Result<(), NmstateError> {
         let mut resolved_ifaces: Vec<Interface> = Vec::new();
-        for ((iface_name, iface_type), iface) in self.user_ifaces.iter() {
-            if iface_type != &InterfaceType::Unknown {
+        for (iface_name, iface) in self.kernel_ifaces.iter() {
+            if iface.iface_type() != InterfaceType::Unknown {
                 continue;
             }
 

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -82,32 +82,27 @@ pub(crate) fn handle_changed_ports(
                 if let Some(cur_iface) =
                     cur_ifaces.kernel_ifaces.get(&iface_name)
                 {
-                    if cur_iface.base_iface().controller != ctrl_name
-                        || cur_iface.base_iface().controller_type != ctrl_type
-                    {
-                        let mut iface = cur_iface.clone_name_type_only();
-                        // Some interface cannot live without controller
-                        if iface.need_controller() && ctrl_name.is_none() {
-                            iface.base_iface_mut().state =
-                                InterfaceState::Absent;
-                        } else {
-                            iface.base_iface_mut().state = InterfaceState::Up;
-                        }
-                        iface.base_iface_mut().controller = ctrl_name;
-                        iface.base_iface_mut().controller_type = ctrl_type;
-                        if !iface.base_iface().can_have_ip() {
-                            iface.base_iface_mut().ipv4 =
-                                Some(InterfaceIpv4::new());
-                            iface.base_iface_mut().ipv6 =
-                                Some(InterfaceIpv6::new());
-                        }
-                        info!(
-                            "Include interface {} to edit as its \
-                            controller required so",
-                            iface_name
-                        );
-                        ifaces.push(iface);
+                    let mut iface = cur_iface.clone_name_type_only();
+                    // Some interface cannot live without controller
+                    if iface.need_controller() && ctrl_name.is_none() {
+                        iface.base_iface_mut().state = InterfaceState::Absent;
+                    } else {
+                        iface.base_iface_mut().state = InterfaceState::Up;
                     }
+                    iface.base_iface_mut().controller = ctrl_name;
+                    iface.base_iface_mut().controller_type = ctrl_type;
+                    if !iface.base_iface().can_have_ip() {
+                        iface.base_iface_mut().ipv4 =
+                            Some(InterfaceIpv4::new());
+                        iface.base_iface_mut().ipv6 =
+                            Some(InterfaceIpv6::new());
+                    }
+                    info!(
+                        "Include interface {} to edit as its \
+                            controller required so",
+                        iface_name
+                    );
+                    ifaces.push(iface);
                 } else {
                     // Do not raise error if detach port
                     if let Some(ctrl_name) = ctrl_name {

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -250,6 +250,11 @@ def test_nm_ovs_plugin_missing():
             )
 
 
+@pytest.mark.xfail(
+    nm_major_minor_version() >= 1.35,
+    reason="https://bugzilla.redhat.com/2052441",
+    strict=True,
+)
 def test_ovs_service_missing_with_system_port_only(eth1_up):
     bridge = Bridge(BRIDGE1)
     bridge.add_system_port(ETH1)


### PR DESCRIPTION
Due to NetworkManager https://bugzilla.redhat.com/show_bug.cgi?id=2052354 ,
our CI is failing on `test_ovsdb_set_external_ids_for_ovs_system_interface`
on rust code.

NetworkManager in Fedora and RHEL 9 has switch to keyfile by default,
the OpenShift is using keyfile in their RHEL 8 image also.
So our CI in main/base branch(2.x) should be.

Also included other pathes to fix the CI:

 * Use CentOS stream 8 shipped NM rpm for stable testing.
 * Mark a OVS test case as xfail due to bug of NM.
 * Fix a rust bridge CI failure.