### PR TITLE
cli: Fix output of dns state

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -312,7 +312,9 @@ fn gen_conf(file_path: &str) -> Result<String, CliError> {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 struct SortedNetworkState {
+    #[serde(rename = "dns-resolver", default)]
     dns: DnsState,
+    #[serde(rename = "route-rules", default)]
     rules: RouteRules,
     routes: Routes,
     interfaces: Vec<Value>,


### PR DESCRIPTION
The correct key name is `dns-resolver` instead of `dns`

Integration test case included.