### PR TITLE
libnm_dbus keyfile: Rewrite the keyfile generation

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -10,6 +10,7 @@ use crate::{
     ifaces::inter_ifaces_controller::{
         check_overbook_ports, find_unknown_type_port, handle_changed_ports,
         preserve_ctrl_cfg_if_unchanged, set_ifaces_up_priority,
+        set_missing_port_to_eth,
     },
     ip::include_current_ip_address_if_dhcp_on_to_off,
     ErrorKind, Interface, InterfaceState, InterfaceType, NmstateError,
@@ -347,6 +348,22 @@ impl Interfaces {
                 false
             }
         })
+    }
+
+    pub(crate) fn set_unknown_iface_to_eth(&mut self) {
+        for iface in self.kernel_ifaces.values_mut() {
+            if iface.iface_type() == InterfaceType::Unknown {
+                log::warn!(
+                    "Setting unknown type interface {} to ethernet",
+                    iface.name()
+                );
+                iface.base_iface_mut().iface_type = InterfaceType::Ethernet;
+            }
+        }
+    }
+
+    pub(crate) fn set_missing_port_to_eth(&mut self) {
+        set_missing_port_to_eth(self);
     }
 
     pub(crate) fn resolve_unknown_ifaces(

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -313,7 +313,11 @@ impl NetworkState {
         &self,
     ) -> Result<HashMap<String, Vec<String>>, NmstateError> {
         let mut ret = HashMap::new();
-        let (add_net_state, _, _) = self.gen_state_for_apply(&Self::new())?;
+        let mut self_clone = self.clone();
+        self_clone.interfaces.set_unknown_iface_to_eth();
+        self_clone.interfaces.set_missing_port_to_eth();
+        let (add_net_state, _, _) =
+            self_clone.gen_state_for_apply(&Self::new())?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&add_net_state)?);
         Ok(ret)
     }

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use serde::Deserialize;
+use zvariant::Value;
 
 use crate::{connection::DbusDictionary, NmError};
 
@@ -37,9 +38,18 @@ impl NmSettingBond {
         Self::default()
     }
 
