### PR TITLE
srpm: Don't include directory rust/target

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include doc/nmstatectl.8.in
 include doc/nmstate-autoconf.8.in
 recursive-include examples *.yml
 exclude packaging/nmstate.spec
+recursive-exclude rust/target *


### PR DESCRIPTION
If the SRPM is created after building rust it will include the rust
binaries inside the SRPM this make run-tests.sh quite slow.