### PR TITLE
test: Add test of ignoring ovs vxlan interface

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -973,3 +973,29 @@ class TestOvsDpdk:
 
         assertlib.assert_absent(BRIDGE0)
         assertlib.assert_absent(PORT1)
+
+
+@pytest.fixture
+def unmanged_ovs_vxlan():
+    cmdlib.exec_cmd("ovs-vsctl add-br br0_with_vxlan".split(), check=True)
+    cmdlib.exec_cmd(
+        "ovs-vsctl add-port br0_with_vxlan vx_node1 -- "
+        "set interface vx_node1 type=vxlan options:remote_ip=192.168.122.174 "
+        "options:dst_port=8472".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        "nmcli d set vxlan_sys_8472 managed false".split(), check=True
+    )
+    try:
+        yield
+    finally:
+        cmdlib.exec_cmd("ovs-vsctl del-br br0_with_vxlan".split())
+
+
+@pytest.mark.tier1
+def test_ovs_vxlan_in_current_not_impact_others(unmanged_ovs_vxlan):
+    with Bridge(BRIDGE1).create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)


### PR DESCRIPTION
Add test case learn where OVS vxlan is created by ovs-vsctl and marked as
unmanaged explicitly in NetworkManager. The follow up desire state(not
mentioned this OVS VXLAN interface) should not be impacted.

The detailed use case is:

   https://bugzilla.redhat.com/show_bug.cgi?id=2078573