### PR TITLE
k8s: Fix skipping exception

### DIFF
--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -29,7 +29,7 @@ from .testlib.examplelib import load_example
 import libnmstate
 from libnmstate import netinfo
 from libnmstate.error import NmstateNotSupportedError
-from libnmstate.error import NmstateDependencyError
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import DNS
 from libnmstate.schema import HostNameState
 
@@ -61,7 +61,7 @@ def test_add_down_remove_vlan(eth1_up):
         "Requires adjusts for k8s. Ref:"
         "https://github.com/nmstate/nmstate/issues/1579"
     ),
-    raises=NmstateDependencyError,
+    raises=NmstateVerificationError,
     strict=False,
 )
 def test_add_remove_ovs_bridge(eth1_up):

--- a/tests/integration/nm/ieee802_1x_test.py
+++ b/tests/integration/nm/ieee802_1x_test.py
@@ -21,7 +21,7 @@ import os
 import pytest
 
 import libnmstate
-from libnmstate.error import NmstateLibnmError
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Ieee8021X
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
@@ -114,7 +114,7 @@ def _stop_802_1x_authenticator():
         "Requires adjusts for k8s. Ref:"
         "https://github.com/nmstate/nmstate/issues/1579"
     ),
-    raises=NmstateLibnmError,
+    raises=NmstateVerificationError,
     strict=False,
 )
 def test_eth_with_802_1x(ieee_802_1x_env):
@@ -196,7 +196,7 @@ def ieee_1x_cli_up(ieee_802_1x_env):
         "Requires adjusts for k8s. Ref:"
         "https://github.com/nmstate/nmstate/issues/1579"
     ),
-    raises=NmstateLibnmError,
+    raises=NmstateVerificationError,
     strict=False,
 )
 def test_apply_ieee_802_1x_with_reserved_password(ieee_1x_cli_up):


### PR DESCRIPTION
Fix the k8s lane after rust is replacing python