### PR TITLE
rust: Support string for integer and boolean

### DIFF
--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -4,6 +4,19 @@ use std::str::FromStr;
 
 use serde::{de, de::Visitor, Deserializer};
 
+pub(crate) fn u8_or_string<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_u8_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            Ok(i)
+        } else {
+            Err(de::Error::custom("Required filed undefined"))
+        }
+    })
+}
+
 pub(crate) fn u16_or_string<'de, D>(deserializer: D) -> Result<u16, D::Error>
 where
     D: Deserializer<'de>,

--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -4,31 +4,181 @@ use std::str::FromStr;
 
 use serde::{de, de::Visitor, Deserializer};
 
-// This function is inspired by https://serde.rs/string-or-struct.html
+pub(crate) fn u16_or_string<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_u16_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            Ok(i)
+        } else {
+            Err(de::Error::custom("Required filed undefined"))
+        }
+    })
+}
+
+pub(crate) fn u32_or_string<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_u32_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            Ok(i)
+        } else {
+            Err(de::Error::custom("Required filed undefined"))
+        }
+    })
+}
+
+pub(crate) fn bool_or_string<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_bool_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            Ok(i)
+        } else {
+            Err(de::Error::custom("Required filed undefined"))
+        }
+    })
+}
+
+pub(crate) fn option_bool_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct IntegerOrString(PhantomData<fn() -> Option<bool>>);
+
+    impl<'de> Visitor<'de> for IntegerOrString {
+        type Value = Option<bool>;
+
+        fn expecting(
+            &self,
+            formatter: &mut std::fmt::Formatter,
+        ) -> std::fmt::Result {
+            formatter.write_str(
+                "Need to be boolean: 1|0|true|false|yes|no|on|off|y|n",
+            )
+        }
+
+        fn visit_bool<E>(self, value: bool) -> Result<Option<bool>, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(value))
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Option<bool>, E>
+        where
+            E: de::Error,
+        {
+            match value.to_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" | "y" => Ok(Some(true)),
+                "0" | "false" | "no" | "off" | "n" => Ok(Some(false)),
+                _ => Err(de::Error::custom(
+                    "Need to be boolean: 1|0|true|false|yes|no|on|off|y|n",
+                )),
+            }
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Option<bool>, E>
+        where
+            E: de::Error,
+        {
+            match value {
+                1 => Ok(Some(true)),
+                0 => Ok(Some(false)),
+                _ => Err(de::Error::custom(
+                    "Need to be boolean: 1|0|true|false|yes|no|on|off|y|n",
+                )),
+            }
+        }
+    }
+
+    deserializer.deserialize_any(IntegerOrString(PhantomData))
+}
+
+pub(crate) fn option_u8_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_u64_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            match u8::try_from(i) {
+                Ok(i) => Ok(Some(i)),
+                Err(e) => Err(de::Error::custom(e)),
+            }
+        } else {
+            Ok(None)
+        }
+    })
+}
+
 pub(crate) fn option_u16_or_string<'de, D>(
     deserializer: D,
 ) -> Result<Option<u16>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    struct IntegerOrString(PhantomData<fn() -> Option<u16>>);
