### PR TITLE
rust cli: Add support of autoconf base on LLDP

### DIFF
--- a/packaging/make_srpm.sh
+++ b/packaging/make_srpm.sh
@@ -38,10 +38,15 @@ TAR_FILE="${TMP_DIR}/nmstate-${VERSION}.tar"
 
     ./packaging/make_spec.sh > "${SPEC_FILE}"
     cp doc/nmstatectl.8.in doc/nmstatectl.8
+    cp doc/nmstate-autoconf.8.in doc/nmstate-autoconf.8
     sed -i -e "s/@DATE@/$(date +'%B %d, %Y')/" ./doc/nmstatectl.8
     sed -i -e "s/@VERSION@/${VERSION}/" ./doc/nmstatectl.8
+    sed -i -e "s/@DATE@/$(date +'%B %d, %Y')/" ./doc/nmstate-autoconf.8
+    sed -i -e "s/@VERSION@/${VERSION}/" ./doc/nmstate-autoconf.8
     git archive --prefix=nmstate-${VERSION}/ HEAD --format=tar \
-        --add-file=doc/nmstatectl.8 --output=${TAR_FILE}
+        --add-file=doc/nmstatectl.8  \
+        --add-file=doc/nmstate-autoconf.8 \
+        --output=${TAR_FILE}
     tar --delete nmstate-${VERSION}/packaging/nmstate.spec --file=$TAR_FILE
     tar --append --file=$TAR_FILE $SPEC_FILE
     gzip "${TAR_FILE}"

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -82,16 +82,22 @@ pushd rust
 env SKIP_PYTHON_INSTALL=1 PREFIX=%{_prefix} LIBDIR=%{_libdir} %make_install
 popd
 ln -s nmstatectl-rust %{buildroot}/%{_bindir}/nmstatectl
+ln -s nmstatectl-rust %{buildroot}/%{_bindir}/nmstate-autoconf
 install -D --mode 644 nmstatectl.8 \
     %{buildroot}/%{_mandir}/man8/nmstatectl.8
+install -D --mode 644 nmstate-autoconf.8 \
+    %{buildroot}/%{_mandir}/man8/nmstate-autoconf.8
 gzip %{buildroot}/%{_mandir}/man8/nmstatectl.8
+gzip %{buildroot}/%{_mandir}/man8/nmstate-autoconf.8
 
 %files
 %doc README.md
 %doc examples/
 %{_mandir}/man8/nmstatectl.8*
+%{_mandir}/man8/nmstate-autoconf.8*
 %{_bindir}/nmstatectl
 %{_bindir}/nmstatectl-rust
+%{_bindir}/nmstate-autoconf
 
 %files libs
 %{_libdir}/libnmstate.so.*

