### PR TITLE
test bridge: Add test for preserving unmanaged port when rollback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,11 +102,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install extra kernel module for vrf
-        run: sudo apt-get -y install linux-modules-extra-azure
-
-      - name: Enable extra kernel modules
-        run: sudo modprobe openvswitch vrf
+      - name: Enable openvswitch kernel module
+        run: sudo modprobe openvswitch
 
       - name: Download compiled rpm
         uses: actions/download-artifact@v3

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -41,6 +41,8 @@ BRIDGE0 = "brtest0"
 DUMMY0 = "dummy0"
 DUMMY1 = "dummy1"
 
+VETH0 = "vethtest0"
+
 
 @pytest.fixture
 def nm_unmanaged_dummy1():
@@ -206,3 +208,59 @@ def test_linux_manage_bridge_keeps_unmanaged_port(
 
     assert DUMMY0 in port_names
     assert DUMMY1 in port_names
+
+
+@pytest.fixture
+def unmanged_veth0():
+    veth_iface = VETH0
+    exec_cmd(
+        f"ip link add {veth_iface} type veth peer {veth_iface}.ep".split(),
+        check=False,
+    )
+    exec_cmd(f"ip link set {veth_iface}.ep up".split(), check=True)
+    yield
+    exec_cmd(f"ip link del {veth_iface}".split())
+    exec_cmd(f"nmcli c del {veth_iface}".split())
+
+
+@pytest.fixture
+def bridge_with_unmanaged_port(eth1_up, unmanged_veth0):
+    with linux_bridge(
+        BRIDGE0,
+        bridge_subtree_state={
+            LB.OPTIONS_SUBTREE: {LB.STP_SUBTREE: {LB.STP.ENABLED: False}},
+            LB.PORT_SUBTREE: [{LB.Port.NAME: "eth1"}],
+        },
+    ):
+        exec_cmd(f"ip link set {VETH0} master {BRIDGE0}".split(), check=True)
+        yield
+
+
+@pytest.mark.tier1
+@pytest.mark.xfail(
+    raises=AssertionError,
+    reason="https://bugzilla.redhat.com/2076131",
+    strict=True,
+)
+def test_linux_bridge_does_not_lose_unmanaged_port_on_rollback(
+    bridge_with_unmanaged_port,
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BRIDGE0,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.TYPE: InterfaceType.LINUX_BRIDGE,
+                    Interface.MTU: 1450,
+                },
+            ]
+        },
+        commit=False,
+    )
+    libnmstate.rollback()
+    current_state = show_only((BRIDGE0,))
+    bridge_state = current_state[Interface.KEY][0][LB.CONFIG_SUBTREE]
+    port_names = [port[LB.Port.NAME] for port in bridge_state[LB.PORT_SUBTREE]]
+    assert "eth1" in port_names
+    assert VETH0 in port_names

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import os
+
 import pytest
 
 import libnmstate
@@ -139,6 +141,10 @@ def vrf1_with_unmanaged_port(unmanaged_port_up):
         )
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason=("CI does not have vrf enabled"),
+)
 class TestVrf:
     def test_create_and_remove(self, vrf0_with_port0):
         pass


### PR DESCRIPTION
Mimic the use case mentioned in
https://bugzilla.redhat.com/show_bug.cgi?id=2035519

This test is marked as xfail due to bug:
https://bugzilla.redhat.com/show_bug.cgi?id=2076131