### PR TITLE
New release 2.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,14 @@
 # Changelog
-## [2.1.0]
+## [2.1.0] - 2022-04-21
+### Breaking changes
+ - Switched to all rust based. We tried our best to avoid breakage of
+   backwards compatibility. (e7da681f)
+
 ### New features
- - Add support to LLDP in nmstate-rust implementation. (d07c215)
- - Add support to memory only apply in nmstate-rust implementation. (66e3147)
- - Add support to interface description in nmstate-rust implementation. (aa6990d)
- - Add support to IEEE 802.1X authentication in nmstate-rust implementation. (2efed41)
- - Add support to show running config only in nmstate-rust implementation. (8ed5100)
+ - N/A
+
+### Bug fixes
+ - N/A
 
 ## [2.0.0] - 2022-02-14
 ### Breaking changes


### PR DESCRIPTION
This release introduced massive code changes for switching libnmstate to
rust code based with best effort backwards compatibility.