### PR TITLE
tests: Move privileged changes to Dockerfile 

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -486,7 +486,7 @@ if [ -n "${RUN_BAREMETAL}" ];then
     run_customize_command
     start_machine_services
 elif [ -n "${RUN_K8S}" ]; then
-    CONTAINER_CMD=docker
+    export CONTAINER_CMD=docker
     k8s::start_cluster
     k8s::pre_test_setup
     run_customize_command

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -76,11 +76,7 @@ function container_pre_test_setup {
 
     create_container
 
-    container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
-        /proc/sys/kernel/core_pattern"
     container_exec "ulimit -c unlimited"
-    # Enable IPv6 in container globally
-    container_exec "sysctl -w net.ipv6.conf.all.disable_ipv6=0"
 }
 
 function copy_workspace_container {

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -6,6 +6,9 @@ RUN sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
     -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
     /etc/systemd/journald.conf
 
+RUN echo net.ipv6.conf.all.disable_ipv6=0 > /etc/sysctl.d/00-enable-ipv6.conf && \
+    echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > /etc/sysctl.d/01-export-kernel-cores.conf
+
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled powertools && \


### PR DESCRIPTION
At some envs running podman with sudo have some issues also is not a
good practice. This change move the bits that force to call run-tests.sh
with sudo to the Dockerfile so the container has the changes up front.
