### PR TITLE
rpm spec: Skip rust build for debug binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - base
 
 jobs:
   rust_lint:

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -87,9 +87,6 @@ This package contains the nmstate plugin for OVS database manipulation.
 
 %build
 %py3_build
-pushd rust
-make
-popd
 
 %install
 %py3_install


### PR DESCRIPTION
The `make` command also build debug binary which is not required for
rpm.