### PR TITLE
[nmstate-1.3] Sync with base

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - base
 
 jobs:
   rust_lint:

--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,9 @@
 specfile_path: nmstate.spec
 upstream_package_name: nmstate
 upstream_project_url: http://nmstate.io
+srpm_build_deps:
+  - python3-pip
+  - python3-setuptools_scm
 actions:
   post-upstream-clone: "bash -c './packaging/make_spec.sh > nmstate.spec'"
   create-archive:

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -210,6 +210,7 @@ function run_tests {
             test_create_and_remove_ovs_bridge_options_specified or \
             test_create_and_remove_ovs_bridge_with_a_system_port or \
             test_create_and_remove_ovs_bridge_with_internal_port_static_ip_and_mac or \
+            test_create_memory_only_ovs_bridge or \
             ovsdb' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
@@ -302,6 +303,13 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/interface_common_test.py \
             -k 'test_iface_description_removal' \
+            ${nmstate_pytest_extra_args}"
+        exec_cmd "
+          env  \
+          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
+          pytest \
+            $PYTEST_OPTIONS \
+            tests/integration/nm/profile_test.py -k memory_only \
             ${nmstate_pytest_extra_args}"
     fi
 }

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -197,6 +197,7 @@ function run_tests {
             tests/integration/veth_test.py \
             tests/integration/dynamic_ip_test.py \
             tests/integration/nm/ieee802_1x_test.py \
+            tests/integration/lldp_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -198,6 +198,7 @@ function run_tests {
             tests/integration/dynamic_ip_test.py \
             tests/integration/nm/ieee802_1x_test.py \
             tests/integration/lldp_test.py \
+            tests/integration/bond_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \
@@ -274,20 +275,6 @@ function run_tests {
             $PYTEST_OPTIONS \
             tests/integration/route_test.py \
             -k 'not test_route_rule_add_with_auto_route_table_id ' \
-            ${nmstate_pytest_extra_args}"
-        exec_cmd "
-          env  \
-          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
-          pytest \
-            $PYTEST_OPTIONS \
-            tests/integration/bond_test.py \
-            -k '\
-            not test_preserve_bond_after_bridge_removal and \
-            not test_bond_mac_restriction_without_mac_in_desire and \
-            not test_bond_mac_restriction_with_mac_in_desire and \
-            not test_bond_mac_restriction_in_desire_mac_in_current and \
-            not test_remove_mode4_bond_and_create_mode5_with_the_same_port and \
-            not test_bond_mac_restriction_in_current_mac_in_desire' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -90,9 +90,6 @@ This package contains the nmstate plugin for OVS database manipulation.
 
 %build
 %py3_build
-pushd rust
-make
-popd
 
 %install
 %py3_install

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0", features = ["derive"] }
 env_logger = "0.9.0"
 log = "0.4.14"
 serde_json = "1.0.75"
+ctrlc = "3.2.1"

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -115,6 +115,12 @@ fn main() {
                         .takes_value(false)
                         .help("Show secrets(hide by default)"),
                 )
+                .arg(
+                    clap::Arg::with_name("MEMORY_ONLY")
+                        .long("memory-only")
+                        .takes_value(false)
+                        .help("Do not make the state persistent"),
+                )
         )
         .subcommand(
             clap::SubCommand::with_name(SUB_CMD_GEN_CONF)
@@ -339,6 +345,7 @@ where
     net_state.set_verify_change(!no_verify);
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
+    net_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
     net_state.apply()?;
     if !matches.is_present("SHOW_SECRETS") {
         net_state.hide_secrets();

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -346,6 +346,15 @@ where
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
     net_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
+
+    ctrlc::set_handler(|| {
+        if let Err(e) = rollback("") {
+            println!("Failed to rollback: {}", e);
+        }
+        std::process::exit(1);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     net_state.apply()?;
     if !matches.is_present("SHOW_SECRETS") {
         net_state.hide_secrets();

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -20,8 +20,7 @@ const NMSTATE_FLAG_NO_VERIFY: u32 = 1 << 2;
 const NMSTATE_FLAG_INCLUDE_STATUS_DATA: u32 = 1 << 3;
 const NMSTATE_FLAG_INCLUDE_SECRETS: u32 = 1 << 4;
 const NMSTATE_FLAG_NO_COMMIT: u32 = 1 << 5;
-// TODO
-// const NMSTATE_FLAG_MEMORY_ONLY: u32 = 1 << 6;
+const NMSTATE_FLAG_MEMORY_ONLY: u32 = 1 << 6;
 const NMSTATE_FLAG_RUNNING_CONFIG_ONLY: u32 = 1 << 7;
 
 const NMSTATE_PASS: c_int = 0;
@@ -168,6 +167,10 @@ pub extern "C" fn nmstate_net_state_apply(
 
     if (flags & NMSTATE_FLAG_NO_COMMIT) > 0 {
         net_state.set_commit(false);
+    }
+
+    if (flags & NMSTATE_FLAG_MEMORY_ONLY) > 0 {
+        net_state.set_memory_only(true);
     }
 
     net_state.set_timeout(rollback_timeout);

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -42,6 +42,8 @@ extern "C" {
 #define NMSTATE_FLAG_INCLUDE_STATUS_DATA    1 << 3
 #define NMSTATE_FLAG_INCLUDE_SECRETS        1 << 4
 #define NMSTATE_FLAG_NO_COMMIT              1 << 5
+#define NMSTATE_FLAG_MEMORY_ONLY            1 << 6
+#define NMSTATE_FLAG_RUNNING_CONFIG_ONLY    1 << 7
 
 /**
  * nmstate_net_state_retrieve - Retrieve network state

--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -23,6 +23,8 @@ const (
 	includeStatusData
 	includeSecrets
 	noCommit
+	memoryOnly
+	runningConfigOnly
 )
 
 func New(options ...func(*Nmstate)) *Nmstate {
@@ -72,6 +74,18 @@ func WithIncludeSecrets() func(*Nmstate) {
 func WithNoCommit() func(*Nmstate) {
 	return func(n *Nmstate) {
 		n.flags = n.flags | noCommit
+	}
+}
+
+func WithMemoryOnly() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | memoryOnly
+	}
+}
+
+func WithRunningConfigOnly() func(*Nmstate) {
+	return func(n *Nmstate) {
+		n.flags = n.flags | runningConfigOnly
 	}
 }
 

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -637,10 +637,13 @@ impl Interface {
         }
     }
 
-    pub(crate) fn validate(&self) -> Result<(), NmstateError> {
+    pub(crate) fn validate(
+        &self,
+        current: Option<&Self>,
+    ) -> Result<(), NmstateError> {
         match self {
             Interface::LinuxBridge(iface) => iface.validate(),
-            Interface::Bond(iface) => iface.validate(),
+            Interface::Bond(iface) => iface.validate(current),
             Interface::MacVlan(iface) => iface.validate(),
             Interface::MacVtap(iface) => iface.validate(),
             _ => Ok(()),

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -621,10 +621,6 @@ impl Interface {
                 }
             }
 
-            if reference.contains("link-aggregation.options") {
-                return Ok(());
-            }
-
             Err(NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ErrorKind, Ieee8021XConfig, InterfaceIpv4, InterfaceIpv6, InterfaceState,
-    InterfaceType, NmstateError, OvsDbIfaceConfig, RouteEntry, RouteRuleEntry,
+    InterfaceType, LldpConfig, NmstateError, OvsDbIfaceConfig, RouteEntry,
+    RouteRuleEntry,
 };
 
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
@@ -40,6 +41,8 @@ pub struct BaseInterface {
     pub ovsdb: Option<OvsDbIfaceConfig>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "802.1x")]
     pub ieee8021x: Option<Ieee8021XConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lldp: Option<LldpConfig>,
     #[serde(skip)]
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.
@@ -89,6 +92,9 @@ impl BaseInterface {
         }
         if other.prop_list.contains(&"ieee8021x") {
             self.ieee8021x = other.ieee8021x.clone();
+        }
+        if other.prop_list.contains(&"lldp") {
+            self.lldp = other.lldp.clone();
         }
 
         if other.prop_list.contains(&"ipv4") {
@@ -161,6 +167,10 @@ impl BaseInterface {
         // Change all veth interface to ethernet for simpler verification
         if self.iface_type == InterfaceType::Veth {
             self.iface_type = InterfaceType::Ethernet;
+        }
+
+        if let Some(lldp_conf) = self.lldp.as_mut() {
+            lldp_conf.pre_verify_cleanup();
         }
     }
 

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -204,6 +204,7 @@ pub enum BondMode {
     TLB,
     #[serde(rename = "balance-alb")]
     ALB,
+    #[serde(rename = "unknown")]
     Unknown,
 }
 
@@ -265,7 +266,7 @@ impl BondConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum BondAdSelect {
@@ -277,13 +278,27 @@ pub enum BondAdSelect {
     Count,
 }
 
-impl BondAdSelect {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Stable => 0,
-            Self::Bandwidth => 1,
-            Self::Count => 2,
+impl From<BondAdSelect> for u8 {
+    fn from(v: BondAdSelect) -> u8 {
+        match v {
+            BondAdSelect::Stable => 0,
+            BondAdSelect::Bandwidth => 1,
+            BondAdSelect::Count => 2,
         }
+    }
+}
+
+impl std::fmt::Display for BondAdSelect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Stable => "stable",
+                Self::Bandwidth => "bandwidth",
+                Self::Count => "count",
+            }
+        )
     }
 }
 
@@ -297,16 +312,20 @@ pub enum BondLacpRate {
     Fast,
 }
 
-impl BondLacpRate {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Slow => 0,
-            Self::Fast => 1,
-        }
+impl std::fmt::Display for BondLacpRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Slow => "slow",
+                Self::Fast => "fast",
+            }
+        )
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum BondAllPortsActive {
@@ -316,11 +335,24 @@ pub enum BondAllPortsActive {
     Delivered,
 }
 
-impl BondAllPortsActive {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Dropped => 0,
-            Self::Delivered => 1,
+impl std::fmt::Display for BondAllPortsActive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Dropped => "dropped",
+                Self::Delivered => "delivered",
+            }
+        )
+    }
+}
+
+impl From<BondAllPortsActive> for u8 {
+    fn from(v: BondAllPortsActive) -> u8 {
+        match v {
+            BondAllPortsActive::Dropped => 0,
+            BondAllPortsActive::Delivered => 1,
         }
     }
 }
@@ -335,26 +367,18 @@ pub enum BondArpAllTargets {
     All,
 }
 
-impl BondArpAllTargets {
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            Self::Any => 0,
-            Self::All => 1,
-        }
+impl std::fmt::Display for BondArpAllTargets {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Any => "any",
+                Self::All => "all",
+            }
+        )
     }
 }
-
-const BOND_STATE_ACTIVE: u8 = 0;
-const BOND_STATE_BACKUP: u8 = 1;
-
-const BOND_ARP_VALIDATE_NONE: u32 = 0;
-const BOND_ARP_VALIDATE_ACTIVE: u32 = 1 << BOND_STATE_ACTIVE as u32;
-const BOND_ARP_VALIDATE_BACKUP: u32 = 1 << BOND_STATE_BACKUP as u32;
-const BOND_ARP_VALIDATE_ALL: u32 =
-    BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_VALIDATE_BACKUP;
-const BOND_ARP_FILTER: u32 = BOND_ARP_VALIDATE_ALL + 1;
-const BOND_ARP_FILTER_ACTIVE: u32 = BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_FILTER;
-const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -371,17 +395,21 @@ pub enum BondArpValidate {
     FilterBackup,
 }
 
-impl BondArpValidate {
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            Self::None => BOND_ARP_VALIDATE_NONE,
-            Self::Active => BOND_ARP_VALIDATE_ACTIVE,
-            Self::Backup => BOND_ARP_VALIDATE_BACKUP,
-            Self::All => BOND_ARP_VALIDATE_ALL,
-            Self::Filter => BOND_ARP_FILTER,
-            Self::FilterActive => BOND_ARP_FILTER_ACTIVE,
-            Self::FilterBackup => BOND_ARP_FILTER_BACKUP,
-        }
+impl std::fmt::Display for BondArpValidate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::None => "none",
+                Self::Active => "active",
+                Self::Backup => "backup",
+                Self::All => "all",
+                Self::Filter => "filter",
+                Self::FilterActive => "filter_active",
+                Self::FilterBackup => "filter_backup",
+            }
+        )
     }
 }
 
@@ -397,13 +425,17 @@ pub enum BondFailOverMac {
     Follow,
 }
 
-impl BondFailOverMac {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::None => 0,
-            Self::Active => 1,
-            Self::Follow => 2,
-        }
+impl std::fmt::Display for BondFailOverMac {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::None => "none",
+                Self::Active => "active",
+                Self::Follow => "follow ",
+            }
+        )
     }
 }
 
@@ -419,13 +451,17 @@ pub enum BondPrimaryReselect {
     Failure,
 }
 
-impl BondPrimaryReselect {
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            Self::Always => 0,
-            Self::Better => 1,
-            Self::Failure => 2,
-        }
+impl std::fmt::Display for BondPrimaryReselect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Always => "always",
+                Self::Better => "better",
+                Self::Failure => "failure",
+            }
+        )
     }
 }
 
@@ -462,6 +498,23 @@ impl BondXmitHashPolicy {
             Self::Encap34 => 4,
             Self::VlanSrcMac => 5,
         }
+    }
+}
+
+impl std::fmt::Display for BondXmitHashPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Layer2 => "layer2",
+                Self::Layer34 => "layer3+4",
+                Self::Layer23 => "layer2+3",
+                Self::Encap23 => "encap2+3",
+                Self::Encap34 => "encap3+4",
+                Self::VlanSrcMac => "vlan+srcmac",
+            }
+        )
     }
 }
 

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -173,6 +173,18 @@ impl BondInterface {
         }
         Ok(())
     }
+
+    pub(crate) fn is_options_reset(&self) -> bool {
+        if let Some(bond_opts) = self
+            .bond
+            .as_ref()
+            .and_then(|bond_conf| bond_conf.options.as_ref())
+        {
+            bond_opts == &BondOptions::default()
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -258,7 +258,9 @@ impl Interfaces {
                 }
             } else {
                 if iface.is_up() {
-                    iface.validate()?;
+                    iface.validate(
+                        current.get_iface(iface.name(), iface.iface_type()),
+                    )?;
                 }
                 match current.kernel_ifaces.get(iface.name()) {
                     Some(cur_iface) => {

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -10,6 +10,7 @@ use crate::{
     ifaces::inter_ifaces_controller::{
         check_overbook_ports, find_unknown_type_port, handle_changed_ports,
         preserve_ctrl_cfg_if_unchanged, set_ifaces_up_priority,
+        set_missing_port_to_eth,
     },
     ip::include_current_ip_address_if_dhcp_on_to_off,
     ErrorKind, Interface, InterfaceState, InterfaceType, NmstateError,
@@ -347,6 +348,22 @@ impl Interfaces {
                 false
             }
         })
+    }
+
+    pub(crate) fn set_unknown_iface_to_eth(&mut self) {
+        for iface in self.kernel_ifaces.values_mut() {
+            if iface.iface_type() == InterfaceType::Unknown {
+                log::warn!(
+                    "Setting unknown type interface {} to ethernet",
+                    iface.name()
+                );
+                iface.base_iface_mut().iface_type = InterfaceType::Ethernet;
+            }
+        }
+    }
+
+    pub(crate) fn set_missing_port_to_eth(&mut self) {
+        set_missing_port_to_eth(self);
     }
 
     pub(crate) fn resolve_unknown_ifaces(

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -4,6 +4,7 @@ mod ieee8021x;
 mod iface;
 mod ifaces;
 mod ip;
+mod lldp;
 mod net_state;
 mod nispor;
 mod nm;
@@ -37,6 +38,13 @@ pub use crate::ifaces::{
     VrfInterface, VxlanConfig, VxlanInterface,
 };
 pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
+pub use crate::lldp::{
+    LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
+    LldpMacPhyConf, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs,
+    LldpNeighborTlv, LldpPortId, LldpPortIdType, LldpPpvids,
+    LldpSystemCapabilities, LldpSystemCapability, LldpSystemDescription,
+    LldpSystemName, LldpVlan, LldpVlans,
+};
 pub use crate::net_state::NetworkState;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 pub use crate::route::{RouteEntry, RouteState, Routes};

--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -1,0 +1,528 @@
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+
+const LLDP_CHASSIS_ID_TYPE: u8 = 1;
+const LLDP_PORT_TYPE: u8 = 2;
+const LLDP_SYSTEM_NAME_TYPE: u8 = 5;
+const LLDP_SYSTEM_DESCRIPTION_TYPE: u8 = 6;
+const LLDP_SYSTEM_CAPABILITIES_TYPE: u8 = 7;
+const LLDP_MANAGEMENT_ADDRESSES_TYPE: u8 = 8;
+const LLDP_ORGANIZATION_SPECIFIC_TYPE: u8 = 127;
+
+const LLDP_CHASSIS_ID_RESERVED: u8 = 0;
+const LLDP_CHASSIS_ID_CHASSIS_COMPONENT: u8 = 1;
+const LLDP_CHASSIS_ID_IFACE_ALIAS: u8 = 2;
+const LLDP_CHASSIS_ID_PORT_COMPONENT: u8 = 3;
+const LLDP_CHASSIS_ID_MAC_ADDR: u8 = 4;
+const LLDP_CHASSIS_ID_NET_ADDR: u8 = 5;
+const LLDP_CHASSIS_ID_IFACE_NAME: u8 = 6;
+const LLDP_CHASSIS_ID_LOCAL: u8 = 7;
+
+const LLDP_PORT_ID_RESERVED: u8 = 0;
+const LLDP_PORT_ID_IFACE_ALIAS: u8 = 1;
+const LLDP_PORT_ID_PORT_COMPONENT: u8 = 2;
+const LLDP_PORT_ID_MAC_ADDR: u8 = 3;
+const LLDP_PORT_ID_NET_ADDR: u8 = 4;
+const LLDP_PORT_ID_IFACE_NAME: u8 = 5;
+const LLDP_PORT_ID_AGENT_CIRCUIT_ID: u8 = 6;
+const LLDP_PORT_ID_LOCAL: u8 = 7;
+
+const LLDP_ORG_OIU_VLAN: &str = "00:80:c2";
+const LLDP_ORG_SUBTYPE_VLAN: u8 = 3;
+
+const LLDP_ORG_OIU_MAC_PHY_CONF: &str = "00:12:0f";
+const LLDP_ORG_SUBTYPE_MAC_PHY_CONF: u8 = 1;
+
+const LLDP_ORG_OIU_PPVIDS: &str = "00:80:c2";
+const LLDP_ORG_SUBTYPE_PPVIDS: u8 = 2;
+
+const LLDP_ORG_OIU_MAX_FRAME_SIZE: &str = "00:12:0f";
+const LLDP_ORG_SUBTYPE_MAX_FRAME_SIZE: u8 = 4;
+
+const LLDP_SYS_CAP_OTHER: u16 = 1;
+const LLDP_SYS_CAP_REPEATER: u16 = 2;
+const LLDP_SYS_CAP_MAC_BRIDGE: u16 = 3;
+const LLDP_SYS_CAP_AP: u16 = 4;
+const LLDP_SYS_CAP_ROUTER: u16 = 5;
+const LLDP_SYS_CAP_TELEPHONE: u16 = 6;
+const LLDP_SYS_CAP_DOCSIS: u16 = 7;
+const LLDP_SYS_CAP_STATION_ONLY: u16 = 8;
+const LLDP_SYS_CAP_CVLAN: u16 = 9;
+const LLDP_SYS_CAP_SVLAN: u16 = 10;
+const LLDP_SYS_CAP_TWO_PORT_MAC_RELAY: u16 = 11;
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct LldpConfig {
+    pub enabled: bool,
+    #[serde(skip_deserializing, skip_serializing_if = "Vec::is_empty")]
+    pub neighbors: Vec<Vec<LldpNeighborTlv>>,
+}
+
+impl LldpConfig {
+    pub(crate) fn pre_verify_cleanup(&mut self) {
+        self.neighbors = Vec::new();
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum LldpNeighborTlv {
+    SystemName(LldpSystemName),
+    SystemDescription(LldpSystemDescription),
+    SystemCapabilities(LldpSystemCapabilities),
+    ChassisId(LldpChassisId),
+    PortId(LldpPortId),
+    Ieee8021Vlans(LldpVlans),
+    Ieee8023MacPhyConf(LldpMacPhyConf),
+    Ieee8021Ppvids(LldpPpvids),
+    ManagementAddresses(LldpMgmtAddrs),
+    Ieee8023MaxFrameSize(LldpMaxFrameSize),
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LldpSystemName(pub String);
+
+impl Serialize for LldpSystemName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_name", 2)?;
+        serial_struct.serialize_field("type", &LLDP_SYSTEM_NAME_TYPE)?;
+        serial_struct.serialize_field("system-name", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct LldpSystemDescription(pub String);
+
+impl Serialize for LldpSystemDescription {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_description", 2)?;
+        serial_struct.serialize_field("type", &LLDP_SYSTEM_DESCRIPTION_TYPE)?;
+        serial_struct.serialize_field("system-description", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpChassisId {
+    pub id: String,
+    pub id_type: LldpChassisIdType,
+}
+
+impl Serialize for LldpChassisId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_chassis_id", 4)?;
+        serial_struct.serialize_field("_description", &self.id_type)?;
+        serial_struct
+            .serialize_field("chassis-id-type", &(self.id_type as u8))?;
+        serial_struct.serialize_field("type", &LLDP_CHASSIS_ID_TYPE)?;
+        serial_struct.serialize_field("chassis-id", &self.id)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum LldpChassisIdType {
+    Reserved,
+    #[serde(rename = "Chassis component")]
+    ChassisComponent,
+    #[serde(rename = "Interface alias")]
+    InterfaceAlias,
+    #[serde(rename = "Port component")]
+    PortComponent,
+    #[serde(rename = "MAC address")]
+    MacAddress,
+    #[serde(rename = "Network address")]
+    NetworkAddress,
+    #[serde(rename = "Interface name")]
+    InterfaceName,
+    #[serde(rename = "Locally assigned")]
+    LocallyAssigned,
+}
+
+impl From<LldpChassisIdType> for u8 {
+    fn from(v: LldpChassisIdType) -> u8 {
+        match v {
+            LldpChassisIdType::Reserved => LLDP_CHASSIS_ID_RESERVED,
+            LldpChassisIdType::ChassisComponent => {
+                LLDP_CHASSIS_ID_CHASSIS_COMPONENT
+            }
+            LldpChassisIdType::InterfaceAlias => LLDP_CHASSIS_ID_IFACE_ALIAS,
+            LldpChassisIdType::PortComponent => LLDP_CHASSIS_ID_PORT_COMPONENT,
+            LldpChassisIdType::MacAddress => LLDP_CHASSIS_ID_MAC_ADDR,
+            LldpChassisIdType::NetworkAddress => LLDP_CHASSIS_ID_NET_ADDR,
+            LldpChassisIdType::InterfaceName => LLDP_CHASSIS_ID_IFACE_NAME,
+            LldpChassisIdType::LocallyAssigned => LLDP_CHASSIS_ID_LOCAL,
+        }
+    }
+}
+
+impl From<u8> for LldpChassisIdType {
+    fn from(i: u8) -> Self {
+        match i {
+            LLDP_CHASSIS_ID_CHASSIS_COMPONENT => Self::ChassisComponent,
+            LLDP_CHASSIS_ID_IFACE_ALIAS => Self::InterfaceAlias,
+            LLDP_CHASSIS_ID_PORT_COMPONENT => Self::PortComponent,
+            LLDP_CHASSIS_ID_MAC_ADDR => Self::MacAddress,
+            LLDP_CHASSIS_ID_NET_ADDR => Self::NetworkAddress,
+            LLDP_CHASSIS_ID_IFACE_NAME => Self::InterfaceName,
+            LLDP_CHASSIS_ID_LOCAL => Self::LocallyAssigned,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+impl Default for LldpChassisIdType {
+    fn default() -> Self {
+        Self::Reserved
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpSystemCapabilities(pub u16);
+
+impl Serialize for LldpSystemCapabilities {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_system_capabilities", 2)?;
+        serial_struct
+            .serialize_field("type", &LLDP_SYSTEM_CAPABILITIES_TYPE)?;
+        serial_struct
+            .serialize_field("system-capabilities", &parse_sys_caps(self.0))?;
+        serial_struct.end()
+    }
+}
+
+fn parse_sys_caps(caps: u16) -> Vec<LldpSystemCapability> {
+    let mut ret = Vec::new();
+    if (caps & 1 << (LLDP_SYS_CAP_OTHER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Other);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_REPEATER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Repeater);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_MAC_BRIDGE - 1)) > 0 {
+        ret.push(LldpSystemCapability::MacBridgeComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_AP - 1)) > 0 {
+        ret.push(LldpSystemCapability::AccessPoint);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_ROUTER - 1)) > 0 {
+        ret.push(LldpSystemCapability::Router);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_TELEPHONE - 1)) > 0 {
+        ret.push(LldpSystemCapability::Telephone);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_DOCSIS - 1)) > 0 {
+        ret.push(LldpSystemCapability::DocsisCableDevice);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_STATION_ONLY - 1)) > 0 {
+        ret.push(LldpSystemCapability::StationOnly);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_CVLAN - 1)) > 0 {
+        ret.push(LldpSystemCapability::CVlanComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_SVLAN - 1)) > 0 {
+        ret.push(LldpSystemCapability::SVlanComponent);
+    }
+    if (caps & 1 << (LLDP_SYS_CAP_TWO_PORT_MAC_RELAY - 1)) > 0 {
+        ret.push(LldpSystemCapability::TwoPortMacRelayComponent);
+    }
+    ret
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum LldpSystemCapability {
+    Other,
+    Repeater,
+    #[serde(rename = "MAC Bridge component")]
+    MacBridgeComponent,
+    #[serde(rename = "802.11 Access Point (AP)")]
+    AccessPoint,
+    Router,
+    Telephone,
+    #[serde(rename = "DOCSIS cable device")]
+    DocsisCableDevice,
+    #[serde(rename = "Station Only")]
+    StationOnly,
+    #[serde(rename = "C-VLAN component")]
+    CVlanComponent,
+    #[serde(rename = "S-VLAN component")]
+    SVlanComponent,
+    #[serde(rename = "Two-port MAC Relay component")]
+    TwoPortMacRelayComponent,
+}
+
+impl Default for LldpSystemCapability {
+    fn default() -> Self {
+        Self::Other
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpPortId {
+    pub id: String,
+    pub id_type: LldpPortIdType,
+}
+
+impl Serialize for LldpPortId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_port_id", 4)?;
+        serial_struct.serialize_field("_description", &self.id_type)?;
+        serial_struct.serialize_field("port-id-type", &(self.id_type as u8))?;
+        serial_struct.serialize_field("type", &LLDP_PORT_TYPE)?;
+        serial_struct.serialize_field("port-id", &self.id)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub enum LldpPortIdType {
+    Reserved,
+    #[serde(rename = "Interface alias")]
+    InterfaceAlias,
+    #[serde(rename = "Port component")]
+    PortComponent,
+    #[serde(rename = "MAC address")]
+    MacAddress,
+    #[serde(rename = "Network address")]
+    NetworkAddress,
+    #[serde(rename = "Interface name")]
+    InterfaceName,
+    #[serde(rename = "Agent circuit ID")]
+    AgentCircuitId,
+    #[serde(rename = "Locally assigned")]
+    LocallyAssigned,
+}
+
+impl Default for LldpPortIdType {
+    fn default() -> Self {
+        Self::Reserved
+    }
+}
+
+impl From<LldpPortIdType> for u8 {
+    fn from(v: LldpPortIdType) -> u8 {
+        match v {
+            LldpPortIdType::Reserved => LLDP_PORT_ID_RESERVED,
+            LldpPortIdType::InterfaceAlias => LLDP_PORT_ID_IFACE_ALIAS,
+            LldpPortIdType::PortComponent => LLDP_PORT_ID_PORT_COMPONENT,
+            LldpPortIdType::MacAddress => LLDP_PORT_ID_MAC_ADDR,
+            LldpPortIdType::NetworkAddress => LLDP_PORT_ID_NET_ADDR,
+            LldpPortIdType::InterfaceName => LLDP_PORT_ID_IFACE_NAME,
+            LldpPortIdType::AgentCircuitId => LLDP_PORT_ID_AGENT_CIRCUIT_ID,
+            LldpPortIdType::LocallyAssigned => LLDP_PORT_ID_LOCAL,
+        }
+    }
+}
+
+impl From<u8> for LldpPortIdType {
+    fn from(v: u8) -> Self {
+        match v {
+            LLDP_PORT_ID_IFACE_ALIAS => Self::InterfaceAlias,
+            LLDP_PORT_ID_PORT_COMPONENT => Self::PortComponent,
+            LLDP_PORT_ID_MAC_ADDR => Self::MacAddress,
+            LLDP_PORT_ID_NET_ADDR => Self::NetworkAddress,
+            LLDP_PORT_ID_IFACE_NAME => Self::InterfaceName,
+            LLDP_PORT_ID_AGENT_CIRCUIT_ID => Self::AgentCircuitId,
+            LLDP_PORT_ID_LOCAL => Self::LocallyAssigned,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpVlans(pub Vec<LldpVlan>);
+
+impl Serialize for LldpVlans {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct = serializer.serialize_struct("lldp_vlans", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-1-vlans", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_VLAN)?;
+        serial_struct.serialize_field("subtype", &LLDP_ORG_SUBTYPE_VLAN)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[non_exhaustive]
+pub struct LldpVlan {
+    pub name: String,
+    pub vid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMacPhyConf {
+    pub autoneg: bool,
+    pub operational_mau_type: u16,
+    pub pmd_autoneg_cap: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+struct _LldpMacPhyConf {
+    autoneg: bool,
+    operational_mau_type: u16,
+    pmd_autoneg_cap: u16,
+}
+
+impl From<&LldpMacPhyConf> for _LldpMacPhyConf {
+    fn from(conf: &LldpMacPhyConf) -> Self {
+        Self {
+            autoneg: conf.autoneg,
+            operational_mau_type: conf.operational_mau_type,
+            pmd_autoneg_cap: conf.pmd_autoneg_cap,
+        }
+    }
+}
+
+impl Serialize for LldpMacPhyConf {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_mac_phy_conf", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field(
+            "ieee-802-3-mac-phy-conf",
+            &_LldpMacPhyConf::from(self),
+        )?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_MAC_PHY_CONF)?;
+        serial_struct
+            .serialize_field("subtype", &LLDP_ORG_SUBTYPE_MAC_PHY_CONF)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpPpvids(pub Vec<u32>);
+impl Serialize for LldpPpvids {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_ppvids", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-1-ppvids", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_PPVIDS)?;
+        serial_struct.serialize_field("subtype", &LLDP_ORG_SUBTYPE_PPVIDS)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMgmtAddrs(pub Vec<LldpMgmtAddr>);
+impl Serialize for LldpMgmtAddrs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_mgmt_addrs", 2)?;
+        serial_struct
+            .serialize_field("type", &LLDP_MANAGEMENT_ADDRESSES_TYPE)?;
+        serial_struct.serialize_field("management-addresses", &self.0)?;
+        serial_struct.end()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub struct LldpMgmtAddr {
+    pub address: String,
+    pub address_subtype: LldpAddressFamily,
+    pub interface_number: u32,
+    pub interface_number_subtype: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum LldpAddressFamily {
+    Unknown,
+    #[serde(rename = "IPv4")]
+    Ipv4,
+    #[serde(rename = "IPv6")]
+    Ipv6,
+    #[serde(rename = "MAC")]
+    Mac,
+}
+
+impl Default for LldpAddressFamily {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+const ADDRESS_FAMILY_IP4: u16 = 1;
+const ADDRESS_FAMILY_IP6: u16 = 2;
+const ADDRESS_FAMILY_MAC: u16 = 6;
+
+impl From<u16> for LldpAddressFamily {
+    fn from(i: u16) -> Self {
+        match i {
+            ADDRESS_FAMILY_IP4 => Self::Ipv4,
+            ADDRESS_FAMILY_IP6 => Self::Ipv6,
+            ADDRESS_FAMILY_MAC => Self::Mac,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct LldpMaxFrameSize(pub u32);
+impl Serialize for LldpMaxFrameSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serial_struct =
+            serializer.serialize_struct("lldp_max_frame_size", 4)?;
+        serial_struct
+            .serialize_field("type", &LLDP_ORGANIZATION_SPECIFIC_TYPE)?;
+        serial_struct.serialize_field("ieee-802-3-max-frame-size", &self.0)?;
+        serial_struct.serialize_field("oui", LLDP_ORG_OIU_MAX_FRAME_SIZE)?;
+        serial_struct
+            .serialize_field("subtype", &LLDP_ORG_SUBTYPE_MAX_FRAME_SIZE)?;
+        serial_struct.end()
+    }
+}

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -313,7 +313,11 @@ impl NetworkState {
         &self,
     ) -> Result<HashMap<String, Vec<String>>, NmstateError> {
         let mut ret = HashMap::new();
-        let (add_net_state, _, _) = self.gen_state_for_apply(&Self::new())?;
+        let mut self_clone = self.clone();
+        self_clone.interfaces.set_unknown_iface_to_eth();
+        self_clone.interfaces.set_missing_port_to_eth();
+        let (add_net_state, _, _) =
+            self_clone.gen_state_for_apply(&Self::new())?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&add_net_state)?);
         Ok(ret)
     }

--- a/rust/src/lib/nm/bond.rs
+++ b/rust/src/lib/nm/bond.rs
@@ -53,7 +53,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.ad_select.as_ref() {
         nm_bond_set
             .options
-            .insert("ad_select".to_string(), v.to_u8().to_string());
+            .insert("ad_select".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.ad_user_port_key.as_ref() {
         nm_bond_set
@@ -63,12 +63,12 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.all_slaves_active.as_ref() {
         nm_bond_set
             .options
-            .insert("all_slaves_active".to_string(), v.to_u8().to_string());
+            .insert("all_slaves_active".to_string(), u8::from(*v).to_string());
     }
     if let Some(v) = bond_opts.arp_all_targets.as_ref() {
         nm_bond_set
             .options
-            .insert("arp_all_targets".to_string(), v.to_u32().to_string());
+            .insert("arp_all_targets".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.arp_interval.as_ref() {
         nm_bond_set
@@ -83,7 +83,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.arp_validate.as_ref() {
         nm_bond_set
             .options
-            .insert("arp_validate".to_string(), v.to_u32().to_string());
+            .insert("arp_validate".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.downdelay.as_ref() {
         nm_bond_set
@@ -93,12 +93,12 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.fail_over_mac.as_ref() {
         nm_bond_set
             .options
-            .insert("fail_over_mac".to_string(), v.to_u8().to_string());
+            .insert("fail_over_mac".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.lacp_rate.as_ref() {
         nm_bond_set
             .options
-            .insert("lacp_rate".to_string(), v.to_u8().to_string());
+            .insert("lacp_rate".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.lp_interval.as_ref() {
         nm_bond_set
@@ -136,7 +136,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.primary_reselect.as_ref() {
         nm_bond_set
             .options
-            .insert("primary_reselect".to_string(), v.to_u8().to_string());
+            .insert("primary_reselect".to_string(), v.to_string());
     }
     if let Some(v) = bond_opts.resend_igmp.as_ref() {
         nm_bond_set
@@ -163,7 +163,7 @@ fn apply_bond_options(
     if let Some(v) = bond_opts.xmit_hash_policy.as_ref() {
         nm_bond_set
             .options
-            .insert("xmit_hash_policy".to_string(), v.to_u8().to_string());
+            .insert("xmit_hash_policy".to_string(), v.to_string());
     }
 
     // Remove all empty string option

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -85,7 +85,6 @@ pub(crate) fn iface_to_nm_connections(
         &base_iface.iface_type,
         nm_ac_uuids,
     );
-
     let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
 
     gen_nm_conn_setting(iface, &mut nm_conn)?;

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -189,18 +189,26 @@ pub(crate) fn iface_type_to_nm(
     iface_type: &InterfaceType,
 ) -> Result<String, NmstateError> {
     match iface_type {
-        InterfaceType::LinuxBridge => Ok("bridge".into()),
-        InterfaceType::Bond => Ok("bond".into()),
-        InterfaceType::Ethernet => Ok("802-3-ethernet".into()),
-        InterfaceType::OvsBridge => Ok("ovs-bridge".into()),
-        InterfaceType::OvsInterface => Ok("ovs-interface".into()),
-        InterfaceType::Vlan => Ok("vlan".to_string()),
-        InterfaceType::Vxlan => Ok("vxlan".to_string()),
-        InterfaceType::Dummy => Ok("dummy".to_string()),
-        InterfaceType::MacVlan => Ok("macvlan".to_string()),
-        InterfaceType::MacVtap => Ok("macvlan".to_string()),
-        InterfaceType::Vrf => Ok("vrf".to_string()),
-        InterfaceType::Veth => Ok("veth".to_string()),
+        InterfaceType::LinuxBridge => Ok(NM_SETTING_BRIDGE_SETTING_NAME.into()),
+        InterfaceType::Bond => Ok(NM_SETTING_BOND_SETTING_NAME.into()),
+        InterfaceType::Ethernet => Ok(NM_SETTING_WIRED_SETTING_NAME.into()),
+        InterfaceType::OvsBridge => {
+            Ok(NM_SETTING_OVS_BRIDGE_SETTING_NAME.into())
+        }
+        InterfaceType::OvsInterface => {
+            Ok(NM_SETTING_OVS_IFACE_SETTING_NAME.into())
+        }
+        InterfaceType::Vlan => Ok(NM_SETTING_VLAN_SETTING_NAME.to_string()),
+        InterfaceType::Vxlan => Ok(NM_SETTING_VXLAN_SETTING_NAME.to_string()),
+        InterfaceType::Dummy => Ok(NM_SETTING_DUMMY_SETTING_NAME.to_string()),
+        InterfaceType::MacVlan => {
+            Ok(NM_SETTING_MACVLAN_SETTING_NAME.to_string())
+        }
+        InterfaceType::MacVtap => {
+            Ok(NM_SETTING_MACVLAN_SETTING_NAME.to_string())
+        }
+        InterfaceType::Vrf => Ok(NM_SETTING_VRF_SETTING_NAME.to_string()),
+        InterfaceType::Veth => Ok(NM_SETTING_VETH_SETTING_NAME.to_string()),
         InterfaceType::Other(s) => Ok(s.to_string()),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -383,6 +383,9 @@ pub(crate) fn gen_nm_conn_setting(
             };
         }
     }
+    if let Some(lldp_conf) = iface.base_iface().lldp.as_ref() {
+        nm_conn_set.lldp = Some(lldp_conf.enabled);
+    }
     nm_conn.connection = Some(nm_conn_set);
     Ok(())
 }

--- a/rust/src/lib/nm/lldp.rs
+++ b/rust/src/lib/nm/lldp.rs
@@ -1,0 +1,260 @@
+use std::convert::TryFrom;
+
+use nm_dbus::{NmConnection, NmLldpNeighbor, NmLldpNeighbor8021Vlan};
+
+use crate::{
+    LldpAddressFamily, LldpChassisId, LldpConfig, LldpMacPhyConf,
+    LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs, LldpNeighborTlv, LldpPortId,
+    LldpPpvids, LldpSystemCapabilities, LldpSystemDescription, LldpSystemName,
+    LldpVlan, LldpVlans,
+};
+
+pub(crate) fn is_lldp_enabled(nm_conn: &NmConnection) -> bool {
+    nm_conn.connection.as_ref().and_then(|s| s.lldp) == Some(true)
+}
+
+pub(crate) fn get_lldp(nm_infos: Vec<NmLldpNeighbor>) -> LldpConfig {
+    let mut neighbors = Vec::new();
+    for nm_info in nm_infos {
+        let tlvs = nm_neighbor_to_nmstate(&nm_info);
+        if !tlvs.is_empty() {
+            neighbors.push(tlvs);
+        }
+    }
+    LldpConfig {
+        enabled: true,
+        neighbors,
+    }
+}
+
+fn nm_neighbor_to_nmstate(nm_info: &NmLldpNeighbor) -> Vec<LldpNeighborTlv> {
+    let mut ret = Vec::new();
+
+    if let Some(c) = get_sys_name(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_sys_description(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_sys_caps(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_chassis_id(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_port_id(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_vlans(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_mac_phy_conf(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_ppvids(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_mgmt_addrs(nm_info) {
+        ret.push(c)
+    }
+    if let Some(c) = get_max_frame_size(nm_info) {
+        ret.push(c)
+    }
+
+    ret
+}
+
+impl From<&[NmLldpNeighbor8021Vlan]> for LldpVlans {
+    fn from(nm_vlans: &[NmLldpNeighbor8021Vlan]) -> Self {
+        let mut vlans = Vec::new();
+        for nm_vlan in nm_vlans {
+            if let (Some(vid), Some(name)) = (nm_vlan.vid, &nm_vlan.name) {
+                vlans.push(LldpVlan {
+                    vid,
+                    name: name.to_string(),
+                });
+            }
+        }
+
+        LldpVlans(vlans)
+    }
+}
+
+fn u8_addr_to_mac_string(data: &[u8]) -> String {
+    let mut addr = String::new();
+    for (i, &val) in data.iter().enumerate() {
+        addr.push_str(&format!("{:02X}", val));
+        if i != data.len() - 1 {
+            addr.push(':');
+        }
+    }
+    addr
+}
+
+fn get_chassis_id(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let (Some(id_type), Some(id)) =
+        (nm_info.chassis_id_type, nm_info.chassis_id.as_deref())
+    {
+        if let Ok(id_type) = u8::try_from(id_type) {
+            let chassis_id = LldpChassisId {
+                id: id.to_string(),
+                id_type: id_type.into(),
+            };
+            return Some(LldpNeighborTlv::ChassisId(chassis_id));
+        } else {
+            log::warn!(
+                "Got unsupported chassis_id_type {}, expecting u8",
+                id_type
+            );
+        }
+    }
+    None
+}
+
+fn get_port_id(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let (Some(id_type), Some(id)) =
+        (nm_info.port_id_type, nm_info.port_id.as_deref())
+    {
+        if let Ok(id_type) = u8::try_from(id_type) {
+            let port_id = LldpPortId {
+                id: id.to_string(),
+                id_type: id_type.into(),
+            };
+            return Some(LldpNeighborTlv::PortId(port_id));
+        } else {
+            log::warn!(
+                "Got unsupported port_id_type {}, expecting u8",
+                id_type
+            );
+        }
+    }
+    None
+}
+
+fn get_sys_caps(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_capabilities {
+        if let Ok(caps) = u16::try_from(s) {
+            return Some(LldpNeighborTlv::SystemCapabilities(
+                LldpSystemCapabilities(caps),
+            ));
+        }
+    }
+    None
+}
+
+fn get_sys_name(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_name.as_deref() {
+        return Some(LldpNeighborTlv::SystemName(LldpSystemName(
+            s.to_string(),
+        )));
+    }
+    None
+}
+
+fn get_sys_description(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.system_description.as_deref() {
+        return Some(LldpNeighborTlv::SystemDescription(
+            LldpSystemDescription(s.to_string()),
+        ));
+    }
+    None
+}
+
+fn get_vlans(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_vlans) = nm_info.ieee_802_1_vlans.as_deref() {
+        return Some(LldpNeighborTlv::Ieee8021Vlans(nm_vlans.into()));
+    }
+    None
+}
+
+fn get_mac_phy_conf(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_conf) = nm_info.ieee_802_3_mac_phy_conf.as_ref() {
+        if let (Some(a), Some(p), Some(o)) = (
+            nm_conf.autoneg,
+            nm_conf.pmd_autoneg_cap,
+            nm_conf.operational_mau_type,
+        ) {
+            if let (Ok(o), Ok(p)) = (u16::try_from(o), u16::try_from(p)) {
+                let conf = LldpMacPhyConf {
+                    autoneg: a > 0,
+                    operational_mau_type: o,
+                    pmd_autoneg_cap: p,
+                };
+                return Some(LldpNeighborTlv::Ieee8023MacPhyConf(conf));
+            }
+        }
+    }
+    None
+}
+
+fn get_ppvids(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_ppvids) = nm_info.ieee_802_1_ppvids.as_ref() {
+        let mut ppvids = Vec::new();
+        for nm_ppvid in nm_ppvids {
+            if let Some(p) = nm_ppvid.ppvid {
+                ppvids.push(p);
+            }
+        }
+        return Some(LldpNeighborTlv::Ieee8021Ppvids(LldpPpvids(ppvids)));
+    }
+    None
+}
+
+fn get_mgmt_addrs(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(nm_mgmt_addrs) = nm_info.management_addresses.as_deref() {
+        let mut addrs = Vec::new();
+        for nm_mgmt_addr in nm_mgmt_addrs {
+            if let (Some(at), Some(a), Some(it), Some(i)) = (
+                nm_mgmt_addr.address_subtype,
+                nm_mgmt_addr.address.as_ref(),
+                nm_mgmt_addr.interface_number_subtype,
+                nm_mgmt_addr.interface_number,
+            ) {
+                if let Ok(at) = u16::try_from(at) {
+                    let mut mgmt_addr = LldpMgmtAddr::default();
+                    let at = LldpAddressFamily::from(at);
+                    let addr = match at {
+                        LldpAddressFamily::Ipv4 => {
+                            if a.len() != 4 {
+                                continue;
+                            }
+                            std::net::Ipv4Addr::new(a[0], a[1], a[2], a[3])
+                                .to_string()
+                        }
+                        LldpAddressFamily::Ipv6 => {
+                            if a.len() != 16 {
+                                continue;
+                            }
+                            let mut buff = [0u8; 16];
+                            buff.copy_from_slice(&a[..16]);
+                            std::net::Ipv6Addr::from(buff).to_string()
+                        }
+                        LldpAddressFamily::Mac => u8_addr_to_mac_string(a),
+                        _ => {
+                            continue;
+                        }
+                    };
+
+                    mgmt_addr.address_subtype = at;
+                    mgmt_addr.address = addr;
+                    mgmt_addr.interface_number_subtype = it;
+                    mgmt_addr.interface_number = i;
+                    addrs.push(mgmt_addr);
+                }
+            }
+        }
+        return Some(LldpNeighborTlv::ManagementAddresses(LldpMgmtAddrs(
+            addrs,
+        )));
+    }
+    None
+}
+
+fn get_max_frame_size(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
+    if let Some(s) = nm_info.ieee_802_3_max_frame_size {
+        return Some(LldpNeighborTlv::Ieee8023MaxFrameSize(LldpMaxFrameSize(
+            s,
+        )));
+    }
+    None
+}

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -9,6 +9,7 @@ mod dns;
 mod error;
 mod ieee8021x;
 mod ip;
+mod lldp;
 mod mac_vlan;
 mod ovs;
 mod profile;

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -103,6 +103,7 @@ pub(crate) fn save_nm_profiles(
     nm_api: &nm_dbus::NmApi,
     nm_conns: &[NmConnection],
     checkpoint: &str,
+    memory_only: bool,
 ) -> Result<(), NmstateError> {
     for (index, nm_conn) in nm_conns.iter().enumerate() {
         // Only extend the timeout every
@@ -117,7 +118,7 @@ pub(crate) fn save_nm_profiles(
         }
         info!("Creating/Modifying connection {:?}", nm_conn);
         nm_api
-            .connection_add(nm_conn)
+            .connection_add(nm_conn, memory_only)
             .map_err(nm_error_to_nmstate)?;
     }
     Ok(())

--- a/rust/src/lib/nm/version.rs
+++ b/rust/src/lib/nm/version.rs
@@ -6,7 +6,8 @@ pub(crate) fn nm_version() -> Result<String, NmstateError> {
     nm_api.version().map_err(nm_error_to_nmstate)
 }
 
-// This helper function will help us to avoid introducing new dependencies to the project.
+// This helper function will help us to avoid introducing new dependencies to
+// the project.
 pub(crate) fn nm_supports_accept_all_mac_addresses_mode(
 ) -> Result<bool, NmstateError> {
     let version = nm_version()?;

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -10,7 +10,8 @@ pub struct OvsDbGlobalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     // When the value been set as None, specified key will be removed instead
     // of merging.
-    // To remove all settings of external_ids or other_config, use empty HashMap
+    // To remove all settings of external_ids or other_config, use empty
+    // HashMap
     pub external_ids: Option<HashMap<String, Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub other_config: Option<HashMap<String, Option<String>>>,

--- a/rust/src/lib/state.rs
+++ b/rust/src/lib/state.rs
@@ -2,7 +2,7 @@ use serde_json::Value;
 
 use crate::NetworkState;
 
-pub(crate) fn get_json_value_difference<'a, 'b>(
+fn _get_json_value_difference<'a, 'b>(
     reference: String,
     desire: &'a Value,
     current: &'b Value,
@@ -70,5 +70,39 @@ pub(crate) fn get_json_value_difference<'a, 'b>(
         }
         (Value::Null, _) => None,
         (_, _) => Some((reference, desire, current)),
+    }
+}
+
+pub(crate) fn get_json_value_difference<'a, 'b>(
+    reference: String,
+    desire: &'a Value,
+    current: &'b Value,
+) -> Option<(String, &'a Value, &'b Value)> {
+    if let Some((reference, desire, current)) =
+        _get_json_value_difference(reference, desire, current)
+    {
+        if should_ignore(reference.as_str(), desire, current) {
+            None
+        } else {
+            Some((reference, desire, current))
+        }
+    } else {
+        None
+    }
+}
+
+fn should_ignore(reference: &str, desire: &Value, current: &Value) -> bool {
+    if reference.contains("interface.link-aggregation.options") {
+        // Per oVirt request, bond option difference should not
+        // fail verification.
+        log::warn!(
+            "Bond option miss-match: {} desire '{}', current '{}'",
+            reference,
+            desire,
+            current
+        );
+        true
+    } else {
+        false
     }
 }

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -1,0 +1,188 @@
+use crate::{BondInterface, ErrorKind, Interface};
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_undefined() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(None).unwrap();
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_for_exist_bond() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(Some(&current_iface));
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_changing_mode() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: 802.3ad
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(Some(&current_iface)).unwrap();
+}
+
+#[test]
+fn test_bond_validate_mac_restricted_with_mac_defined_changing_opt() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+mac-address: 00:01:02:03:04:05
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: follow
+"#,
+    )
+    .unwrap();
+    let current_iface: Interface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: active-backup
+  options:
+    fail_over_mac: active
+"#,
+    )
+    .unwrap();
+    iface.validate(Some(&current_iface)).unwrap();
+}
+
+#[test]
+fn test_bond_validate_bond_mode_not_defined_for_new_iface() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_ad_actor_system_mac_address() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: 802.3ad
+  options:
+    ad_actor_system: "01:00:5E:00:0f:01"
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_validate_miimon_and_arp_interval() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: 802.3ad
+  options:
+    miimon: 100
+    arp_interval: 60
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(None);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -18,7 +18,8 @@ fn test_resolve_unknown_type_absent_eth() {
     ifaces.push(absent_iface);
 
     ifaces.resolve_unknown_ifaces(&cur_ifaces).unwrap();
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     let del_ifaces = del_ifaces.to_vec();
 
@@ -40,7 +41,8 @@ fn test_resolve_unknown_type_absent_multiple() {
     let mut ifaces = Interfaces::new();
     ifaces.push(absent_iface);
 
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     let del_ifaces = del_ifaces.to_vec();
 
@@ -63,7 +65,8 @@ fn test_mark_orphan_vlan_as_absent() {
     eth0.base_iface_mut().state = InterfaceState::Absent;
     desired.push(eth0);
 
-    let (_, _, del_ifaces) = desired.gen_state_for_apply(&current).unwrap();
+    let (_, _, del_ifaces) =
+        desired.gen_state_for_apply(&current, false).unwrap();
     assert_eq!(del_ifaces.to_vec().len(), 2);
     assert!(del_ifaces.kernel_ifaces["eth0"].is_absent());
     assert!(del_ifaces.kernel_ifaces["eth0.10"].is_absent());
@@ -83,7 +86,7 @@ fn test_check_orphan_vlan_change_parent() {
     desired.push(new_eth_iface("eth1"));
 
     let (_, chg_ifaces, del_ifaces) =
-        desired.gen_state_for_apply(&current).unwrap();
+        desired.gen_state_for_apply(&current, false).unwrap();
     assert_eq!(del_ifaces.to_vec().len(), 1);
     assert!(del_ifaces.kernel_ifaces["eth0"].is_absent());
     assert!(!chg_ifaces.kernel_ifaces["eth0.10"].is_absent());

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -14,8 +14,9 @@ fn test_ifaces_up_order_no_ctrler_reserse_order() {
     ifaces.push(new_eth_iface("eth2"));
     ifaces.push(new_eth_iface("eth1"));
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["eth1"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["eth2"].base_iface().up_priority, 0);
@@ -39,8 +40,9 @@ fn test_ifaces_up_order_nested_4_depth_worst_case() {
     ifaces.push(br1);
     ifaces.push(br0);
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["br1"].base_iface().up_priority, 1);
@@ -79,7 +81,7 @@ fn test_ifaces_up_order_nested_5_depth_worst_case() {
     ifaces.push(br0);
     ifaces.push(br4);
 
-    let result = ifaces.gen_state_for_apply(&Interfaces::new());
+    let result = ifaces.gen_state_for_apply(&Interfaces::new(), false);
     assert!(result.is_err());
 
     if let Err(e) = result {
@@ -106,8 +108,9 @@ fn test_ifaces_up_order_nested_5_depth_good_case() {
     ifaces.push(p2);
     ifaces.push(p1);
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     assert_eq!(ifaces.kernel_ifaces["br4"].base_iface().up_priority, 0);
     assert_eq!(ifaces.kernel_ifaces["br0"].base_iface().up_priority, 1);
@@ -133,8 +136,9 @@ fn test_auto_include_ovs_interface() {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
 
-    let (add_ifaces, _, _) =
-        ifaces.gen_state_for_apply(&Interfaces::new()).unwrap();
+    let (add_ifaces, _, _) = ifaces
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
 
     println!("{:?}", ifaces);
 
@@ -193,7 +197,8 @@ fn test_auto_absent_ovs_interface() {
     let mut ifaces = Interfaces::new();
     ifaces.push(Interface::OvsBridge(absent_br0));
 
-    let (_, _, del_ifaces) = ifaces.gen_state_for_apply(&cur_ifaces).unwrap();
+    let (_, _, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
 
     println!("{:?}", ifaces);
 

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod bond;
+#[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use serde::Deserialize;
+use zvariant::Value;
 
 use crate::{connection::DbusDictionary, NmError};
 
@@ -37,9 +38,18 @@ impl NmSettingBond {
         Self::default()
     }
 
-    pub(crate) fn to_value(
+    pub(crate) fn to_keyfile(
         &self,
-    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        ret.insert("mode".to_string(), Value::new(self.mode.as_str()));
+        for (key, value) in self.options.iter() {
+            ret.insert(key.to_string(), Value::new(value));
+        }
+        Ok(ret)
+    }
+
+    pub(crate) fn to_value(&self) -> Result<HashMap<&str, Value>, NmError> {
         let mut merged_opts = self.options.clone();
         let mut ret = HashMap::new();
 
@@ -61,7 +71,7 @@ impl NmSettingBond {
         }
 
         if !merged_opts.is_empty() {
-            ret.insert("options", zvariant::Value::from(merged_opts.clone()));
+            ret.insert("options", Value::from(merged_opts.clone()));
         }
         Ok(ret)
     }

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -10,25 +10,21 @@ use crate::{connection::DbusDictionary, NmError};
 #[serde(try_from = "DbusDictionary")]
 #[non_exhaustive]
 pub struct NmSettingBond {
-    pub mode: String,
     pub options: HashMap<String, String>,
-    _other: HashMap<String, String>,
+    _other: HashMap<String, zvariant::OwnedValue>,
 }
 
 impl TryFrom<DbusDictionary> for NmSettingBond {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
-        let mut options = HashMap::<String, String>::new();
-        let mut other = HashMap::<String, String>::new();
-
-        if let Some(value) = _from_map!(v, "options", HashMap::try_from)? {
-            options = value.clone();
-            other = value;
-        }
         Ok(Self {
-            mode: String::new(),
-            options,
-            _other: other,
+            options: _from_map!(
+                v,
+                "options",
+                <HashMap<String, String>>::try_from
+            )?
+            .unwrap_or_default(),
+            _other: v,
         })
     }
 }
@@ -38,49 +34,24 @@ impl NmSettingBond {
         Self::default()
     }
 
+    pub(crate) fn to_value(
+        &self,
+    ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        ret.insert("options", zvariant::Value::from(self.options.clone()));
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+
     pub(crate) fn to_keyfile(
         &self,
     ) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
-        ret.insert("mode".to_string(), Value::new(self.mode.as_str()));
         for (key, value) in self.options.iter() {
             ret.insert(key.to_string(), Value::new(value));
         }
         Ok(ret)
-    }
-
-    pub(crate) fn to_value(&self) -> Result<HashMap<&str, Value>, NmError> {
-        let mut merged_opts = self.options.clone();
-        let mut ret = HashMap::new();
-
-        // Do not merge existing options if the user specified empty options
-        merged_opts.extend(
-            self._other
-                .iter()
-                .filter(|(k, _)| !self.options.contains_key(*k))
-                .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-        if let Some(arp_ip_target) = self.options.get("arp_ip_target") {
-            if arp_ip_target.is_empty() {
-                merged_opts.remove("arp_ip_target");
-            }
-        }
-
-        if !self.mode.is_empty() {
-            merged_opts.insert("mode".to_string(), self.mode.clone());
-        }
-
-        if !merged_opts.is_empty() {
-            ret.insert("options", Value::from(merged_opts.clone()));
-        }
-        Ok(ret)
-    }
-
-    pub fn clear_existing_opts(&mut self) {
-        self._other.clear();
-    }
-
-    pub fn get_current_mode(&self) -> Option<&String> {
-        self._other.get(&String::from("mode"))
     }
 }

--- a/rust/src/libnm_dbus/connection/conn.rs
+++ b/rust/src/libnm_dbus/connection/conn.rs
@@ -320,6 +320,7 @@ pub struct NmSettingConnection {
     pub controller_type: Option<String>,
     pub autoconnect: Option<bool>,
     pub autoconnect_ports: Option<bool>,
+    pub lldp: Option<bool>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -338,6 +339,7 @@ impl TryFrom<DbusDictionary> for NmSettingConnection {
             autoconnect_ports: NmSettingConnection::i32_to_autoconnect_ports(
                 _from_map!(v, "autoconnect-slaves", i32::try_from)?,
             ),
+            lldp: _from_map!(v, "lldp", i32::try_from)?.map(|i| i == 1),
             _other: v,
         })
     }
@@ -392,6 +394,9 @@ impl NmSettingConnection {
         }
         if let Some(v) = &self.controller_type {
             ret.insert("slave-type", zvariant::Value::new(v.as_str()));
+        }
+        if let Some(v) = &self.lldp {
+            ret.insert("lldp", zvariant::Value::new(v));
         }
 
         ret.insert(

--- a/rust/src/libnm_dbus/connection/ieee8021x.rs
+++ b/rust/src/libnm_dbus/connection/ieee8021x.rs
@@ -64,6 +64,59 @@ impl NmSetting8021X {
         Ok(ret)
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.identity {
+            ret.insert("identity".to_string(), zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.private_key {
+            ret.insert(
+                "private-key".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.eap {
+            // Need NULL append at the end
+            let mut new_eaps = v.clone();
+            new_eaps.push("".to_string());
+            ret.insert("eap".to_string(), zvariant::Value::new(new_eaps));
+        }
+        if let Some(v) = &self.client_cert {
+            ret.insert(
+                "client-cert".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.ca_cert {
+            println!("HAHA {:?}", Self::glib_bytes_to_file_path(v));
+            ret.insert(
+                "ca-cert".to_string(),
+                if let Ok(path) = Self::glib_bytes_to_file_path(v) {
+                    zvariant::Value::new(path)
+                } else {
+                    zvariant::Value::new(v)
+                },
+            );
+        }
+        if let Some(v) = &self.private_key_password {
+            ret.insert(
+                "private-key-password".to_string(),
+                zvariant::Value::new(v),
+            );
+        }
+        Ok(ret)
+    }
+
     pub fn new() -> Self {
         Self::default()
     }

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -166,6 +166,38 @@ impl NmSettingIp {
         Self::default()
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if !vec!["address-data", "route-data", "dns"].contains(&k) {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        for (i, addr) in self.addresses.as_slice().iter().enumerate() {
+            ret.insert(format!("address{}", i), zvariant::Value::new(addr));
+        }
+
+        for (i, route) in self.routes.as_slice().iter().enumerate() {
+            for (k, v) in route.to_keyfile().drain() {
+                ret.insert(
+                    if k.is_empty() {
+                        format!("route{}", i)
+                    } else {
+                        format!("route{}_{}", i, k)
+                    },
+                    zvariant::Value::new(v),
+                );
+            }
+        }
+        if let Some(dns) = self.dns.as_ref() {
+            ret.insert("dns".to_string(), zvariant::Value::new(dns));
+        }
+
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/mac_vlan.rs
+++ b/rust/src/libnm_dbus/connection/mac_vlan.rs
@@ -30,6 +30,16 @@ impl TryFrom<DbusDictionary> for NmSettingMacVlan {
 }
 
 impl NmSettingMacVlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/ovs.rs
+++ b/rust/src/libnm_dbus/connection/ovs.rs
@@ -49,6 +49,16 @@ impl TryFrom<DbusDictionary> for NmSettingOvsBridge {
 }
 
 impl NmSettingOvsBridge {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -103,6 +113,16 @@ impl NmSettingOvsPort {
         Self::default()
     }
 
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -142,6 +162,16 @@ impl TryFrom<DbusDictionary> for NmSettingOvsIface {
 }
 
 impl NmSettingOvsIface {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/sriov.rs
+++ b/rust/src/libnm_dbus/connection/sriov.rs
@@ -56,6 +56,28 @@ impl TryFrom<DbusDictionary> for NmSettingSriov {
 }
 
 impl NmSettingSriov {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if k != "vfs" {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        if let Some(vfs) = self.vfs.as_ref() {
+            for vf in vfs {
+                if let Some(i) = vf.index {
+                    ret.insert(
+                        format!("vf.{}", i),
+                        zvariant::Value::new(vf.to_keyfile()),
+                    );
+                }
+            }
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {
@@ -124,6 +146,36 @@ impl TryFrom<DbusDictionary> for NmSettingSriovVf {
 }
 
 impl NmSettingSriovVf {
+    pub(crate) fn to_keyfile(&self) -> String {
+        let mut ret = String::new();
+        if let Some(v) = self.mac.as_ref() {
+            ret += &format!("mac={} ", v);
+        }
+        if let Some(v) = self.spoof_check {
+            ret += &format!("spoof-check={} ", v);
+        }
+        if let Some(v) = self.trust {
+            ret += &format!("trust={} ", v);
+        }
+        if let Some(v) = self.min_tx_rate {
+            ret += &format!("min-tx-rate={} ", v);
+        }
+        if let Some(v) = self.max_tx_rate {
+            ret += &format!("max-tx-rate={} ", v);
+        }
+        if let Some(vlans) = self.vlans.as_ref() {
+            let mut vlans_str = Vec::new();
+            for vlan in vlans {
+                vlans_str.push(vlan.to_keyfile());
+            }
+            ret += &format!("vlans={}", vlans_str.join(";"));
+        }
+        if ret.ends_with(' ') {
+            ret.pop();
+        }
+        ret
+    }
+
     pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
         let mut ret = zvariant::Dict::new(
             zvariant::Signature::from_str_unchecked("s"),
@@ -219,6 +271,13 @@ impl TryFrom<DbusDictionary> for NmSettingSriovVfVlan {
 }
 
 impl NmSettingSriovVfVlan {
+    pub(crate) fn to_keyfile(&self) -> String {
+        match self.protocol {
+            NmVlanProtocol::Dot1Q => format!("{}.{}.q", self.id, self.qos),
+            NmVlanProtocol::Dot1Ad => format!("{}.{}.ad", self.id, self.qos),
+        }
+    }
+
     pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
         let mut ret = zvariant::Dict::new(
             zvariant::Signature::from_str_unchecked("s"),

--- a/rust/src/libnm_dbus/connection/user.rs
+++ b/rust/src/libnm_dbus/connection/user.rs
@@ -59,4 +59,16 @@ impl NmSettingUser {
         }));
         Ok(ret)
     }
+
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(data) = self.data.as_ref() {
+            for (k, v) in data.iter() {
+                ret.insert(k.to_string(), zvariant::Value::new(v));
+            }
+        }
+        Ok(ret)
+    }
 }

--- a/rust/src/libnm_dbus/connection/veth.rs
+++ b/rust/src/libnm_dbus/connection/veth.rs
@@ -24,6 +24,16 @@ impl TryFrom<DbusDictionary> for NmSettingVeth {
 }
 
 impl NmSettingVeth {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -27,6 +27,16 @@ impl TryFrom<DbusDictionary> for NmSettingVlan {
 }
 
 impl NmSettingVlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vrf.rs
+++ b/rust/src/libnm_dbus/connection/vrf.rs
@@ -24,6 +24,16 @@ impl TryFrom<DbusDictionary> for NmSettingVrf {
 }
 
 impl NmSettingVrf {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/vxlan.rs
+++ b/rust/src/libnm_dbus/connection/vxlan.rs
@@ -30,6 +30,16 @@ impl TryFrom<DbusDictionary> for NmSettingVxlan {
 }
 
 impl NmSettingVxlan {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            ret.insert(k.to_string(), v);
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/connection/wired.rs
+++ b/rust/src/libnm_dbus/connection/wired.rs
@@ -63,6 +63,24 @@ impl TryFrom<DbusDictionary> for NmSettingWired {
 }
 
 impl NmSettingWired {
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        for (k, v) in self.to_value()?.drain() {
+            if k != "cloned-mac-address" {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        if let Some(v) = &self.cloned_mac_address {
+            ret.insert(
+                "cloned-mac-address".to_string(),
+                zvariant::Value::new(v),
+            );
+        }
+        Ok(ret)
+    }
+
     pub(crate) fn to_value(
         &self,
     ) -> Result<HashMap<&str, zvariant::Value>, NmError> {

--- a/rust/src/libnm_dbus/keyfile.rs
+++ b/rust/src/libnm_dbus/keyfile.rs
@@ -1,13 +1,38 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use log::error;
 
 use crate::{ErrorKind, NmError};
 
-pub(crate) fn zvariant_value_to_keyfile(
+pub(crate) const DEFAULT_SEPARATOR: &str = ";";
+
+pub(crate) fn keyfile_sections_to_string(
+    sections: &[(&str, HashMap<String, zvariant::Value>)],
+) -> Result<String, NmError> {
+    let mut ret = String::new();
+    for (section_name, data) in sections {
+        ret += &format!("[{}]\n", section_name);
+        // Sort the keys
+        let mut keys: Vec<&String> = data.keys().collect();
+        keys.sort_unstable();
+        for key in keys {
+            if let Some(v) = data.get(key) {
+                let v = zvariant_value_to_string(v)?;
+                if !v.is_empty() {
+                    ret += &format!("{}={}\n", key, v);
+                }
+            }
+        }
+        ret += "\n";
+    }
+    if ret.ends_with("\n\n") {
+        ret.pop();
+    }
+    Ok(ret)
+}
+
+fn zvariant_value_to_string(
     value: &zvariant::Value,
-    section_name: &str,
 ) -> Result<String, NmError> {
     match value {
         zvariant::Value::Bool(b) => Ok(if *b {
@@ -23,101 +48,18 @@ pub(crate) fn zvariant_value_to_keyfile(
         zvariant::Value::U64(d) => Ok(format!("{}", d)),
         zvariant::Value::I64(d) => Ok(format!("{}", d)),
         zvariant::Value::Dict(d) => {
-            let data: HashMap<String, zvariant::Value> =
-                HashMap::try_from(d.clone())?;
-            if data.is_empty() {
-                return Ok("".to_string());
-            }
-            let mut ret = String::new();
-
-            let mut names: Vec<String> = data.keys().cloned().collect();
-            if section_name.is_empty() {
-                // Only sort the top level sections
-                names.sort_unstable();
-            } else {
-                // place the sub-section at the end of section_names.
-                names.sort_unstable_by(|a, b| {
-                    let a_is_subsection =
-                        matches!(data.get(a), Some(zvariant::Value::Dict(_)));
-                    let b_is_subsection =
-                        matches!(data.get(b), Some(zvariant::Value::Dict(_)));
-                    a_is_subsection.cmp(&b_is_subsection)
-                });
-            }
-
-            for key in &names {
-                let key = if section_name == "ipv4" || section_name == "ipv6" {
-                    if key == "addresses" || key == "routes" {
-                        // Ignore deprecated 'addresses' in favor of
-                        // 'address-data'.
-                        // Ignore deprecated 'routes' in favor of 'route-data'
-                        continue;
-                    } else if key == "dhcp-client-id" {
-                        "dhcp-iaid".to_string()
-                    } else {
-                        key.to_string()
-                    }
-                } else {
-                    key.to_string()
-                };
-
-                if let Some(section_value) = data.get(&key) {
-                    if key == "mac-address" {
-                        ret += &format!(
-                            "mac-address={}\n",
-                            mac_address_value_to_string(section_value)
-                        );
-                    } else if key == "type" && section_name == "connection" {
-                        let iface_type = zvariant_value_to_keyfile(
-                            section_value,
-                            section_name,
-                        )?;
-                        ret += &format!(
-                            "type={}\n",
-                            if iface_type == "802-3-ethernet" {
-                                "ethernet".to_string()
-                            } else {
-                                iface_type
-                            }
-                        );
-                    } else if key == "address-data" {
-                        ret += &ip_address_value_to_string(section_value);
-                    } else if let zvariant::Value::Dict(_) = section_value {
-                        let sub_section: HashMap<String, zvariant::Value> =
-                            HashMap::try_from(section_value.clone())?;
-                        if sub_section.is_empty() {
-                            continue;
-                        }
-
-                        let sub_section_name = if section_name.is_empty() {
-                            key.to_string()
-                        } else {
-                            format!("{}-{}", section_name, key)
-                        };
-                        ret += &format!("\n[{}]\n", sub_section_name);
-                        ret += &zvariant_value_to_keyfile(
-                            section_value,
-                            &sub_section_name,
-                        )?;
-                    } else {
-                        ret += &format!(
-                            "{}={}\n",
-                            key,
-                            zvariant_value_to_keyfile(
-                                section_value,
-                                section_name
-                            )?
-                        );
-                    }
-                }
-            }
-            Ok(ret)
+            let e = NmError::new(
+                ErrorKind::Bug,
+                format!("Cannot convert Dict {:?} to key file format", d),
+            );
+            log::error!("{}", e);
+            Err(e)
         }
         zvariant::Value::Array(a) => {
             let mut ret = String::new();
             for item in a.get() {
-                ret += &zvariant_value_to_keyfile(item, section_name)?;
-                ret += ";";
+                ret += &zvariant_value_to_string(item)?;
+                ret += DEFAULT_SEPARATOR;
             }
             ret.pop();
             Ok(ret)
@@ -126,60 +68,10 @@ pub(crate) fn zvariant_value_to_keyfile(
         _ => {
             let e = NmError::new(
                 ErrorKind::Bug,
-                format!(
-                    "BUG: Unknown value type in section {}: {:?}",
-                    section_name, value
-                ),
+                format!("BUG: Unknown value type in section {:?}", value),
             );
             error!("{}", e);
             Err(e)
         }
     }
-}
-
-fn mac_address_value_to_string(value: &zvariant::Value) -> String {
-    let mut ret = String::new();
-    if let zvariant::Value::Array(a) = value {
-        for item in a.get() {
-            if let Ok(s) = zvariant_value_to_keyfile(item, "") {
-                ret += &s;
-                ret += ":";
-            }
-        }
-        ret.pop();
-    }
-    ret
-}
-
-fn ip_address_value_to_string(value: &zvariant::Value) -> String {
-    let mut ret = String::new();
-    let mut index = 0u32;
-    if let zvariant::Value::Array(ip_addrs) = value {
-        for ip_addr_value in ip_addrs.get() {
-            let ip_addr_value = if let zvariant::Value::Dict(i) = ip_addr_value
-            {
-                i
-            } else {
-                continue;
-            };
-            let address = if let Ok(Some(s)) = ip_addr_value.get("address") {
-                zvariant_value_to_keyfile(s, "")
-            } else {
-                continue;
-            };
-            let prefix = if let Ok(Some(p)) = ip_addr_value.get("prefix") {
-                zvariant_value_to_keyfile(p, "")
-            } else {
-                continue;
-            };
-            if let Ok(address) = address {
-                if let Ok(prefix) = prefix {
-                    ret +=
-                        &format!("address{}={}/{}\n", index, address, prefix);
-                    index += 1;
-                }
-            }
-        }
-    }
-    ret
 }

--- a/rust/src/libnm_dbus/lib.rs
+++ b/rust/src/libnm_dbus/lib.rs
@@ -21,6 +21,7 @@ mod device;
 mod dns;
 mod error;
 mod keyfile;
+mod lldp;
 mod nm_api;
 
 pub use crate::active_connection::NmActiveConnection;
@@ -36,4 +37,9 @@ pub use crate::connection::{
 pub use crate::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 pub use crate::dns::NmDnsEntry;
 pub use crate::error::{ErrorKind, NmError};
+pub use crate::lldp::{
+    NmLldpNeighbor, NmLldpNeighbor8021Ppvid, NmLldpNeighbor8021Vlan,
+    NmLldpNeighbor8023MacPhyConf, NmLldpNeighbor8023PowerViaMdi,
+    NmLldpNeighborMgmtAddr,
+};
 pub use crate::nm_api::NmApi;

--- a/rust/src/libnm_dbus/lldp.rs
+++ b/rust/src/libnm_dbus/lldp.rs
@@ -1,0 +1,248 @@
+use std::convert::TryFrom;
+
+use serde::Deserialize;
+
+use crate::{
+    connection::{DbusDictionary, _from_map},
+    NmError,
+};
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor {
+    pub raw: Option<Vec<u8>>,
+    pub chassis_id_type: Option<u32>,
+    pub chassis_id: Option<String>,
+    pub port_id_type: Option<u32>,
+    pub port_id: Option<String>,
+    pub destination: Option<String>,
+    pub port_description: Option<String>,
+    pub system_name: Option<String>,
+    pub system_description: Option<String>,
+    pub system_capabilities: Option<u32>,
+    pub management_addresses: Option<Vec<NmLldpNeighborMgmtAddr>>,
+    pub ieee_802_1_pvid: Option<u32>,
+    pub ieee_802_1_ppvid: Option<u32>,
+    pub ieee_802_1_ppvid_flags: Option<u32>,
+    pub ieee_802_1_ppvids: Option<Vec<NmLldpNeighbor8021Ppvid>>,
+    pub ieee_802_1_vid: Option<u32>,
+    pub ieee_802_1_vlan_name: Option<String>,
+    pub ieee_802_1_vlans: Option<Vec<NmLldpNeighbor8021Vlan>>,
+    pub ieee_802_3_mac_phy_conf: Option<NmLldpNeighbor8023MacPhyConf>,
+    pub ieee_802_3_power_via_mdi: Option<NmLldpNeighbor8023PowerViaMdi>,
+    pub ieee_802_3_max_frame_size: Option<u32>,
+    _other: DbusDictionary,
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            raw: _from_map!(v, "raw", <Vec<u8>>::try_from)?,
+            chassis_id_type: _from_map!(v, "chassis-id-type", <u32>::try_from)?,
+            chassis_id: _from_map!(v, "chassis-id", <String>::try_from)?,
+            port_id_type: _from_map!(v, "port-id-type", <u32>::try_from)?,
+            port_id: _from_map!(v, "port-id", <String>::try_from)?,
+            destination: _from_map!(v, "destination", <String>::try_from)?,
+            port_description: _from_map!(
+                v,
+                "port-description",
+                <String>::try_from
+            )?,
+            system_name: _from_map!(v, "system-name", <String>::try_from)?,
+            system_description: _from_map!(
+                v,
+                "system-description",
+                <String>::try_from
+            )?,
+            system_capabilities: _from_map!(
+                v,
+                "system-capabilities",
+                <u32>::try_from
+            )?,
+            management_addresses: _from_map!(
+                v,
+                "management-addresses",
+                parse_mgmt_addrs
+            )?,
+            ieee_802_1_pvid: _from_map!(v, "ieee-802-1-pvid", <u32>::try_from)?,
+            ieee_802_1_ppvid: _from_map!(
+                v,
+                "ieee-802-1-ppvid",
+                <u32>::try_from
+            )?,
+            ieee_802_1_ppvid_flags: _from_map!(
+                v,
+                "ieee-802-1-ppvid-flags",
+                <u32>::try_from
+            )?,
+            ieee_802_1_ppvids: _from_map!(
+                v,
+                "ieee-802-1-ppvids",
+                parse_ppvids
+            )?,
+            ieee_802_1_vid: _from_map!(v, "ieee-802-1-vid", <u32>::try_from)?,
+            ieee_802_1_vlan_name: _from_map!(
+                v,
+                "ieee-802-1-vlan-name",
+                <String>::try_from
+            )?,
+            ieee_802_1_vlans: _from_map!(v, "ieee-802-1-vlans", parse_vlans)?,
+            ieee_802_3_mac_phy_conf: _from_map!(
+                v,
+                "ieee-802-3-mac-phy-conf",
+                NmLldpNeighbor8023MacPhyConf::try_from
+            )?,
+            ieee_802_3_power_via_mdi: _from_map!(
+                v,
+                "ieee-802-3-power-via-mdi",
+                NmLldpNeighbor8023PowerViaMdi::try_from
+            )?,
+            ieee_802_3_max_frame_size: _from_map!(
+                v,
+                "ieee-802-3-max-frame-size",
+                <u32>::try_from
+            )?,
+            _other: v,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor8021Ppvid {
+    pub ppvid: Option<u32>,
+    pub flags: Option<u32>,
+}
+
+fn parse_ppvids(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighbor8021Ppvid>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighbor8021Ppvid::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor8021Ppvid {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            ppvid: _from_map!(v, "ppvid", <u32>::try_from)?,
+            flags: _from_map!(v, "flags", <u32>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighbor8021Vlan {
+    pub vid: Option<u32>,
+    pub name: Option<String>,
+}
+
+fn parse_vlans(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighbor8021Vlan>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighbor8021Vlan::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighbor8021Vlan {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            vid: _from_map!(v, "vid", <u32>::try_from)?,
+            name: _from_map!(v, "name", <String>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct NmLldpNeighbor8023MacPhyConf {
+    pub autoneg: Option<u32>,
+    pub pmd_autoneg_cap: Option<u32>,
+    pub operational_mau_type: Option<u32>,
+}
+
+impl TryFrom<zvariant::OwnedValue> for NmLldpNeighbor8023MacPhyConf {
+    type Error = NmError;
+    fn try_from(v: zvariant::OwnedValue) -> Result<Self, Self::Error> {
+        let mut v = DbusDictionary::try_from(v)?;
+        Ok(Self {
+            autoneg: _from_map!(v, "autoneg", <u32>::try_from)?,
+            pmd_autoneg_cap: _from_map!(v, "pmd-autoneg-cap", <u32>::try_from)?,
+            operational_mau_type: _from_map!(
+                v,
+                "operational-mau-type",
+                <u32>::try_from
+            )?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+pub struct NmLldpNeighbor8023PowerViaMdi {
+    pub mdi_power_support: Option<u32>,
+    pub pse_power_pair: Option<u32>,
+    pub power_class: Option<u32>,
+}
+
+impl TryFrom<zvariant::OwnedValue> for NmLldpNeighbor8023PowerViaMdi {
+    type Error = NmError;
+    fn try_from(v: zvariant::OwnedValue) -> Result<Self, Self::Error> {
+        let mut v = DbusDictionary::try_from(v)?;
+        Ok(Self {
+            mdi_power_support: _from_map!(
+                v,
+                "mdi-power-support",
+                <u32>::try_from
+            )?,
+            pse_power_pair: _from_map!(v, "pse-power-pair", <u32>::try_from)?,
+            power_class: _from_map!(v, "power-class", <u32>::try_from)?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+pub struct NmLldpNeighborMgmtAddr {
+    pub address_subtype: Option<u32>,
+    pub address: Option<Vec<u8>>,
+    pub interface_number_subtype: Option<u32>,
+    pub interface_number: Option<u32>,
+}
+
+fn parse_mgmt_addrs(
+    v: zvariant::OwnedValue,
+) -> Result<Vec<NmLldpNeighborMgmtAddr>, NmError> {
+    let mut ret = Vec::new();
+    for value in Vec::<DbusDictionary>::try_from(v)? {
+        ret.push(NmLldpNeighborMgmtAddr::try_from(value)?);
+    }
+    Ok(ret)
+}
+
+impl TryFrom<DbusDictionary> for NmLldpNeighborMgmtAddr {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address_subtype: _from_map!(v, "address-subtype", <u32>::try_from)?,
+            address: _from_map!(v, "address", <Vec<u8>>::try_from)?,
+            interface_number_subtype: _from_map!(
+                v,
+                "interface-number-subtype",
+                <u32>::try_from
+            )?,
+            interface_number: _from_map!(
+                v,
+                "interface-number",
+                <u32>::try_from
+            )?,
+        })
+    }
+}

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -24,11 +24,12 @@ use crate::{
     connection::{nm_con_get_from_obj_path, NmConnection},
     dbus::NmDbus,
     device::{
-        nm_dev_delete, nm_dev_from_obj_path, NmDevice, NmDeviceState,
-        NmDeviceStateReason,
+        nm_dev_delete, nm_dev_from_obj_path, nm_dev_get_llpd, NmDevice,
+        NmDeviceState, NmDeviceStateReason,
     },
     dns::NmDnsEntry,
     error::{ErrorKind, NmError},
+    lldp::NmLldpNeighbor,
 };
 
 pub struct NmApi<'a> {
@@ -261,6 +262,13 @@ impl<'a> NmApi<'a> {
 
     pub fn device_delete(&self, nm_dev_obj_path: &str) -> Result<(), NmError> {
         nm_dev_delete(&self.dbus.connection, nm_dev_obj_path)
+    }
+
+    pub fn device_lldp_neighbor_get(
+        &self,
+        nm_dev_obj_path: &str,
+    ) -> Result<Vec<NmLldpNeighbor>, NmError> {
+        nm_dev_get_llpd(&self.dbus.connection, nm_dev_obj_path)
     }
 
     // If any device is with NewActivation or IpConfig state,

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -155,14 +155,19 @@ impl<'a> NmApi<'a> {
     pub fn connection_add(
         &self,
         nm_conn: &NmConnection,
+        memory_only: bool,
     ) -> Result<(), NmError> {
         debug!("connection_add: {:?}", nm_conn);
         if let Some(uuid) = nm_conn.uuid() {
             if let Ok(con_obj_path) = self.dbus.get_connection_by_uuid(uuid) {
-                return self.dbus.connection_update(&con_obj_path, nm_conn);
+                return self.dbus.connection_update(
+                    &con_obj_path,
+                    nm_conn,
+                    memory_only,
+                );
             }
         };
-        self.dbus.connection_add(nm_conn)?;
+        self.dbus.connection_add(nm_conn, memory_only)?;
         Ok(())
     }
 

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -45,7 +45,7 @@ NMSTATE_FLAG_NO_VERIFY = 1 << 2
 NMSTATE_FLAG_INCLUDE_STATUS_DATA = 1 << 3
 NMSTATE_FLAG_INCLUDE_SECRETS = 1 << 4
 NMSTATE_FLAG_NO_COMMIT = 1 << 5
-# NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
+NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
 NMSTATE_FLAG_RUNNING_CONFIG_ONLY = 1 << 7
 NMSTATE_PASS = 0
 
@@ -110,6 +110,9 @@ def apply_net_state(
 
     if not commit:
         flags |= NMSTATE_FLAG_NO_COMMIT
+
+    if not save_to_disk:
+        flags |= NMSTATE_FLAG_MEMORY_ONLY
 
     rc = lib.nmstate_net_state_apply(
         flags,


### PR DESCRIPTION
fb09f9a9 rust nm bond: better serialization
67372d26 rust bond: Improve bond option handling
8847ca41 rust bond: Improve validation code
5aad3741 rust cli: Rollback when got ctrl+c signal
12c4ec31 clib: expose memory_only and running_config_only flags
d07c215d Rust: Add LLDP support
6de3b33e libnm_dbus keyfile: Rewrite the keyfile generation
0daa3365 Github CI: no need to run CI on merge action of base branch
29a7f912 rpm spec: Skip rust build for debug binary
b3bde9e2 go: Add missing flag for memory only and running config only
66e31476 rust: Support memory only apply
0723935f Packit: build SRPMs in Copr
23af1ef1 rust: Use From and Display to ser/des type