### PR TITLE
nm checkpoint: Wait on device deactivating on rollback

### DIFF
--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -281,6 +281,7 @@ impl<'a> NmApi<'a> {
             for nm_dev in &nm_devs {
                 if nm_dev.state_reason == NmDeviceStateReason::NewActivation
                     || nm_dev.state == NmDeviceState::IpConfig
+                    || nm_dev.state == NmDeviceState::Deactivating
                 {
                     waiting_nm_dev.push(nm_dev);
                 }


### PR DESCRIPTION
When rollback a checkpoint, we should also wait deactivating device.

This fix the random failure of `test_manual_rollback`, found at
https://github.com/nmstate/nmstate/runs/6303016595?check_suite_focus=true

Included another fix to retry on race problem of device deactivation and deletion.