### PR TITLE
[nmstate-2.0] ovs, dpdk: add support to rx_queue parameter

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -30,10 +30,6 @@ PYTEST_OPTIONS="--verbose --verbose \
         --log-date-format='%Y-%m-%d %H:%M:%S' \
         --log-format='%(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s' \
         --durations=5 \
-        --cov /usr/lib/python*/site-packages/libnmstate \
-        --cov /usr/lib/python*/site-packages/nmstatectl \
-        --cov-report=term \
-        --cov-report=xml \
         --log-file=pytest-run.log"
 
 NMSTATE_TEMPDIR=$(mktemp -d /tmp/nmstate-test-XXXX)
@@ -127,7 +123,6 @@ function run_tests {
             pytest \
             $PYTEST_OPTIONS \
             --junitxml=junit.integ.xml \
-            --cov-report=html:htmlcov-integ \
             tests/integration \
             ${nmstate_pytest_extra_args}"
     fi
@@ -137,7 +132,6 @@ function run_tests {
         exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
-            --cov-report=html:htmlcov-integ_tier1 \
             --junitxml=junit.integ_tier1.xml \
             -m tier1 \
             tests/integration \
@@ -149,7 +143,6 @@ function run_tests {
         exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
-            --cov-report=html:htmlcov-integ_tier2 \
             --junitxml=junit.integ_tier2.xml \
             -m tier2 \
             tests/integration \
@@ -162,7 +155,6 @@ function run_tests {
         exec_cmd "
           pytest \
             $PYTEST_OPTIONS \
-            --cov-report=html:htmlcov-integ_slow \
             --junitxml=junit.integ_slow.xml \
             -m slow --runslow \
             tests/integration \

--- a/examples/ovsbridge_dpdk_create.yml
+++ b/examples/ovsbridge_dpdk_create.yml
@@ -13,3 +13,4 @@ interfaces:
     state: up
     dpdk:
       devargs: "000:18:00.2"
+      rx-queue: 10

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -280,6 +280,14 @@ class OvsInternalIface(BaseIface):
         )
 
     @property
+    def rx_queue(self):
+        return (
+            self.dpdk_config.get(OVSInterface.Dpdk.RX_QUEUE)
+            if self.dpdk_config
+            else None
+        )
+
+    @property
     def peer(self):
         return (
             self.patch_config.get(OVSInterface.Patch.PEER)
@@ -293,8 +301,13 @@ class OvsInternalIface(BaseIface):
             OVSInterface.Patch.PEER,
         )
         validate_string(
-            self.patch_config.get(OVSInterface.Dpdk.DEVARGS),
+            self.dpdk_config.get(OVSInterface.Dpdk.DEVARGS),
             OVSInterface.Dpdk.DEVARGS,
+        )
+        validate_integer(
+            self.dpdk_config.get(OVSInterface.Dpdk.RX_QUEUE),
+            OVSInterface.Dpdk.RX_QUEUE,
+            minimum=0,
         )
         super().pre_edit_validation_and_cleanup()
         self._validate_ovs_mtu_mac_confliction()

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -149,6 +149,7 @@ def create_patch_setting(patch_state):
 def create_dpdk_setting(dpdk_state):
     dpdk_setting = NM.SettingOvsDpdk.new()
     dpdk_setting.props.devargs = dpdk_state[OVSInterface.Dpdk.DEVARGS]
+    dpdk_setting.props.n_rxq = dpdk_state[OVSInterface.Dpdk.RX_QUEUE]
 
     return dpdk_setting
 
@@ -215,6 +216,7 @@ def get_interface_info(act_con):
         if dpdk_setting:
             info[OVSInterface.DPDK_CONFIG_SUBTREE] = {
                 OVSInterface.Dpdk.DEVARGS: dpdk_setting.props.devargs,
+                OVSInterface.Dpdk.RX_QUEUE: dpdk_setting.props.n_rxq,
             }
 
     return info

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -300,6 +300,7 @@ class OVSInterface(OvsDB):
 
     class Dpdk:
         DEVARGS = "devargs"
+        RX_QUEUE = "rx-queue"
 
 
 class OVSBridge(Bridge, OvsDB):

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -48,18 +48,19 @@ fn net_state_to_nispor(
             np_ifaces.push(nmstate_iface_to_np(iface, np_iface_type)?);
         } else if iface.is_absent() {
             println!("del {:?} {:?}", iface.name(), iface.iface_type());
-            np_ifaces.push(nispor::IfaceConf {
-                name: iface.name().to_string(),
-                iface_type: Some(nmstate_iface_type_to_np(&iface.iface_type())),
-                state: nispor::IfaceState::Absent,
-                ..Default::default()
-            });
+            let mut iface_conf = nispor::IfaceConf::default();
+            iface_conf.name = iface.name().to_string();
+            iface_conf.iface_type =
+                Some(nmstate_iface_type_to_np(&iface.iface_type()));
+            iface_conf.state = nispor::IfaceState::Absent;
+            np_ifaces.push(iface_conf);
         }
     }
 
-    Ok(nispor::NetConf {
-        ifaces: Some(np_ifaces),
-    })
+    let mut net_conf = nispor::NetConf::default();
+    net_conf.ifaces = Some(np_ifaces);
+
+    Ok(net_conf)
 }
 
 fn nmstate_iface_type_to_np(
@@ -79,12 +80,10 @@ fn nmstate_iface_to_np(
     nms_iface: &Interface,
     np_iface_type: nispor::IfaceType,
 ) -> Result<nispor::IfaceConf, NmstateError> {
-    let mut np_iface = nispor::IfaceConf {
-        name: nms_iface.name().to_string(),
-        iface_type: Some(np_iface_type),
-        state: nispor::IfaceState::Up,
-        ..Default::default()
-    };
+    let mut np_iface = nispor::IfaceConf::default();
+    np_iface.name = nms_iface.name().to_string();
+    np_iface.iface_type = Some(np_iface_type);
+    np_iface.state = nispor::IfaceState::Up;
     let base_iface = &nms_iface.base_iface();
     if let Some(ctrl_name) = &base_iface.controller {
         np_iface.controller = Some(ctrl_name.to_string())

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -76,9 +76,11 @@ pub(crate) fn nmstate_ipv4_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv4) = nms_ipv4 {
         for nms_addr in &nms_ipv4.addresses {
-            np_ip_conf.addresses.push(nispor::IpAddrConf {
-                address: nms_addr.ip.to_string(),
-                prefix_len: nms_addr.prefix_length as u8,
+            np_ip_conf.addresses.push({
+                let mut ip_conf = nispor::IpAddrConf::default();
+                ip_conf.address = nms_addr.ip.to_string();
+                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf
             });
         }
     }
@@ -91,9 +93,11 @@ pub(crate) fn nmstate_ipv6_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
     if let Some(nms_ipv6) = nms_ipv6 {
         for nms_addr in &nms_ipv6.addresses {
-            np_ip_conf.addresses.push(nispor::IpAddrConf {
-                address: nms_addr.ip.to_string(),
-                prefix_len: nms_addr.prefix_length as u8,
+            np_ip_conf.addresses.push({
+                let mut ip_conf = nispor::IpAddrConf::default();
+                ip_conf.address = nms_addr.ip.to_string();
+                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf
             });
         }
     }

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -19,7 +19,9 @@ pub(crate) fn np_veth_to_nmstate(
 pub(crate) fn nms_veth_conf_to_np(
     nms_veth_conf: Option<&VethConfig>,
 ) -> Option<nispor::VethConf> {
-    nms_veth_conf.map(|nms_veth_conf| nispor::VethConf {
-        peer: nms_veth_conf.peer.to_string(),
+    nms_veth_conf.map(|nms_veth_conf| {
+        let mut veth_conf = nispor::VethConf::default();
+        veth_conf.peer = nms_veth_conf.peer.to_string();
+        veth_conf
     })
 }

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -18,8 +18,10 @@ pub(crate) fn np_vlan_to_nmstate(
 pub(crate) fn nms_vlan_conf_to_np(
     nms_vlan_conf: Option<&VlanConfig>,
 ) -> Option<nispor::VlanConf> {
-    nms_vlan_conf.map(|nms_vlan_conf| nispor::VlanConf {
-        vlan_id: nms_vlan_conf.id,
-        base_iface: nms_vlan_conf.base_iface.clone(),
+    nms_vlan_conf.map(|nms_vlan_conf| {
+        let mut np_vlan_conf = nispor::VlanConf::default();
+        np_vlan_conf.vlan_id = nms_vlan_conf.id;
+        np_vlan_conf.base_iface = nms_vlan_conf.base_iface.clone();
+        np_vlan_conf
     })
 }

--- a/rust/src/libnm_dbus/active_connection.rs
+++ b/rust/src/libnm_dbus/active_connection.rs
@@ -4,7 +4,7 @@ use crate::{
     ErrorKind, NmError,
 };
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NmActiveConnection {
     pub uuid: String,
     pub iface_type: String,

--- a/rust/src/libnm_dbus/connection/bond.rs
+++ b/rust/src/libnm_dbus/connection/bond.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::{connection::DbusDictionary, NmError};
 
-#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
 #[non_exhaustive]
 pub struct NmSettingBond {

--- a/rust/src/libnm_dbus/connection/ip.rs
+++ b/rust/src/libnm_dbus/connection/ip.rs
@@ -35,7 +35,7 @@ use crate::{
     error::{ErrorKind, NmError},
 };
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(try_from = "zvariant::OwnedValue")]
 #[non_exhaustive]
 pub enum NmSettingIpMethod {

--- a/rust/src/libnm_dbus/connection/vlan.rs
+++ b/rust/src/libnm_dbus/connection/vlan.rs
@@ -51,7 +51,7 @@ impl NmSettingVlan {
 const NM_VLAN_PROTOCOL_802_1Q: &str = "802.1Q";
 const NM_VLAN_PROTOCOL_802_1AD: &str = "802.1AD";
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum NmVlanProtocol {
     Dot1Q,

--- a/rust/src/libnm_dbus/device.rs
+++ b/rust/src/libnm_dbus/device.rs
@@ -52,7 +52,7 @@ const NM_DEVICE_STATE_ACTIVATED: u32 = 100;
 const NM_DEVICE_STATE_DEACTIVATING: u32 = 110;
 const NM_DEVICE_STATE_FAILED: u32 = 120;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum NmDeviceState {
     Unknown,
@@ -169,7 +169,7 @@ const NM_DEVICE_STATE_REASON_IP_METHOD_UNSUPPORTED: u32 = 65;
 const NM_DEVICE_STATE_REASON_SRIOV_CONFIGURATION_FAILED: u32 = 66;
 const NM_DEVICE_STATE_REASON_PEER_NOT_FOUND: u32 = 67;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum NmDeviceStateReason {
     Null,

--- a/rust/src/libnm_dbus/error.rs
+++ b/rust/src/libnm_dbus/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
     DbusConnectionError,

--- a/tests/lib/ifaces/ovs_iface_test.py
+++ b/tests/lib/ifaces/ovs_iface_test.py
@@ -431,6 +431,18 @@ class TestOvsInternalIface:
 
         assert iface.devargs == "000:18:00.2"
 
+    def test_rx_queue(self):
+        iface_info = {
+            Interface.NAME: "ovs0",
+            Interface.TYPE: InterfaceType.OVS_INTERFACE,
+            OVSInterface.DPDK_CONFIG_SUBTREE: {
+                OVSInterface.Dpdk.RX_QUEUE: 1000
+            },
+        }
+        iface = OvsInternalIface(iface_info)
+
+        assert iface.rx_queue == 1000
+
     def test_dpdk_config(self):
         iface_info = {
             Interface.NAME: "ovs0",
@@ -455,6 +467,18 @@ class TestOvsInternalIface:
 
         iface.pre_edit_validation_and_cleanup()
 
+    def test_valid_ovs_interface_with_rx_queue(self):
+        iface_info = {
+            Interface.NAME: "ovs0",
+            Interface.TYPE: InterfaceType.OVS_INTERFACE,
+            OVSInterface.DPDK_CONFIG_SUBTREE: {
+                OVSInterface.Dpdk.RX_QUEUE: 1000
+            },
+        }
+        iface = OvsInternalIface(iface_info)
+
+        iface.pre_edit_validation_and_cleanup()
+
     def test_invalid_ovs_interface_with_devargs(self):
         iface_info = {
             Interface.NAME: "ovs0",
@@ -465,7 +489,19 @@ class TestOvsInternalIface:
         }
         iface = OvsInternalIface(iface_info)
 
-        iface.pre_edit_validation_and_cleanup()
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
+
+    def test_invalid_ovs_interface_with_rx_queue(self):
+        iface_info = {
+            Interface.NAME: "ovs0",
+            Interface.TYPE: InterfaceType.OVS_INTERFACE,
+            OVSInterface.DPDK_CONFIG_SUBTREE: {OVSInterface.Dpdk.RX_QUEUE: -1},
+        }
+        iface = OvsInternalIface(iface_info)
+
+        with pytest.raises(NmstateValueError):
+            iface.pre_edit_validation_and_cleanup()
 
     def test_valid_ovs_interface_with_peer(self):
         iface_info = {


### PR DESCRIPTION
```
---
interfaces:
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      options:
        datapath: netdev
      port:
        - name: ovs0
  - name: ovs0
    type: ovs-interface
    state: up
    dpdk:
      devargs: "000:18:00.2"
      rx_queue: 1000
```

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>