### PR TITLE
rust: Disable at the same time ipv4 and remove a route with an static interface

### DIFF
--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -70,6 +70,10 @@ fn gen_nm_ipv4_setting(
             nm_setting.gateway = None;
         }
     }
+    if !iface_ip.enabled {
+        // Clean up static routes if ip is disabled
+        nm_setting.routes = Vec::new();
+    }
     if let Some(rules) = rules {
         nm_setting.route_rules = gen_nm_ip_rules(rules, false)?;
     }

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -468,6 +468,34 @@ def test_disable_ipv4_with_routes_in_current(eth1_up):
 
 
 @pytest.mark.tier1
+def test_disable_ipv4_and_remove_wildcard_route(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: _get_ipv4_test_routes()},
+        }
+    )
+
+    eth1_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    eth1_state[Interface.IPV4] = {InterfaceIPv4.ENABLED: False}
+
+    absent_route = {
+        Route.STATE: Route.STATE_ABSENT,
+        Route.NEXT_HOP_INTERFACE: "eth1",
+    }
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [eth1_state],
+            Route.KEY: {Route.CONFIG: [absent_route]},
+        }
+    )
+
+    cur_state = libnmstate.show()
+    _assert_routes([], cur_state)
+
+
+@pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
     libnmstate.apply(


### PR DESCRIPTION
When at the same state ipv4 is disabled and a route is removed, the routes are never removed and verify fails.

Use case:

current state:
```yaml
---                                                                             
interfaces:                                                                     
  - name: veth1                                                                 
    type: ethernet                                                              
    state: up                                                                   
    ipv4:                                                                       
      address:                                                                  
        - ip: 192.0.2.251                                                       
          prefix-length: 24                                                     
      dhcp: false                                                               
      enabled: true                                                             
                                                                                
routes:                                                                         
  config:                                                                       
    - destination: 198.51.100.0/24                                              
      metric: 150                                                               
      next-hop-address: 192.0.2.1                                               
      next-hop-interface: veth1                                                 
      table-id: 254                       
```
desired state:
```yaml
---                                                                             
interfaces:                                                                     
  - name: veth1                                                                 
    ipv4:                                                                       
      enabled: false                                                            
routes:                                                                         
  config:                                                                       
    - next-hop-interface: veth1                                                 
      state: absent                       
```

Failure:
```
NmstateError: VerificationError: Desired absent route RouteEntry { state: Some(Absent), destination: None, next_hop_iface: Some("veth1"), next_hop_addr: None, metric: None, table_id: None } still found after apply: RouteEntry { state: None, destination: Some("192.0.2.1/32"), next_hop_iface: Some("veth1"), next_hop_addr: Some("0.0.0.0"), metric: Some(150), table_id: Some(254) }
```