### PR TITLE
nispor: Remove HAHA debug print on linux-bridge

### DIFF
--- a/rust/src/lib/nispor/linux_bridge.rs
+++ b/rust/src/lib/nispor/linux_bridge.rs
@@ -53,7 +53,6 @@ pub(crate) fn append_bridge_port_config(
                 .and_then(|br_info| br_info.vlan_filtering)
                 == Some(true)
             {
-                println!("HAHA {:?}", np_port_info.vlans);
                 port_conf.vlan = np_port_info
                     .vlans
                     .as_ref()


### PR DESCRIPTION
There were a debug print when nmstatectl show is called and there is a
linux-bridge with vlan-filtering.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>