### PR TITLE
test vrf: Enable VRF tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,8 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Enable openvswitch kernel module
-        run: sudo modprobe openvswitch
+      - name: Install extra kernel module for vrf
+        run: sudo apt-get -y install linux-modules-extra-azure
+
+      - name: Enable extra kernel modules
+        run: sudo modprobe openvswitch vrf
 
       - name: Download compiled rpm
         uses: actions/download-artifact@v3

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -17,8 +17,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-import os
-
 import pytest
 
 import libnmstate
@@ -141,10 +139,6 @@ def vrf1_with_unmanaged_port(unmanaged_port_up):
         )
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason=("CI does not have vrf enabled"),
-)
 class TestVrf:
     def test_create_and_remove(self, vrf0_with_port0):
         pass


### PR DESCRIPTION
By installing `linux-modules-extra-azure`, the github CI could support VRF
tests.