### PR TITLE
rust bond: misc fixes

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -198,6 +198,7 @@ function run_tests {
             tests/integration/dynamic_ip_test.py \
             tests/integration/nm/ieee802_1x_test.py \
             tests/integration/lldp_test.py \
+            tests/integration/bond_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \
@@ -274,20 +275,6 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/route_test.py \
             -k 'not test_route_rule_add_with_auto_route_table_id ' \
-            ${nmstate_pytest_extra_args}"
-        exec_cmd "
-          env  \
-          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
-          pytest \
-            $PYTEST_OPTIONS \
-            tests/integration/bond_test.py \
-            -k '\
-            not test_preserve_bond_after_bridge_removal and \
-            not test_bond_mac_restriction_without_mac_in_desire and \
-            not test_bond_mac_restriction_with_mac_in_desire and \
-            not test_bond_mac_restriction_in_desire_mac_in_current and \
-            not test_remove_mode4_bond_and_create_mode5_with_the_same_port and \
-            not test_bond_mac_restriction_in_current_mac_in_desire' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -637,10 +637,13 @@ impl Interface {
         }
     }
 
-    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+    pub(crate) fn validate(
+        &self,
+        current: Option<&Self>,
+    ) -> Result<(), NmstateError> {
         match self {
             Interface::LinuxBridge(iface) => iface.validate(),
-            Interface::Bond(iface) => iface.validate(),
+            Interface::Bond(iface) => iface.validate(current),
             Interface::MacVlan(iface) => iface.validate(),
             Interface::MacVtap(iface) => iface.validate(),
             _ => Ok(()),

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -621,10 +621,6 @@ impl Interface {
                 }
             }
 
-            if reference.contains("link-aggregation.options") {
-                return Ok(());
-            }
-
             Err(NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -204,6 +204,7 @@ pub enum BondMode {
     TLB,
     #[serde(rename = "balance-alb")]
     ALB,
+    #[serde(rename = "unknown")]
     Unknown,
 }
 
@@ -265,7 +266,7 @@ impl BondConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum BondAdSelect {
@@ -277,13 +278,27 @@ pub enum BondAdSelect {
     Count,
 }
 
-impl BondAdSelect {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Stable => 0,
-            Self::Bandwidth => 1,
-            Self::Count => 2,
+impl From<BondAdSelect> for u8 {
+    fn from(v: BondAdSelect) -> u8 {
+        match v {
+            BondAdSelect::Stable => 0,
+            BondAdSelect::Bandwidth => 1,
+            BondAdSelect::Count => 2,
         }
+    }
+}
+
+impl std::fmt::Display for BondAdSelect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Stable => "stable",
+                Self::Bandwidth => "bandwidth",
+                Self::Count => "count",
+            }
+        )
     }
 }
 
@@ -297,16 +312,20 @@ pub enum BondLacpRate {
     Fast,
 }
 
-impl BondLacpRate {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Slow => 0,
-            Self::Fast => 1,
-        }
+impl std::fmt::Display for BondLacpRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Slow => "slow",
+                Self::Fast => "fast",
+            }
+        )
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum BondAllPortsActive {
@@ -316,11 +335,24 @@ pub enum BondAllPortsActive {
     Delivered,
 }
 
-impl BondAllPortsActive {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Dropped => 0,
-            Self::Delivered => 1,
+impl std::fmt::Display for BondAllPortsActive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Dropped => "dropped",
+                Self::Delivered => "delivered",
+            }
+        )
+    }
+}
+
+impl From<BondAllPortsActive> for u8 {
+    fn from(v: BondAllPortsActive) -> u8 {
+        match v {
+            BondAllPortsActive::Dropped => 0,
+            BondAllPortsActive::Delivered => 1,
         }
     }
 }
@@ -335,26 +367,18 @@ pub enum BondArpAllTargets {
     All,
 }
 
-impl BondArpAllTargets {
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            Self::Any => 0,
-            Self::All => 1,
-        }
+impl std::fmt::Display for BondArpAllTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Any => "any",
+                Self::All => "all",
+            }
+        )
     }
 }
-
-const BOND_STATE_ACTIVE: u8 = 0;
-const BOND_STATE_BACKUP: u8 = 1;
-
-const BOND_ARP_VALIDATE_NONE: u32 = 0;
-const BOND_ARP_VALIDATE_ACTIVE: u32 = 1 << BOND_STATE_ACTIVE as u32;
-const BOND_ARP_VALIDATE_BACKUP: u32 = 1 << BOND_STATE_BACKUP as u32;
-const BOND_ARP_VALIDATE_ALL: u32 =
-    BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_VALIDATE_BACKUP;
-const BOND_ARP_FILTER: u32 = BOND_ARP_VALIDATE_ALL + 1;
-const BOND_ARP_FILTER_ACTIVE: u32 = BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_FILTER;
-const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -371,17 +395,21 @@ pub enum BondArpValidate {
     FilterBackup,
 }
 