+    option_u64_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            match u16::try_from(i) {
+                Ok(i) => Ok(Some(i)),
+                Err(e) => Err(de::Error::custom(e)),
+            }
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+pub(crate) fn option_u32_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    option_u64_or_string(deserializer).and_then(|i| {
+        if let Some(i) = i {
+            match u32::try_from(i) {
+                Ok(i) => Ok(Some(i)),
+                Err(e) => Err(de::Error::custom(e)),
+            }
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+// This function is inspired by https://serde.rs/string-or-struct.html
+pub(crate) fn option_u64_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct IntegerOrString(PhantomData<fn() -> Option<u64>>);
 
     impl<'de> Visitor<'de> for IntegerOrString {
-        type Value = Option<u16>;
+        type Value = Option<u64>;
 
         fn expecting(
             &self,
             formatter: &mut std::fmt::Formatter,
         ) -> std::fmt::Result {
-            formatter.write_str("integer or string")
+            formatter.write_str("unsigned integer or string")
         }
 
-        fn visit_str<E>(self, value: &str) -> Result<Option<u16>, E>
+        fn visit_str<E>(self, value: &str) -> Result<Option<u64>, E>
         where
             E: de::Error,
         {
             if let Some(prefix_len) = value.strip_prefix("0x") {
-                u16::from_str_radix(prefix_len, 16)
+                u64::from_str_radix(prefix_len, 16)
                     .map_err(de::Error::custom)
                     .map(Some)
             } else {
@@ -38,13 +188,56 @@ where
             }
         }
 
-        fn visit_u64<E>(self, value: u64) -> Result<Option<u16>, E>
+        fn visit_u64<E>(self, value: u64) -> Result<Option<u64>, E>
         where
             E: de::Error,
         {
-            TryFrom::try_from(value)
+            Ok(Some(value))
+        }
+    }
+
+    deserializer.deserialize_any(IntegerOrString(PhantomData))
+}
+
+pub(crate) fn option_i64_or_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct IntegerOrString(PhantomData<fn() -> Option<i64>>);
+
+    impl<'de> Visitor<'de> for IntegerOrString {
+        type Value = Option<i64>;
+
+        fn expecting(
+            &self,
+            formatter: &mut std::fmt::Formatter,
+        ) -> std::fmt::Result {
+            formatter.write_str("signed integer or string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Option<i64>, E>
+        where
+            E: de::Error,
+        {
+            FromStr::from_str(value)
                 .map_err(de::Error::custom)
                 .map(Some)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Option<i64>, E>
+        where
+            E: de::Error,
+        {
+            i64::try_from(value).map_err(de::Error::custom).map(Some)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Option<i64>, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(value))
         }
     }
 

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -280,13 +280,12 @@ fn is_iface_valid_for_dns(is_ipv6: bool, iface: &Interface) -> Option<bool> {
     if is_ipv6 {
         iface.base_iface().ipv6.as_ref().map(|ip_conf| {
             ip_conf.enabled
-                && ((!ip_conf.dhcp && !ip_conf.autoconf)
-                    || (ip_conf.auto_dns == Some(false)))
+                && (!ip_conf.is_auto() || (ip_conf.auto_dns == Some(false)))
         })
     } else {
         iface.base_iface().ipv4.as_ref().map(|ip_conf| {
             ip_conf.enabled
-                && (!ip_conf.dhcp || ip_conf.auto_dns == Some(false))
+                && (!ip_conf.is_auto() || ip_conf.auto_dns == Some(false))
         })
     }
 }

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -11,6 +11,7 @@ const DEFAULT_DNS_PRIORITY: i32 = 40;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct DnsState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running: Option<DnsClientState>,
@@ -135,6 +136,7 @@ impl DnsState {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct DnsClientState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server: Option<Vec<String>>,

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -44,7 +44,10 @@ impl NmstateError {
 
 impl From<serde_json::Error> for NmstateError {
     fn from(e: serde_json::Error) -> Self {
-        NmstateError::new(ErrorKind::Bug, format!("serde_json::Error: {}", e))
+        NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!("Invalid propriety: {}", e),
+        )
     }
 }
 

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -221,7 +221,27 @@ impl<'de> Deserialize<'de> for Interface {
     where
         D: Deserializer<'de>,
     {
-        let v = serde_json::Value::deserialize(deserializer)?;
+        let mut v = serde_json::Value::deserialize(deserializer)?;
+
+        // Ignore all properties except type if state: absent
+        if matches!(
+            Option::deserialize(&v["state"])
+                .map_err(serde::de::Error::custom)?,
+            Some(InterfaceState::Absent)
+        ) {
+            let mut new_value = serde_json::map::Map::new();
+            if let Some(n) = v.get("name") {
+                new_value.insert("name".to_string(), n.clone());
+            }
+            if let Some(t) = v.get("type") {
+                new_value.insert("type".to_string(), t.clone());
+            }
+            if let Some(s) = v.get("state") {
+                new_value.insert("state".to_string(), s.clone());
+            }
+            v = serde_json::value::Value::Object(new_value);
+        }
+
         match Option::deserialize(&v["type"])
             .map_err(serde::de::Error::custom)?
         {

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -154,10 +154,10 @@ impl BaseInterface {
         }
 
         if let Some(ref mut ipv4) = self.ipv4 {
-            ipv4.pre_edit_cleanup()?
+            ipv4.pre_edit_cleanup();
         }
         if let Some(ref mut ipv6) = self.ipv6 {
-            ipv6.pre_edit_cleanup()?
+            ipv6.pre_edit_cleanup();
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -9,7 +9,7 @@ use crate::{
 
 // TODO: Use prop_list to Serialize like InterfaceIpv4 did
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct BaseInterface {
     pub name: String,

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -25,7 +25,11 @@ pub struct BaseInterface {
     pub mac_address: Option<String>,
     #[serde(skip)]
     pub permanent_mac_address: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub mtu: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv4: Option<InterfaceIpv4>,
@@ -33,7 +37,11 @@ pub struct BaseInterface {
     pub ipv6: Option<InterfaceIpv6>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub accept_all_mac_addresses: Option<bool>,
     #[serde(skip_serializing)]
     pub copy_mac_from: Option<String>,

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1,5 +1,5 @@
 use crate::{BaseInterface, ErrorKind, Interface, InterfaceType, NmstateError};
-use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -384,14 +384,19 @@ impl std::fmt::Display for BondArpAllTargets {
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum BondArpValidate {
+    #[serde(alias = "0")]
     None,
+    #[serde(alias = "1")]
     Active,
+    #[serde(alias = "2")]
     Backup,
+    #[serde(alias = "3")]
     All,
+    #[serde(alias = "4")]
     Filter,
-    #[serde(rename = "filter_active")]
+    #[serde(rename = "filter_active", alias = "5")]
     FilterActive,
-    #[serde(rename = "filter_backup")]
+    #[serde(rename = "filter_backup", alias = "6")]
     FilterBackup,
 }
 
@@ -524,8 +529,8 @@ impl std::fmt::Display for BondXmitHashPolicy {
 pub struct BondOptions {
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u16",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
     )]
     pub ad_actor_sys_prio: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -534,8 +539,8 @@ pub struct BondOptions {
     pub ad_select: Option<BondAdSelect>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u16",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
     )]
     pub ad_user_port_key: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -544,8 +549,8 @@ pub struct BondOptions {
     pub arp_all_targets: Option<BondArpAllTargets>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub arp_interval: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -554,8 +559,8 @@ pub struct BondOptions {
     pub arp_validate: Option<BondArpValidate>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub downdelay: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -564,38 +569,38 @@ pub struct BondOptions {
     pub lacp_rate: Option<BondLacpRate>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub lp_interval: Option<u32>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub miimon: Option<u32>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub min_links: Option<u32>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u8",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
     pub num_grat_arp: Option<u8>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u8",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
     pub num_unsol_na: Option<u8>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub packets_per_slave: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -604,73 +609,30 @@ pub struct BondOptions {
     pub primary_reselect: Option<BondPrimaryReselect>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub resend_igmp: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub tlb_dynamic_lb: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "json_to_u32",
-        default
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub updelay: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub use_carrier: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub xmit_hash_policy: Option<BondXmitHashPolicy>,
-}
-
-fn json_to_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let json_value: serde_json::Value = Deserialize::deserialize(deserializer)?;
-    let u32_value: u32 = match json_value.as_u64() {
-        None => {
-            if let Some(str_value) = json_value.as_str() {
-                if str_value.chars().all(char::is_numeric) {
-                    str_value.parse::<u32>().map_err(D::Error::custom)?
-                } else {
-                    return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!("Property value: {} is not valid, only numeric values are allowed.", str_value)))
-                    .map_err(D::Error::custom);
-                }
-            } else {
-                return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!("Property value: {} is not valid, only numeric values are allowed.", json_value)))
-                .map_err(D::Error::custom);
-            }
-        }
-        Some(u64_value) => u64_value as u32,
-    };
-
-    Ok(Some(u32_value))
-}
-
-fn json_to_u16<'de, D>(deserializer: D) -> Result<Option<u16>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    if let Some(u32_value) = json_to_u32(deserializer)? {
-        Ok(Some(u32_value as u16))
-    } else {
-        Ok(None)
-    }
-}
-
-fn json_to_u8<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    if let Some(u32_value) = json_to_u32(deserializer)? {
-        Ok(Some(u32_value as u8))
-    } else {
-        Ok(None)
-    }
 }
 
 impl BondOptions {

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -234,7 +234,7 @@ impl std::fmt::Display for BondMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct BondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -520,6 +520,7 @@ impl std::fmt::Display for BondXmitHashPolicy {
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct BondOptions {
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -114,7 +114,7 @@ impl std::fmt::Display for EthernetDuplex {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthernetConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -121,10 +121,16 @@ pub struct EthernetConfig {
     pub sr_iov: Option<SrIovConfig>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        rename = "auto-negotiation"
+        rename = "auto-negotiation",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub auto_neg: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub speed: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duplex: Option<EthernetDuplex>,

--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct EthtoolConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pause: Option<EthtoolPauseConfig>,
@@ -23,6 +24,7 @@ impl EthtoolConfig {
     Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default, Copy,
 )]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct EthtoolPauseConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rx: Option<bool>,
@@ -82,7 +84,7 @@ impl EthtoolFeatureConfig {
 #[derive(
     Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default, Copy,
 )]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthtoolCoalesceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +140,7 @@ impl EthtoolCoalesceConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthtoolRingConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -26,11 +26,23 @@ impl EthtoolConfig {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct EthtoolPauseConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub tx: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub autoneg: Option<bool>,
 }
 
@@ -46,31 +58,73 @@ impl EthtoolPauseConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthtoolFeatureConfig {
-    #[serde(skip_serializing_if = "Option::is_none", alias = "rx")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "rx",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx_checksum: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "gro")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "gro",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx_gro: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "lro")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "lro",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx_lro: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "rxvlan")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "rxvlan",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx_vlan_hw_parse: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "txvlan")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "txvlan",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub tx_vlan_hw_insert: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         alias = "ntuple",
-        alias = "ntuple-filters"
+        alias = "ntuple-filters",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub rx_ntuple_filter: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "rxhash")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "rxhash",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rx_hashing: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub tx_scatter_gather: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub tx_tcp_segmentation: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        alias = "generic-segmentation-offload"
+        alias = "generic-segmentation-offload",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub tx_generic_segmentation: Option<bool>,
 }
@@ -87,49 +141,137 @@ impl EthtoolFeatureConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthtoolCoalesceConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub adaptive_rx: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub adaptive_tx: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub pkt_rate_high: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub pkt_rate_low: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_frames: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_frames_high: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_frames_irq: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_frames_low: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_usecs: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_usecs_high: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_usecs_irq: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_usecs_low: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub sample_interval: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub stats_block_usecs: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_frames: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_frames_high: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_frames_irq: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_frames_low: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_usecs: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_usecs_high: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_usecs_irq: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_usecs_low: Option<u32>,
 }
 
@@ -143,21 +285,53 @@ impl EthtoolCoalesceConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct EthtoolRingConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_max: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_jumbo: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_jumbo_max: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_mini: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub rx_mini_max: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub tx_max: Option<u32>,
 }
 

--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -61,6 +61,7 @@ pub struct EthtoolFeatureConfig {
     #[serde(
         skip_serializing_if = "Option::is_none",
         alias = "rx",
+        alias = "rx-checksumming",
         default,
         deserialize_with = "crate::deserializer::option_bool_or_string"
     )]

--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -127,6 +127,12 @@ pub struct EthtoolFeatureConfig {
         deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub tx_generic_segmentation: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub highdma: Option<bool>,
 }
 
 impl EthtoolFeatureConfig {

--- a/rust/src/lib/ifaces/infiniband.rs
+++ b/rust/src/lib/ifaces/infiniband.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for InfiniBandMode {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct InfiniBandConfig {
     pub mode: InfiniBandMode,

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -267,13 +267,24 @@ impl LinuxBridgeConfig {
 #[non_exhaustive]
 pub struct LinuxBridgePortConfig {
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub stp_hairpin_mode: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub stp_path_cost: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub stp_priority: Option<u16>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub vlan: Option<LinuxBridgePortVlanConfig>,
 }
 
@@ -316,39 +327,99 @@ pub struct LinuxBridgeOptions {
     // The group_forward_mask is the same with group_fwd_mask. The former is
     // used by NetworkManager, the later is used by sysfs. Nmstate support
     // both.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub group_forward_mask: Option<u16>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub group_fwd_mask: Option<u16>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub hash_max: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hello_timer: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub mac_ageing_time: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub multicast_last_member_count: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_last_member_interval: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_membership_interval: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub multicast_querier: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_querier_interval: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_query_interval: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_query_response_interval: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub multicast_query_use_ifaddr: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multicast_router: Option<LinuxBridgeMulticastRouterType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub multicast_snooping: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub multicast_startup_query_count: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u64_or_string"
+    )]
     pub multicast_startup_query_interval: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stp: Option<LinuxBridgeStpOptions>,
@@ -372,15 +443,35 @@ impl LinuxBridgeOptions {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgeStpOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub enabled: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
+    )]
     pub forward_delay: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
+    )]
     pub hello_time: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
+    )]
     pub max_age: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub priority: Option<u16>,
 }
 
@@ -496,11 +587,19 @@ impl std::fmt::Display for LinuxBridgeMulticastRouterType {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgePortVlanConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub enable_native: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<LinuxBridgePortVlanMode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub tag: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trunk_tags: Option<Vec<LinuxBridgePortTunkTag>>,
@@ -576,6 +675,7 @@ impl Default for LinuxBridgePortVlanMode {
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum LinuxBridgePortTunkTag {
+    #[serde(deserialize_with = "crate::deserializer::u16_or_string")]
     Id(u16),
     IdRange(LinuxBridgePortVlanRange),
 }
@@ -593,6 +693,8 @@ impl LinuxBridgePortTunkTag {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct LinuxBridgePortVlanRange {
+    #[serde(deserialize_with = "crate::deserializer::u16_or_string")]
     pub max: u16,
+    #[serde(deserialize_with = "crate::deserializer::u16_or_string")]
     pub min: u16,
 }

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -55,10 +55,20 @@ impl LinuxBridgeInterface {
         self.flatten_port_vlan_ranges();
         self.sort_port_vlans();
         self.treat_none_vlan_as_empty_dict();
+        self.remove_runtime_only_timers();
     }
 
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn remove_runtime_only_timers(&mut self) {
+        if let Some(ref mut br_conf) = self.bridge {
+            if let Some(ref mut opts) = &mut br_conf.options {
+                opts.gc_timer = None;
+                opts.hello_timer = None;
+            }
+        }
     }
 
     fn sort_ports(&mut self) {
@@ -222,7 +232,7 @@ impl LinuxBridgeInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -253,7 +263,7 @@ impl LinuxBridgeConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgePortConfig {
     pub name: String,
@@ -296,11 +306,10 @@ impl LinuxBridgePortConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgeOptions {
-    // `gc_timer` is runtime status, not allowing for changing
-    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gc_timer: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_addr: Option<String>,
@@ -313,8 +322,7 @@ pub struct LinuxBridgeOptions {
     pub group_fwd_mask: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash_max: Option<u32>,
-    // `hello_timer` is runtime status, not allowing for changing
-    #[serde(skip_serializing_if = "Option::is_none", skip_deserializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hello_timer: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_ageing_time: Option<u32>,
@@ -361,7 +369,7 @@ impl LinuxBridgeOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgeStpOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -485,7 +493,7 @@ impl std::fmt::Display for LinuxBridgeMulticastRouterType {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LinuxBridgePortVlanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -583,6 +591,7 @@ impl LinuxBridgePortTunkTag {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct LinuxBridgePortVlanRange {
     pub max: u16,
     pub min: u16,

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -61,7 +61,7 @@ impl MacVlanInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct MacVlanConfig {
     pub base_iface: String,

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -66,7 +66,13 @@ impl MacVlanInterface {
 pub struct MacVlanConfig {
     pub base_iface: String,
     pub mode: MacVlanMode,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "promiscuous")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "promiscuous",
+        alias = "accept-all-mac",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub accept_all_mac: Option<bool>,
 }
 

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -61,7 +61,7 @@ impl MacVtapInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct MacVtapConfig {
     pub base_iface: String,

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -66,7 +66,13 @@ impl MacVtapInterface {
 pub struct MacVtapConfig {
     pub base_iface: String,
     pub mode: MacVtapMode,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "promiscuous")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "promiscuous",
+        alias = "accept-all-mac",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub accept_all_mac: Option<bool>,
 }
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -95,7 +95,7 @@ impl OvsBridgeInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,7 +117,7 @@ impl OvsBridgeConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgeOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -137,7 +137,7 @@ impl OvsBridgeOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgePortConfig {
     pub name: String,

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -120,11 +120,23 @@ impl OvsBridgeConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgeOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub stp: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub rstp: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub mcast_snooping_enable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fail_mode: Option<String>,
@@ -187,9 +199,17 @@ pub struct OvsBridgeBondConfig {
     pub mode: Option<OvsBridgeBondMode>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
     pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub bond_downdelay: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub bond_updelay: Option<u32>,
 }
 

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -7,7 +7,11 @@ use crate::{ErrorKind, Interface, InterfaceType, Interfaces, NmstateError};
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SrIovConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub total_vfs: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vfs: Option<Vec<SrIovVfConfig>>,
@@ -113,22 +117,47 @@ impl SrIovConfig {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SrIovVfConfig {
+    #[serde(deserialize_with = "crate::deserializer::u32_or_string")]
     pub id: u32,
     #[serde(skip)]
     pub(crate) iface_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub spoof_check: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub trust: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub min_tx_rate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub max_tx_rate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub vlan_id: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub qos: Option<u32>,
 }
 

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{ErrorKind, Interface, InterfaceType, Interfaces, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SrIovConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,7 +110,7 @@ impl SrIovConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct SrIovVfConfig {
     pub id: u32,

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -47,6 +47,7 @@ impl VlanInterface {
 #[non_exhaustive]
 pub struct VlanConfig {
     pub base_iface: String,
+    #[serde(deserialize_with = "crate::deserializer::u16_or_string")]
     pub id: u16,
 }
 

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -43,7 +43,7 @@ impl VlanInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct VlanConfig {
     pub base_iface: String,

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -57,7 +57,10 @@ impl VrfInterface {
 #[serde(deny_unknown_fields)]
 pub struct VrfConfig {
     pub port: Option<Vec<String>>,
-    #[serde(rename = "route-table-id")]
+    #[serde(
+        rename = "route-table-id",
+        deserialize_with = "crate::deserializer::u32_or_string"
+    )]
     pub table_id: u32,
 }
 

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -54,6 +54,7 @@ impl VrfInterface {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct VrfConfig {
     pub port: Option<Vec<String>>,
     #[serde(rename = "route-table-id")]

--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -43,7 +43,7 @@ impl VxlanInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct VxlanConfig {
     pub base_iface: String,

--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -47,10 +47,14 @@ impl VxlanInterface {
 #[non_exhaustive]
 pub struct VxlanConfig {
     pub base_iface: String,
+    #[serde(deserialize_with = "crate::deserializer::u32_or_string")]
     pub id: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote: Option<std::net::IpAddr>,
-    #[serde(rename = "destination-port")]
+    #[serde(
+        rename = "destination-port",
+        deserialize_with = "crate::deserializer::option_u16_or_string"
+    )]
     pub dst_port: Option<u16>,
 }
 

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -1,249 +1,55 @@
-use std::fmt;
+use std::net::IpAddr;
 use std::str::FromStr;
 
-use log::{debug, warn};
-use serde::de::{self, Deserializer, MapAccess, Visitor};
-use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crate::{DnsClientState, ErrorKind, Interfaces, NmstateError};
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[non_exhaustive]
 pub struct InterfaceIpv4 {
+    #[serde(default, deserialize_with = "crate::deserializer::bool_or_string")]
     pub enabled: bool,
-    pub prop_list: Vec<&'static str>,
-    pub dhcp: bool,
-    pub addresses: Vec<InterfaceIpAddr>,
+    #[serde(skip)]
+    pub(crate) prop_list: Vec<&'static str>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub dhcp: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "address")]
+    pub addresses: Option<Vec<InterfaceIpAddr>>,
+    #[serde(skip)]
     pub(crate) dns: Option<DnsClientState>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-dns",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_dns: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-gateway",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_gateway: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-routes",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_routes: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-route-table-id",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub auto_table_id: Option<u32>,
-}
-
-impl Serialize for InterfaceIpv4 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut serial_struct = serializer.serialize_struct(
-            "ipv4",
-            if self.enabled {
-                if self.dhcp {
-                    self.prop_list.len()
-                } else {
-                    std::cmp::min(3, self.prop_list.len())
-                }
-            } else {
-                1
-            },
-        )?;
-        serial_struct.serialize_field("enabled", &self.enabled)?;
-        if self.enabled {
-            if self.prop_list.contains(&"dhcp") {
-                serial_struct.serialize_field("dhcp", &self.dhcp)?;
-            }
-            if self.dhcp {
-                if self.prop_list.contains(&"auto_dns") {
-                    serial_struct
-                        .serialize_field("auto-dns", &self.auto_dns)?;
-                }
-                if self.prop_list.contains(&"auto_gateway") {
-                    serial_struct
-                        .serialize_field("auto-gateway", &self.auto_gateway)?;
-                }
-                if self.prop_list.contains(&"auto_routes") {
-                    serial_struct
-                        .serialize_field("auto-routes", &self.auto_routes)?;
-                }
-                if self.prop_list.contains(&"auto_table_id") {
-                    serial_struct.serialize_field(
-                        "auto-route-table-id",
-                        &self.auto_table_id,
-                    )?;
-                }
-            }
-            if self.prop_list.contains(&"addresses") {
-                serial_struct.serialize_field("address", &self.addresses)?;
-            }
-        }
-        serial_struct.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for InterfaceIpv4 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        enum Field {
-            Enabled,
-            Dhcp,
-            Address,
-            AutoDns,
-            AutoGateway,
-            AutoRoutes,
-            AutoRouteTableId,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(
-                        &self,
-                        formatter: &mut fmt::Formatter,
-                    ) -> fmt::Result {
-                        formatter.write_str(
-                            "`enabled`, `dhcp`, `address`\
-                            `auto-dns`, `auto-gateway`, `auto-routes` or \
-                            `auto-route-table-id`",
-                        )
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "enabled" => Ok(Field::Enabled),
-                            "dhcp" => Ok(Field::Dhcp),
-                            "address" => Ok(Field::Address),
-                            "auto-dns" => Ok(Field::AutoDns),
-                            "auto-gateway" => Ok(Field::AutoGateway),
-                            "auto-routes" => Ok(Field::AutoRoutes),
-                            "auto-route-table-id" => {
-                                Ok(Field::AutoRouteTableId)
-                            }
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct InterfaceIpv4Visitor;
-
-        impl<'de> Visitor<'de> for InterfaceIpv4Visitor {
-            type Value = InterfaceIpv4;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct InterfaceIpv4")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<InterfaceIpv4, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut enabled = false;
-                let mut dhcp = false;
-                let mut prop_list: Vec<&'static str> = Vec::new();
-                let mut addresses: Vec<InterfaceIpAddr> = Vec::new();
-                let mut auto_dns = None;
-                let mut auto_routes = None;
-                let mut auto_gateway = None;
-                let mut auto_table_id = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Enabled => {
-                            if prop_list.contains(&"enabled") {
-                                return Err(de::Error::duplicate_field(
-                                    "enabled",
-                                ));
-                            }
-                            enabled = map.next_value()?;
-                            prop_list.push("enabled");
-                        }
-                        Field::Dhcp => {
-                            if prop_list.contains(&"dhcp") {
-                                return Err(de::Error::duplicate_field("dhcp"));
-                            }
-                            dhcp = map.next_value()?;
-                            prop_list.push("dhcp");
-                        }
-                        Field::Address => {
-                            if prop_list.contains(&"addresses") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            addresses = map.next_value()?;
-                            prop_list.push("addresses");
-                        }
-                        Field::AutoDns => {
-                            if prop_list.contains(&"auto_dns") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_dns = map.next_value()?;
-                            prop_list.push("auto_dns");
-                        }
-                        Field::AutoGateway => {
-                            if prop_list.contains(&"auto_gateway") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_gateway = map.next_value()?;
-                            prop_list.push("auto_gateway");
-                        }
-                        Field::AutoRoutes => {
-                            if prop_list.contains(&"auto_routes") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_routes = map.next_value()?;
-                            prop_list.push("auto_routes");
-                        }
-                        Field::AutoRouteTableId => {
-                            if prop_list.contains(&"auto_table_id") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_table_id = map.next_value()?;
-                            prop_list.push("auto_table_id");
-                        }
-                    }
-                }
-                Ok(InterfaceIpv4 {
-                    enabled,
-                    prop_list,
-                    dhcp,
-                    addresses,
-                    auto_dns,
-                    auto_gateway,
-                    auto_routes,
-                    auto_table_id,
-                    dns: None,
-                })
-            }
-        }
-        const FIELDS: &[&str] = &[
-            "enabled",
-            "dhcp",
-            "address",
-            "auto-dns",
-            "auto-gateway",
-            "auto-routes",
-            "auto-route-table-id",
-        ];
-        deserializer.deserialize_struct(
-            "InterfaceIpv4",
-            FIELDS,
-            InterfaceIpv4Visitor,
-        )
-    }
 }
 
 impl InterfaceIpv4 {
@@ -251,13 +57,19 @@ impl InterfaceIpv4 {
         Self::default()
     }
 
+    pub(crate) fn is_auto(&self) -> bool {
+        self.enabled && self.dhcp == Some(true)
+    }
+
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;
         }
+
         if other.prop_list.contains(&"dhcp") {
             self.dhcp = other.dhcp;
         }
+
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();
         }
@@ -276,23 +88,37 @@ impl InterfaceIpv4 {
         if other.prop_list.contains(&"auto_table_id") {
             self.auto_table_id = other.auto_table_id;
         }
+
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
                 self.prop_list.push(other_prop_name);
             }
         }
+        self.cleanup()
+    }
+
+    // * Disable DHCP and remove address if enabled: false
+    // * Set DHCP options to None if DHCP is false
+    fn cleanup(&mut self) {
+        if !self.enabled {
+            self.dhcp = None;
+            self.addresses = None;
+        }
+
+        if self.dhcp != Some(true) {
+            self.auto_dns = None;
+            self.auto_gateway = None;
+            self.auto_routes = None;
+            self.auto_table_id = None;
+        }
     }
 
     // Clean up before sending to plugin for applying
-    // * Convert expanded IP address to compacted
     // * Set auto_dns, auto_gateway and auto_routes to true if DHCP enabled and
     //   those options is None
     // * Remove static IP address when DHCP enabled.
-    pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
-        for addr in &mut self.addresses {
-            addr.sanitize()?;
-        }
-        if self.enabled && self.dhcp {
+    pub(crate) fn pre_edit_cleanup(&mut self) {
+        if self.is_auto() {
             if self.auto_dns.is_none() {
                 self.auto_dns = Some(true);
             }
@@ -302,309 +128,116 @@ impl InterfaceIpv4 {
             if self.auto_gateway.is_none() {
                 self.auto_gateway = Some(true);
             }
-            if !self.addresses.is_empty() {
+            if !self.addresses.as_deref().unwrap_or_default().is_empty() {
                 log::warn!(
                     "Static addresses {:?} are ignored when dynamic \
                     IP is enabled",
-                    self.addresses.as_slice()
+                    self.addresses.as_deref().unwrap_or_default()
                 );
-                self.addresses = Vec::new();
+                self.addresses = None;
             }
         }
-        Ok(())
+        self.cleanup();
     }
 
     // Clean up before verification
     // * Sort IP address
-    // * Convert expanded IP address to compacted
-    // * Add optional properties to prop_list
     // * Ignore DHCP options if DHCP disabled
     // * Ignore address if DHCP enabled
     // * Set DHCP as off if enabled and dhcp is None
     pub(crate) fn pre_verify_cleanup(&mut self) {
-        self.addresses.sort_unstable_by(|a, b| {
-            (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
-        });
-        for addr in &mut self.addresses {
-            if let Err(e) = addr.sanitize() {
-                warn!("BUG: IP address sanitize failure: {}", e);
-            }
+        self.cleanup();
+        if self.dhcp == Some(true) {
+            self.addresses = None;
         }
-        debug!("IPv4 after pre_verify_cleanup: {:?}", self);
-        self.prop_list.push("dhcp");
-        if !self.enabled || !self.dhcp {
-            self.prop_list.retain(|p| {
-                !["auto_dns", "auto_routes", "auto_gateway", "auto_table_id"]
-                    .contains(p)
-            });
-        }
-        if self.enabled && self.dhcp && self.prop_list.contains(&"addresses") {
-            self.prop_list.retain(|p| p != &"addresses")
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable_by(|a, b| {
+                (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
+            })
+        };
+        if self.dhcp != Some(true) {
+            self.dhcp = Some(false);
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct InterfaceIpv6 {
+    #[serde(default, deserialize_with = "crate::deserializer::bool_or_string")]
     pub enabled: bool,
-    pub prop_list: Vec<&'static str>,
-    pub dhcp: bool,
-    pub autoconf: bool,
-    pub addresses: Vec<InterfaceIpAddr>,
+    #[serde(skip)]
+    pub(crate) prop_list: Vec<&'static str>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub dhcp: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub autoconf: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "address")]
+    pub addresses: Option<Vec<InterfaceIpAddr>>,
+    #[serde(skip)]
     pub(crate) dns: Option<DnsClientState>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        rename = "auto-dns",
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_dns: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        rename = "auto-gateway",
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_gateway: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-routes",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub auto_routes: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-route-table-id",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub auto_table_id: Option<u32>,
-}
-
-impl Serialize for InterfaceIpv6 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut serial_struct = serializer.serialize_struct(
-            "ipv6",
-            if self.enabled {
-                if self.dhcp || self.autoconf {
-                    self.prop_list.len()
-                } else {
-                    // If DHCP disabled, we can only show
-                    std::cmp::min(4, self.prop_list.len())
-                }
-            } else {
-                1
-            },
-        )?;
-        serial_struct.serialize_field("enabled", &self.enabled)?;
-        if self.enabled {
-            if self.prop_list.contains(&"dhcp") {
-                serial_struct.serialize_field("dhcp", &self.dhcp)?;
-            }
-            if self.prop_list.contains(&"autoconf") {
-                serial_struct.serialize_field("autoconf", &self.autoconf)?;
-            }
-            if self.dhcp || self.autoconf {
-                if self.prop_list.contains(&"auto_dns") {
-                    serial_struct
-                        .serialize_field("auto-dns", &self.auto_dns)?;
-                }
-                if self.prop_list.contains(&"auto_gateway") {
-                    serial_struct
-                        .serialize_field("auto-gateway", &self.auto_gateway)?;
-                }
-                if self.prop_list.contains(&"auto_routes") {
-                    serial_struct
-                        .serialize_field("auto-routes", &self.auto_routes)?;
-                }
-                if self.prop_list.contains(&"auto_table_id") {
-                    serial_struct.serialize_field(
-                        "auto-route-table-id",
-                        &self.auto_table_id,
-                    )?;
-                }
-            }
-            if self.prop_list.contains(&"addresses") {
-                serial_struct.serialize_field("address", &self.addresses)?;
-            }
-        }
-        serial_struct.end()
-    }
-}
-
-impl<'de> Deserialize<'de> for InterfaceIpv6 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        enum Field {
-            Enabled,
-            Dhcp,
-            Autoconf,
-            Address,
-            AutoDns,
-            AutoGateway,
-            AutoRoutes,
-            AutoRouteTableId,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(
-                        &self,
-                        formatter: &mut fmt::Formatter,
-                    ) -> fmt::Result {
-                        formatter.write_str(
-                            "`enabled`, `dhcp`, `autoconf`, `address` \
-                            `auto-dns`, `auto-gateway`, `auto-routes` or \
-                            `auto-route-table-id`",
-                        )
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "enabled" => Ok(Field::Enabled),
-                            "dhcp" => Ok(Field::Dhcp),
-                            "autoconf" => Ok(Field::Autoconf),
-                            "address" => Ok(Field::Address),
-                            "auto-dns" => Ok(Field::AutoDns),
-                            "auto-gateway" => Ok(Field::AutoGateway),
-                            "auto-routes" => Ok(Field::AutoRoutes),
-                            "auto-route-table-id" => {
-                                Ok(Field::AutoRouteTableId)
-                            }
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct InterfaceIpv6Visitor;
-
-        impl<'de> Visitor<'de> for InterfaceIpv6Visitor {
-            type Value = InterfaceIpv6;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct InterfaceIpv6")
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<InterfaceIpv6, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut enabled = false;
-                let mut dhcp = false;
-                let mut autoconf = false;
-                let mut prop_list: Vec<&'static str> = Vec::new();
-                let mut addresses: Vec<InterfaceIpAddr> = Vec::new();
-                let mut auto_dns = None;
-                let mut auto_routes = None;
-                let mut auto_gateway = None;
-                let mut auto_table_id = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Enabled => {
-                            if prop_list.contains(&"enabled") {
-                                return Err(de::Error::duplicate_field(
-                                    "enabled",
-                                ));
-                            }
-                            enabled = map.next_value()?;
-                            prop_list.push("enabled");
-                        }
-                        Field::Dhcp => {
-                            if prop_list.contains(&"dhcp") {
-                                return Err(de::Error::duplicate_field("dhcp"));
-                            }
-                            dhcp = map.next_value()?;
-                            prop_list.push("dhcp");
-                        }
-                        Field::Autoconf => {
-                            if prop_list.contains(&"autoconf") {
-                                return Err(de::Error::duplicate_field(
-                                    "autoconf",
-                                ));
-                            }
-                            autoconf = map.next_value()?;
-                            prop_list.push("autoconf");
-                        }
-                        Field::Address => {
-                            if prop_list.contains(&"addresses") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            addresses = map.next_value()?;
-                            prop_list.push("addresses");
-                        }
-                        Field::AutoDns => {
-                            if prop_list.contains(&"auto_dns") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_dns = map.next_value()?;
-                            prop_list.push("auto_dns");
-                        }
-                        Field::AutoGateway => {
-                            if prop_list.contains(&"auto_gateway") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_gateway = map.next_value()?;
-                            prop_list.push("auto_gateway");
-                        }
-                        Field::AutoRoutes => {
-                            if prop_list.contains(&"auto_routes") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_routes = map.next_value()?;
-                            prop_list.push("auto_routes");
-                        }
-                        Field::AutoRouteTableId => {
-                            if prop_list.contains(&"auto_table_id") {
-                                return Err(de::Error::duplicate_field(
-                                    "address",
-                                ));
-                            }
-                            auto_table_id = map.next_value()?;
-                            prop_list.push("auto_table_id");
-                        }
-                    }
-                }
-                Ok(InterfaceIpv6 {
-                    enabled,
-                    prop_list,
-                    dhcp,
-                    autoconf,
-                    addresses,
-                    auto_dns,
-                    auto_gateway,
-                    auto_routes,
-                    auto_table_id,
-                    dns: None,
-                })
-            }
-        }
-        const FIELDS: &[&str] = &[
-            "enabled",
-            "dhcp",
-            "autoconf",
-            "address",
-            "auto-dns",
-            "auto-gateway",
-            "auto-routes",
-            "auto-route-table-id",
-        ];
-        deserializer.deserialize_struct(
-            "InterfaceIpv6",
-            FIELDS,
-            InterfaceIpv6Visitor,
-        )
-    }
 }
 
 impl InterfaceIpv6 {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn is_auto(&self) -> bool {
+        self.enabled && (self.dhcp == Some(true) || self.autoconf == Some(true))
+    }
+
+    // * Disable DHCP and remove address if enabled: false
+    // * Set DHCP options to None if DHCP is false
+    fn cleanup(&mut self) {
+        if !self.enabled {
+            self.dhcp = None;
+            self.autoconf = None;
+            self.addresses = None;
+        }
+
+        if !self.is_auto() {
+            self.auto_dns = None;
+            self.auto_gateway = None;
+            self.auto_routes = None;
+            self.auto_table_id = None;
+        }
     }
 
     pub(crate) fn update(&mut self, other: &Self) {
@@ -640,65 +273,64 @@ impl InterfaceIpv6 {
                 self.prop_list.push(other_prop_name);
             }
         }
+        self.cleanup()
     }
 
     // Clean up before verification
     // * Remove link-local address
-    // * Sanitize the expanded IP address
-    // * Add optional properties to prop_list
     // * Ignore DHCP options if DHCP disabled
     // * Ignore IP address when DHCP/autoconf enabled.
+    // * Set DHCP None to Some(false)
     pub(crate) fn pre_verify_cleanup(&mut self) {
-        self.addresses.retain(|addr| {
-            !is_ipv6_unicast_link_local(&addr.ip, addr.prefix_length)
-        });
-        self.addresses.sort_unstable_by(|a, b| {
-            (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
-        });
-        for addr in &mut self.addresses {
-            if let Err(e) = addr.sanitize() {
-                warn!("BUG: IP address sanitize failure: {}", e);
-            }
+        self.cleanup();
+        if self.is_auto() {
+            self.addresses = None;
         }
-        self.prop_list.push("dhcp");
-        self.prop_list.push("autoconf");
-        if !self.enabled || (!self.dhcp && !self.autoconf) {
-            self.prop_list.retain(|p| {
-                !["auto_dns", "auto_routes", "auto_gateway", "auto_table_id"]
-                    .contains(p)
-            });
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.retain(|addr| {
+                !is_ipv6_unicast_link_local(
+                    &addr.ip.to_string(),
+                    addr.prefix_length,
+                )
+            })
+        };
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable_by(|a, b| {
+                (&a.ip, a.prefix_length).cmp(&(&b.ip, b.prefix_length))
+            })
+        };
+        if self.dhcp != Some(true) {
+            self.dhcp = Some(false);
         }
-        if self.enabled
-            && (self.dhcp || self.autoconf)
-            && self.prop_list.contains(&"addresses")
-        {
-            self.prop_list.retain(|p| p != &"addresses")
+        if self.autoconf != Some(true) {
+            self.autoconf = Some(false);
         }
-        debug!("IPv6 after pre_verify_cleanup: {:?}", self);
     }
 
     // Clean up before Apply
     // * Remove link-local address
-    // * Sanitize the expanded IP address
     // * Set auto_dns, auto_gateway and auto_routes to true if DHCP/autoconf
     //   enabled and those options is None
     // * Remove static IP address when DHCP/autoconf enabled.
-    pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
-        self.addresses.retain(|addr| {
-            if is_ipv6_unicast_link_local(&addr.ip, addr.prefix_length) {
-                warn!(
-                    "Ignoring IPv6 link local address {}/{}",
-                    &addr.ip, addr.prefix_length
-                );
-                false
-            } else {
-                true
-            }
-        });
-        for addr in &mut self.addresses {
-            addr.sanitize()?;
-        }
-        if self.enabled && (self.dhcp || self.autoconf) {
+    pub(crate) fn pre_edit_cleanup(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.retain(|addr| {
+                if is_ipv6_unicast_link_local(
+                    &addr.ip.to_string(),
+                    addr.prefix_length,
+                ) {
+                    log::warn!(
+                        "Ignoring IPv6 link local address {}/{}",
+                        &addr.ip,
+                        addr.prefix_length
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
+        };
+        if self.is_auto() {
             if self.auto_dns.is_none() {
                 self.auto_dns = Some(true);
             }
@@ -708,33 +340,34 @@ impl InterfaceIpv6 {
             if self.auto_gateway.is_none() {
                 self.auto_gateway = Some(true);
             }
-            if !self.addresses.is_empty() {
+            if !self.addresses.as_deref().unwrap_or_default().is_empty() {
                 log::warn!(
                     "Static addresses {:?} are ignored when dynamic \
                     IP is enabled",
-                    self.addresses.as_slice()
+                    self.addresses.as_deref().unwrap_or_default()
                 );
-                self.addresses = Vec::new();
+                self.addresses = None;
             }
         }
-        Ok(())
+        self.cleanup();
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct InterfaceIpAddr {
-    pub ip: String,
+    pub ip: IpAddr,
+    #[serde(deserialize_with = "crate::deserializer::u8_or_string")]
     pub prefix_length: u8,
 }
 
-impl InterfaceIpAddr {
-    // TOOD: Check prefix_length also for 32 and 128 limitation.
-    pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
-        let ip = std::net::IpAddr::from_str(&self.ip)?;
-        self.ip = ip.to_string();
-        Ok(())
+impl Default for InterfaceIpAddr {
+    fn default() -> Self {
+        Self {
+            ip: IpAddr::V6(std::net::Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+            prefix_length: 128,
+        }
     }
 }
 
@@ -757,9 +390,17 @@ impl std::convert::TryFrom<&str> for InterfaceIpAddr {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let mut addr: Vec<&str> = value.split('/').collect();
         addr.resize(2, "");
-        let ip = addr[0].to_string();
+        let ip = IpAddr::from_str(addr[0]).map_err(|e| {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!("Invalid IP address {}: {}", addr[0], e),
+            );
+            log::error!("{}", e);
+            e
+        })?;
+
         let prefix_length = if addr[1].is_empty() {
-            if is_ipv6_addr(&ip) {
+            if ip.is_ipv6() {
                 128
             } else {
                 32
@@ -795,30 +436,25 @@ pub(crate) fn include_current_ip_address_if_dhcp_on_to_off(
             continue;
         };
         if let Some(cur_ip_conf) = cur_iface.base_iface().ipv4.as_ref() {
-            if cur_ip_conf.dhcp && !cur_ip_conf.addresses.is_empty() {
+            if cur_ip_conf.is_auto() && cur_ip_conf.addresses.is_some() {
                 if let Some(ip_conf) = iface.base_iface_mut().ipv4.as_mut() {
                     if ip_conf.enabled
-                        && !ip_conf.dhcp
-                        && !ip_conf.prop_list.contains(&"addresses")
+                        && !ip_conf.is_auto()
+                        && ip_conf.addresses.is_none()
                     {
                         ip_conf.addresses = cur_ip_conf.addresses.clone();
-                        ip_conf.prop_list.push("addresses");
                     }
                 }
             }
         }
         if let Some(cur_ip_conf) = cur_iface.base_iface().ipv6.as_ref() {
-            if (cur_ip_conf.dhcp || cur_ip_conf.autoconf)
-                && !cur_ip_conf.addresses.is_empty()
-            {
+            if cur_ip_conf.is_auto() && cur_ip_conf.addresses.is_some() {
                 if let Some(ip_conf) = iface.base_iface_mut().ipv6.as_mut() {
                     if ip_conf.enabled
-                        && !ip_conf.dhcp
-                        && !ip_conf.autoconf
-                        && !ip_conf.prop_list.contains(&"addresses")
+                        && !ip_conf.is_auto()
+                        && ip_conf.addresses.is_none()
                     {
                         ip_conf.addresses = cur_ip_conf.addresses.clone();
-                        ip_conf.prop_list.push("addresses");
                     }
                 }
             }

--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -54,6 +54,7 @@ const LLDP_SYS_CAP_TWO_PORT_MAC_RELAY: u16 = 11;
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct LldpConfig {
+    #[serde(deserialize_with = "crate::deserializer::bool_or_string")]
     pub enabled: bool,
     #[serde(skip_deserializing, skip_serializing_if = "Vec::is_empty")]
     pub neighbors: Vec<Vec<LldpNeighborTlv>>,

--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -52,6 +52,7 @@ const LLDP_SYS_CAP_TWO_PORT_MAC_RELAY: u16 = 11;
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct LldpConfig {
     pub enabled: bool,
     #[serde(skip_deserializing, skip_serializing_if = "Vec::is_empty")]

--- a/rust/src/lib/nispor/ethtool.rs
+++ b/rust/src/lib/nispor/ethtool.rs
@@ -59,6 +59,9 @@ fn gen_ethtool_config(ethtool_info: &nispor::EthtoolInfo) -> EthtoolConfig {
         {
             feature_config.tx_tcp_segmentation = Some(*tx_tcp_segmentation);
         }
+        if let Some(highdma) = changeable.get("highdma") {
+            feature_config.highdma = Some(*highdma);
+        }
         ret.feature = Some(feature_config);
     }
     if let Some(coalesce) = &ethtool_info.coalesce {

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 
 pub(crate) fn np_ipv4_to_nmstate(
@@ -8,22 +10,35 @@ pub(crate) fn np_ipv4_to_nmstate(
         let mut ip = InterfaceIpv4::default();
         ip.prop_list.push("enabled");
         ip.prop_list.push("addresses");
-        if !np_ip.addresses.is_empty() {
-            ip.enabled = true;
+        if np_ip.addresses.is_empty() {
+            ip.enabled = false;
+            return Some(ip);
         }
+        ip.enabled = true;
+        let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
-                ip.dhcp = true;
+                ip.dhcp = Some(true);
                 ip.prop_list.push("dhcp");
                 if running_config_only {
                     continue;
                 }
             }
-            ip.addresses.push(InterfaceIpAddr {
-                ip: np_addr.address.clone(),
-                prefix_length: np_addr.prefix_len,
-            });
+            match std::net::IpAddr::from_str(np_addr.address.as_str()) {
+                Ok(i) => addresses.push(InterfaceIpAddr {
+                    ip: i,
+                    prefix_length: np_addr.prefix_len,
+                }),
+                Err(e) => {
+                    log::warn!(
+                        "BUG: nispor got invalid IP address {}, error {}",
+                        np_addr.address.as_str(),
+                        e
+                    );
+                }
+            }
         }
+        ip.addresses = Some(addresses);
         Some(ip)
     } else {
         // IP might just disabled
@@ -47,22 +62,35 @@ pub(crate) fn np_ipv6_to_nmstate(
         let mut ip = InterfaceIpv6::default();
         ip.prop_list.push("enabled");
         ip.prop_list.push("addresses");
-        if !np_ip.addresses.is_empty() {
-            ip.enabled = true;
+        if np_ip.addresses.is_empty() {
+            ip.enabled = false;
+            return Some(ip);
         }
+        ip.enabled = true;
+        let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
-                ip.autoconf = true;
+                ip.autoconf = Some(true);
                 ip.prop_list.push("autoconf");
                 if running_config_only {
                     continue;
                 }
             }
-            ip.addresses.push(InterfaceIpAddr {
-                ip: np_addr.address.clone(),
-                prefix_length: np_addr.prefix_len,
-            });
+            match std::net::IpAddr::from_str(np_addr.address.as_str()) {
+                Ok(i) => addresses.push(InterfaceIpAddr {
+                    ip: i,
+                    prefix_length: np_addr.prefix_len,
+                }),
+                Err(e) => {
+                    log::warn!(
+                        "BUG: nispor got invalid IP address {}, error {}",
+                        np_addr.address.as_str(),
+                        e
+                    );
+                }
+            }
         }
+        ip.addresses = Some(addresses);
         Some(ip)
     } else {
         // IP might just disabled
@@ -83,7 +111,7 @@ pub(crate) fn nmstate_ipv4_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv4) = nms_ipv4 {
-        for nms_addr in &nms_ipv4.addresses {
+        for nms_addr in nms_ipv4.addresses.as_deref().unwrap_or_default() {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
@@ -100,7 +128,7 @@ pub(crate) fn nmstate_ipv6_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv6) = nms_ipv6 {
-        for nms_addr in &nms_ipv6.addresses {
+        for nms_addr in nms_ipv6.addresses.as_deref().unwrap_or_default() {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();

--- a/rust/src/lib/nm/ethtool.rs
+++ b/rust/src/lib/nm/ethtool.rs
@@ -52,6 +52,7 @@ fn apply_feature_options(
     nm_ethtool_set.feature_sg = feature_conf.tx_scatter_gather;
     nm_ethtool_set.feature_tso = feature_conf.tx_tcp_segmentation;
     nm_ethtool_set.feature_tso = feature_conf.tx_generic_segmentation;
+    nm_ethtool_set.feature_highdma = feature_conf.highdma
 }
 
 fn apply_coalesce_options(

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -135,10 +135,10 @@ pub(crate) fn activate_nm_profiles(
             if nm_ac_uuids.contains(&uuid) {
                 if let Err(e) = nm_api.connection_reapply(nm_conn) {
                     log::info!(
-                    "Reapply operation failed trying activation, reason: {}, \
-                    retry on normal activation",
-                    e
-                );
+                        "Reapply operation failed trying activation, \
+                        reason: {}, retry on normal activation",
+                        e
+                    );
                     nm_api
                         .connection_activate(uuid)
                         .map_err(nm_error_to_nmstate)?;
@@ -167,10 +167,10 @@ pub(crate) fn activate_nm_profiles(
                 );
                 if let Err(e) = nm_api.connection_reapply(nm_conn) {
                     log::info!(
-                    "Reapply operation failed trying activation, reason: {}, \
-                    retry on normal activation",
-                    e
-                );
+                        "Reapply operation failed trying activation, \
+                        reason: {}, retry on normal activation",
+                        e
+                    );
                     log::info!(
                         "Activating connection {}: {}/{}",
                         uuid,

--- a/rust/src/lib/nm/route.rs
+++ b/rust/src/lib/nm/route.rs
@@ -17,7 +17,7 @@ pub(crate) fn gen_nm_ip_routes(
             }
             let ip_addr = InterfaceIpAddr::try_from(v)?;
             nm_route.prefix = Some(ip_addr.prefix_length as u32);
-            nm_route.dest = Some(ip_addr.ip);
+            nm_route.dest = Some(ip_addr.ip.to_string());
         }
         nm_route.metric = match route.metric {
             Some(RouteEntry::USE_DEFAULT_METRIC) => None,

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -25,7 +25,7 @@ pub(crate) fn gen_nm_ip_rules(
                 (true, true) | (false, false) => {
                     let ip_addr = InterfaceIpAddr::try_from(addr)?;
                     nm_rule.from_len = Some(ip_addr.prefix_length);
-                    nm_rule.from = Some(ip_addr.ip);
+                    nm_rule.from = Some(ip_addr.ip.to_string());
                 }
                 _ => continue,
             }
@@ -35,7 +35,7 @@ pub(crate) fn gen_nm_ip_rules(
                 (true, true) | (false, false) => {
                     let ip_addr = InterfaceIpAddr::try_from(addr)?;
                     nm_rule.to_len = Some(ip_addr.prefix_length);
-                    nm_rule.to = Some(ip_addr.ip);
+                    nm_rule.to = Some(ip_addr.ip.to_string());
                 }
                 _ => continue,
             }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -7,6 +7,7 @@ use crate::{ip::is_ipv6_addr, ErrorKind, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct Routes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub running: Option<Vec<RouteEntry>>,
@@ -234,6 +235,7 @@ impl Default for RouteState {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct RouteEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<RouteState>,

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -251,9 +251,17 @@ pub struct RouteEntry {
         rename = "next-hop-address"
     )]
     pub next_hop_addr: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_i64_or_string"
+    )]
     pub metric: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub table_id: Option<u32>,
 }
 

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -7,6 +7,7 @@ use crate::{ip::is_ipv6_addr, ErrorKind, InterfaceIpAddr, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct RouteRules {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Vec<RouteRuleEntry>>,
@@ -192,6 +193,7 @@ impl Default for RouteRuleState {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct RouteRuleEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<RouteRuleState>,

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -201,9 +201,18 @@ pub struct RouteRuleEntry {
     pub ip_from: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_to: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_i64_or_string"
+    )]
     pub priority: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "route-table")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "route-table",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub table_id: Option<u32>,
 }
 

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -1,0 +1,14 @@
+use crate::BaseInterface;
+
+#[test]
+fn test_base_iface_stringlized_attributes() {
+    let iface: BaseInterface = serde_yaml::from_str(
+        r#"
+name: "eth1"
+mtu: "1500"
+accept-all-mac-addresses: "true"
+"#,
+    )
+    .unwrap();
+    assert_eq!(iface.accept_all_mac_addresses, Some(true));
+}

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -1,4 +1,7 @@
-use crate::{BondInterface, ErrorKind, Interface};
+use crate::{
+    BondAdSelect, BondAllPortsActive, BondArpValidate, BondFailOverMac,
+    BondInterface, BondLacpRate, BondPrimaryReselect, ErrorKind, Interface,
+};
 
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_undefined() {
@@ -185,4 +188,66 @@ link-aggregation:
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
+}
+
+#[test]
+fn test_bond_stringlized_attributes() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: 802.3ad
+  options:
+    ad_actor_sys_prio: "555"
+    ad_select: "1"
+    ad_user_port_key: "16"
+    all_slaves_active: "1"
+    arp_interval: "100"
+    arp_validate: "1"
+    downdelay: "50"
+    fail_over_mac: "1"
+    lacp_rate: "0"
+    lp_interval: "101"
+    miimon: "200"
+    min_links: "2"
+    num_grat_arp: "3"
+    num_unsol_na: "4"
+    packets_per_slave: "1000"
+    primary_reselect: "1"
+    resend_igmp: "103"
+    tlb_dynamic_lb: "true"
+    updelay: "104"
+    use_carrier: "false"
+"#,
+    )
+    .unwrap();
+    let bond_opts = iface.bond.unwrap().options.unwrap();
+    assert_eq!(bond_opts.ad_actor_sys_prio, Some(555));
+    assert_eq!(bond_opts.ad_select, Some(BondAdSelect::Bandwidth));
+    assert_eq!(bond_opts.ad_user_port_key, Some(16));
+    assert_eq!(
+        bond_opts.all_slaves_active,
+        Some(BondAllPortsActive::Delivered)
+    );
+    assert_eq!(bond_opts.arp_interval, Some(100));
+    assert_eq!(bond_opts.arp_validate, Some(BondArpValidate::Active));
+    assert_eq!(bond_opts.downdelay, Some(50));
+    assert_eq!(bond_opts.fail_over_mac, Some(BondFailOverMac::Active));
+    assert_eq!(bond_opts.lacp_rate, Some(BondLacpRate::Slow));
+    assert_eq!(bond_opts.lp_interval, Some(101));
+    assert_eq!(bond_opts.miimon, Some(200));
+    assert_eq!(bond_opts.min_links, Some(2));
+    assert_eq!(bond_opts.num_grat_arp, Some(3));
+    assert_eq!(bond_opts.num_unsol_na, Some(4));
+    assert_eq!(bond_opts.packets_per_slave, Some(1000));
+    assert_eq!(
+        bond_opts.primary_reselect,
+        Some(BondPrimaryReselect::Better)
+    );
+    assert_eq!(bond_opts.resend_igmp, Some(103));
+    assert_eq!(bond_opts.tlb_dynamic_lb, Some(true));
+    assert_eq!(bond_opts.updelay, Some(104));
+    assert_eq!(bond_opts.use_carrier, Some(false));
 }

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -1,0 +1,40 @@
+use crate::EthernetInterface;
+
+#[test]
+fn test_ethernet_stringlized_attributes() {
+    let iface: EthernetInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+ethernet:
+  auto-negotiation: "false"
+  speed: "1000"
+  sr-iov:
+    total-vfs: "64"
+    vfs:
+      - id: "0"
+        spoof-check: "true"
+        trust: "false"
+        min-tx-rate: "100"
+        max-tx-rate: "101"
+        vlan-id: "102"
+        qos: "103"
+"#,
+    )
+    .unwrap();
+
+    let eth_conf = iface.ethernet.unwrap();
+    let sriov_conf = eth_conf.sr_iov.as_ref().unwrap();
+    let vf_conf = sriov_conf.vfs.as_ref().unwrap().get(0).unwrap();
+
+    assert_eq!(eth_conf.speed, Some(1000));
+    assert_eq!(sriov_conf.total_vfs, Some(64));
+    assert_eq!(vf_conf.id, 0);
+    assert_eq!(vf_conf.spoof_check, Some(true));
+    assert_eq!(vf_conf.trust, Some(false));
+    assert_eq!(vf_conf.min_tx_rate, Some(100));
+    assert_eq!(vf_conf.max_tx_rate, Some(101));
+    assert_eq!(vf_conf.vlan_id, Some(102));
+    assert_eq!(vf_conf.qos, Some(103));
+}

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -1,0 +1,113 @@
+use crate::EthernetInterface;
+
+#[test]
+fn test_ethtool_stringlized_attributes() {
+    let iface: EthernetInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+ethtool:
+  pause:
+    rx: "off"
+    tx: "off"
+    autoneg: "off"
+  feature:
+    rx-checksum: "true"
+    rx-gro: "true"
+    rx-lro: "true"
+    rx-vlan-hw-parse: "true"
+    tx-vlan-hw-insert: "true"
+    rx-ntuple-filter: "true"
+    rx-hashing: "true"
+    tx-scatter-gather: "true"
+    tx-tcp-segmentation: "true"
+    tx-generic-segmentation: "true"
+  coalesce:
+    adaptive-rx: "0"
+    adaptive-tx: "0"
+    pkt-rate-high: "101"
+    pkt-rate-low: "102"
+    rx-frames: "103"
+    rx-frames-high: "104"
+    rx-frames-irq: "105"
+    rx-frames-low: "106"
+    rx-usecs: "107"
+    rx-usecs-high: "108"
+    rx-usecs-irq: "109"
+    rx-usecs-low: "110"
+    sample-interval: "111"
+    stats-block-usecs: "112"
+    tx-frames: "113"
+    tx-frames-high: "114"
+    tx-frames-irq: "115"
+    tx-frames-low: "116"
+    tx-usecs: "117"
+    tx-usecs-high: "118"
+    tx-usecs-irq: "119"
+    tx-usecs-low: "120"
+  ring:
+    rx: "200"
+    rx-max: "201"
+    rx-jumbo: "202"
+    rx-jumbo-max: "203"
+    rx-mini: "204"
+    rx-mini-max: "205"
+    tx: "206"
+    tx-max: "207"
+
+"#,
+    )
+    .unwrap();
+
+    let ethtool_conf = iface.base.ethtool.unwrap();
+    let feature = ethtool_conf.feature.as_ref().unwrap();
+    let pause = ethtool_conf.pause.as_ref().unwrap();
+    let coalesce = ethtool_conf.coalesce.as_ref().unwrap();
+    let ring = ethtool_conf.ring.as_ref().unwrap();
+
+    assert_eq!(feature.rx_checksum, Some(true));
+    assert_eq!(feature.rx_gro, Some(true));
+    assert_eq!(feature.rx_lro, Some(true));
+    assert_eq!(feature.rx_vlan_hw_parse, Some(true));
+    assert_eq!(feature.tx_vlan_hw_insert, Some(true));
+    assert_eq!(feature.rx_ntuple_filter, Some(true));
+    assert_eq!(feature.rx_hashing, Some(true));
+    assert_eq!(feature.tx_scatter_gather, Some(true));
+    assert_eq!(feature.tx_tcp_segmentation, Some(true));
+    assert_eq!(feature.tx_generic_segmentation, Some(true));
+    assert_eq!(pause.tx, Some(false));
+    assert_eq!(pause.rx, Some(false));
+    assert_eq!(pause.autoneg, Some(false));
+
+    assert_eq!(coalesce.adaptive_rx, Some(false));
+    assert_eq!(coalesce.adaptive_tx, Some(false));
+    assert_eq!(coalesce.pkt_rate_high, Some(101));
+    assert_eq!(coalesce.pkt_rate_low, Some(102));
+    assert_eq!(coalesce.rx_frames, Some(103));
+    assert_eq!(coalesce.rx_frames_high, Some(104));
+    assert_eq!(coalesce.rx_frames_irq, Some(105));
+    assert_eq!(coalesce.rx_frames_low, Some(106));
+    assert_eq!(coalesce.rx_usecs, Some(107));
+    assert_eq!(coalesce.rx_usecs_high, Some(108));
+    assert_eq!(coalesce.rx_usecs_irq, Some(109));
+    assert_eq!(coalesce.rx_usecs_low, Some(110));
+    assert_eq!(coalesce.sample_interval, Some(111));
+    assert_eq!(coalesce.stats_block_usecs, Some(112));
+    assert_eq!(coalesce.tx_frames, Some(113));
+    assert_eq!(coalesce.tx_frames_high, Some(114));
+    assert_eq!(coalesce.tx_frames_irq, Some(115));
+    assert_eq!(coalesce.tx_frames_low, Some(116));
+    assert_eq!(coalesce.tx_usecs, Some(117));
+    assert_eq!(coalesce.tx_usecs_high, Some(118));
+    assert_eq!(coalesce.tx_usecs_irq, Some(119));
+    assert_eq!(coalesce.tx_usecs_low, Some(120));
+    assert_eq!(ring.rx, Some(200));
+    assert_eq!(ring.rx_max, Some(201));
+    assert_eq!(ring.rx_jumbo, Some(202));
+    assert_eq!(ring.rx_jumbo_max, Some(203));
+    assert_eq!(ring.rx_mini, Some(204));
+    assert_eq!(ring.rx_mini_max, Some(205));
+    assert_eq!(ring.tx, Some(206));
+    assert_eq!(ring.tx_max, Some(207));
+}

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,0 +1,69 @@
+use crate::{BaseInterface, Interface, InterfaceState};
+
+#[test]
+fn test_ip_stringlized_attributes() {
+    let iface: BaseInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+ipv4:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "192.168.1.1"
+    prefix-length: "24"
+ipv6:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+    prefix-length: "64"
+"#,
+    )
+    .unwrap();
+    let ipv4_conf = iface.ipv4.unwrap();
+    let ipv6_conf = iface.ipv6.unwrap();
+
+    assert_eq!(ipv4_conf.enabled, true);
+    assert_eq!(ipv4_conf.dhcp, Some(false));
+    assert_eq!(
+        ipv4_conf.addresses.as_deref().unwrap()[0].ip.to_string(),
+        "192.168.1.1"
+    );
+    assert_eq!(ipv4_conf.addresses.as_deref().unwrap()[0].prefix_length, 24);
+    assert_eq!(ipv6_conf.enabled, true);
+    assert_eq!(
+        ipv6_conf.addresses.as_deref().unwrap()[0].ip.to_string(),
+        "2001:db8:85a3::8a2e:370:7331",
+    );
+    assert_eq!(ipv6_conf.addresses.as_deref().unwrap()[0].prefix_length, 64);
+}
+
+#[test]
+fn test_ip_ignore_deserialize_error_of_absent_iface() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: absent
+ipv4:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "g.g.g.g"
+    prefix-length: "24"
+ipv6:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "::g"
+    prefix-length: "64"
+"#,
+    )
+    .unwrap();
+    assert_eq!(iface.base_iface().state, InterfaceState::Absent);
+    assert_eq!(iface.name(), "eth1");
+    assert_eq!(iface.base_iface().ipv4, None);
+    assert_eq!(iface.base_iface().ipv6, None);
+}

--- a/rust/src/lib/unit_tests/lldp.rs
+++ b/rust/src/lib/unit_tests/lldp.rs
@@ -1,0 +1,33 @@
+use crate::LldpConfig;
+
+#[test]
+fn test_lldp_stringlized_attributes() {
+    let confs: Vec<LldpConfig> = serde_yaml::from_str(
+        r#"
+- enabled: "true"
+- enabled: true
+- enabled: "yes"
+- enabled: "y"
+- enabled: 1
+- enabled: "1"
+"#,
+    )
+    .unwrap();
+    for conf in &confs {
+        assert!(conf.enabled);
+    }
+    let confs: Vec<LldpConfig> = serde_yaml::from_str(
+        r#"
+- enabled: "false"
+- enabled: false
+- enabled: "no"
+- enabled: "n"
+- enabled: 0
+- enabled: "0"
+"#,
+    )
+    .unwrap();
+    for conf in &confs {
+        assert!(!conf.enabled);
+    }
+}

--- a/rust/src/lib/unit_tests/mac_vlan.rs
+++ b/rust/src/lib/unit_tests/mac_vlan.rs
@@ -1,0 +1,20 @@
+use crate::MacVlanInterface;
+
+#[test]
+fn test_mac_vlan_stringlized_attributes() {
+    let iface: MacVlanInterface = serde_yaml::from_str(
+        r#"---
+name: mac1
+type: mac-vlan
+state: up
+mac-vlan:
+  base-iface: "eth1"
+  mode: "vepa"
+  accept-all-mac: "true"
+"#,
+    )
+    .unwrap();
+
+    let mac_conf = iface.mac_vlan.unwrap();
+    assert_eq!(mac_conf.accept_all_mac, Some(true));
+}

--- a/rust/src/lib/unit_tests/mac_vtap.rs
+++ b/rust/src/lib/unit_tests/mac_vtap.rs
@@ -1,0 +1,20 @@
+use crate::MacVtapInterface;
+
+#[test]
+fn test_mac_vtap_stringlized_attributes() {
+    let iface: MacVtapInterface = serde_yaml::from_str(
+        r#"---
+name: mac1
+type: mac-vtap
+state: up
+mac-vtap:
+  base-iface: "eth1"
+  mode: "vepa"
+  accept-all-mac: "true"
+"#,
+    )
+    .unwrap();
+
+    let mac_conf = iface.mac_vtap.unwrap();
+    assert_eq!(mac_conf.accept_all_mac, Some(true));
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -15,6 +15,8 @@ mod ifaces_ctrller;
 #[cfg(test)]
 mod infiniband;
 #[cfg(test)]
+mod ip;
+#[cfg(test)]
 mod lldp;
 #[cfg(test)]
 mod mac_vlan;

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,13 +1,25 @@
 #[cfg(test)]
+mod base;
+#[cfg(test)]
 mod bond;
 #[cfg(test)]
 mod bridge;
+#[cfg(test)]
+mod ethernet;
+#[cfg(test)]
+mod ethtool;
 #[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;
 #[cfg(test)]
 mod infiniband;
+#[cfg(test)]
+mod lldp;
+#[cfg(test)]
+mod mac_vlan;
+#[cfg(test)]
+mod mac_vtap;
 #[cfg(test)]
 mod ovs;
 #[cfg(test)]
@@ -18,3 +30,9 @@ mod route_rule;
 mod sriov;
 #[cfg(test)]
 mod testlib;
+#[cfg(test)]
+mod vlan;
+#[cfg(test)]
+mod vrf;
+#[cfg(test)]
+mod vxlan;

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -287,3 +287,16 @@ config:
         assert_eq!(e.kind(), ErrorKind::VerificationError);
     }
 }
+
+#[test]
+fn test_route_stringlized_attributes() {
+    let route: RouteEntry = serde_yaml::from_str(
+        r#"
+metric: "500"
+table-id: "129"
+"#,
+    )
+    .unwrap();
+    assert_eq!(route.table_id, Some(129));
+    assert_eq!(route.metric, Some(500));
+}

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -156,3 +156,16 @@ fn gen_rule_entry(
         priority: Some(priority),
     }
 }
+
+#[test]
+fn test_route_rule_stringlized_attributes() {
+    let rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+priority: "500"
+route-table: "129"
+"#,
+    )
+    .unwrap();
+    assert_eq!(rule.table_id, Some(129));
+    assert_eq!(rule.priority, Some(500));
+}

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -1,0 +1,18 @@
+use crate::VlanInterface;
+
+#[test]
+fn test_vlan_stringlized_attributes() {
+    let iface: VlanInterface = serde_yaml::from_str(
+        r#"---
+name: vlan1
+type: vlan
+state: up
+vlan:
+  base-iface: "eth1"
+  id: "101"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(iface.vlan.unwrap().id, 101);
+}

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -1,0 +1,17 @@
+use crate::VrfInterface;
+
+#[test]
+fn test_vrf_stringlized_attributes() {
+    let iface: VrfInterface = serde_yaml::from_str(
+        r#"---
+name: vrf1
+type: vrf
+state: up
+vrf:
+  route-table-id: "101"
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(iface.vrf.unwrap().table_id, 101);
+}

--- a/rust/src/lib/unit_tests/vxlan.rs
+++ b/rust/src/lib/unit_tests/vxlan.rs
@@ -1,0 +1,21 @@
+use crate::VxlanInterface;
+
+#[test]
+fn test_vxlan_stringlized_attributes() {
+    let iface: VxlanInterface = serde_yaml::from_str(
+        r#"---
+name: vxlan1
+type: vxlan
+state: up
+vxlan:
+  base-iface: "eth1"
+  id: "101"
+  destination-port: "3389"
+"#,
+    )
+    .unwrap();
+    let vxlan_conf = iface.vxlan.unwrap();
+
+    assert_eq!(vxlan_conf.id, 101);
+    assert_eq!(vxlan_conf.dst_port, Some(3389));
+}

--- a/rust/src/libnm_dbus/connection/ethtool.rs
+++ b/rust/src/libnm_dbus/connection/ethtool.rs
@@ -39,6 +39,7 @@ pub struct NmSettingEthtool {
     pub feature_tso: Option<bool>,
     pub feature_gro: Option<bool>,
     pub feature_gso: Option<bool>,
+    pub feature_highdma: Option<bool>,
     pub feature_rxhash: Option<bool>,
     pub feature_lro: Option<bool>,
     pub feature_ntuple: Option<bool>,
@@ -178,6 +179,7 @@ impl TryFrom<DbusDictionary> for NmSettingEthtool {
             feature_ntuple: _from_map!(v, "feature-ntuple", bool::try_from)?,
             feature_rxvlan: _from_map!(v, "feature-rxvlan", bool::try_from)?,
             feature_txvlan: _from_map!(v, "feature-txvlan", bool::try_from)?,
+            feature_highdma: _from_map!(v, "feature-highdma", bool::try_from)?,
             ring_rx: _from_map!(v, "ring-rx", u32::try_from)?,
             ring_rx_jumbo: _from_map!(v, "ring-rx-jumbo", u32::try_from)?,
             ring_rx_mini: _from_map!(v, "ring-rx-mini", u32::try_from)?,
@@ -306,6 +308,9 @@ impl NmSettingEthtool {
         }
         if let Some(v) = &self.feature_txvlan {
             ret.insert("feature-txvlan", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.feature_highdma {
+            ret.insert("feature-highdma", zvariant::Value::new(v));
         }
         if let Some(v) = &self.ring_rx {
             ret.insert("ring-rx", zvariant::Value::new(v));

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -242,7 +242,7 @@ def test_rollback_for_bond(eth1_up, eth2_up):
 
     desired_state[Interface.KEY][0]["invalid_key"] = "foo"
 
-    with pytest.raises(NmstateVerificationError):
+    with pytest.raises((NmstateVerificationError, NmstateValueError)):
         libnmstate.apply(desired_state)
 
     time.sleep(5)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -395,7 +395,7 @@ def test_rollback_for_linux_bridge():
     original_state = libnmstate.show()
     bridge_name = TEST_BRIDGE0
     bridge_state = _create_bridge_subtree_config(())
-    with pytest.raises(NmstateVerificationError):
+    with pytest.raises((NmstateVerificationError, NmstateValueError)):
         with linux_bridge(bridge_name, bridge_state) as desired_state:
             desired_state[Interface.KEY][0]["invalid_key"] = "foo"
             libnmstate.apply(desired_state)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -250,6 +250,9 @@ def test_nm_ovs_plugin_missing():
             )
 
 
+@pytest.mark.xfail(
+    reason="https://bugzilla.redhat.com/2052441",
+)
 def test_ovs_service_missing_with_system_port_only(eth1_up):
     bridge = Bridge(BRIDGE1)
     bridge.add_system_port(ETH1)

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -453,7 +453,12 @@ def test_disable_static_ipv6_and_rollback(setup_eth1_ipv6):
         ]
     }
 
-    with pytest.raises(libnmstate.error.NmstateVerificationError):
+    with pytest.raises(
+        (
+            libnmstate.error.NmstateVerificationError,
+            libnmstate.error.NmstateValueError,
+        )
+    ):
         libnmstate.apply(desired_state)
 
     assertlib.assert_state(setup_eth1_ipv6)
@@ -480,7 +485,12 @@ def test_enable_ipv6_and_rollback_to_disable_ipv6(setup_eth1_ipv6_disable):
         ]
     }
 
-    with pytest.raises(libnmstate.error.NmstateVerificationError):
+    with pytest.raises(
+        (
+            libnmstate.error.NmstateVerificationError,
+            libnmstate.error.NmstateValueError,
+        )
+    ):
         libnmstate.apply(desired_state)
 
     assertlib.assert_state(setup_eth1_ipv6_disable)

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -23,6 +23,7 @@ import time
 import pytest
 
 import libnmstate
+from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import VLAN
 from libnmstate.schema import Interface
@@ -138,7 +139,7 @@ def test_rollback_for_vlans(eth1_up):
     desired_state = create_two_vlans_state()
 
     desired_state[Interface.KEY][1]["invalid_key"] = "foo"
-    with pytest.raises(NmstateVerificationError):
+    with pytest.raises((NmstateVerificationError, NmstateValueError)):
         libnmstate.apply(desired_state)
 
     time.sleep(5)  # Give some time for NetworkManager to rollback

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -23,6 +23,7 @@ import pytest
 
 import libnmstate
 
+from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import VXLAN
@@ -90,7 +91,7 @@ def test_rollback_for_vxlans(eth1_up):
         ]
     )
     desired_state[Interface.KEY][1]["invalid_key"] = "foo"
-    with pytest.raises(NmstateVerificationError):
+    with pytest.raises((NmstateVerificationError, NmstateValueError)):
         libnmstate.apply(desired_state)
 
     time.sleep(5)  # Give some time for NetworkManager to rollback


### PR DESCRIPTION
Allowing integer and boolean in string form for all struct member.

For unsigned integer, hex format string is also supported. For boolean,
supporting `1|0|true|false|yes|no|on|off|y|n`

Unit test cases included.