### PR TITLE
Packit: build SRPMs in Copr

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,9 @@
 specfile_path: nmstate.spec
 upstream_package_name: nmstate
 upstream_project_url: http://nmstate.io
+srpm_build_deps:
+  - python3-pip
+  - python3-setuptools_scm
 actions:
   post-upstream-clone: "bash -c './packaging/make_spec.sh > nmstate.spec'"
   create-archive:


### PR DESCRIPTION
Add srpm_build_deps key to the Packit configuration to specify the needed dependencies for SRPM build
and indicate to build SRPM in Copr.

If you are interested in the transition to building SRPMs in Copr, you can read more about it [here](https://packit.dev/posts/copr-srpms/).