-impl BondArpValidate {
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            Self::None => BOND_ARP_VALIDATE_NONE,
-            Self::Active => BOND_ARP_VALIDATE_ACTIVE,
-            Self::Backup => BOND_ARP_VALIDATE_BACKUP,
-            Self::All => BOND_ARP_VALIDATE_ALL,
-            Self::Filter => BOND_ARP_FILTER,
-            Self::FilterActive => BOND_ARP_FILTER_ACTIVE,
-            Self::FilterBackup => BOND_ARP_FILTER_BACKUP,
-        }
+impl std::fmt::Display for BondArpValidate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::None => "none",
+                Self::Active => "active",
+                Self::Backup => "backup",
+                Self::All => "all",
+                Self::Filter => "filter",
+                Self::FilterActive => "filter_active",
+                Self::FilterBackup => "filter_backup",
+            }
+        )
     }
 }
 
@@ -397,13 +425,17 @@ pub enum BondFailOverMac {
     Follow,
 }
 
-impl BondFailOverMac {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::None => 0,
-            Self::Active => 1,
-            Self::Follow => 2,
-        }
+impl std::fmt::Display for BondFailOverMac {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::None => "none",
+                Self::Active => "active",
+                Self::Follow => "follow ",
+            }
+        )
     }
 }
 
@@ -419,13 +451,17 @@ pub enum BondPrimaryReselect {
     Failure,
 }
 
-impl BondPrimaryReselect {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Always => 0,
-            Self::Better => 1,
-            Self::Failure => 2,
-        }
+impl std::fmt::Display for BondPrimaryReselect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Always => "always",
+                Self::Better => "better",
+                Self::Failure => "failure",
+            }
+        )
     }
 }
 
@@ -462,6 +498,23 @@ impl BondXmitHashPolicy {
             Self::Encap34 => 4,
             Self::VlanSrcMac => 5,
         }
+    }
+}
+
+impl std::fmt::Display for BondXmitHashPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Layer2 => "layer2",
+                Self::Layer34 => "layer3+4",
+                Self::Layer23 => "layer2+3",
+                Self::Encap23 => "encap2+3",
+                Self::Encap34 => "encap3+4",
+                Self::VlanSrcMac => "vlan+srcmac",
+            }
+        )
     }
 }
 

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -173,6 +173,18 @@ impl BondInterface {
         }
         Ok(())
     }
