### PR TITLE
nm ethtool pause: Fix error when both autoneg true and rx/tx defined

### DIFF
--- a/rust/src/lib/nm/ethtool.rs
+++ b/rust/src/lib/nm/ethtool.rs
@@ -48,8 +48,10 @@ fn apply_pause_options(
     nm_ethtool_set: &mut NmSettingEthtool,
     pause_conf: &EthtoolPauseConfig,
 ) {
-    nm_ethtool_set.pause_rx = pause_conf.rx;
-    nm_ethtool_set.pause_tx = pause_conf.tx;
+    if pause_conf.autoneg == Some(false) {
+        nm_ethtool_set.pause_rx = pause_conf.rx;
+        nm_ethtool_set.pause_tx = pause_conf.tx;
+    }
     nm_ethtool_set.pause_autoneg = pause_conf.autoneg;
 }
 


### PR DESCRIPTION
When applying

```yaml
  pause:
    rx: true
    tx: true
    autoneg: true
```

we got error:

    libnmstate.error.NmstateInternalError: DbusConnectionError:
    org.freedesktop.NetworkManager.Settings.Connection.InvalidProperty:
    ethtool.pause-autoneg: pause-autoneg cannot be enabled when setting
    rx/tx options dbus:

Change the code to ignore rx/tx setting when autoneg set to True.

Integration test case included.