### PR TITLE
rust: Fix soname version

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2.0.0"
+rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2.0.1"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'


### PR DESCRIPTION
The forced soname was not bumped with version bump.

Signed-off-by: Quique Llorente <ellorent@redhat.com>