### PR TITLE
ovs, dpdk: add support to rx-queue parameter

### DIFF
--- a/examples/ovsbridge_dpdk_create.yml
+++ b/examples/ovsbridge_dpdk_create.yml
@@ -13,6 +13,7 @@ interfaces:
     state: up
     dpdk:
       devargs: "000:18:00.2"
+      rx-queue: 10
 ovs-db:
   other_config:
     dpdk-init: "true"

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -351,8 +351,10 @@ pub struct OvsPatchConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct OvsDpdkConfig {
     pub devargs: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_queue: Option<u32>,
 }

--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -287,6 +287,7 @@ impl NmSettingOvsPatch {
 #[non_exhaustive]
 pub struct NmSettingOvsDpdk {
     pub devargs: Option<String>,
+    pub n_rxq: Option<u32>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -295,6 +296,7 @@ impl TryFrom<DbusDictionary> for NmSettingOvsDpdk {
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
         Ok(Self {
             devargs: _from_map!(v, "devargs", String::try_from)?,
+            n_rxq: _from_map!(v, "n-rxq", u32::try_from)?,
             _other: v,
         })
     }
@@ -317,6 +319,9 @@ impl NmSettingOvsDpdk {
         let mut ret = HashMap::new();
         if let Some(v) = &self.devargs {
             ret.insert("devargs", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.n_rxq {
+            ret.insert("n-rxq", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/ovs.rs
+++ b/rust/src/lib/nm/ovs.rs
@@ -295,13 +295,14 @@ pub(crate) fn gen_nm_ovs_iface_setting(
         let mut nm_ovs_patch = NmSettingOvsPatch::default();
         nm_ovs_patch.peer = Some(peer.to_string());
         nm_conn.ovs_patch = Some(nm_ovs_patch);
-    } else if let Some(dpdk_devargs) =
-        iface.dpdk.as_ref().map(|c| c.devargs.as_str())
-    {
-        nm_ovs_iface_set.iface_type = Some("dpdk".to_string());
-        let mut nm_ovs_dpdk = NmSettingOvsDpdk::default();
-        nm_ovs_dpdk.devargs = Some(dpdk_devargs.to_string());
-        nm_conn.ovs_dpdk = Some(nm_ovs_dpdk);
+    } else if let Some(dpdk_iface) = iface.dpdk.as_ref() {
+        if !dpdk_iface.devargs.is_empty() {
+            nm_ovs_iface_set.iface_type = Some("dpdk".to_string());
+            let mut nm_ovs_dpdk = NmSettingOvsDpdk::default();
+            nm_ovs_dpdk.devargs = Some(dpdk_iface.devargs.to_string());
+            nm_ovs_dpdk.n_rxq = dpdk_iface.rx_queue;
+            nm_conn.ovs_dpdk = Some(nm_ovs_dpdk);
+        }
     } else {
         nm_ovs_iface_set.iface_type = Some("internal".to_string());
     }
@@ -378,6 +379,7 @@ pub(crate) fn get_ovs_dpdk_config(
         if let Some(devargs) = nm_ovs_dpdk_set.devargs.as_deref() {
             return Some(OvsDpdkConfig {
                 devargs: devargs.to_string(),
+                rx_queue: nm_ovs_dpdk_set.n_rxq,
             });
         }
     }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -300,6 +300,7 @@ class OVSInterface(OvsDB):
 
     class Dpdk:
         DEVARGS = "devargs"
+        RX_QUEUE = "rx-queue"
 
 
 class OVSBridge(Bridge, OvsDB):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -940,10 +940,32 @@ def test_add_route_rule_to_ovs_interface_dhcp_auto_route_table(
     reason="Need to define TEST_PCI_PATH for OVS DPDK tests.",
 )
 class TestOvsDpdk:
-    def test_create_ovs_dpdk_and_remove(self, setup_ovs_dpdk):
+    def test_create_ovs_dpdk_and_remove(self):
         dpdk0_state = {OVSInterface.Dpdk.DEVARGS: _test_pci_path()}
         bridge = Bridge(BRIDGE0)
         bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)
+        bridge.set_options({OVSBridge.Options.DATAPATH: "netdev"})
+        desired_state = bridge.state
+        try:
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+        finally:
+            for iface in desired_state[Interface.KEY]:
+                iface[Interface.STATE] = InterfaceState.ABSENT
+            libnmstate.apply(desired_state)
+
+        assertlib.assert_absent(BRIDGE0)
+        assertlib.assert_absent(PORT1)
+
+    @pytest.mark.tier1
+    def test_create_ovs_dpdk_with_rx_queue(self):
+        dpdk0_state = {
+            OVSInterface.Dpdk.DEVARGS: _test_pci_path(),
+            OVSInterface.Dpdk.RX_QUEUE: 10,
+        }
+        bridge = Bridge(BRIDGE0)
+        bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)
+        bridge.set_options({OVSBridge.Options.DATAPATH: "netdev"})
         desired_state = bridge.state
         try:
             libnmstate.apply(desired_state)
@@ -957,7 +979,7 @@ class TestOvsDpdk:
         assertlib.assert_absent(PORT1)
 
     @pytest.mark.parametrize("datapaths", ("netdev", "system"))
-    def test_create_ovs_dpdk_with_datapath(self, setup_ovs_dpdk, datapaths):
+    def test_create_ovs_dpdk_with_datapath(self, datapaths):
         dpdk0_state = {OVSInterface.Dpdk.DEVARGS: _test_pci_path()}
         bridge = Bridge(BRIDGE0)
         bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)


### PR DESCRIPTION
```
---
interfaces:
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      options:
        datapath: netdev
      port:
        - name: ovs0
  - name: ovs0
    type: ovs-interface
    state: up
    dpdk:
      devargs: "000:18:00.2"
      rx-queue: 1000
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>