### PR TITLE
CI: Remove dependency on NetworkManager-config-server

### DIFF
--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -17,7 +17,6 @@ RUN dnf update -y && \
                    NetworkManager \
                    NetworkManager-ovs \
                    NetworkManager-team \
-                   NetworkManager-config-server \
                    openvswitch2.11 \
                    python3-openvswitch2.11 \
                    systemd-udev \

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -34,8 +34,6 @@ Summary:        C binding of nmstate
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
 Recommends:     NetworkManager
-# Avoid automatically generated profiles
-Recommends:     NetworkManager-config-server
 
 %description libs
 C binding of nmstate.
@@ -54,8 +52,6 @@ Requires:       NetworkManager-libnm >= 1:1.26.0
 # Use Recommends for NetworkManager because only access to NM DBus is required,
 # but NM could be running on a different host
 Recommends:     NetworkManager
-# Avoid automatically generated profiles
-Recommends:     NetworkManager-config-server
 Recommends:     (nmstate-plugin-ovsdb if openvswitch)
 # Use Suggests for NetworkManager-ovs and NetworkManager-team since it is only
 # required for OVS and team support


### PR DESCRIPTION
Openshift CNV host could not install NetworkManager-config-server RPM,
hence our CI should mimic the use case