-    pub(crate) fn to_value(
+    pub(crate) fn to_keyfile(
         &self,
-    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        ret.insert("mode".to_string(), Value::new(self.mode.as_str()));
+        for (key, value) in self.options.iter() {
+            ret.insert(key.to_string(), Value::new(value));
+        }
+        Ok(ret)
+    }
+
+    pub(crate) fn to_value(&self) -> Result<HashMap<&str, Value>, NmError> {
         let mut merged_opts = self.options.clone();
         let mut ret = HashMap::new();
 
@@ -61,7 +71,7 @@ impl NmSettingBond {
         }
 
         if !merged_opts.is_empty() {
-            ret.insert("options", zvariant::Value::from(merged_opts.clone()));
+            ret.insert("options", Value::from(merged_opts.clone()));
         }
         Ok(ret)
     }

--- a/rust/src/libnm_dbus/connection/ieee8021x.rs
+++ b/rust/src/libnm_dbus/connection/ieee8021x.rs
@@ -64,6 +64,59 @@ impl NmSetting8021X {
         Ok(ret)
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.identity {
+            ret.insert("identity".to_string(), zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.private_key {
+            ret.insert(
+                "private-key".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.eap {
+            // Need NULL append at the end
+            let mut new_eaps = v.clone();
+            new_eaps.push("".to_string());
+            ret.insert("eap".to_string(), zvariant::Value::new(new_eaps));
+        }
+        if let Some(v) = &self.client_cert {
+            ret.insert(
+                "client-cert".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.ca_cert {
+            println!("HAHA {:?}", Self::glib_bytes_to_file_path(v));
+            ret.insert(
+                "ca-cert".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.private_key_password {
+            ret.insert(
+                "private-key-password".to_string(),
+                zvariant::Value::new(v),
+            );
+        }
+        Ok(ret)
+    }
+
     pub fn new() -> Self {
         Self::default()
     }

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -166,6 +166,38 @@ impl NmSettingIp {
         Self::default()
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if !vec!["address-data", "route-data", "dns"].contains(&k) {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        for (i, addr) in self.addresses.as_slice().iter().enumerate() {
+            ret.insert(format!("address{}", i), zvariant::Value::new(addr));
+        }
+
+        for (i, route) in self.routes.as_slice().iter().enumerate() {
+            for (k, v) in route.to_keyfile().drain() {
+                ret.insert(
+                    if k.is_empty() {
+                        format!("route{}", i)
+                    } else {
+                        format!("route{}_{}", i, k)
+                    },
+                    zvariant::Value::new(v),
+                );
+            }
+        }
+        if let Some(dns) = self.dns.as_ref() {
+            ret.insert("dns".to_string(), zvariant::Value::new(dns));
+        }
+
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/mac_vlan.rs
+++ b/rust/src/libnm_dbus/connection/mac_vlan.rs
@@ -30,6 +30,16 @@ impl TryFrom<DbusDictionary> for NmSettingMacVlan {
 }
 
 impl NmSettingMacVlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/ovs.rs
+++ b/rust/src/libnm_dbus/connection/ovs.rs
@@ -49,6 +49,16 @@ impl TryFrom<DbusDictionary> for NmSettingOvsBridge {
 }
 
 impl NmSettingOvsBridge {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -103,6 +113,16 @@ impl NmSettingOvsPort {
         Self::default()
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -142,6 +162,16 @@ impl TryFrom<DbusDictionary> for NmSettingOvsIface {
 }
 
 impl NmSettingOvsIface {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/sriov.rs
+++ b/rust/src/libnm_dbus/connection/sriov.rs
@@ -56,6 +56,28 @@ impl TryFrom<DbusDictionary> for NmSettingSriov {
 }
 
 impl NmSettingSriov {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if k != "vfs" {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        if let Some(vfs) = self.vfs.as_ref() {
+            for vf in vfs {
+                if let Some(i) = vf.index {
+                    ret.insert(
+                        format!("vf.{}", i),
+                        zvariant::Value::new(vf.to_keyfile()),
+                    );
+                }
+            }
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -124,6 +146,36 @@ impl TryFrom<DbusDictionary> for NmSettingSriovVf {
 }
 
 impl NmSettingSriovVf {
+    pub(crate) fn to_keyfile(&self) -> String {
+        let mut ret = String::new();
+        if let Some(v) = self.mac.as_ref() {
+            ret += &format!("mac={} ", v);
+        }
+        if let Some(v) = self.spoof_check {
+            ret += &format!("spoof-check={} ", v);
+        }
+        if let Some(v) = self.trust {
+            ret += &format!("trust={} ", v);
+        }
+        if let Some(v) = self.min_tx_rate {
+            ret += &format!("min-tx-rate={} ", v);
+        }
+        if let Some(v) = self.max_tx_rate {
+            ret += &format!("max-tx-rate={} ", v);
+        }
+        if let Some(vlans) = self.vlans.as_ref() {
+            let mut vlans_str = Vec::new();
+            for vlan in vlans {
+                vlans_str.push(vlan.to_keyfile());
+            }
+            ret += &format!("vlans={}", vlans_str.join(";"));
+        }
+        if ret.ends_with(' ') {
+            ret.pop();
+        }
+        ret
+    }
+
     pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
         let mut ret = zvariant::Dict::new(
             zvariant::Signature::from_str_unchecked("s"),
@@ -219,6 +271,13 @@ impl TryFrom<DbusDictionary> for NmSettingSriovVfVlan {
 }
 
 impl NmSettingSriovVfVlan {
+    pub(crate) fn to_keyfile(&self) -> String {
+        match self.protocol {
+            NmVlanProtocol::Dot1Q => format!("{}.{}.q", self.id, self.qos),
+            NmVlanProtocol::Dot1Ad => format!("{}.{}.ad", self.id, self.qos),
+        }
+    }
+
     pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
         let mut ret = zvariant::Dict::new(
             zvariant::Signature::from_str_unchecked("s"),

--- a/rust/src/libnm_dbus/connection/user.rs
+++ b/rust/src/libnm_dbus/connection/user.rs
@@ -59,4 +59,16 @@ impl NmSettingUser {
         }));
         Ok(ret)
     }
+
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(data) = self.data.as_ref() {
+            for (k, v) in data.iter() {
+                ret.insert(k.to_string(), zvariant::Value::new(v));
+            }
+        }
+        Ok(ret)
+    }
 }

--- a/rust/src/libnm_dbus/connection/veth.rs
+++ b/rust/src/libnm_dbus/connection/veth.rs
@@ -24,6 +24,16 @@ impl TryFrom<DbusDictionary> for NmSettingVeth {
 }
 
 impl NmSettingVeth {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -27,6 +27,16 @@ impl TryFrom<DbusDictionary> for NmSettingVlan {
 }
 
 impl NmSettingVlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vrf.rs
+++ b/rust/src/libnm_dbus/connection/vrf.rs
@@ -24,6 +24,16 @@ impl TryFrom<DbusDictionary> for NmSettingVrf {
 }
 
 impl NmSettingVrf {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vxlan.rs
+++ b/rust/src/libnm_dbus/connection/vxlan.rs
@@ -30,6 +30,16 @@ impl TryFrom<DbusDictionary> for NmSettingVxlan {
 }
 
 impl NmSettingVxlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/wired.rs
+++ b/rust/src/libnm_dbus/connection/wired.rs
@@ -63,6 +63,24 @@ impl TryFrom<DbusDictionary> for NmSettingWired {
 }
 
 impl NmSettingWired {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if k != "cloned-mac-address" {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        if let Some(v) = &self.cloned_mac_address {
+            ret.insert(
+                "cloned-mac-address".to_string(),
+                zvariant::Value::new(v),
+            );
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/keyfile.rs
+++ b/rust/src/libnm_dbus/keyfile.rs
@@ -1,13 +1,38 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use log::error;
 
 use crate::{ErrorKind, NmError};
 
-pub(crate) fn zvariant_value_to_keyfile(
+pub(crate) const DEFAULT_SEPARATOR: &str = ";";
+
+pub(crate) fn keyfile_sections_to_string(
+    sections: &[(&str, HashMap<String, zvariant::Value>)],
+) -> Result<String, NmError> {
+    let mut ret = String::new();
+    for (section_name, data) in sections {
+        ret += &format!("[{}]\n", section_name);
+        // Sort the keys
+        let mut keys: Vec<&String> = data.keys().collect();
+        keys.sort_unstable();
+        for key in keys {
+            if let Some(v) = data.get(key) {
+                let v = zvariant_value_to_string(v)?;
+                if !v.is_empty() {
+                    ret += &format!("{}={}\n", key, v);
+                }
+            }
+        }
+        ret += "\n";
+    }
+    if ret.ends_with("\n\n") {
+        ret.pop();
+    }
+    Ok(ret)
+}
+
+fn zvariant_value_to_string(
     value: &zvariant::Value,
-    section_name: &str,
 ) -> Result<String, NmError> {
     match value {
         zvariant::Value::Bool(b) => Ok(if *b {
@@ -23,101 +48,18 @@ pub(crate) fn zvariant_value_to_keyfile(
         zvariant::Value::U64(d) => Ok(format!("{}", d)),
         zvariant::Value::I64(d) => Ok(format!("{}", d)),
         zvariant::Value::Dict(d) => {
-            let data: HashMap<String, zvariant::Value> =
-                HashMap::try_from(d.clone())?;
-            if data.is_empty() {
-                return Ok("".to_string());
-            }
-            let mut ret = String::new();
-
-            let mut names: Vec<String> = data.keys().cloned().collect();
-            if section_name.is_empty() {
-                // Only sort the top level sections
-                names.sort_unstable();
-            } else {
-                // place the sub-section at the end of section_names.
-                names.sort_unstable_by(|a, b| {
-                    let a_is_subsection =
-                        matches!(data.get(a), Some(zvariant::Value::Dict(_)));
-                    let b_is_subsection =
-                        matches!(data.get(b), Some(zvariant::Value::Dict(_)));
-                    a_is_subsection.cmp(&b_is_subsection)
-                });
-            }
-
-            for key in &names {
-                let key = if section_name == "ipv4" || section_name == "ipv6" {
-                    if key == "addresses" || key == "routes" {
-                        // Ignore deprecated 'addresses' in favor of
-                        // 'address-data'.
-                        // Ignore deprecated 'routes' in favor of 'route-data'
-                        continue;
-                    } else if key == "dhcp-client-id" {
-                        "dhcp-iaid".to_string()
-                    } else {
-                        key.to_string()
-                    }
-                } else {
-                    key.to_string()
-                };
-
-                if let Some(section_value) = data.get(&key) {
-                    if key == "mac-address" {
-                        ret += &format!(
-                            "mac-address={}\n",
-                            mac_address_value_to_string(section_value)
-                        );
-                    } else if key == "type" && section_name == "connection" {
-                        let iface_type = zvariant_value_to_keyfile(
-                            section_value,
-                            section_name,
-                        )?;
-                        ret += &format!(
-                            "type={}\n",
-                            if iface_type == "802-3-ethernet" {
-                                "ethernet".to_string()
-                            } else {
-                                iface_type
-                            }
-                        );
-                    } else if key == "address-data" {
-                        ret += &ip_address_value_to_string(section_value);
-                    } else if let zvariant::Value::Dict(_) = section_value {
-                        let sub_section: HashMap<String, zvariant::Value> =
-                            HashMap::try_from(section_value.clone())?;
-                        if sub_section.is_empty() {
-                            continue;
-                        }
-
-                        let sub_section_name = if section_name.is_empty() {
-                            key.to_string()
-                        } else {
-                            format!("{}-{}", section_name, key)
-                        };
-                        ret += &format!("\n[{}]\n", sub_section_name);
-                        ret += &zvariant_value_to_keyfile(
-                            section_value,
-                            &sub_section_name,
-                        )?;
-                    } else {
-                        ret += &format!(
-                            "{}={}\n",
-                            key,
-                            zvariant_value_to_keyfile(
-                                section_value,
-                                section_name
-                            )?
-                        );
-                    }
-                }
-            }
-            Ok(ret)
+            let e = NmError::new(
+                ErrorKind::Bug,
+                format!("Cannot convert Dict {:?} to key file format", d),
+            );
+            log::error!("{}", e);
+            Err(e)
         }
         zvariant::Value::Array(a) => {
             let mut ret = String::new();
             for item in a.get() {
-                ret += &zvariant_value_to_keyfile(item, section_name)?;
-                ret += ";";
+                ret += &zvariant_value_to_string(item)?;
+                ret += DEFAULT_SEPARATOR;
             }
             ret.pop();
             Ok(ret)
@@ -126,60 +68,10 @@ pub(crate) fn zvariant_value_to_keyfile(
         _ => {
             let e = NmError::new(
                 ErrorKind::Bug,
-                format!(
-                    "BUG: Unknown value type in section {}: {:?}",
-                    section_name, value
-                ),
+                format!("BUG: Unknown value type in section {:?}", value),
             );
             error!("{}", e);
             Err(e)
         }
     }
-}
-
-fn mac_address_value_to_string(value: &zvariant::Value) -> String {
-    let mut ret = String::new();
-    if let zvariant::Value::Array(a) = value {
-        for item in a.get() {
-            if let Ok(s) = zvariant_value_to_keyfile(item, "") {
-                ret += &s;
-                ret += ":";
-            }
-        }
-        ret.pop();
-    }
-    ret
-}
-
-fn ip_address_value_to_string(value: &zvariant::Value) -> String {
-    let mut ret = String::new();
-    let mut index = 0u32;
-    if let zvariant::Value::Array(ip_addrs) = value {
-        for ip_addr_value in ip_addrs.get() {
-            let ip_addr_value = if let zvariant::Value::Dict(i) = ip_addr_value
-            {
-                i
-            } else {
-                continue;
-            };
-            let address = if let Ok(Some(s)) = ip_addr_value.get("address") {
-                zvariant_value_to_keyfile(s, "")
-            } else {
-                continue;
-            };
-            let prefix = if let Ok(Some(p)) = ip_addr_value.get("prefix") {
-                zvariant_value_to_keyfile(p, "")
-            } else {
-                continue;
-            };
-            if let Ok(address) = address {
-                if let Ok(prefix) = prefix {
-                    ret +=
-                        &format!("address{}={}/{}\n", index, address, prefix);
-                    index += 1;
-                }
-            }
-        }
-    }
-    ret
 }


### PR DESCRIPTION
* Each NmSettingXXX class is responsible to provide function as
   `to_keyfile()` which return `HashMap<String, zvariant::Value>`.

 * Changed `Interfaces` to automatically set unknown interface/port
   as ethernet as Python API did. With a warning message of course.

Test is no good way testing this `gen_conf`, will include in later
patches.