--- a/rust/src/cli/autoconf.rs
+++ b/rust/src/cli/autoconf.rs
@@ -1,0 +1,200 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+use crate::error::CliError;
+use nmstate::{
+    BaseInterface, BondConfig, BondInterface, BondMode, Interface,
+    InterfaceState, InterfaceType, Interfaces, LldpNeighborTlv, NetworkState,
+    VlanConfig, VlanInterface,
+};
+
+const APP_NAME: &str = "nmstatectl-autoconf";
+const EXIT_FAILURE: i32 = 1;
+const BOND_PREFIX: &str = "bond";
+
+pub(crate) fn autoconf(argv: &[String]) {
+    let matches = clap::App::new(APP_NAME)
+        .version(clap::crate_version!())
+        .author("Gris Ge <fge@redhat.com>")
+        .about("Network Auto-Configure using LLDP information")
+        .arg(
+            clap::Arg::with_name("DRY_RUN")
+                .long("dry-run")
+                .short("d")
+                .takes_value(false)
+                .help(
+                    "Generate the network state that is going to be \
+                    applied and print it out without applying any change.",
+                ),
+        )
+        .arg(
+            clap::Arg::with_name("ONLY")
+                .index(1)
+                .help("Use only the specified NICs (comma-separated)"),
+        )
+        .get_matches_from(argv);
+    let mut log_builder = env_logger::Builder::new();
+
+    log_builder.filter(Some("autoconf"), log::LevelFilter::Info);
+    log_builder.filter(Some("nmstate"), log::LevelFilter::Info);
+    log_builder.filter(Some("nm_dbus"), log::LevelFilter::Info);
+    log_builder.init();
+
+    let mut cur_state = NetworkState::new();
+    if let Err(e) = cur_state.retrieve() {
+        print_error_and_exit(e.into(), EXIT_FAILURE);
+    }
+    if let Err(e) = filter_net_state(&mut cur_state, matches.value_of("ONLY")) {
+        print_error_and_exit(e, EXIT_FAILURE);
+    }
+
+    let vlan_to_iface = get_lldp_vlans(&cur_state);
+
+    let desire_state = gen_desire_state(&vlan_to_iface);
+
+    if matches.is_present("DRY_RUN") {
+        print_result_and_exit(
+            serde_yaml::to_string(&desire_state).map_err(|e| e.into()),
+            EXIT_FAILURE,
+        );
+    } else {
+        eprintln!("This is a experimental function!");
+        if let Err(e) = desire_state.apply() {
+            print_error_and_exit(e.into(), EXIT_FAILURE);
+        } else {
+            print_result_and_exit(
+                serde_yaml::to_string(&desire_state).map_err(|e| e.into()),
+                EXIT_FAILURE,
+            );
+        }
+    }
+}
+
+fn filter_net_state(
+    net_state: &mut NetworkState,
+    filters: Option<&str>,
+) -> Result<(), CliError> {
+    if let Some(filters) = filters {
+        let mut new_ifaces = Interfaces::new();
+        for filter in filters.split(',') {
+            if let Some(iface) = net_state
+                .interfaces
+                .get_iface(filter, InterfaceType::Unknown)
+            {
+                new_ifaces.push(iface.clone());
+            } else {
+                return Err(CliError {
+                    msg: format!("Interface {} not found", filter),
+                });
+            }
+        }
+        net_state.interfaces = new_ifaces;
+    }
+    Ok(())
+}
+
+// Use T instead of String where T has Serialize
+fn print_result_and_exit(result: Result<String, CliError>, errno: i32) {
+    match result {
+        Ok(s) => print_string_and_exit(s),
+        Err(e) => print_error_and_exit(e, errno),
+    }
+}
+
+fn print_error_and_exit(e: CliError, errno: i32) {
+    eprintln!("{}", e);
+    std::process::exit(errno);
+}
+
+fn print_string_and_exit(s: String) {
+    println!("{}", s);
+    std::process::exit(0);
+}
+
+// Return HashMap:
+//  key:  (vlan_id, vlan_name)
+//  value: Vec<interface_name>
+fn get_lldp_vlans(net_state: &NetworkState) -> HashMap<(u32, &str), Vec<&str>> {
+    let mut ret: HashMap<(u32, &str), Vec<&str>> = HashMap::new();
+    for iface in net_state.interfaces.to_vec() {
+        if let Some(lldp_neighbors) = iface
+            .base_iface()
+            .lldp
+            .as_ref()
+            .map(|l| l.neighbors.as_slice())
+        {
+            if lldp_neighbors.is_empty() {
+                continue;
+            }
+            for lldp_tlvs in lldp_neighbors {
+                for lldp_tlv in lldp_tlvs {
+                    if let LldpNeighborTlv::Ieee8021Vlans(lldp_vlans) = lldp_tlv
+                    {
+                        for lldp_vlan in &lldp_vlans.0 {
+                            match ret
+                                .entry((lldp_vlan.vid, lldp_vlan.name.as_str()))
+                            {
+                                Entry::Occupied(o) => {
+                                    o.into_mut().push(iface.name());
+                                }
+                                Entry::Vacant(v) => {
+                                    v.insert(vec![iface.name()]);
+                                }
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+    ret
+}
+
+fn gen_desire_state(
+    lldp_vlan_info: &HashMap<(u32, &str), Vec<&str>>,
+) -> NetworkState {
+    let mut ret = NetworkState::new();
+    for ((vid, name), ifaces) in lldp_vlan_info.iter() {
+        if ifaces.len() > 1 {
+            let bond_iface_name = format!("{}{}", BOND_PREFIX, vid);
+            ret.append_interface_data(gen_bond_iface(&bond_iface_name, ifaces));
+            ret.append_interface_data(gen_vlan_iface(
+                name,
+                *vid,
+                &bond_iface_name,
+            ));
+        } else if let Some(iface) = ifaces.get(0) {
+            ret.append_interface_data(gen_vlan_iface(name, *vid, iface));
+        }
+    }
+    ret
+}
+
+fn gen_bond_iface(bond_name: &str, ifaces: &[&str]) -> Interface {
+    let mut base_iface = BaseInterface::new();
+    base_iface.name = bond_name.to_string();
+    base_iface.iface_type = InterfaceType::Bond;
+    base_iface.state = InterfaceState::Up;
+    let mut bond_conf = BondConfig::new();
+    bond_conf.mode = Some(BondMode::RoundRobin);
+    bond_conf.port = Some(ifaces.iter().map(|i| i.to_string()).collect());
+    let mut bond_iface = BondInterface::new();
+    bond_iface.base = base_iface;
+    bond_iface.bond = Some(bond_conf);
+    Interface::Bond(bond_iface)
+}
+
+fn gen_vlan_iface(vlan_name: &str, id: u32, parent: &str) -> Interface {
+    let mut base_iface = BaseInterface::new();
+    base_iface.name = vlan_name.to_string();
+    base_iface.iface_type = InterfaceType::Vlan;
+    base_iface.state = InterfaceState::Up;
+    let mut vlan_conf = VlanConfig::default();
+    vlan_conf.base_iface = parent.to_string();
+    vlan_conf.id = id.try_into().unwrap();
+    let mut vlan_iface = VlanInterface::new();
+    vlan_iface.base = base_iface;
+    vlan_iface.vlan = Some(vlan_conf);
+    Interface::Vlan(vlan_iface)
+}

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -1,3 +1,4 @@
+mod autoconf;
 mod error;
 
 use std::fs::File;
@@ -21,11 +22,22 @@ const SUB_CMD_COMMIT: &str = "commit";
 const SUB_CMD_ROLLBACK: &str = "rollback";
 const SUB_CMD_EDIT: &str = "edit";
 const SUB_CMD_VERSION: &str = "version";
+const SUB_CMD_AUTOCONF: &str = "autoconf";
 
 const EX_DATAERR: i32 = 65;
 const EXIT_FAILURE: i32 = 1;
 
 fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    if argv[0].ends_with("-autoconf") {
+        autoconf::autoconf(argv.as_slice());
+        return;
+    }
+    if argv.get(1) == Some(&"autoconf".to_string()) {
+        autoconf::autoconf(&argv[1..]);
+        return;
+    }
+
     let matches = clap::App::new(APP_NAME)
         .version(clap::crate_version!())
         .author("Gris Ge <fge@redhat.com>")
@@ -37,6 +49,12 @@ fn main() {
                 .multiple(true)
                 .help("Set verbose level")
                 .global(true),
+        )
+        .subcommand(
+            clap::SubCommand::with_name(SUB_CMD_AUTOCONF)
+                .about(
+                    "Automatically configure network base on LLDP \
+                    information(experimental)")
         )
         .subcommand(
             clap::SubCommand::with_name(SUB_CMD_SHOW)
@@ -231,7 +249,6 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_SHOW) {
         print_result_and_exit(show(matches), EXIT_FAILURE);
     } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_APPLY) {
-        let argv: Vec<String> = std::env::args().collect();
         if argv.get(1) == Some(&"set".to_string()) {
             eprintln!("Using 'set' is deprecated, use 'apply' instead.");
         }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -102,7 +102,7 @@ impl Interfaces {
         ifaces
     }
 
-    pub(crate) fn get_iface<'a, 'b>(
+    pub fn get_iface<'a, 'b>(
         &'a self,
         iface_name: &'b str,
         iface_type: InterfaceType,

--- a/tests/integration/nmstate_autoconf_test.py
+++ b/tests/integration/nmstate_autoconf_test.py
@@ -78,12 +78,6 @@ def lldpifaces_env():
         _iface_cleanup(BOND50)
 
 
-@pytest.mark.xfail(
-    hasattr(libnmstate, "BASE_ON_RUST"),
-    raises=FileNotFoundError,
-    reason="Nmstate rust has no support of LLDP autoconf yet",
-    strict=True,
-)
 def test_autoconf_prodnet_and_mgmtnet(lldpifaces_env):
     with lldp_enabled(LLDP_BASIC_STATE):
         _send_lldp_packet(LLDPTEST1_PEER, "lldp_prodnet.pcap")
@@ -102,12 +96,6 @@ def test_autoconf_prodnet_and_mgmtnet(lldpifaces_env):
         assert LLDPTEST3 == vlan_mgmt[VLAN.CONFIG_SUBTREE][VLAN.BASE_IFACE]
 
 
-@pytest.mark.xfail(
-    hasattr(libnmstate, "BASE_ON_RUST"),
-    raises=FileNotFoundError,
-    reason="Nmstate rust has no support of LLDP autoconf yet",
-    strict=True,
-)
 def test_autoconf_all_prodnet(lldpifaces_env):
     with lldp_enabled(LLDP_BASIC_STATE):
         _send_lldp_packet(LLDPTEST1_PEER, "lldp_prodnet.pcap")


### PR DESCRIPTION
Add subcommand `autoconf` to nmstatectl.

If nmstatectl is been invoked with soft link as `nmstate-autoconf`, run as
`autoconf` subcommand. With this we don't have to keep two binary file,
considering rust binary is almost static linking, this could some some
unnecessary storage space.

Integration test case enabled.