### PR TITLE
[nmstate-1.3] nm bridge: Fix multicast_router option

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -941,3 +941,25 @@ def test_desire_port_only_should_preserve_ctrl_setting(bridge0_with_port0):
 
     assert len(ports) == 1
     assert ports[0][LinuxBridge.Port.NAME] == "eth1"
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "mcast_router_value",
+    [
+        0,
+        2,
+        1,
+    ],
+    ids=["disabled", "enabled", "auto"],
+)
+def test_linux_bridge_multicast_router(bridge0_with_port0, mcast_router_value):
+    iface_state = {
+        Interface.NAME: TEST_BRIDGE0,
+        LinuxBridge.CONFIG_SUBTREE: {
+            LinuxBridge.OPTIONS_SUBTREE: {
+                LinuxBridge.Options.MULTICAST_ROUTER: mcast_router_value,
+            }
+        },
+    }
+    libnmstate.apply({Interface.KEY: [iface_state]})


### PR DESCRIPTION
Adding the missing support of multicast_router option of linux bridge
with these values:
    * 0: disabled
    * 1: auto
    * 2: enabled

Integration test case included and marked as tier 1 as oVirt requested
this.