### PR TITLE
rust: Support ignore interface when applying

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -200,6 +200,7 @@ function run_tests {
             tests/integration/lldp_test.py \
             tests/integration/bond_test.py \
             tests/integration/ethtool_test.py \
+            tests/integration/linux_bridge_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \
@@ -249,16 +250,6 @@ function run_tests {
             test_rollback_for_vlans or \
             test_set_vlan_iface_down or \
             test_add_new_base_iface_with_vlan' \
-            ${nmstate_pytest_extra_args}"
-        exec_cmd "
-          env  \
-          PYTHONPATH=$CONTAINER_WORKSPACE/rust/src/python \
-          pytest \
-            $PYTEST_OPTIONS \
-            tests/integration/linux_bridge_test.py \
-            -k '\
-            not test_linux_bridge_over_bond_over_port_in_one_transaction and \
-            not test_explicitly_ignore_a_bridge_port' \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -134,6 +134,7 @@ pub enum InterfaceState {
     Down,
     Absent,
     Unknown,
+    Ignore,
 }
 
 impl Default for InterfaceState {
@@ -148,6 +149,7 @@ impl From<&str> for InterfaceState {
             "up" => Self::Up,
             "down" => Self::Down,
             "absent" => Self::Absent,
+            "ignore" => Self::Ignore,
             _ => Self::Unknown,
         }
     }
@@ -364,6 +366,10 @@ impl Interface {
 
     pub fn is_down(&self) -> bool {
         self.base_iface().state == InterfaceState::Down
+    }
+
+    pub fn is_ignore(&self) -> bool {
+        self.base_iface().state == InterfaceState::Ignore
     }
 
     pub fn is_virtual(&self) -> bool {
@@ -648,6 +654,8 @@ impl Interface {
 
     pub(crate) fn remove_port(&mut self, port_name: &str) {
         if let Interface::LinuxBridge(br_iface) = self {
+            br_iface.remove_port(port_name);
+        } else if let Interface::OvsBridge(br_iface) = self {
             br_iface.remove_port(port_name);
         } else if let Interface::Bond(iface) = self {
             iface.remove_port(port_name);

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -80,6 +80,18 @@ impl OvsBridgeInterface {
         }
         ret
     }
+
+    // Only support remove non-bonding port or the bond itself as bond require
+    // two ports, removal any of them will trigger error.
+    pub(crate) fn remove_port(&mut self, port_name: &str) {
+        if let Some(br_ports) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.ports.as_mut())
+        {
+            br_ports.retain(|p| p.name.as_str() != port_name)
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -1,0 +1,101 @@
+use crate::Interfaces;
+
+#[test]
+fn test_linux_bridge_ignore_port() {
+    let mut ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let mut cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth2
+  type: ethernet
+  state: up
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+
+    let ignored_kernel_ifaces = ifaces.ignored_kernel_iface_names();
+
+    assert_eq!(ignored_kernel_ifaces, vec!["eth1".to_string()]);
+
+    let ignored_user_ifaces = ifaces.ignored_user_iface_name_types();
+    assert!(ignored_user_ifaces.is_empty());
+
+    ifaces.remove_ignored_ifaces(&ignored_kernel_ifaces, &ignored_user_ifaces);
+    cur_ifaces
+        .remove_ignored_ifaces(&ignored_kernel_ifaces, &ignored_user_ifaces);
+
+    let (add_ifaces, chg_ifaces, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
+
+    assert!(!ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!cur_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert_eq!(ifaces.kernel_ifaces["br0"].ports(), Some(vec!["eth2"]));
+    assert_eq!(cur_ifaces.kernel_ifaces["br0"].ports(), Some(vec!["eth2"]));
+    assert!(!add_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!chg_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!del_ifaces.kernel_ifaces.contains_key("eth1"));
+}
+
+#[test]
+fn test_linux_bridge_verify_ignore_port() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth2
+  type: ethernet
+  state: up
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+
+    ifaces.verify(&cur_ifaces).unwrap();
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,9 +1,13 @@
 #[cfg(test)]
 mod bond;
 #[cfg(test)]
+mod bridge;
+#[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;
+#[cfg(test)]
+mod ovs;
 #[cfg(test)]
 mod route;
 #[cfg(test)]

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -1,0 +1,110 @@
+use crate::{InterfaceType, Interfaces};
+
+#[test]
+fn test_ovs_bridge_ignore_port() {
+    let mut ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+  state: up
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let mut cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth2
+  type: ethernet
+  state: up
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+
+    let ignored_kernel_ifaces = ifaces.ignored_kernel_iface_names();
+
+    assert_eq!(ignored_kernel_ifaces, vec!["eth1".to_string()]);
+
+    let ignored_user_ifaces = ifaces.ignored_user_iface_name_types();
+    assert!(ignored_user_ifaces.is_empty());
+
+    ifaces.remove_ignored_ifaces(&ignored_kernel_ifaces, &ignored_user_ifaces);
+    cur_ifaces
+        .remove_ignored_ifaces(&ignored_kernel_ifaces, &ignored_user_ifaces);
+
+    let (add_ifaces, chg_ifaces, del_ifaces) =
+        ifaces.gen_state_for_apply(&cur_ifaces, false).unwrap();
+
+    assert!(!ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!cur_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert_eq!(
+        ifaces.user_ifaces[&("br0".to_string(), InterfaceType::OvsBridge)]
+            .ports(),
+        Some(vec!["eth2"])
+    );
+    assert_eq!(
+        cur_ifaces.user_ifaces[&("br0".to_string(), InterfaceType::OvsBridge)]
+            .ports(),
+        Some(vec!["eth2"])
+    );
+    assert!(!add_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!chg_ifaces.kernel_ifaces.contains_key("eth1"));
+    assert!(!del_ifaces.kernel_ifaces.contains_key("eth1"));
+}
+
+#[test]
+fn test_ovs_bridge_verify_ignore_port() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth2
+  type: ethernet
+  state: up
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+
+    ifaces.verify(&cur_ifaces).unwrap();
+}


### PR DESCRIPTION
Support `state: ignore` as python API did.

Unit test case included.

Enabled all integration test case for linux bridge.