### PR TITLE
rust: Sync to latest nispor git

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -11,7 +11,8 @@ path = "lib.rs"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 nm-dbus = {path = "../libnm_dbus"}
-nispor = "1.2.3"
+#nispor = "1.2.4"
+nispor = { git = "https://github.com/nispor/nispor", branch="base" }
 log = "0.4.14"
 libc = "0.2.106"
 

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -48,18 +48,19 @@ fn net_state_to_nispor(
             np_ifaces.push(nmstate_iface_to_np(iface, np_iface_type)?);
         } else if iface.is_absent() {
             println!("del {:?} {:?}", iface.name(), iface.iface_type());
-            np_ifaces.push(nispor::IfaceConf {
-                name: iface.name().to_string(),
-                iface_type: Some(nmstate_iface_type_to_np(&iface.iface_type())),
-                state: nispor::IfaceState::Absent,
-                ..Default::default()
-            });
+            let mut iface_conf = nispor::IfaceConf::default();
+            iface_conf.name = iface.name().to_string();
+            iface_conf.iface_type =
+                Some(nmstate_iface_type_to_np(&iface.iface_type()));
+            iface_conf.state = nispor::IfaceState::Absent;
+            np_ifaces.push(iface_conf);
         }
     }
 
-    Ok(nispor::NetConf {
-        ifaces: Some(np_ifaces),
-    })
+    let mut net_conf = nispor::NetConf::default();
+    net_conf.ifaces = Some(np_ifaces);
+
+    Ok(net_conf)
 }
 
 fn nmstate_iface_type_to_np(
@@ -79,12 +80,10 @@ fn nmstate_iface_to_np(
     nms_iface: &Interface,
     np_iface_type: nispor::IfaceType,
 ) -> Result<nispor::IfaceConf, NmstateError> {
-    let mut np_iface = nispor::IfaceConf {
-        name: nms_iface.name().to_string(),
-        iface_type: Some(np_iface_type),
-        state: nispor::IfaceState::Up,
-        ..Default::default()
-    };
+    let mut np_iface = nispor::IfaceConf::default();
+    np_iface.name = nms_iface.name().to_string();
+    np_iface.iface_type = Some(np_iface_type);
+    np_iface.state = nispor::IfaceState::Up;
     let base_iface = &nms_iface.base_iface();
     if let Some(ctrl_name) = &base_iface.controller {
         np_iface.controller = Some(ctrl_name.to_string())

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -84,9 +84,11 @@ pub(crate) fn nmstate_ipv4_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv4) = nms_ipv4 {
         for nms_addr in &nms_ipv4.addresses {
-            np_ip_conf.addresses.push(nispor::IpAddrConf {
-                address: nms_addr.ip.to_string(),
-                prefix_len: nms_addr.prefix_length as u8,
+            np_ip_conf.addresses.push({
+                let mut ip_conf = nispor::IpAddrConf::default();
+                ip_conf.address = nms_addr.ip.to_string();
+                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf
             });
         }
     }
@@ -99,9 +101,11 @@ pub(crate) fn nmstate_ipv6_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv6) = nms_ipv6 {
         for nms_addr in &nms_ipv6.addresses {
-            np_ip_conf.addresses.push(nispor::IpAddrConf {
-                address: nms_addr.ip.to_string(),
-                prefix_len: nms_addr.prefix_length as u8,
+            np_ip_conf.addresses.push({
+                let mut ip_conf = nispor::IpAddrConf::default();
+                ip_conf.address = nms_addr.ip.to_string();
+                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf
             });
         }
     }

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -19,7 +19,9 @@ pub(crate) fn np_veth_to_nmstate(
 pub(crate) fn nms_veth_conf_to_np(
     nms_veth_conf: Option<&VethConfig>,
 ) -> Option<nispor::VethConf> {
-    nms_veth_conf.map(|nms_veth_conf| nispor::VethConf {
-        peer: nms_veth_conf.peer.to_string(),
+    nms_veth_conf.map(|nms_veth_conf| {
+        let mut veth_conf = nispor::VethConf::default();
+        veth_conf.peer = nms_veth_conf.peer.to_string();
+        veth_conf
     })
 }

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -18,8 +18,10 @@ pub(crate) fn np_vlan_to_nmstate(
 pub(crate) fn nms_vlan_conf_to_np(
     nms_vlan_conf: Option<&VlanConfig>,
 ) -> Option<nispor::VlanConf> {
-    nms_vlan_conf.map(|nms_vlan_conf| nispor::VlanConf {
-        vlan_id: nms_vlan_conf.id,
-        base_iface: nms_vlan_conf.base_iface.clone(),
+    nms_vlan_conf.map(|nms_vlan_conf| {
+        let mut np_vlan_conf = nispor::VlanConf::default();
+        np_vlan_conf.vlan_id = nms_vlan_conf.id;
+        np_vlan_conf.base_iface = nms_vlan_conf.base_iface.clone();
+        np_vlan_conf
     })
 }


### PR DESCRIPTION
Latest nispor is enforcing `non_exhaustive`[1], hence we should not
use constructor for any nispor struct any more.

[1]: https://doc.rust-lang.org/reference/attributes/type_system.html