### PR TITLE
rust: Set vlan-filtering 0 on port.vlan: {}

### DIFF
--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -291,7 +291,7 @@ impl LinuxBridgePortConfig {
     fn vlan_filtering_is_enabled(&self) -> bool {
         self.vlan
             .as_ref()
-            .map_or(false, |v| *v != LinuxBridgePortVlanConfig::default())
+            .map_or(true, |v| *v != LinuxBridgePortVlanConfig::default())
     }
 }
 

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -581,7 +581,7 @@ class TestVlanFiltering:
         with linux_bridge(
             TEST_BRIDGE0, bridge_config_subtree
         ) as desired_state:
-            assertlib.assert_state_match(desired_state)
+            assertlib.assert_state(desired_state)
             assert not _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_pretty_state_port_name_first(

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -584,6 +584,20 @@ class TestVlanFiltering:
             assertlib.assert_state(desired_state)
             assert not _vlan_filtering_enabled(TEST_BRIDGE0)
 
+    def test_keep_vlan_filtering_on_bridge_when_not_set(
+        self,
+        bridge_with_trunk_port_and_native_config,
+    ):
+        bridge_state = bridge_with_trunk_port_and_native_config[Interface.KEY][
+            0
+        ]
+        bridge_config_subtree = bridge_state[LinuxBridge.CONFIG_SUBTREE]
+        bridge_ports = bridge_config_subtree[LinuxBridge.PORT_SUBTREE]
+        bridge_ports[0].pop(LinuxBridge.Port.VLAN_SUBTREE, {})
+
+        with linux_bridge(TEST_BRIDGE0, bridge_config_subtree):
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
+
     def test_pretty_state_port_name_first(
         self, bridge_with_trunk_port_and_native_config
     ):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -147,6 +147,18 @@ def bond0(port0_up):
         yield bond0
 
 
+def _vlan_filtering_enabled(bridge_name):
+    _, npc_output, _ = exec_cmd(
+        cmd=(
+            "npc",
+            "iface",
+            bridge_name,
+        ),
+        check=True,
+    )
+    return "vlan_filtering: true" in npc_output
+
+
 def test_create_and_remove_linux_bridge_with_min_desired_state():
     bridge_name = TEST_BRIDGE0
     with linux_bridge(bridge_name, bridge_subtree_state=None) as desired_state:
@@ -460,6 +472,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(trunk_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     @pytest.mark.parametrize(
         "is_native_vlan", [True, False], ids=["native", "not-native"]
@@ -481,6 +494,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(trunk_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_access_port_config(self, port0_up):
         access_port_state = generate_vlan_filtering_config(
@@ -491,6 +505,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(access_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_update_trunk_port_to_access_port(
         self, bridge_with_trunk_port_and_native_config, port0_up
@@ -505,6 +520,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(new_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_update_trunk_port_tag_ids(
         self, bridge_with_trunk_port_and_native_config, port0_up
@@ -519,6 +535,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(new_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_update_access_port_tag_id(
         self, bridge_with_access_port_config, port0_up
@@ -533,6 +550,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(new_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_activate_vlan_filtering_on_bridge(
         self, bridge0_with_port0, port0_up
@@ -547,6 +565,7 @@ class TestVlanFiltering:
         bridge_state[LinuxBridge.PORT_SUBTREE][0].update(new_port_state)
         with linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_disable_vlan_filtering_on_bridge(
         self,
@@ -563,6 +582,7 @@ class TestVlanFiltering:
             TEST_BRIDGE0, bridge_config_subtree
         ) as desired_state:
             assertlib.assert_state_match(desired_state)
+            assert not _vlan_filtering_enabled(TEST_BRIDGE0)
 
     def test_pretty_state_port_name_first(
         self, bridge_with_trunk_port_and_native_config


### PR DESCRIPTION
The vlan-filtering at linux-bridge is set to 0 if there is no vlan
configured at ports, but previously with the python version it was also
true if the vlan diciontary was empty. This change implement a fix for
that regression comparing with "default" struct.