### PR TITLE
ethtool: Support more ethtool feature options

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -160,6 +160,9 @@ impl BaseInterface {
         if let Some(ref mut ipv6) = self.ipv6 {
             ipv6.pre_edit_cleanup();
         }
+        if let Some(ref mut ethtool_conf) = self.ethtool {
+            ethtool_conf.pre_edit_cleanup();
+        }
         Ok(())
     }
 
@@ -185,6 +188,9 @@ impl BaseInterface {
 
         if let Some(lldp_conf) = self.lldp.as_mut() {
             lldp_conf.pre_verify_cleanup();
+        }
+        if let Some(ethtool_conf) = self.ethtool.as_mut() {
+            ethtool_conf.pre_verify_cleanup();
         }
     }
 

--- a/rust/src/lib/nispor/ethtool.rs
+++ b/rust/src/lib/nispor/ethtool.rs
@@ -1,16 +1,11 @@
 use crate::{
-    EthtoolCoalesceConfig, EthtoolConfig, EthtoolFeatureConfig,
-    EthtoolPauseConfig, EthtoolRingConfig,
+    EthtoolCoalesceConfig, EthtoolConfig, EthtoolPauseConfig, EthtoolRingConfig,
 };
 
 pub(crate) fn np_ethtool_to_nmstate(
     np_iface: &nispor::Iface,
 ) -> Option<EthtoolConfig> {
-    if let Some(ethtool_info) = &np_iface.ethtool {
-        return Some(gen_ethtool_config(ethtool_info));
-    }
-
-    None
+    np_iface.ethtool.as_ref().map(gen_ethtool_config)
 }
 
 fn gen_ethtool_config(ethtool_info: &nispor::EthtoolInfo) -> EthtoolConfig {
@@ -23,46 +18,7 @@ fn gen_ethtool_config(ethtool_info: &nispor::EthtoolInfo) -> EthtoolConfig {
         ret.pause = Some(pause_config);
     }
     if let Some(feature) = &ethtool_info.features {
-        let mut feature_config = EthtoolFeatureConfig::new();
-        let changeable = &feature.changeable;
-        if let Some(rx_checksum) = changeable.get("rx-checksum") {
-            feature_config.rx_checksum = Some(*rx_checksum);
-        }
-        if let Some(tx_generic_segmentation) =
-            changeable.get("tx-generic-segmentation")
-        {
-            feature_config.tx_generic_segmentation =
-                Some(*tx_generic_segmentation);
-        }
-        if let Some(rx_gro) = changeable.get("rx-gro") {
-            feature_config.rx_gro = Some(*rx_gro);
-        }
-        if let Some(rx_lro) = changeable.get("rx-lro") {
-            feature_config.rx_lro = Some(*rx_lro);
-        }
-        if let Some(rx_vlan_hw_parse) = changeable.get("rx-vlan-hw-parse") {
-            feature_config.rx_vlan_hw_parse = Some(*rx_vlan_hw_parse);
-        }
-        if let Some(tx_vlan_hw_insert) = changeable.get("tx-vlan-hw-insert") {
-            feature_config.tx_vlan_hw_insert = Some(*tx_vlan_hw_insert);
-        }
-        if let Some(rx_ntuple_filter) = changeable.get("rx-ntuple-filter") {
-            feature_config.rx_ntuple_filter = Some(*rx_ntuple_filter);
-        }
-        if let Some(rx_hashing) = changeable.get("rx-hashing") {
-            feature_config.rx_hashing = Some(*rx_hashing);
-        }
-        if let Some(tx_scatter_gather) = changeable.get("tx-scatter-gather") {
-            feature_config.tx_scatter_gather = Some(*tx_scatter_gather);
-        }
-        if let Some(tx_tcp_segmentation) = changeable.get("tx-tcp-segmentation")
-        {
-            feature_config.tx_tcp_segmentation = Some(*tx_tcp_segmentation);
-        }
-        if let Some(highdma) = changeable.get("highdma") {
-            feature_config.highdma = Some(*highdma);
-        }
-        ret.feature = Some(feature_config);
+        ret.feature = Some(feature.changeable.clone());
     }
     if let Some(coalesce) = &ethtool_info.coalesce {
         let mut coalesce_config = EthtoolCoalesceConfig::new();

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -147,7 +147,7 @@ pub(crate) fn iface_to_nm_connections(
     gen_nm_ovs_ext_ids_setting(iface, &mut nm_conn);
     gen_nm_802_1x_setting(iface, &mut nm_conn);
     gen_nm_user_setting(iface, &mut nm_conn);
-    gen_ethtool_setting(iface, &mut nm_conn);
+    gen_ethtool_setting(iface, &mut nm_conn)?;
 
     match iface {
         Interface::OvsBridge(ovs_br_iface) => {

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -61,21 +61,21 @@ ethtool:
     .unwrap();
 
     let ethtool_conf = iface.base.ethtool.unwrap();
-    let feature = ethtool_conf.feature.as_ref().unwrap();
+    let features = ethtool_conf.feature.as_ref().unwrap();
     let pause = ethtool_conf.pause.as_ref().unwrap();
     let coalesce = ethtool_conf.coalesce.as_ref().unwrap();
     let ring = ethtool_conf.ring.as_ref().unwrap();
 
-    assert_eq!(feature.rx_checksum, Some(true));
-    assert_eq!(feature.rx_gro, Some(true));
-    assert_eq!(feature.rx_lro, Some(true));
-    assert_eq!(feature.rx_vlan_hw_parse, Some(true));
-    assert_eq!(feature.tx_vlan_hw_insert, Some(true));
-    assert_eq!(feature.rx_ntuple_filter, Some(true));
-    assert_eq!(feature.rx_hashing, Some(true));
-    assert_eq!(feature.tx_scatter_gather, Some(true));
-    assert_eq!(feature.tx_tcp_segmentation, Some(true));
-    assert_eq!(feature.tx_generic_segmentation, Some(true));
+    assert_eq!(features.get("rx-checksum"), Some(&true));
+    assert_eq!(features.get("rx-gro"), Some(&true));
+    assert_eq!(features.get("rx-lro"), Some(&true));
+    assert_eq!(features.get("rx-vlan-hw-parse"), Some(&true));
+    assert_eq!(features.get("tx-vlan-hw-insert"), Some(&true));
+    assert_eq!(features.get("rx-ntuple-filter"), Some(&true));
+    assert_eq!(features.get("rx-hashing"), Some(&true));
+    assert_eq!(features.get("tx-scatter-gather"), Some(&true));
+    assert_eq!(features.get("tx-tcp-segmentation"), Some(&true));
+    assert_eq!(features.get("tx-generic-segmentation"), Some(&true));
     assert_eq!(pause.tx, Some(false));
     assert_eq!(pause.rx, Some(false));
     assert_eq!(pause.autoneg, Some(false));


### PR DESCRIPTION
At the top level, nmstate allows arbitrary ethtool features to show
and deserialize, but at the NM plugin, we only allows 58 features
supported by NM daemon.

Integration test case passed by manual tests(special hardware required).