### PR TITLE
rust cli: Rollback when got ctrl+c signal

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 env_logger = "0.9.0"
 log = "0.4.14"
 serde_json = "1.0.75"
+ctrlc = "3.2.1"

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -346,6 +346,15 @@ where
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
     net_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
+
+    ctrlc::set_handler(|| {
+        if let Err(e) = rollback("") {
+            println!("Failed to rollback: {}", e);
+        }
+        std::process::exit(1);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     net_state.apply()?;
     if !matches.is_present("SHOW_SECRETS") {
         net_state.hide_secrets();


### PR DESCRIPTION
When got Ctrl+C(SIGINT) signal, the rust CLI should do rollback during 
applying state.