### PR TITLE
ip: Add NM may-fail option

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -50,6 +50,13 @@ pub struct InterfaceIpv4 {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub auto_table_id: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "may-fail",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub may_fail: Option<bool>,
 }
 
 impl InterfaceIpv4 {
@@ -212,6 +219,13 @@ pub struct InterfaceIpv6 {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub auto_table_id: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "may-fail",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub may_fail: Option<bool>,
 }
 
 impl InterfaceIpv6 {

--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -49,6 +49,7 @@ fn gen_nm_ipv4_setting(
     let mut nm_setting = nm_conn.ipv4.as_ref().cloned().unwrap_or_default();
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
+    nm_setting.may_fail = iface_ip.may_fail;
     if iface_ip.is_auto() {
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.dhcp_client_id = Some("mac".to_string());
@@ -139,6 +140,7 @@ fn gen_nm_ipv6_setting(
     let mut nm_setting = nm_conn.ipv6.as_ref().cloned().unwrap_or_default();
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
+    nm_setting.may_fail = iface_ip.may_fail;
     if iface_ip.is_auto() {
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.ra_timeout = Some(i32::MAX);

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -110,6 +110,7 @@ pub struct NmSettingIp {
     pub dhcp_client_id: Option<String>,
     pub dhcp_timeout: Option<i32>,
     pub gateway: Option<String>,
+    pub may_fail: Option<bool>,
     // IPv6 only
     pub ra_timeout: Option<i32>,
     // IPv6 only
@@ -142,6 +143,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
                 "ignore-auto-routes",
                 bool::try_from
             )?,
+            may_fail: _from_map!(v, "may-fail", bool::try_from)?,
             dhcp_client_id: _from_map!(v, "dhcp-client-id", String::try_from)?,
             dhcp_timeout: _from_map!(v, "dhcp-timeout", i32::try_from)?,
             ra_timeout: _from_map!(v, "ra-timeout", i32::try_from)?,
@@ -260,6 +262,9 @@ impl NmSettingIp {
         }
         if let Some(v) = self.never_default {
             ret.insert("never-default", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.may_fail {
+            ret.insert("may-fail", zvariant::Value::new(v));
         }
         if let Some(v) = &self.dhcp_client_id {
             ret.insert("dhcp-client-id", zvariant::Value::new(v));

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -130,6 +130,7 @@ class InterfaceIP:
     AUTO_GATEWAY = "auto-gateway"
     AUTO_ROUTES = "auto-routes"
     AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
+    MAY_FAIL = "may-fail"
 
 
 class InterfaceIPv4(InterfaceIP):


### PR DESCRIPTION
At some environments [1] is needed to set the may-fail attribute from
NetworkManager [2], this change add that attribute to the ip settings.

Closes https://bugzilla.redhat.com/show_bug.cgi?id=2082042

[1] https://github.com/openshift/machine-config-operator/blob/master/templates/common/_base/files/configure-ovs-network.yaml#L304
[2] https://developer-old.gnome.org/NetworkManager/stable/settings-ipv4.html