### PR TITLE
[nmstate-1.3] ovs: Do not validate on non-desired interface

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -159,7 +159,8 @@ class Ifaces:
             self._apply_copy_mac_from()
             self.gen_metadata()
             for iface in self.all_ifaces():
-                iface.pre_edit_validation_and_cleanup()
+                if iface.is_desired and iface.is_up:
+                    iface.pre_edit_validation_and_cleanup()
 
             self._pre_edit_validation_and_cleanup()
 
@@ -293,7 +294,11 @@ class Ifaces:
         When OVS patch peer does not exist or is down, raise an error.
         """
         for iface in self._kernel_ifaces.values():
-            if iface.type == InterfaceType.OVS_INTERFACE and iface.is_up:
+            if (
+                iface.type == InterfaceType.OVS_INTERFACE
+                and iface.is_up
+                and iface.is_desired
+            ):
                 if iface.peer:
                     peer_iface = self._kernel_ifaces.get(iface.peer)
                     if not peer_iface or not peer_iface.is_up:
@@ -315,9 +320,9 @@ class Ifaces:
         Validate that vlan is not being created over infiniband interface
         """
         for iface in self._kernel_ifaces.values():
-
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
+                and iface.is_desired
                 and iface.is_up
             ):
                 if (
@@ -338,9 +343,9 @@ class Ifaces:
         If base MTU is not present, set same as vlan MTU
         """
         for iface in self._kernel_ifaces.values():
-
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
+                and iface.is_desired
                 and iface.is_up
                 and iface.mtu
             ):
@@ -423,6 +428,7 @@ class Ifaces:
         for ifname, iface in self._kernel_ifaces.items():
             if (
                 iface.type == InterfaceType.VETH
+                and iface.is_desired
                 and iface.is_up
                 and not iface.peer
             ):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -970,3 +970,29 @@ class TestOvsDpdk:
 
         assertlib.assert_absent(BRIDGE0)
         assertlib.assert_absent(PORT1)
+
+
+@pytest.fixture
+def unmanged_ovs_vxlan():
+    cmdlib.exec_cmd("ovs-vsctl add-br br0_with_vxlan".split(), check=True)
+    cmdlib.exec_cmd(
+        "ovs-vsctl add-port br0_with_vxlan vx_node1 -- "
+        "set interface vx_node1 type=vxlan options:remote_ip=192.168.122.174 "
+        "options:dst_port=8472".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        "nmcli d set vxlan_sys_8472 managed false".split(), check=True
+    )
+    try:
+        yield
+    finally:
+        cmdlib.exec_cmd("ovs-vsctl del-br br0_with_vxlan".split())
+
+
+@pytest.mark.tier1
+def test_ovs_vxlan_in_current_not_impact_others(unmanged_ovs_vxlan):
+    with Bridge(BRIDGE1).create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)


### PR DESCRIPTION
Currently nmstate is showing unmanaged ovs vxlan with empty parent which
failure the apply() even it is not mentioned in desire state.

The fix is skip all the validations on non-desired interfaces.

Integration test case included.