### PR TITLE
rust nm: Improve performance for massive apply

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,7 @@ jobs:
           - job_type: "c8s-nm_main-integ_tier2"
           - job_type: "c8s-nm_main-integ_slow"
           - job_type: "c8s-nm_main-integ_rust"
+          - job_type: "c8s-nm_main-integ_rust_slow"
           - job_type: "c8s-nm_main-rust_go"
           - job_type: "ovs2_11-nm_stable-integ_tier1"
           - job_type: "vdsm_el8-nm_main-vdsm"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -18,6 +18,7 @@ TEST_TYPE_INTEG_TIER1="integ_tier1"
 TEST_TYPE_INTEG_TIER2="integ_tier2"
 TEST_TYPE_INTEG_SLOW="integ_slow"
 TEST_TYPE_INTEG_RUST="integ_rust"
+TEST_TYPE_INTEG_RUST_SLOW="integ_rust_slow"
 
 FEDORA_IMAGE_DEV="docker.io/nmstate/fedora-nmstate-dev"
 CENTOS_IMAGE_DEV="quay.io/nmstate/c8s-nmstate-dev"
@@ -173,6 +174,18 @@ function run_tests {
             --junitxml=junit.integ_slow.xml \
             -m slow --runslow \
             tests/integration \
+            ${nmstate_pytest_extra_args}"
+    fi
+
+    if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
+       [ $TEST_TYPE == $TEST_TYPE_INTEG_RUST_SLOW ];then
+        exec_cmd "cd $CONTAINER_WORKSPACE"
+        exec_cmd "
+          pytest \
+            $PYTEST_OPTIONS \
+            -m slow --runslow \
+            tests/integration/timeout_test.py  \
+            tests/integration/dynamic_ip_test.py \
             ${nmstate_pytest_extra_args}"
     fi
 
@@ -478,6 +491,7 @@ while true; do
         echo "     * $TEST_TYPE_INTEG_TIER2"
         echo "     * $TEST_TYPE_INTEG_SLOW"
         echo "     * $TEST_TYPE_INTEG_RUST"
+        echo "     * $TEST_TYPE_INTEG_RUST_SLOW"
         echo "     * $TEST_TYPE_UNIT_PY36"
         echo "     * $TEST_TYPE_UNIT_PY38"
         echo "     * $TEST_TYPE_RUST_GO"

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -25,6 +25,7 @@ const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
 const VERIFY_RETRY_COUNT: usize = 5;
 const VERIFY_RETRY_COUNT_SRIOV: usize = 60;
 const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
+const MAX_SUPPORTED_INTERFACES: usize = 1000;
 
 #[derive(Clone, Debug, Serialize, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -213,6 +214,16 @@ impl NetworkState {
         cur_net_state.set_kernel_only(self.kernel_only);
         cur_net_state.set_include_secrets(true);
         cur_net_state.retrieve()?;
+
+        if desire_state_to_apply.interfaces.to_vec().len()
+            >= MAX_SUPPORTED_INTERFACES
+        {
+            log::warn!(
+                "Interfaces count exceeds the support limit {} in \
+                desired state",
+                MAX_SUPPORTED_INTERFACES,
+            );
+        }
 
         let ignored_kernel_ifaces = desire_state_to_apply
             .interfaces

--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -125,6 +125,9 @@ fn apply_single_state(
     checkpoint: &str,
     memory_only: bool,
 ) -> Result<(), NmstateError> {
+    if net_state.interfaces.to_vec().is_empty() {
+        return Ok(());
+    }
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
 
     let exist_nm_conns =
@@ -224,7 +227,12 @@ fn apply_single_state(
         delete_exist_profiles(nm_api, &exist_nm_conns, &nm_conns_to_activate)?;
     }
 
-    activate_nm_profiles(nm_api, nm_conns_to_activate.as_slice(), checkpoint)?;
+    activate_nm_profiles(
+        nm_api,
+        nm_conns_to_activate.as_slice(),
+        nm_ac_uuids.as_slice(),
+        checkpoint,
+    )?;
     deactivate_nm_profiles(
         nm_api,
         nm_conns_to_deactivate.as_slice(),

--- a/rust/src/lib/nm/checkpoint.rs
+++ b/rust/src/lib/nm/checkpoint.rs
@@ -3,12 +3,14 @@ use nm_dbus::NmApi;
 
 use crate::{nm::error::nm_error_to_nmstate, NmstateError};
 
-// Wait maximum 30 seconds for rollback
-const CHECKPOINT_ROLLBACK_TIMEOUT: u32 = 30;
+// Wait maximum 60 seconds for rollback
+pub(crate) const CHECKPOINT_ROLLBACK_TIMEOUT: u32 = 60;
 
 pub(crate) fn nm_checkpoint_create() -> Result<String, NmstateError> {
     let nm_api = NmApi::new().map_err(nm_error_to_nmstate)?;
-    nm_api.checkpoint_create().map_err(nm_error_to_nmstate)
+    nm_api
+        .checkpoint_create(CHECKPOINT_ROLLBACK_TIMEOUT)
+        .map_err(nm_error_to_nmstate)
 }
 
 pub(crate) fn nm_checkpoint_rollback(

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -36,6 +36,14 @@ pub(crate) const NM_SETTING_VRF_SETTING_NAME: &str = "vrf";
 pub(crate) const NM_SETTING_VLAN_SETTING_NAME: &str = "vlan";
 pub(crate) const NM_SETTING_VXLAN_SETTING_NAME: &str = "vxlan";
 
+pub(crate) const NM_SETTING_CONTROLLERS: [&str; 5] = [
+    NM_SETTING_BOND_SETTING_NAME,
+    NM_SETTING_BRIDGE_SETTING_NAME,
+    NM_SETTING_OVS_BRIDGE_SETTING_NAME,
+    NM_SETTING_OVS_PORT_SETTING_NAME,
+    NM_SETTING_VRF_SETTING_NAME,
+];
+
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
 ) -> Result<Vec<String>, NmstateError> {

--- a/rust/src/libnm_dbus/connection/ieee8021x.rs
+++ b/rust/src/libnm_dbus/connection/ieee8021x.rs
@@ -98,7 +98,6 @@ impl NmSetting8021X {
             );
         }
         if let Some(v) = &self.ca_cert {
-            println!("HAHA {:?}", Self::glib_bytes_to_file_path(v));
             ret.insert(
                 "ca-cert".to_string(),
                 if let Ok(path) = Self::glib_bytes_to_file_path(v) {

--- a/rust/src/libnm_dbus/dbus.rs
+++ b/rust/src/libnm_dbus/dbus.rs
@@ -31,8 +31,6 @@ const NM_CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES: u32 = 0x04;
 pub(crate) const NM_TERNARY_TRUE: i32 = 1;
 pub(crate) const NM_TERNARY_FALSE: i32 = 0;
 
-const CHECKPOINT_TMO: u32 = 30;
-
 const OBJ_PATH_NULL_STR: &str = "/";
 
 pub(crate) const NM_DBUS_INTERFACE_ROOT: &str =
@@ -80,10 +78,13 @@ impl<'a> NmDbus<'a> {
         Ok(self.proxy.version()?)
     }
 
-    pub(crate) fn checkpoint_create(&self) -> Result<String, NmError> {
+    pub(crate) fn checkpoint_create(
+        &self,
+        timeout: u32,
+    ) -> Result<String, NmError> {
         match self.proxy.checkpoint_create(
             &[],
-            CHECKPOINT_TMO,
+            timeout,
             NM_CHECKPOINT_CREATE_FLAG_DELETE_NEW_CONNECTIONS
                 | NM_CHECKPOINT_CREATE_FLAG_DISCONNECT_NEW_DEVICES,
         ) {

--- a/rust/src/libnm_dbus/nm_api.rs
+++ b/rust/src/libnm_dbus/nm_api.rs
@@ -50,9 +50,9 @@ impl<'a> NmApi<'a> {
         self.dbus.version()
     }
 
-    pub fn checkpoint_create(&self) -> Result<String, NmError> {
+    pub fn checkpoint_create(&self, timeout: u32) -> Result<String, NmError> {
         debug!("checkpoint_create");
-        let cp = self.dbus.checkpoint_create()?;
+        let cp = self.dbus.checkpoint_create(timeout)?;
         debug!("checkpoint created: {}", &cp);
         Ok(cp)
     }
@@ -340,7 +340,7 @@ where
             if cur_count == count - 1 {
                 return Err(e);
             } else {
-                eprintln!("Retrying on NM dbus failure: {}", e);
+                log::info!("Retrying on NM dbus failure: {}", e);
                 std::thread::sleep(std::time::Duration::from_millis(
                     interval_ms,
                 ));

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -58,6 +58,10 @@ def bond99_with_dummy_port_by_iproute():
     cmdlib.exec_cmd(f"ip link del {BOND99}".split())
 
 
+@pytest.mark.xfail(
+    reason="https://bugzilla.redhat.com/2070855",
+    strict=False,
+)
 def test_external_managed_subordnates(bond99_with_dummy_port_by_iproute):
     libnmstate.apply(
         {

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -250,11 +250,6 @@ def test_nm_ovs_plugin_missing():
             )
 
 
-@pytest.mark.xfail(
-    nm_major_minor_version() >= 1.37,
-    reason="https://bugzilla.redhat.com/2052441",
-    strict=True,
-)
 def test_ovs_service_missing_with_system_port_only(eth1_up):
     bridge = Bridge(BRIDGE1)
     bridge.add_system_port(ETH1)


### PR DESCRIPTION
Changed the code to only extend checkpoint timeout when half of it
elapsed. Also changed the default timeout for checkpoint to 60 seconds
to align with python code.

Also skip reapply is there is no active connection.

Also skip activation for new controller and new ports as controller
activation will automatically activate its new ports.

Warning user if interface count exceeded 1000 in single desire state.

This is performance result on the same host:

    100 bridge over 100 vlan
        Rust:       5.728s
        Python:     6.423s

    300 bridge over 300 vlan
        Rust:       34.571s
        Python:     38.903s

    500 bridge over 500 vlan
        Rust:       1m39.321s
        Python:     1m40.501s

    1000 bridge over 1000 vlan
        Rust:       8m33.536s
        Python:     5m57.810s

Considering 1000+ interfaces are not supported, this result is
acceptable.

Enabled slow integration test cases for rust.
