### PR TITLE
ovs: Fix absent action of OVS bridge with the same name

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -176,18 +176,12 @@ fn handle_changed_ports_of_iface(
         Some(p) => HashSet::from_iter(p.iter().cloned()),
         None => return Ok(()),
     };
-    let current_port_names =
-        match cur_ifaces.kernel_ifaces.get(iface.name()).or_else(|| {
-            cur_ifaces
-                .user_ifaces
-                .get(&(iface.name().to_string(), iface.iface_type()))
-        }) {
-            Some(cur_iface) => match cur_iface.ports() {
-                Some(p) => HashSet::from_iter(p.iter().cloned()),
-                None => HashSet::new(),
-            },
-            None => HashSet::new(),
-        };
+
+    let current_port_names = cur_ifaces
+        .get_iface(iface.name(), iface.iface_type())
+        .and_then(|cur_iface| cur_iface.ports())
+        .map(|ports| HashSet::<&str>::from_iter(ports.iter().cloned()))
+        .unwrap_or_default();
 
     // Attaching new port to controller
     for port_name in desire_port_names.difference(&current_port_names) {

--- a/rust/src/lib/nm/lldp.rs
+++ b/rust/src/lib/nm/lldp.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt::Write;
 
 use crate::nm::nm_dbus::{
     NmConnection, NmLldpNeighbor, NmLldpNeighbor8021Vlan,
@@ -85,7 +86,7 @@ impl From<&[NmLldpNeighbor8021Vlan]> for LldpVlans {
 fn u8_addr_to_mac_string(data: &[u8]) -> String {
     let mut addr = String::new();
     for (i, &val) in data.iter().enumerate() {
-        addr.push_str(&format!("{:02X}", val));
+        let _ = write!(addr, "{:02X}", val);
         if i != data.len() - 1 {
             addr.push(':');
         }

--- a/rust/src/lib/nm/nm_dbus/connection/sriov.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/sriov.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Write;
 
 use serde::Deserialize;
 
@@ -145,26 +146,26 @@ impl NmSettingSriovVf {
     pub(crate) fn to_keyfile(&self) -> String {
         let mut ret = String::new();
         if let Some(v) = self.mac.as_ref() {
-            ret += &format!("mac={} ", v);
+            let _ = write!(ret, "mac={} ", v);
         }
         if let Some(v) = self.spoof_check {
-            ret += &format!("spoof-check={} ", v);
+            let _ = write!(ret, "spoof-check={} ", v);
         }
         if let Some(v) = self.trust {
-            ret += &format!("trust={} ", v);
+            let _ = write!(ret, "trust={} ", v);
         }
         if let Some(v) = self.min_tx_rate {
-            ret += &format!("min-tx-rate={} ", v);
+            let _ = write!(ret, "min-tx-rate={} ", v);
         }
         if let Some(v) = self.max_tx_rate {
-            ret += &format!("max-tx-rate={} ", v);
+            let _ = write!(ret, "max-tx-rate={} ", v);
         }
         if let Some(vlans) = self.vlans.as_ref() {
             let mut vlans_str = Vec::new();
             for vlan in vlans {
                 vlans_str.push(vlan.to_keyfile());
             }
-            ret += &format!("vlans={}", vlans_str.join(";"));
+            let _ = write!(ret, "vlans={}", vlans_str.join(";"));
         }
         if ret.ends_with(' ') {
             ret.pop();

--- a/rust/src/lib/nm/nm_dbus/keyfile.rs
+++ b/rust/src/lib/nm/nm_dbus/keyfile.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use log::error;
 
@@ -11,7 +12,7 @@ pub(crate) fn keyfile_sections_to_string(
 ) -> Result<String, NmError> {
     let mut ret = String::new();
     for (section_name, data) in sections {
-        ret += &format!("[{}]\n", section_name);
+        let _ = writeln!(ret, "[{}]", section_name);
         // Sort the keys
         let mut keys: Vec<&String> = data.keys().collect();
         keys.sort_unstable();
@@ -19,7 +20,7 @@ pub(crate) fn keyfile_sections_to_string(
             if let Some(v) = data.get(key) {
                 let v = zvariant_value_to_string(v)?;
                 if !v.is_empty() {
-                    ret += &format!("{}={}\n", key, v);
+                    let _ = writeln!(ret, "{}={}", key, v);
                 }
             }
         }

--- a/rust/src/lib/nm/unit_tests/profiles.rs
+++ b/rust/src/lib/nm/unit_tests/profiles.rs
@@ -83,7 +83,7 @@ fn test_use_uuid_for_controller_reference_with_ovs_bond() {
         &mut nm_conns,
         &user_ifaces,
         &HashMap::new(),
-        &vec![],
+        &[],
     )
     .unwrap();
 

--- a/rust/src/lib/tests/testlib/context.rs
+++ b/rust/src/lib/tests/testlib/context.rs
@@ -1,6 +1,6 @@
-pub(crate) fn with_clean_up_afterwords<T, C>(test: T, cleanup: C) -> ()
+pub(crate) fn with_clean_up_afterwords<T, C>(test: T, cleanup: C)
 where
-    T: FnOnce() -> () + std::panic::UnwindSafe,
+    T: FnOnce() + std::panic::UnwindSafe,
     C: FnOnce(),
 {
     let result = std::panic::catch_unwind(|| {

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -33,7 +33,7 @@ fn test_resolve_unknown_type_absent_eth() {
 #[test]
 fn test_resolve_unknown_type_absent_multiple() {
     let mut cur_ifaces = Interfaces::new();
-    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
     cur_ifaces.push(new_ovs_iface("br0", "br0"));
     cur_ifaces.push(new_ovs_iface("p1", "br0"));
 

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -134,7 +134,7 @@ fn test_ifaces_up_order_nested_5_depth_good_case() {
 #[test]
 fn test_auto_include_ovs_interface() {
     let mut ifaces = Interfaces::new();
-    ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
 
     let (add_ifaces, _, _) = ifaces
         .gen_state_for_apply(&Interfaces::new(), false)
@@ -187,7 +187,7 @@ fn test_auto_include_ovs_interface() {
 #[test]
 fn test_auto_absent_ovs_interface() {
     let mut cur_ifaces = Interfaces::new();
-    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
     cur_ifaces.push(new_ovs_iface("p1", "br0"));
     cur_ifaces.push(new_ovs_iface("p2", "br0"));
 

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -1,5 +1,7 @@
 use crate::{
-    ifaces::get_ignored_ifaces, InterfaceType, Interfaces, OvsBridgeInterface,
+    ifaces::get_ignored_ifaces,
+    ifaces::inter_ifaces_controller::handle_changed_ports, InterfaceType,
+    Interfaces, OvsBridgeInterface,
 };
 
 #[test]
@@ -140,4 +142,46 @@ bridge:
     assert_eq!(opts.mcast_snooping_enable, Some(false));
     assert_eq!(bond_conf.bond_downdelay, Some(100));
     assert_eq!(bond_conf.bond_updelay, Some(101));
+}
+
+#[test]
+fn test_ovs_bridge_same_name_absent() {
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+- name: br1
+  type: ovs-interface
+- name: br1
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: br1
+    - name: eth1
+"#,
+    )
+    .unwrap();
+
+    let mut desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: br1
+  type: ovs-bridge
+  state: absent
+"#,
+    )
+    .unwrap();
+
+    handle_changed_ports(&mut desired, &current).unwrap();
+
+    let br_iface = desired.get_iface("br1", InterfaceType::OvsBridge).unwrap();
+    let ovs_iface = desired
+        .get_iface("br1", InterfaceType::OvsInterface)
+        .unwrap();
+    let eth_iface = desired.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+
+    assert!(br_iface.is_absent());
+    assert!(ovs_iface.is_absent());
+    assert!(!eth_iface.is_absent());
+    assert_eq!(eth_iface.base_iface().controller.as_deref(), Some(""));
 }

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -246,7 +246,7 @@ config:
 "#,
     )
     .unwrap();
-    routes.remove_ignored_iface_routes(&vec!["eth1".to_string()]);
+    routes.remove_ignored_iface_routes(&["eth1".to_string()]);
 
     let config_routes = routes.config.unwrap();
 


### PR DESCRIPTION
When OVS bridge holding the same name of its OVS interface, the deletion
of OVS bridge will automatically mark its OVS system interface(e.g.
eth1) as changed.

Please refer to https://bugzilla.redhat.com/show_bug.cgi?id=2082034 for
detail.

The root cause is we does not use interface type when searching for
current interface.

Unit test case and integration test cases included.