### PR TITLE
Rust: Add LLDP support

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -197,6 +197,7 @@ function run_tests {
             tests/integration/veth_test.py \
             tests/integration/dynamic_ip_test.py \
             tests/integration/nm/ieee802_1x_test.py \
+            tests/integration/lldp_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ErrorKind, Ieee8021XConfig, InterfaceIpv4, InterfaceIpv6, InterfaceState,
-    InterfaceType, NmstateError, OvsDbIfaceConfig, RouteEntry, RouteRuleEntry,
+    InterfaceType, LldpConfig, NmstateError, OvsDbIfaceConfig, RouteEntry,
+    RouteRuleEntry,
 };
 
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
@@ -40,6 +41,8 @@ pub struct BaseInterface {
     pub ovsdb: Option<OvsDbIfaceConfig>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "802.1x")]
     pub ieee8021x: Option<Ieee8021XConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lldp: Option<LldpConfig>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.
@@ -89,6 +92,9 @@ impl BaseInterface {
         }
         if other.prop_list.contains(&"ieee8021x") {
             self.ieee8021x = other.ieee8021x.clone();
+        }
+        if other.prop_list.contains(&"lldp") {
+            self.lldp = other.lldp.clone();
         }
 
         if other.prop_list.contains(&"ipv4") {
@@ -161,6 +167,10 @@ impl BaseInterface {
         // Change all veth interface to ethernet for simpler verification
         if self.iface_type == InterfaceType::Veth {
             self.iface_type = InterfaceType::Ethernet;
+        }
+
+        if let Some(lldp_conf) = self.lldp.as_mut() {
+            lldp_conf.pre_verify_cleanup();
         }
     }
 

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -4,6 +4,7 @@ mod ieee8021x;
 mod iface;
 mod ifaces;
 mod ip;
+mod lldp;
 mod net_state;
 mod nispor;
 mod nm;
@@ -37,6 +38,13 @@ pub use crate::ifaces::{
     VrfInterface, VxlanConfig, VxlanInterface,
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
+pub use crate::lldp::{
+    LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
+    LldpMacPhyConf, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs,
+    LldpNeighborTlv, LldpPortId, LldpPortIdType, LldpPpvids,
+    LldpSystemCapabilities, LldpSystemCapability, LldpSystemDescription,
+    LldpSystemName, LldpVlan, LldpVlans,
+};
 pub use crate::net_state::NetworkState;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 pub use crate::route::{RouteEntry, RouteState, Routes};

--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -1,0 +1,528 @@
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+
+const LLDP_CHASSIS_ID_TYPE: u8 = 1;
+const LLDP_PORT_TYPE: u8 = 2;
+const LLDP_SYSTEM_NAME_TYPE: u8 = 5;
+const LLDP_SYSTEM_DESCRIPTION_TYPE: u8 = 6;
+const LLDP_SYSTEM_CAPABILITIES_TYPE: u8 = 7;
+const LLDP_MANAGEMENT_ADDRESSES_TYPE: u8 = 8;
+const LLDP_ORGANIZATION_SPECIFIC_TYPE: u8 = 127;
+
+const LLDP_CHASSIS_ID_RESERVED: u8 = 0;
+const LLDP_CHASSIS_ID_CHASSIS_COMPONENT: u8 = 1;
+const LLDP_CHASSIS_ID_IFACE_ALIAS: u8 = 2;
+const LLDP_CHASSIS_ID_PORT_COMPONENT: u8 = 3;
+const LLDP_CHASSIS_ID_MAC_ADDR: u8 = 4;
+const LLDP_CHASSIS_ID_NET_ADDR: u8 = 5;
+const LLDP_CHASSIS_ID_IFACE_NAME: u8 = 6;
+const LLDP_CHASSIS_ID_LOCAL: u8 = 7;
+
+const LLDP_PORT_ID_RESERVED: u8 = 0;
+const LLDP_PORT_ID_IFACE_ALIAS: u8 = 1;
+const LLDP_PORT_ID_PORT_COMPONENT: u8 = 2;
+const LLDP_PORT_ID_MAC_ADDR: u8 = 3;
+const LLDP_PORT_ID_NET_ADDR: u8 = 4;
+const LLDP_PORT_ID_IFACE_NAME: u8 = 5;
+const LLDP_PORT_ID_AGENT_CIRCUIT_ID: u8 = 6;
+const LLDP_PORT_ID_LOCAL: u8 = 7;
+
+const LLDP_ORG_OIU_VLAN: &str = "00:80:c2";
+const LLDP_ORG_SUBTYPE_VLAN: u8 = 3;
+
+const LLDP_ORG_OIU_MAC_PHY_CONF: &str = "00:12:0f";
+const LLDP_ORG_SUBTYPE_MAC_PHY_CONF: u8 = 1;
+
+const LLDP_ORG_OIU_PPVIDS: &str = "00:80:c2";
+const LLDP_ORG_SUBTYPE_PPVIDS: u8 = 2;
+
+const LLDP_ORG_OIU_MAX_FRAME_SIZE: &str = "00:12:0f";
+const LLDP_ORG_SUBTYPE_MAX_FRAME_SIZE: u8 = 4;
+
+const LLDP_SYS_CAP_OTHER: u16 = 1;
+const LLDP_SYS_CAP_REPEATER: u16 = 2;
+const LLDP_SYS_CAP_MAC_BRIDGE: u16 = 3;
+const LLDP_SYS_CAP_AP: u16 = 4;
+const LLDP_SYS_CAP_ROUTER: u16 = 5;
+const LLDP_SYS_CAP_TELEPHONE: u16 = 6;
+const LLDP_SYS_CAP_DOCSIS: u16 = 7;
+const LLDP_SYS_CAP_STATION_ONLY: u16 = 8;
+const LLDP_SYS_CAP_CVLAN: u16 = 9;
+const LLDP_SYS_CAP_SVLAN: u16 = 10;
+const LLDP_SYS_CAP_TWO_PORT_MAC_RELAY: u16 = 11;
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct LldpConfig {
+    pub enabled: bool,
+    #[serde(skip_deserializing, skip_serializing_if = "Vec::is_empty")]
+    pub neighbors: Vec<Vec<LldpNeighborTlv>>,
+}
+
+impl LldpConfig {
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        self.neighbors = Vec::new();
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum LldpNeighborTlv {
+    SystemName(LldpSystemName),
+    SystemDescription(LldpSystemDescription),
+    SystemCapabilities(LldpSystemCapabilities),
+    ChassisId(LldpChassisId),
+    PortId(LldpPortId),
+    Ieee8021Vlans(LldpVlans),
+    Ieee8023MacPhyConf(LldpMacPhyConf),
+    Ieee8021Ppvids(LldpPpvids),
+    ManagementAddresses(LldpMgmtAddrs),
+    Ieee8023MaxFrameSize(LldpMaxFrameSize),
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LldpSystemName(pub String);
+
+impl Serialize for LldpSystemName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_name", 2)?;
+        serial_struct.serialize_field("type", &LLDP_SYSTEM_NAME_TYPE)?;
+        serial_struct.serialize_field("system-name", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LldpSystemDescription(pub String);
+
+impl Serialize for LldpSystemDescription {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_description", 2)?;
+        serial_struct.serialize_field("type", &LLDP_SYSTEM_DESCRIPTION_TYPE)?;
+        serial_struct.serialize_field("system-description", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpChassisId {
+    pub id: String,
+    pub id_type: LldpChassisIdType,
+}
+
+impl Serialize for LldpChassisId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_chassis_id", 4)?;
+        serial_struct.serialize_field("_description", &self.id_type)?;
+        serial_struct
+            .serialize_field("chassis-id-type", &(self.id_type as u8))?;
+        serial_struct.serialize_field("type", &LLDP_CHASSIS_ID_TYPE)?;
+        serial_struct.serialize_field("chassis-id", &self.id)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum LldpChassisIdType {
+    Reserved,
+    #[serde(rename = "Chassis component")]
+    ChassisComponent,
+    #[serde(rename = "Interface alias")]
+    InterfaceAlias,
+    #[serde(rename = "Port component")]
+    PortComponent,
+    #[serde(rename = "MAC address")]
+    MacAddress,
+    #[serde(rename = "Network address")]
+    NetworkAddress,
+    #[serde(rename = "Interface name")]
+    InterfaceName,
+    #[serde(rename = "Locally assigned")]
+    LocallyAssigned,
+}
+
+impl From<LldpChassisIdType> for u8 {
+    fn from(v: LldpChassisIdType) -> u8 {
+        match v {
+            LldpChassisIdType::Reserved => LLDP_CHASSIS_ID_RESERVED,
+            LldpChassisIdType::ChassisComponent => {
+                LLDP_CHASSIS_ID_CHASSIS_COMPONENT
+            }
+            LldpChassisIdType::InterfaceAlias => LLDP_CHASSIS_ID_IFACE_ALIAS,
+            LldpChassisIdType::PortComponent => LLDP_CHASSIS_ID_PORT_COMPONENT,
+            LldpChassisIdType::MacAddress => LLDP_CHASSIS_ID_MAC_ADDR,
+            LldpChassisIdType::NetworkAddress => LLDP_CHASSIS_ID_NET_ADDR,
+            LldpChassisIdType::InterfaceName => LLDP_CHASSIS_ID_IFACE_NAME,
+            LldpChassisIdType::LocallyAssigned => LLDP_CHASSIS_ID_LOCAL,
+        }
+    }
+}
+
+impl From<u8> for LldpChassisIdType {
+    fn from(i: u8) -> Self {
+        match i {
+            LLDP_CHASSIS_ID_CHASSIS_COMPONENT => Self::ChassisComponent,
+            LLDP_CHASSIS_ID_IFACE_ALIAS => Self::InterfaceAlias,
+            LLDP_CHASSIS_ID_PORT_COMPONENT => Self::PortComponent,
+            LLDP_CHASSIS_ID_MAC_ADDR => Self::MacAddress,
+            LLDP_CHASSIS_ID_NET_ADDR => Self::NetworkAddress,
+            LLDP_CHASSIS_ID_IFACE_NAME => Self::InterfaceName,
+            LLDP_CHASSIS_ID_LOCAL => Self::LocallyAssigned,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+impl Default for LldpChassisIdType {
+    fn default() -> Self {
+        Self::Reserved
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpSystemCapabilities(pub u16);
+
+impl Serialize for LldpSystemCapabilities {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_capabilities", 2)?;
+        serial_struct
+            .serialize_field("type", &LLDP_SYSTEM_CAPABILITIES_TYPE)?;
+        serial_struct
+            .serialize_field("system-capabilities", &parse_sys_caps(self.0))?;
+        serial_struct.end()
+    }
+}
+
+fn parse_sys_caps(caps: u16) -> Vec<LldpSystemCapability> {
+    let mut ret = Vec::new();
+    if (caps & 1 << (LLDP_SYS_CAP_OTHER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Other);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_REPEATER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Repeater);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_MAC_BRIDGE - 1)) > 0 {
+        ret.push(LldpSystemCapability::MacBridgeComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_AP - 1)) > 0 {
+        ret.push(LldpSystemCapability::AccessPoint);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_ROUTER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Router);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_TELEPHONE - 1)) > 0 {
+        ret.push(LldpSystemCapability::Telephone);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_DOCSIS - 1)) > 0 {
+        ret.push(LldpSystemCapability::DocsisCableDevice);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_STATION_ONLY - 1)) > 0 {
+        ret.push(LldpSystemCapability::StationOnly);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_CVLAN - 1)) > 0 {
+        ret.push(LldpSystemCapability::CVlanComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_SVLAN - 1)) > 0 {
+        ret.push(LldpSystemCapability::SVlanComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_TWO_PORT_MAC_RELAY - 1)) > 0 {
+        ret.push(LldpSystemCapability::TwoPortMacRelayComponent);
+    }
+    ret
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum LldpSystemCapability {
+    Other,
+    Repeater,
+    #[serde(rename = "MAC Bridge component")]
+    MacBridgeComponent,
+    #[serde(rename = "802.11 Access Point (AP)")]
+    AccessPoint,
+    Router,
+    Telephone,
+    #[serde(rename = "DOCSIS cable device")]
+    DocsisCableDevice,
+    #[serde(rename = "Station Only")]
+    StationOnly,
+    #[serde(rename = "C-VLAN component")]
+    CVlanComponent,
+    #[serde(rename = "S-VLAN component")]
+    SVlanComponent,
+    #[serde(rename = "Two-port MAC Relay component")]
+    TwoPortMacRelayComponent,
+}
+
+impl Default for LldpSystemCapability {
+    fn default() -> Self {
+        Self::Other
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpPortId {
+    pub id: String,
+    pub id_type: LldpPortIdType,
+}
+
+impl Serialize for LldpPortId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_port_id", 4)?;
+        serial_struct.serialize_field("_description", &self.id_type)?;
+        serial_struct.serialize_field("port-id-type", &(self.id_type as u8))?;
+        serial_struct.serialize_field("type", &LLDP_PORT_TYPE)?;
+        serial_struct.serialize_field("port-id", &self.id)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum LldpPortIdType {
+    Reserved,
+    #[serde(rename = "Interface alias")]
+    InterfaceAlias,
+    #[serde(rename = "Port component")]
+    PortComponent,
+    #[serde(rename = "MAC address")]
+    MacAddress,
+    #[serde(rename = "Network address")]
+    NetworkAddress,
+    #[serde(rename = "Interface name")]
+    InterfaceName,
+    #[serde(rename = "Agent circuit ID")]
+    AgentCircuitId,
+    #[serde(rename = "Locally assigned")]
+    LocallyAssigned,
+}
+
+impl Default for LldpPortIdType {
+    fn default() -> Self {
+        Self::Reserved
+    }
+}
+
+impl From<LldpPortIdType> for u8 {
+    fn from(v: LldpPortIdType) -> u8 {
+        match v {
+            LldpPortIdType::Reserved => LLDP_PORT_ID_RESERVED,
+            LldpPortIdType::InterfaceAlias => LLDP_PORT_ID_IFACE_ALIAS,
+            LldpPortIdType::PortComponent => LLDP_PORT_ID_PORT_COMPONENT,
+            LldpPortIdType::MacAddress => LLDP_PORT_ID_MAC_ADDR,
+            LldpPortIdType::NetworkAddress => LLDP_PORT_ID_NET_ADDR,
+            LldpPortIdType::InterfaceName => LLDP_PORT_ID_IFACE_NAME,
+            LldpPortIdType::AgentCircuitId => LLDP_PORT_ID_AGENT_CIRCUIT_ID,
+            LldpPortIdType::LocallyAssigned => LLDP_PORT_ID_LOCAL,
+        }
+    }
+}
+
+impl From<u8> for LldpPortIdType {
+    fn from(v: u8) -> Self {
+        match v {
+            LLDP_PORT_ID_IFACE_ALIAS => Self::InterfaceAlias,
+            LLDP_PORT_ID_PORT_COMPONENT => Self::PortComponent,
+            LLDP_PORT_ID_MAC_ADDR => Self::MacAddress,
+            LLDP_PORT_ID_NET_ADDR => Self::NetworkAddress,
+            LLDP_PORT_ID_IFACE_NAME => Self::InterfaceName,
+            LLDP_PORT_ID_AGENT_CIRCUIT_ID => Self::AgentCircuitId,
+            LLDP_PORT_ID_LOCAL => Self::LocallyAssigned,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpVlans(pub Vec<LldpVlan>);
+
+impl Serialize for LldpVlans {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct = serializer.serialize_struct("lldp_vlans", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-1-vlans", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_VLAN)?;
+        serial_struct.serialize_field("subtype", &LLDP_ORG_SUBTYPE_VLAN)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[non_exhaustive]
+pub struct LldpVlan {
+    pub name: String,
+    pub vid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMacPhyConf {
+    pub autoneg: bool,
+    pub operational_mau_type: u16,
+    pub pmd_autoneg_cap: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+struct _LldpMacPhyConf {
+    autoneg: bool,
+    operational_mau_type: u16,
+    pmd_autoneg_cap: u16,
+}
+
+impl From<&LldpMacPhyConf> for _LldpMacPhyConf {
+    fn from(conf: &LldpMacPhyConf) -> Self {
+        Self {
+            autoneg: conf.autoneg,
+            operational_mau_type: conf.operational_mau_type,
+            pmd_autoneg_cap: conf.pmd_autoneg_cap,
+        }
+    }
+}
+
+impl Serialize for LldpMacPhyConf {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_mac_phy_conf", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field(
+            "ieee-802-3-mac-phy-conf",
+            &_LldpMacPhyConf::from(self),
+        )?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_MAC_PHY_CONF)?;
+        serial_struct
+            .serialize_field("subtype", &LLDP_ORG_SUBTYPE_MAC_PHY_CONF)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpPpvids(pub Vec<u32>);
+impl Serialize for LldpPpvids {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_ppvids", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-1-ppvids", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_PPVIDS)?;
+        serial_struct.serialize_field("subtype", &LLDP_ORG_SUBTYPE_PPVIDS)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMgmtAddrs(pub Vec<LldpMgmtAddr>);
+impl Serialize for LldpMgmtAddrs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_mgmt_addrs", 2)?;
+        serial_struct
+            .serialize_field("type", &LLDP_MANAGEMENT_ADDRESSES_TYPE)?;
+        serial_struct.serialize_field("management-addresses", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub struct LldpMgmtAddr {
+    pub address: String,
+    pub address_subtype: LldpAddressFamily,
+    pub interface_number: u32,
+    pub interface_number_subtype: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum LldpAddressFamily {
+    Unknown,
+    #[serde(rename = "IPv4")]
+    Ipv4,
+    #[serde(rename = "IPv6")]
+    Ipv6,
+    #[serde(rename = "MAC")]
+    Mac,
+}
+
+impl Default for LldpAddressFamily {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+const ADDRESS_FAMILY_IP4: u16 = 1;
+const ADDRESS_FAMILY_IP6: u16 = 2;
+const ADDRESS_FAMILY_MAC: u16 = 6;
+
+impl From<u16> for LldpAddressFamily {
+    fn from(i: u16) -> Self {
+        match i {
+            ADDRESS_FAMILY_IP4 => Self::Ipv4,
+            ADDRESS_FAMILY_IP6 => Self::Ipv6,
+            ADDRESS_FAMILY_MAC => Self::Mac,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMaxFrameSize(pub u32);
+impl Serialize for LldpMaxFrameSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_max_frame_size", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-3-max-frame-size", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_MAX_FRAME_SIZE)?;
+        serial_struct
+            .serialize_field("subtype", &LLDP_ORG_SUBTYPE_MAX_FRAME_SIZE)?;
+        serial_struct.end()
+    }
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -383,6 +383,9 @@ pub(crate) fn gen_nm_conn_setting(
             };
         }
     }
+    if let Some(lldp_conf) = iface.base_iface().lldp.as_ref() {
+        nm_conn_set.lldp = Some(lldp_conf.enabled);
+    }
     nm_conn.connection = Some(nm_conn_set);
     Ok(())
 }

--- a/rust/src/lib/nm/lldp.rs
+++ b/rust/src/lib/nm/lldp.rs
@@ -1,0 +1,260 @@
+use std::convert::TryFrom;
+
+use nm_dbus::{NmConnection, NmLldpNeighbor, NmLldpNeighbor8021Vlan};
+
+use crate::{
+    LldpAddressFamily, LldpChassisId, LldpConfig, LldpMacPhyConf,
+    LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs, LldpNeighborTlv, LldpPortId,
+    LldpPpvids, LldpSystemCapabilities, LldpSystemDescription, LldpSystemName,
+    LldpVlan, LldpVlans,
+};
+
+pub(crate) fn is_lldp_enabled(nm_conn: &NmConnection) -> bool {
+    nm_conn.connection.as_ref().and_then(|s| s.lldp) == Some(true)
+}
+
+pub(crate) fn get_lldp(nm_infos: Vec<NmLldpNeighbor>) -> LldpConfig {
+    let mut neighbors = Vec::new();
+    for nm_info in nm_infos {
+        let tlvs = nm_neighbor_to_nmstate(&nm_info);
+        if !tlvs.is_empty() {
+            neighbors.push(tlvs);
+        }
+    }
+    LldpConfig {
+        enabled: true,
+        neighbors,
+    }
+}
+
+fn nm_neighbor_to_nmstate(nm_info: &NmLldpNeighbor) -> Vec<LldpNeighborTlv> {
+    let mut ret = Vec::new();
+
+    if let Some(c) = get_sys_name(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_sys_description(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_sys_caps(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_chassis_id(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_port_id(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_vlans(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_mac_phy_conf(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_ppvids(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_mgmt_addrs(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_max_frame_size(nm_info) {
+        ret.push(c)
+    }
+
+    ret
+}
+
+impl From<&[NmLldpNeighbor8021Vlan]> for LldpVlans {
+    fn from(nm_vlans: &[NmLldpNeighbor8021Vlan]) -> Self {
+        let mut vlans = Vec::new();
+        for nm_vlan in nm_vlans {
+            if let (Some(vid), Some(name)) = (nm_vlan.vid, &nm_vlan.name) {
+                vlans.push(LldpVlan {
+                    vid,
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        LldpVlans(vlans)
+    }
+}
+
+fn u8_addr_to_mac_string(data: &[u8]) -> String {
+    let mut addr = String::new();
+    for (i, &val) in data.iter().enumerate() {
+        addr.push_str(&format!("{:02X}", val));
+        if i != data.len() - 1 {
+            addr.push(':');
+        }
+    }
+    addr
+}
+
+fn get_chassis_id(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let (Some(id_type), Some(id)) =
+        (nm_info.chassis_id_type, nm_info.chassis_id.as_deref())
+    {
+        if let Ok(id_type) = u8::try_from(id_type) {
+            let chassis_id = LldpChassisId {
+                id: id.to_string(),
+                id_type: id_type.into(),
+            };
+            return Some(LldpNeighborTlv::ChassisId(chassis_id));
+        } else {
+            log::warn!(
+                "Got unsupported chassis_id_type {}, expecting u8",
+                id_type
+            );
+        }
+    }
+    None
+}
+
+fn get_port_id(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let (Some(id_type), Some(id)) =
+        (nm_info.port_id_type, nm_info.port_id.as_deref())
+    {
+        if let Ok(id_type) = u8::try_from(id_type) {
+            let port_id = LldpPortId {
+                id: id.to_string(),
+                id_type: id_type.into(),
+            };
+            return Some(LldpNeighborTlv::PortId(port_id));
+        } else {
+            log::warn!(
+                "Got unsupported port_id_type {}, expecting u8",
+                id_type
+            );
+        }
+    }
+    None
+}
+
+fn get_sys_caps(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_capabilities {
+        if let Ok(caps) = u16::try_from(s) {
+            return Some(LldpNeighborTlv::SystemCapabilities(
+                LldpSystemCapabilities(caps),
+            ));
+        }
+    }
+    None
+}
+
+fn get_sys_name(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_name.as_deref() {
+        return Some(LldpNeighborTlv::SystemName(LldpSystemName(
+            s.to_string(),
+        )));
+    }
+    None
+}
+
+fn get_sys_description(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_description.as_deref() {
+        return Some(LldpNeighborTlv::SystemDescription(
+            LldpSystemDescription(s.to_string()),
+        ));
+    }
+    None
+}
+
+fn get_vlans(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_vlans) = nm_info.ieee_802_1_vlans.as_deref() {
+        return Some(LldpNeighborTlv::Ieee8021Vlans(nm_vlans.into()));
+    }
+    None
+}
+
+fn get_mac_phy_conf(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_conf) = nm_info.ieee_802_3_mac_phy_conf.as_ref() {
+        if let (Some(a), Some(p), Some(o)) = (
+            nm_conf.autoneg,
+            nm_conf.pmd_autoneg_cap,
+            nm_conf.operational_mau_type,
+        ) {
+            if let (Ok(o), Ok(p)) = (u16::try_from(o), u16::try_from(p)) {
+                let conf = LldpMacPhyConf {
+                    autoneg: a > 0,
+                    operational_mau_type: o,
+                    pmd_autoneg_cap: p,
+                };
+                return Some(LldpNeighborTlv::Ieee8023MacPhyConf(conf));
+            }
+        }
+    }
+    None
+}
+
+fn get_ppvids(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_ppvids) = nm_info.ieee_802_1_ppvids.as_ref() {
+        let mut ppvids = Vec::new();
+        for nm_ppvid in nm_ppvids {
+            if let Some(p) = nm_ppvid.ppvid {
+                ppvids.push(p);
+            }
+        }
+        return Some(LldpNeighborTlv::Ieee8021Ppvids(LldpPpvids(ppvids)));
+    }
+    None
+}
+
+fn get_mgmt_addrs(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_mgmt_addrs) = nm_info.management_addresses.as_deref() {
+        let mut addrs = Vec::new();
+        for nm_mgmt_addr in nm_mgmt_addrs {
+            if let (Some(at), Some(a), Some(it), Some(i)) = (
+                nm_mgmt_addr.address_subtype,
+                nm_mgmt_addr.address.as_ref(),
+                nm_mgmt_addr.interface_number_subtype,
+                nm_mgmt_addr.interface_number,
+            ) {
+                if let Ok(at) = u16::try_from(at) {
+                    let mut mgmt_addr = LldpMgmtAddr::default();
+                    let at = LldpAddressFamily::from(at);
+                    let addr = match at {
+                        LldpAddressFamily::Ipv4 => {
+                            if a.len() != 4 {
+                                continue;
+                            }
+                            std::net::Ipv4Addr::new(a[0], a[1], a[2], a[3])
+                                .to_string()
+                        }
+                        LldpAddressFamily::Ipv6 => {
+                            if a.len() != 16 {
+                                continue;
+                            }
+                            let mut buff = [0u8; 16];
+                            buff.copy_from_slice(&a[..16]);
+                            std::net::Ipv6Addr::from(buff).to_string()
+                        }
+                        LldpAddressFamily::Mac => u8_addr_to_mac_string(a),
+                        _ => {
+                            continue;
+                        }
+                    };
+
+                    mgmt_addr.address_subtype = at;
+                    mgmt_addr.address = addr;
+                    mgmt_addr.interface_number_subtype = it;
+                    mgmt_addr.interface_number = i;
+                    addrs.push(mgmt_addr);
+                }
+            }
+        }
+        return Some(LldpNeighborTlv::ManagementAddresses(LldpMgmtAddrs(
+            addrs,
+        )));
+    }
+    None
+}
+
+fn get_max_frame_size(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.ieee_802_3_max_frame_size {
+        return Some(LldpNeighborTlv::Ieee8023MaxFrameSize(LldpMaxFrameSize(
+            s,
+        )));
+    }
+    None
+}

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -9,6 +9,7 @@ mod dns;
 mod error;
 mod ieee8021x;
 mod ip;
+mod lldp;
 mod mac_vlan;
 mod ovs;
 mod profile;

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -320,6 +320,7 @@ pub struct NmSettingConnection {
     pub controller_type: Option<String>,
     pub autoconnect: Option<bool>,
     pub autoconnect_ports: Option<bool>,
+    pub lldp: Option<bool>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -338,6 +339,7 @@ impl TryFrom<DbusDictionary> for NmSettingConnection {
             autoconnect_ports: NmSettingConnection::i32_to_autoconnect_ports(
                 _from_map!(v, "autoconnect-slaves", i32::try_from)?,
             ),
+            lldp: _from_map!(v, "lldp", i32::try_from)?.map(|i| i == 1),
             _other: v,
         })
     }
@@ -392,6 +394,9 @@ impl NmSettingConnection {
         }
         if let Some(v) = &self.controller_type {
             ret.insert("slave-type", zvariant::Value::new(v.as_str()));
+        }
+        if let Some(v) = &self.lldp {
+            ret.insert("lldp", zvariant::Value::new(v));
         }
 
         ret.insert(

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -21,6 +21,7 @@ mod device;
 mod dns;
 mod error;
 mod keyfile;
+mod lldp;
 mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;
@@ -36,4 +37,9 @@ pub use crate::connection::{
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::dns::NmDnsEntry;
 pub use crate::error::{ErrorKind, NmError};
+pub use crate::lldp::{
+    NmLldpNeighbor, NmLldpNeighbor8021Ppvid, NmLldpNeighbor8021Vlan,
+    NmLldpNeighbor8023MacPhyConf, NmLldpNeighbor8023PowerViaMdi,
+    NmLldpNeighborMgmtAddr,
+};
 pub use crate::nm_api::NmApi;

--- a/rust/src/libnm_dbus/lldp.rs
+++ b/rust/src/libnm_dbus/lldp.rs
@@ -1,0 +1,248 @@
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{
+    connection::{DbusDictionary, _from_map},
+    NmError,
+};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor {
+    pub raw: Option<Vec<u8>>,
+    pub chassis_id_type: Option<u32>,
+    pub chassis_id: Option<String>,
+    pub port_id_type: Option<u32>,
+    pub port_id: Option<String>,
+    pub destination: Option<String>,
+    pub port_description: Option<String>,
+    pub system_name: Option<String>,
+    pub system_description: Option<String>,
+    pub system_capabilities: Option<u32>,
+    pub management_addresses: Option<Vec<NmLldpNeighborMgmtAddr>>,
+    pub ieee_802_1_pvid: Option<u32>,
+    pub ieee_802_1_ppvid: Option<u32>,
+    pub ieee_802_1_ppvid_flags: Option<u32>,
+    pub ieee_802_1_ppvids: Option<Vec<NmLldpNeighbor8021Ppvid>>,
+    pub ieee_802_1_vid: Option<u32>,
+    pub ieee_802_1_vlan_name: Option<String>,
+    pub ieee_802_1_vlans: Option<Vec<NmLldpNeighbor8021Vlan>>,
+    pub ieee_802_3_mac_phy_conf: Option<NmLldpNeighbor8023MacPhyConf>,
+    pub ieee_802_3_power_via_mdi: Option<NmLldpNeighbor8023PowerViaMdi>,
+    pub ieee_802_3_max_frame_size: Option<u32>,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            raw: _from_map!(v, "raw", <Vec<u8>>::try_from)?,
+            chassis_id_type: _from_map!(v, "chassis-id-type", <u32>::try_from)?,
+            chassis_id: _from_map!(v, "chassis-id", <String>::try_from)?,
+            port_id_type: _from_map!(v, "port-id-type", <u32>::try_from)?,
+            port_id: _from_map!(v, "port-id", <String>::try_from)?,
+            destination: _from_map!(v, "destination", <String>::try_from)?,
+            port_description: _from_map!(
+                v,
+                "port-description",
+                <String>::try_from
+            )?,
+            system_name: _from_map!(v, "system-name", <String>::try_from)?,
+            system_description: _from_map!(
+                v,
+                "system-description",
+                <String>::try_from
+            )?,
+            system_capabilities: _from_map!(
+                v,
+                "system-capabilities",
+                <u32>::try_from
+            )?,
+            management_addresses: _from_map!(
+                v,
+                "management-addresses",
+                parse_mgmt_addrs
+            )?,
+            ieee_802_1_pvid: _from_map!(v, "ieee-802-1-pvid", <u32>::try_from)?,
+            ieee_802_1_ppvid: _from_map!(
+                v,
+                "ieee-802-1-ppvid",
+                <u32>::try_from
+            )?,
+            ieee_802_1_ppvid_flags: _from_map!(
+                v,
+                "ieee-802-1-ppvid-flags",
+                <u32>::try_from
+            )?,
+            ieee_802_1_ppvids: _from_map!(
+                v,
+                "ieee-802-1-ppvids",
+                parse_ppvids
+            )?,
+            ieee_802_1_vid: _from_map!(v, "ieee-802-1-vid", <u32>::try_from)?,
+            ieee_802_1_vlan_name: _from_map!(
+                v,
+                "ieee-802-1-vlan-name",
+                <String>::try_from
+            )?,
+            ieee_802_1_vlans: _from_map!(v, "ieee-802-1-vlans", parse_vlans)?,
+            ieee_802_3_mac_phy_conf: _from_map!(
+                v,
+                "ieee-802-3-mac-phy-conf",
+                NmLldpNeighbor8023MacPhyConf::try_from
+            )?,
+            ieee_802_3_power_via_mdi: _from_map!(
+                v,
+                "ieee-802-3-power-via-mdi",
+                NmLldpNeighbor8023PowerViaMdi::try_from
+            )?,
+            ieee_802_3_max_frame_size: _from_map!(
+                v,
+                "ieee-802-3-max-frame-size",
+                <u32>::try_from
+            )?,
+            _other: v,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor8021Ppvid {
+    pub ppvid: Option<u32>,
+    pub flags: Option<u32>,
+}
+
+fn parse_ppvids(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighbor8021Ppvid>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighbor8021Ppvid::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor8021Ppvid {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            ppvid: _from_map!(v, "ppvid", <u32>::try_from)?,
+            flags: _from_map!(v, "flags", <u32>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor8021Vlan {
+    pub vid: Option<u32>,
+    pub name: Option<String>,
+}
+
+fn parse_vlans(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighbor8021Vlan>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighbor8021Vlan::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor8021Vlan {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vid: _from_map!(v, "vid", <u32>::try_from)?,
+            name: _from_map!(v, "name", <String>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct NmLldpNeighbor8023MacPhyConf {
+    pub autoneg: Option<u32>,
+    pub pmd_autoneg_cap: Option<u32>,
+    pub operational_mau_type: Option<u32>,
+}
+
+impl TryFrom<zvariant::OwnedValue> for NmLldpNeighbor8023MacPhyConf {
+    type Error = NmError;
+    fn try_from(v: zvariant::OwnedValue) -> Result<Self, Self::Error> {
+        let mut v = DbusDictionary::try_from(v)?;
+        Ok(Self {
+            autoneg: _from_map!(v, "autoneg", <u32>::try_from)?,
+            pmd_autoneg_cap: _from_map!(v, "pmd-autoneg-cap", <u32>::try_from)?,
+            operational_mau_type: _from_map!(
+                v,
+                "operational-mau-type",
+                <u32>::try_from
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct NmLldpNeighbor8023PowerViaMdi {
+    pub mdi_power_support: Option<u32>,
+    pub pse_power_pair: Option<u32>,
+    pub power_class: Option<u32>,
+}
+
+impl TryFrom<zvariant::OwnedValue> for NmLldpNeighbor8023PowerViaMdi {
+    type Error = NmError;
+    fn try_from(v: zvariant::OwnedValue) -> Result<Self, Self::Error> {
+        let mut v = DbusDictionary::try_from(v)?;
+        Ok(Self {
+            mdi_power_support: _from_map!(
+                v,
+                "mdi-power-support",
+                <u32>::try_from
+            )?,
+            pse_power_pair: _from_map!(v, "pse-power-pair", <u32>::try_from)?,
+            power_class: _from_map!(v, "power-class", <u32>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighborMgmtAddr {
+    pub address_subtype: Option<u32>,
+    pub address: Option<Vec<u8>>,
+    pub interface_number_subtype: Option<u32>,
+    pub interface_number: Option<u32>,
+}
+
+fn parse_mgmt_addrs(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighborMgmtAddr>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighborMgmtAddr::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighborMgmtAddr {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address_subtype: _from_map!(v, "address-subtype", <u32>::try_from)?,
+            address: _from_map!(v, "address", <Vec<u8>>::try_from)?,
+            interface_number_subtype: _from_map!(
+                v,
+                "interface-number-subtype",
+                <u32>::try_from
+            )?,
+            interface_number: _from_map!(
+                v,
+                "interface-number",
+                <u32>::try_from
+            )?,
+        })
+    }
+}

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -24,11 +24,12 @@ use crate::{
     connection::{nm_con_get_from_obj_path, NmConnection},
     dbus::NmDbus,
     device::{
-        nm_dev_delete, nm_dev_from_obj_path, NmDevice, NmDeviceState,
-        NmDeviceStateReason,
+        nm_dev_delete, nm_dev_from_obj_path, nm_dev_get_llpd, NmDevice,
+        NmDeviceState, NmDeviceStateReason,
     },
     dns::NmDnsEntry,
     error::{ErrorKind, NmError},
+    lldp::NmLldpNeighbor,
 };
 
 pub struct NmApi<'a> {
@@ -261,6 +262,13 @@ impl<'a> NmApi<'a> {
 
     pub fn device_delete(&self, nm_dev_obj_path: &str) -> Result<(), NmError> {
         nm_dev_delete(&self.dbus.connection, nm_dev_obj_path)
+    }
+
+    pub fn device_lldp_neighbor_get(
+        &self,
+        nm_dev_obj_path: &str,
+    ) -> Result<Vec<NmLldpNeighbor>, NmError> {
+        nm_dev_get_llpd(&self.dbus.connection, nm_dev_obj_path)
     }
 
     // If any device is with NewActivation or IpConfig state,


### PR DESCRIPTION
Provide identical output of current python API.

Integration test cases enabled.