### PR TITLE
checkpoint: Extend rollback with timeout

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::collections::HashMap;
 
 use log::{debug, info, warn};
@@ -278,9 +277,8 @@ impl NetworkState {
                     VERIFY_RETRY_COUNT
                 };
 
-            let checkpoint = nm_checkpoint_create(
-                self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT),
-            )?;
+            let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
+            let checkpoint = nm_checkpoint_create(timeout)?;
             info!("Created checkpoint {}", &checkpoint);
 
             with_nm_checkpoint(&checkpoint, self.no_commit, || {
@@ -298,13 +296,7 @@ impl NetworkState {
                 if ovsdb_is_running() {
                     ovsdb_apply(&desire_state_to_apply, &cur_net_state)?;
                 }
-                nm_checkpoint_timeout_extend(
-                    &checkpoint,
-                    cmp::min(
-                        DEFAULT_ROLLBACK_TIMEOUT,
-                        self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT),
-                    ),
-                )?;
+                nm_checkpoint_timeout_extend(&checkpoint, timeout)?;
                 if !self.no_verify {
                     with_retry(
                         VERIFY_RETRY_INTERVAL_MILLISECONDS,


### PR DESCRIPTION
The checkpoint rollback timeout has to be extended so it start to count
after apply is executed and some ovs operations are done, the extended
NM dbus operation is adding that "now" not to the checkpoint timeout.
This change set the extended time to timeout instead of choosing min
with will make checkpoint timeout be always the default 60s.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>