### PR TITLE
rust cli: Add support of `edit` command

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -214,6 +214,7 @@ function run_tests {
             tests/integration/bond_test.py \
             tests/integration/ethtool_test.py \
             tests/integration/linux_bridge_test.py \
+            tests/integration/nmstatectl_edit_test.py \
             ${nmstate_pytest_extra_args}"
         exec_cmd "
           env  \

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -17,3 +17,4 @@ env_logger = "0.9.0"
 log = "0.4.14"
 serde_json = "1.0.75"
 ctrlc = "3.2.1"
+uuid = { version = "0.8", features = ["v4"] }

--- a/tests/integration/nmstatectl_edit_test.py
+++ b/tests/integration/nmstatectl_edit_test.py
@@ -26,13 +26,13 @@ from .testlib import cmdlib
 RC_SUCCESS = 0
 
 
-def test_edit_cancel():
+def test_edit_cancel(eth1_up):
     runenv = dict(os.environ)
     env = {"EDITOR": "false"}
 
     runenv.update(env)
 
-    cmds = ["nmstatectl", "edit", "lo"]
+    cmds = ["nmstatectl", "edit", "eth1"]
     ret = cmdlib.exec_cmd(cmds, env=runenv)
     rc, out, err = ret
 


### PR DESCRIPTION
Allow user to run `nmstatectl-rust edit eth1` like they did for python
CLI.

Integration test cases enabled.