### PR TITLE
python, ethtool: raise NmstateValueError for unsupported features

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -301,10 +301,10 @@ class BaseIface:
                 ip_state.remove_link_local_address()
                 self._info[family] = ip_state.to_dict()
                 if self.ethtool:
-                    self.ethtool.pre_edit_validation_and_cleanup()
                     self.ethtool.canonicalize(
                         self._origin_info.get(Ethtool.CONFIG_SUBTREE, {})
                     )
+                    self.ethtool.pre_edit_validation_and_cleanup()
                     self._info[Ethtool.CONFIG_SUBTREE] = self.ethtool.to_dict()
 
             if self.is_absent and not self._save_to_disk:

--- a/libnmstate/ifaces/ethtool.py
+++ b/libnmstate/ifaces/ethtool.py
@@ -20,6 +20,7 @@
 from copy import deepcopy
 import logging
 
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Ethtool
 from libnmstate.validator import validate_boolean
 from libnmstate.validator import validate_integer
@@ -121,6 +122,15 @@ class IfaceEthtool:
 
     def pre_edit_validation_and_cleanup(self):
         self._validate_ethtool_properties()
+        self._validate_ethtool_supported_features()
+
+    def _validate_ethtool_supported_features(self):
+        if self.feature:
+            for feature_name, value in self.feature.items():
+                if feature_name not in self.feature._SUPPORTED_FEATURES:
+                    raise NmstateValueError(
+                        f"The feature {feature_name} is not supported."
+                    )
 
     def _validate_ethtool_properties(self):
         if self.pause:
@@ -225,6 +235,18 @@ class IfaceEthtoolFeature:
         "ntuple-filters": "rx-ntuple-filter",
         "rxhash": "rx-hashing",
         "receive-hashing": "rx-hashing",
+    }
+    _SUPPORTED_FEATURES = {
+        "rx-checksum",
+        "tx-scatter-gather",
+        "tx-tcp-segmentation",
+        "tx-gro",
+        "tx-generic-segmentation",
+        "rx-hashing",
+        "rx-lro",
+        "rx-ntuple-filter",
+        "rx-vlan-hw-parse",
+        "tx-vlan-hw-insert",
     }
 
     def __init__(self, feature_info):

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -208,6 +208,18 @@ class EthtoolInfo:
         Ethtool.Coalesce.TX_USECS_IRQ: "tx_usecs_irq",
         Ethtool.Coalesce.TX_USECS_LOW: "tx_usecs_low",
     }
+    _NISPOR_ETHTOOL_FEATURE_SUPPORTED = [
+        "rx-checksum",
+        "tx-scatter-gather",
+        "tx-tcp-segmentation",
+        "tx-gro",
+        "tx-generic-segmentation",
+        "rx-hashing",
+        "rx-lro",
+        "rx-ntuple-filter",
+        "rx-vlan-hw-parse",
+        "tx-vlan-hw-insert",
+    ]
 
     def __init__(self, np_ethtool):
         self._np_ethtool = np_ethtool
@@ -223,7 +235,11 @@ class EthtoolInfo:
             }
         np_features = self._np_ethtool.features
         if np_features:
-            info[Ethtool.Feature.CONFIG_SUBTREE] = np_features.changeable
+            features = {}
+            for (key, value) in np_features.changeable.items():
+                if key in self._NISPOR_ETHTOOL_FEATURE_SUPPORTED:
+                    features[key] = value
+            info[Ethtool.Feature.CONFIG_SUBTREE] = features
 
         np_ring = self._np_ethtool.ring
         if np_ring:

--- a/tests/lib/ifaces/ethtool_test.py
+++ b/tests/lib/ifaces/ethtool_test.py
@@ -170,7 +170,7 @@ class TestIfaceEthtool:
     def test_valid_ethtool_feature(self):
         iface_info = gen_foo_iface_info()
         iface_info[Ethtool.CONFIG_SUBTREE] = {
-            Ethtool.Feature.CONFIG_SUBTREE: {"rx-all": False}
+            Ethtool.Feature.CONFIG_SUBTREE: {"rx": False}
         }
         iface = BaseIface(iface_info)
         iface.mark_as_desired()


### PR DESCRIPTION
When the user specify an unsupported ethtool feature, Nmstate should
raise a NmstateValueError instead of failing on verification without a
proper explanation.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>