### PR TITLE
[nmstate-1.3] ovs, dpdk: add support to rx_queue parameter

### DIFF
--- a/examples/ovsbridge_dpdk_create.yml
+++ b/examples/ovsbridge_dpdk_create.yml
@@ -13,3 +13,4 @@ interfaces:
     state: up
     dpdk:
       devargs: "000:18:00.2"
+      rx-queue: 1000

--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -237,6 +237,14 @@ class OvsInternalIface(BaseIface):
         )
 
     @property
+    def rx_queue(self):
+        return (
+            self.dpdk_config.get(OVSInterface.Dpdk.RX_QUEUE)
+            if self.dpdk_config
+            else None
+        )
+
+    @property
     def peer(self):
         return (
             self.patch_config.get(OVSInterface.Patch.PEER)

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -149,6 +149,7 @@ def create_patch_setting(patch_state):
 def create_dpdk_setting(dpdk_state):
     dpdk_setting = NM.SettingOvsDpdk.new()
     dpdk_setting.props.devargs = dpdk_state[OVSInterface.Dpdk.DEVARGS]
+    dpdk_setting.props.n_rxq = dpdk_state[OVSInterface.Dpdk.RX_QUEUE]
 
     return dpdk_setting
 
@@ -215,6 +216,7 @@ def get_interface_info(act_con):
         if dpdk_setting:
             info[OVSInterface.DPDK_CONFIG_SUBTREE] = {
                 OVSInterface.Dpdk.DEVARGS: dpdk_setting.props.devargs,
+                OVSInterface.Dpdk.RX_QUEUE: dpdk_setting.props.n_rxq,
             }
 
     return info

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -358,6 +358,7 @@ class OVSInterface(OvsDB):
 
     class Dpdk:
         DEVARGS = "devargs"
+        RX_QUEUE = "rx-queue"
 
 
 class OVSBridge(Bridge, OvsDB):

--- a/rust/src/lib/nm/lldp.rs
+++ b/rust/src/lib/nm/lldp.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::fmt::Write;
 
 use nm_dbus::{NmConnection, NmLldpNeighbor, NmLldpNeighbor8021Vlan};
 
@@ -83,7 +84,7 @@ impl From<&[NmLldpNeighbor8021Vlan]> for LldpVlans {
 fn u8_addr_to_mac_string(data: &[u8]) -> String {
     let mut addr = String::new();
     for (i, &val) in data.iter().enumerate() {
-        addr.push_str(&format!("{:02X}", val));
+        let _ = write!(addr, "{:02X}", val);
         if i != data.len() - 1 {
             addr.push(':');
         }

--- a/rust/src/lib/nm/unit_tests/profiles.rs
+++ b/rust/src/lib/nm/unit_tests/profiles.rs
@@ -83,7 +83,7 @@ fn test_use_uuid_for_controller_reference_with_ovs_bond() {
         &mut nm_conns,
         &user_ifaces,
         &HashMap::new(),
-        &vec![],
+        &[],
     )
     .unwrap();
 

--- a/rust/src/lib/tests/testlib/context.rs
+++ b/rust/src/lib/tests/testlib/context.rs
@@ -1,6 +1,6 @@
-pub(crate) fn with_clean_up_afterwords<T, C>(test: T, cleanup: C) -> ()
+pub(crate) fn with_clean_up_afterwords<T, C>(test: T, cleanup: C)
 where
-    T: FnOnce() -> () + std::panic::UnwindSafe,
+    T: FnOnce() + std::panic::UnwindSafe,
     C: FnOnce(),
 {
     let result = std::panic::catch_unwind(|| {

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -32,7 +32,7 @@ fn test_resolve_unknown_type_absent_eth() {
 #[test]
 fn test_resolve_unknown_type_absent_multiple() {
     let mut cur_ifaces = Interfaces::new();
-    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
     cur_ifaces.push(new_ovs_iface("br0", "br0"));
     cur_ifaces.push(new_ovs_iface("p1", "br0"));
 

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -134,7 +134,7 @@ fn test_ifaces_up_order_nested_5_depth_good_case() {
 #[test]
 fn test_auto_include_ovs_interface() {
     let mut ifaces = Interfaces::new();
-    ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
 
     let (add_ifaces, _, _) = ifaces
         .gen_state_for_apply(&Interfaces::new(), false)
@@ -187,7 +187,7 @@ fn test_auto_include_ovs_interface() {
 #[test]
 fn test_auto_absent_ovs_interface() {
     let mut cur_ifaces = Interfaces::new();
-    cur_ifaces.push(new_ovs_br_iface("br0", &vec!["p1", "p2"]));
+    cur_ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
     cur_ifaces.push(new_ovs_iface("p1", "br0"));
     cur_ifaces.push(new_ovs_iface("p2", "br0"));
 

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -246,7 +246,7 @@ config:
 "#,
     )
     .unwrap();
-    routes.remove_ignored_iface_routes(&vec!["eth1".to_string()]);
+    routes.remove_ignored_iface_routes(&["eth1".to_string()]);
 
     let config_routes = routes.config.unwrap();
 

--- a/rust/src/libnm_dbus/connection/sriov.rs
+++ b/rust/src/libnm_dbus/connection/sriov.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Write;
 
 use serde::Deserialize;
 
@@ -149,26 +150,26 @@ impl NmSettingSriovVf {
     pub(crate) fn to_keyfile(&self) -> String {
         let mut ret = String::new();
         if let Some(v) = self.mac.as_ref() {
-            ret += &format!("mac={} ", v);
+            let _ = write!(ret, "mac={} ", v);
         }
         if let Some(v) = self.spoof_check {
-            ret += &format!("spoof-check={} ", v);
+            let _ = write!(ret, "spoof-check={} ", v);
         }
         if let Some(v) = self.trust {
-            ret += &format!("trust={} ", v);
+            let _ = write!(ret, "trust={} ", v);
         }
         if let Some(v) = self.min_tx_rate {
-            ret += &format!("min-tx-rate={} ", v);
+            let _ = write!(ret, "min-tx-rate={} ", v);
         }
         if let Some(v) = self.max_tx_rate {
-            ret += &format!("max-tx-rate={} ", v);
+            let _ = write!(ret, "max-tx-rate={} ", v);
         }
         if let Some(vlans) = self.vlans.as_ref() {
             let mut vlans_str = Vec::new();
             for vlan in vlans {
                 vlans_str.push(vlan.to_keyfile());
             }
-            ret += &format!("vlans={}", vlans_str.join(";"));
+            let _ = write!(ret, "vlans={}", vlans_str.join(";"));
         }
         if ret.ends_with(' ') {
             ret.pop();

--- a/rust/src/libnm_dbus/keyfile.rs
+++ b/rust/src/libnm_dbus/keyfile.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use log::error;
 
@@ -11,7 +12,7 @@ pub(crate) fn keyfile_sections_to_string(
 ) -> Result<String, NmError> {
     let mut ret = String::new();
     for (section_name, data) in sections {
-        ret += &format!("[{}]\n", section_name);
+        let _ = writeln!(ret, "[{}]", section_name);
         // Sort the keys
         let mut keys: Vec<&String> = data.keys().collect();
         keys.sort_unstable();
@@ -19,7 +20,7 @@ pub(crate) fn keyfile_sections_to_string(
             if let Some(v) = data.get(key) {
                 let v = zvariant_value_to_string(v)?;
                 if !v.is_empty() {
-                    ret += &format!("{}={}\n", key, v);
+                    let _ = writeln!(ret, "{}={}", key, v);
                 }
             }
         }

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -971,28 +971,21 @@ class TestOvsDpdk:
         assertlib.assert_absent(BRIDGE0)
         assertlib.assert_absent(PORT1)
 
+    def test_create_ovs_dpdk_with_rx_queue(self, setup_ovs_dpdk):
+        dpdk0_state = {
+            OVSInterface.Dpdk.DEVARGS: _test_pci_path(),
+            OVSInterface.Dpdk.RX_QUEUE: 1000,
+        }
+        bridge = Bridge(BRIDGE0)
+        bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)
+        desired_state = bridge.state
+        try:
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+        finally:
+            for iface in desired_state[Interface.KEY]:
+                iface[Interface.STATE] = InterfaceState.ABSENT
+            libnmstate.apply(desired_state)
 
-@pytest.fixture
-def unmanged_ovs_vxlan():
-    cmdlib.exec_cmd("ovs-vsctl add-br br0_with_vxlan".split(), check=True)
-    cmdlib.exec_cmd(
-        "ovs-vsctl add-port br0_with_vxlan vx_node1 -- "
-        "set interface vx_node1 type=vxlan options:remote_ip=192.168.122.174 "
-        "options:dst_port=8472".split(),
-        check=True,
-    )
-    cmdlib.exec_cmd(
-        "nmcli d set vxlan_sys_8472 managed false".split(), check=True
-    )
-    try:
-        yield
-    finally:
-        cmdlib.exec_cmd("ovs-vsctl del-br br0_with_vxlan".split())
-
-
-@pytest.mark.tier1
-def test_ovs_vxlan_in_current_not_impact_others(unmanged_ovs_vxlan):
-    with Bridge(BRIDGE1).create() as state:
-        assertlib.assert_state_match(state)
-
-    assertlib.assert_absent(BRIDGE1)
+        assertlib.assert_absent(BRIDGE0)
+        assertlib.assert_absent(PORT1)

--- a/tests/lib/ifaces/ovs_iface_test.py
+++ b/tests/lib/ifaces/ovs_iface_test.py
@@ -267,6 +267,18 @@ class TestOvsInternalIface:
 
         assert iface.devargs == "000:18:00.2"
 
+    def test_rx_queue(self):
+        iface_info = {
+            Interface.NAME: "ovs0",
+            Interface.TYPE: InterfaceType.OVS_INTERFACE,
+            OVSInterface.DPDK_CONFIG_SUBTREE: {
+                OVSInterface.Dpdk.RX_QUEUE: 1000
+            },
+        }
+        iface = OvsInternalIface(iface_info)
+
+        assert iface.rx_queue == 1000
+
     def test_dpdk_config(self):
         iface_info = {
             Interface.NAME: "ovs0",
@@ -291,12 +303,12 @@ class TestOvsInternalIface:
 
         iface.pre_edit_validation_and_cleanup()
 
-    def test_invalid_ovs_interface_with_devargs(self):
+    def test_valid_ovs_interface_with_rx_queue(self):
         iface_info = {
             Interface.NAME: "ovs0",
             Interface.TYPE: InterfaceType.OVS_INTERFACE,
             OVSInterface.DPDK_CONFIG_SUBTREE: {
-                OVSInterface.Dpdk.DEVARGS: 23232
+                OVSInterface.Dpdk.RX_QUEUE: 1000
             },
         }
         iface = OvsInternalIface(iface_info)


### PR DESCRIPTION
```
---
interfaces:
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      options:
        datapath: netdev
      port:
        - name: ovs0
  - name: ovs0
    type: ovs-interface
    state: up
    dpdk:
      devargs: "000:18:00.2"
      rx_queue: 1000
```

Integration test case added.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>
(cherry picked from commit 3624a760dcd3df96eec2236d15f98a2c7ae7a5e4)