### PR TITLE
lib: Use base to serialize unknown interfaces

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -312,6 +312,7 @@ while true; do
         RUN_BAREMETAL="true"
         ;;
     --k8s)
+        CONTAINER_IMAGE=$CENTOS_STREAM_IMAGE_DEV
         RUN_K8S="true"
         ;;
     --use-installed-nmstate)

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -162,10 +162,8 @@ impl From<&str> for InterfaceState {
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 #[non_exhaustive]
 pub struct UnknownInterface {
-    #[serde(skip)]
-    pub base: BaseInterface,
     #[serde(flatten)]
-    other: serde_json::Value,
+    pub base: BaseInterface,
 }
 
 impl UnknownInterface {
@@ -192,7 +190,6 @@ impl<'de> Deserialize<'de> for UnknownInterface {
             serde_json::value::Value::Object(base_value),
         )
         .map_err(serde::de::Error::custom)?;
-        ret.other = v;
         Ok(ret)
     }
 }


### PR DESCRIPTION
When there is a UnknownInterface the state is serialized as "- {}" since
the "other" field is not being set. This change convert "base" from serde skip
to flatten and remove the field other.