### PR TITLE
test,k8s: Ignore calico interfaces

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -486,7 +486,7 @@ if [ -n "${RUN_BAREMETAL}" ];then
     run_customize_command
     start_machine_services
 elif [ -n "${RUN_K8S}" ]; then
-    #start_machine_services
+    CONTAINER_CMD=docker
     k8s::start_cluster
     k8s::pre_test_setup
     run_customize_command

--- a/automation/tests-k8s-utils.sh
+++ b/automation/tests-k8s-utils.sh
@@ -71,6 +71,8 @@ spec:
         value: "${SHIPPABLE}"
       - name: RUN_K8S
         value: "true"
+      - name: NMSTATE_TEST_IGNORE_IFACE
+        value: "cali"
       volumeMounts:
       - name: dbus-socket
         mountPath: /run/dbus/system_bus_socket


### PR DESCRIPTION
The integration tests should ignore interfaces related to the CNI used
by the k8s cluster calico. This change introduces an env var to pass
inteface substring to ignore.