+
+    pub(crate) fn is_options_reset(&self) -> bool {
+        if let Some(bond_opts) = self
+            .bond
+            .as_ref()
+            .and_then(|bond_conf| bond_conf.options.as_ref())
+        {
+            bond_opts == &BondOptions::default()
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -258,7 +258,9 @@ impl Interfaces {
                 }
             } else {
                 if iface.is_up() {
-                    iface.validate()?;
+                    iface.validate(
+                        current.get_iface(iface.name(), iface.iface_type()),
+                    )?;
                 }
                 match current.kernel_ifaces.get(iface.name()) {
                     Some(cur_iface) => {

--- a/rust/src/lib/nm/bond.rs
+++ b/rust/src/lib/nm/bond.rs
@@ -53,7 +53,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.ad_select.as_ref() {
         nm_bond_set
             .options
-            .insert("ad_select".to_string(), v.to_u8().to_string());
+            .insert("ad_select".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.ad_user_port_key.as_ref() {
         nm_bond_set
@@ -63,12 +63,12 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.all_slaves_active.as_ref() {
         nm_bond_set
             .options
-            .insert("all_slaves_active".to_string(), v.to_u8().to_string());
+            .insert("all_slaves_active".to_string(), u8::from(*v).to_string());
     }
     if let Some(v) = bond_opts.arp_all_targets.as_ref() {
         nm_bond_set
             .options
-            .insert("arp_all_targets".to_string(), v.to_u32().to_string());
+            .insert("arp_all_targets".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.arp_interval.as_ref() {
         nm_bond_set
@@ -83,7 +83,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.arp_validate.as_ref() {
         nm_bond_set
             .options
-            .insert("arp_validate".to_string(), v.to_u32().to_string());
+            .insert("arp_validate".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.downdelay.as_ref() {
         nm_bond_set
@@ -93,12 +93,12 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.fail_over_mac.as_ref() {
         nm_bond_set
             .options
-            .insert("fail_over_mac".to_string(), v.to_u8().to_string());
+            .insert("fail_over_mac".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.lacp_rate.as_ref() {
         nm_bond_set
             .options
-            .insert("lacp_rate".to_string(), v.to_u8().to_string());
+            .insert("lacp_rate".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.lp_interval.as_ref() {
         nm_bond_set
@@ -136,7 +136,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.primary_reselect.as_ref() {
         nm_bond_set
             .options
-            .insert("primary_reselect".to_string(), v.to_u8().to_string());
+            .insert("primary_reselect".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.resend_igmp.as_ref() {
         nm_bond_set
@@ -163,7 +163,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.xmit_hash_policy.as_ref() {
         nm_bond_set
             .options
-            .insert("xmit_hash_policy".to_string(), v.to_u8().to_string());
+            .insert("xmit_hash_policy".to_string(), v.to_string());
     }
 
     // Remove all empty string option

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -85,7 +85,6 @@ pub(crate) fn iface_to_nm_connections(
         &base_iface.iface_type,
         nm_ac_uuids,
     );
-
     let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
 
     gen_nm_conn_setting(iface, &mut nm_conn)?;

--- a/rust/src/lib/state.rs
+++ b/rust/src/lib/state.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::NetworkState;
 
-pub(crate) fn get_json_value_difference<'a, 'b>(
+fn _get_json_value_difference<'a, 'b>(
     reference: String,
     desire: &'a Value,
     current: &'b Value,
@@ -70,5 +70,39 @@ pub(crate) fn get_json_value_difference<'a, 'b>(
         }
         (Value::Null, _) => None,
         (_, _) => Some((reference, desire, current)),
+    }
+}
+
+pub(crate) fn get_json_value_difference<'a, 'b>(
+    reference: String,
+    desire: &'a Value,
+    current: &'b Value,
+) -> Option<(String, &'a Value, &'b Value)> {
+    if let Some((reference, desire, current)) =
+        _get_json_value_difference(reference, desire, current)
+    {
+        if should_ignore(reference.as_str(), desire, current) {
+            None
+        } else {
+            Some((reference, desire, current))
+        }
+    } else {
+        None
+    }
+}
+
+fn should_ignore(reference: &str, desire: &Value, current: &Value) -> bool {
+    if reference.contains("interface.link-aggregation.options") {
+        // Per oVirt request, bond option difference should not
+        // fail verification.
+        log::warn!(
+            "Bond option miss-match: {} desire '{}', current '{}'",
+            reference,
+            desire,
+            current
+        );
+        true
+    } else {
+        false
     }
 }

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -1,0 +1,188 @@
+use crate::{BondInterface, ErrorKind, Interface};
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_undefined() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(None).unwrap();
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_for_exist_bond() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(Some(&current_iface));
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_changing_mode() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: 802.3ad
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(Some(&current_iface)).unwrap();
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_changing_opt() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: follow
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(Some(&current_iface)).unwrap();
+}
+
+#[test]
+fn test_bond_validate_bond_mode_not_defined_for_new_iface() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_ad_actor_system_mac_address() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: 802.3ad
+  options:
+    ad_actor_system: "01:00:5E:00:0f:01"
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_miimon_and_arp_interval() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: 802.3ad
+  options:
+    miimon: 100
+    arp_interval: 60
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod bond;
+#[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -10,25 +10,21 @@ use crate::{connection::DbusDictionary, NmError};
 #[serde(try_from = "DbusDictionary")]
 #[non_exhaustive]
 pub struct NmSettingBond {
-    pub mode: String,
     pub options: HashMap<String, String>,
-    _other: HashMap<String, String>,
+    _other: HashMap<String, zvariant::OwnedValue>,
 }
 
 impl TryFrom<DbusDictionary> for NmSettingBond {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
-        let mut options = HashMap::<String, String>::new();
-        let mut other = HashMap::<String, String>::new();
-
-        if let Some(value) = _from_map!(v, "options", HashMap::try_from)? {
-            options = value.clone();
-            other = value;
-        }
         Ok(Self {
-            mode: String::new(),
-            options,
-            _other: other,
+            options: _from_map!(
+                v,
+                "options",
+                <HashMap<String, String>>::try_from
+            )?
+            .unwrap_or_default(),
+            _other: v,
         })
     }
 }
@@ -38,49 +34,24 @@ impl NmSettingBond {
         Self::default()
     }
 
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        ret.insert("options", zvariant::Value::from(self.options.clone()));
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
     pub(crate) fn to_keyfile(
         &self,
     ) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
-        ret.insert("mode".to_string(), Value::new(self.mode.as_str()));
         for (key, value) in self.options.iter() {
             ret.insert(key.to_string(), Value::new(value));
         }
         Ok(ret)
-    }
-
-    pub(crate) fn to_value(&self) -> Result<HashMap<&str, Value>, NmError> {
-        let mut merged_opts = self.options.clone();
-        let mut ret = HashMap::new();
-
-        // Do not merge existing options if the user specified empty options
-        merged_opts.extend(
-            self._other
-                .iter()
-                .filter(|(k, _)| !self.options.contains_key(*k))
-                .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-        if let Some(arp_ip_target) = self.options.get("arp_ip_target") {
-            if arp_ip_target.is_empty() {
-                merged_opts.remove("arp_ip_target");
-            }
-        }
-
-        if !self.mode.is_empty() {
-            merged_opts.insert("mode".to_string(), self.mode.clone());
-        }
-
-        if !merged_opts.is_empty() {
-            ret.insert("options", Value::from(merged_opts.clone()));
-        }
-        Ok(ret)
-    }
-
-    pub fn clear_existing_opts(&mut self) {
-        self._other.clear();
-    }
-
-    pub fn get_current_mode(&self) -> Option<&String> {
-        self._other.get(&String::from("mode"))
     }
 }


### PR DESCRIPTION
* Enable all bond integration test cases
 * Use `Display` and `From` trait for NM dbus serialization of NmSettingBond.
 * Merge bond options in stead of overriding.