### PR TITLE
port: Show IP as disable instead of hide

### DIFF
--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -42,15 +42,11 @@ pub(crate) fn np_ipv4_to_nmstate(
         Some(ip)
     } else {
         // IP might just disabled
-        if np_iface.controller == None {
-            Some(InterfaceIpv4 {
-                enabled: false,
-                prop_list: vec!["enabled"],
-                ..Default::default()
-            })
-        } else {
-            None
-        }
+        Some(InterfaceIpv4 {
+            enabled: false,
+            prop_list: vec!["enabled"],
+            ..Default::default()
+        })
     }
 }
 
@@ -94,15 +90,11 @@ pub(crate) fn np_ipv6_to_nmstate(
         Some(ip)
     } else {
         // IP might just disabled
-        if np_iface.controller == None {
-            Some(InterfaceIpv6 {
-                enabled: false,
-                prop_list: vec!["enabled"],
-                ..Default::default()
-            })
-        } else {
-            None
-        }
+        Some(InterfaceIpv6 {
+            enabled: false,
+            prop_list: vec!["enabled"],
+            ..Default::default()
+        })
     }
 }
 

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -973,3 +973,15 @@ def test_linux_bridge_multicast_router(bridge0_with_port0, mcast_router_value):
         },
     }
     libnmstate.apply({Interface.KEY: [iface_state]})
+
+
+@pytest.mark.tier1
+def test_linux_bridge_show_port_ip_as_disabled(bridge0_with_port0):
+    state = show_only(("eth1",))
+
+    assert state[Interface.KEY][0][Interface.IPV4] == {
+        InterfaceIPv4.ENABLED: False
+    }
+    assert state[Interface.KEY][0][Interface.IPV6] == {
+        InterfaceIPv6.ENABLED: False
+    }


### PR DESCRIPTION
For port which is not allowed to hold IP information, we should show its IP
ad disabled as we did in python code.

Integration test case included.