### PR TITLE
nm: Support backend specific configuration

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -11,6 +11,7 @@ use crate::{
     nm::ieee8021x::gen_nm_802_1x_setting,
     nm::infiniband::gen_nm_ib_setting,
     nm::ip::gen_nm_ip_setting,
+    nm::nm_specific::apply_backend_specific_config,
     nm::ovs::{
         create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
         gen_nm_ovs_ext_ids_setting, gen_nm_ovs_iface_setting,
@@ -264,6 +265,10 @@ pub(crate) fn iface_to_nm_connections(
     // its NmSettingOvsIface setting
     if base_iface.controller.as_deref() == Some("") {
         nm_conn.ovs_iface = None;
+    }
+
+    if let Some(be_config) = iface.base_iface().backend_specific.as_ref() {
+        apply_backend_specific_config(be_config, &mut nm_conn);
     }
 
     ret.insert(0, nm_conn);

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -14,6 +14,7 @@ mod ip;
 mod lldp;
 mod mac_vlan;
 mod nm_dbus;
+mod nm_specific;
 mod ovs;
 mod profile;
 mod route;

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -110,6 +110,7 @@ pub struct NmSettingIp {
     pub dhcp_client_id: Option<String>,
     pub dhcp_timeout: Option<i32>,
     pub gateway: Option<String>,
+    pub may_fail: Option<bool>,
     // IPv6 only
     pub ra_timeout: Option<i32>,
     // IPv6 only
@@ -150,6 +151,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             dhcp_iaid: _from_map!(v, "dhcp-iaid", String::try_from)?,
             route_table: _from_map!(v, "route-table", u32::try_from)?,
             gateway: _from_map!(v, "gateway", String::try_from)?,
+            may_fail: _from_map!(v, "may-fail", bool::try_from)?,
             ..Default::default()
         };
 
@@ -284,6 +286,9 @@ impl NmSettingIp {
         }
         if let Some(v) = &self.gateway {
             ret.insert("gateway", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.may_fail {
+            ret.insert("may-fail", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/nm_specific.rs
+++ b/rust/src/lib/nm/nm_specific.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use crate::nm::nm_dbus::NmConnection;
+
+const BACKEND_SPECIFIC_KEY: &str = "networkmanager";
+
+const NM_ID_KEY: &str = "connection.id";
+const NM_UUID_KEY: &str = "connection.uuid";
+const NM_IPV4_MAY_FAIL_KEY: &str = "ipv4.may-fail";
+const NM_IPV6_MAY_FAIL_KEY: &str = "ipv6.may-fail";
+
+// We are not allowing arbitrary settings be case we are supposed to set the
+// data type before sending to NM via dbus
+pub(crate) fn apply_backend_specific_config(
+    config: &HashMap<String, serde_json::Value>,
+    nm_conn: &mut NmConnection,
+) {
+    if let Some(config) =
+        config.get(BACKEND_SPECIFIC_KEY).and_then(|v| v.as_object())
+    {
+        if let Some(v) = config.get(NM_ID_KEY).and_then(|v| v.as_str()) {
+            if let Some(nm_set) = nm_conn.connection.as_mut() {
+                nm_set.id = Some(v.to_string());
+            }
+        }
+        if let Some(v) = config.get(NM_UUID_KEY).and_then(|v| v.as_str()) {
+            if let Some(nm_set) = nm_conn.connection.as_mut() {
+                nm_set.uuid = Some(v.to_string());
+            }
+        }
+        if let Some(v) = value_get_bool(config, NM_IPV4_MAY_FAIL_KEY) {
+            if let Some(nm_set) = nm_conn.ipv4.as_mut() {
+                nm_set.may_fail = Some(v);
+            }
+        }
+        if let Some(v) = value_get_bool(config, NM_IPV6_MAY_FAIL_KEY) {
+            if let Some(nm_set) = nm_conn.ipv6.as_mut() {
+                nm_set.may_fail = Some(v);
+            }
+        }
+    }
+}
+
+pub(crate) fn get_backend_specific_config(
+    nm_conn: &NmConnection,
+) -> HashMap<String, serde_json::Value> {
+    let mut nm_specific = serde_json::Map::new();
+    if let Some(v) = nm_conn.id() {
+        nm_specific.insert(
+            NM_ID_KEY.to_string(),
+            serde_json::Value::String(v.to_string()),
+        );
+    }
+    if let Some(v) = nm_conn.uuid() {
+        nm_specific.insert(
+            NM_UUID_KEY.to_string(),
+            serde_json::Value::String(v.to_string()),
+        );
+    }
+    if let Some(nm_set) = nm_conn.ipv4.as_ref() {
+        nm_specific.insert(
+            NM_IPV4_MAY_FAIL_KEY.to_string(),
+            serde_json::Value::Bool(nm_set.may_fail.unwrap_or(true)),
+        );
+    }
+    if let Some(nm_set) = nm_conn.ipv6.as_ref() {
+        nm_specific.insert(
+            NM_IPV6_MAY_FAIL_KEY.to_string(),
+            serde_json::Value::Bool(nm_set.may_fail.unwrap_or(true)),
+        );
+    }
+
+    let mut ret = HashMap::new();
+    ret.insert(
+        BACKEND_SPECIFIC_KEY.to_string(),
+        serde_json::Value::Object(nm_specific),
+    );
+    ret
+}
+
+fn value_get_bool(
+    value: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<bool> {
+    if let Some(v) = value.get(key) {
+        if let Some(v) = v.as_str() {
+            match v {
+                "true" | "True" | "yes" | "y" | "1" => return Some(true),
+                "false" | "False" | "no" | "n" | "0" => return Some(false),
+                _ => (),
+            }
+        }
+        if let Some(v) = v.as_bool() {
+            return Some(v);
+        }
+        if let Some(v) = v.as_u64() {
+            match v {
+                1 => Some(true),
+                0 => Some(false),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -24,6 +24,7 @@ use crate::{
     nm::ieee8021x::nm_802_1x_to_nmstate,
     nm::ip::{nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6},
     nm::lldp::{get_lldp, is_lldp_enabled},
+    nm::nm_specific::get_backend_specific_config,
     nm::ovs::{
         get_ovs_dpdk_config, get_ovs_patch_config, nm_ovs_bridge_conf_get,
     },
@@ -202,6 +203,7 @@ fn nm_conn_to_base_iface(
             "ieee8021x",
             "description",
             "lldp",
+            "backend_specific",
         ];
         base_iface.state = InterfaceState::Up;
         base_iface.iface_type = nm_dev_iface_type_to_nmstate(nm_dev);
@@ -209,6 +211,8 @@ fn nm_conn_to_base_iface(
         base_iface.ipv6 = ipv6;
         base_iface.controller = nm_conn.controller().map(|c| c.to_string());
         base_iface.description = get_description(nm_conn);
+        base_iface.backend_specific =
+            Some(get_backend_specific_config(nm_conn));
         base_iface.lldp =
             Some(lldp_neighbors.map(get_lldp).unwrap_or_default());
         if let Some(nm_saved_conn) = nm_saved_conn {
@@ -312,6 +316,7 @@ fn iface_get(
                 return None;
             }
         };
+
         debug!("Found interface {:?}", iface);
         Some(iface)
     } else {

--- a/rust/src/lib/state.rs
+++ b/rust/src/lib/state.rs
@@ -22,6 +22,29 @@ fn _get_json_value_difference<'a, 'b>(
                 None
             }
         }
+        (Value::Number(des), Value::Bool(cur)) => {
+            if (des.as_u64() == Some(1) && *cur)
+                || (des.as_u64() == Some(0) && !(*cur))
+            {
+                None
+            } else {
+                Some((reference, desire, current))
+            }
+        }
+        (Value::String(des), Value::Bool(cur)) => {
+            if str_to_bool(des) == Some(*cur) {
+                None
+            } else {
+                Some((reference, desire, current))
+            }
+        }
+        (Value::String(des), Value::Number(cur)) => {
+            if &cur.to_string() == des {
+                None
+            } else {
+                Some((reference, desire, current))
+            }
+        }
         (Value::String(des), Value::String(cur)) => {
             if des != cur {
                 if des == NetworkState::PASSWORD_HID_BY_NMSTATE {
@@ -104,5 +127,13 @@ fn should_ignore(reference: &str, desire: &Value, current: &Value) -> bool {
         true
     } else {
         false
+    }
+}
+
+fn str_to_bool(v: &str) -> Option<bool> {
+    match v {
+        "True" | "yes" | "1" | "true" | "y" => Some(true),
+        "False" | "no" | "0" | "false" | "n" => Some(false),
+        _ => None,
     }
 }

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -33,6 +33,8 @@ mod route_rule;
 #[cfg(test)]
 mod sriov;
 #[cfg(test)]
+mod state;
+#[cfg(test)]
 mod testlib;
 #[cfg(test)]
 mod vlan;

--- a/rust/src/lib/unit_tests/state.rs
+++ b/rust/src/lib/unit_tests/state.rs
@@ -1,0 +1,54 @@
+use crate::state::get_json_value_difference;
+
+#[test]
+fn test_verify_stringlized_boolean() {
+    let desired: serde_json::Value = serde_yaml::from_str(
+        r#"---
+backend-specific:
+  boolean_false:
+    a: "False"
+    b: "false"
+    c: "no"
+    d: "n"
+    e: "0"
+  boolean_true:
+    a: "True"
+    b: "true"
+    c: "yes"
+    d: "y"
+    e: "1"
+  boolean_uint:
+    a: "124567"
+  boolean_int:
+    a: "-124567"
+"#,
+    )
+    .unwrap();
+
+    let current: serde_json::Value = serde_yaml::from_str(
+        r#"---
+backend-specific:
+  boolean_false:
+    a: false
+    b: false
+    c: false
+    d: false
+    e: false
+  boolean_true:
+    a: true
+    b: true
+    c: true
+    d: true
+    e: true
+  boolean_uint:
+    a: 124567
+  boolean_int:
+    a: -124567
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        get_json_value_difference("".to_string(), &desired, &current),
+        None
+    );
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -33,6 +33,7 @@ class Interface:
     MTU = "mtu"
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
+    BACKEND_SPECIFIC = "backend-specific"
 
 
 class Route:

--- a/tests/integration/nm/backend_specific_test.py
+++ b/tests/integration/nm/backend_specific_test.py
@@ -1,0 +1,103 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+
+from ..testlib import cmdlib
+
+NM_TEST_ID = "test_eth1"
+NM_TEST_UUID = "067490bf-95fd-45ed-b32c-228713d8080d"
+TEST_TRUE_VALUES = ["True", "true", True, "yes", "y", "1", 1]
+TEST_FALSE_VALUES = ["False", "false", False, "no", "n", "0", 0]
+
+
+def test_nm_backend_specific_setting_uuid_id(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.BACKEND_SPECIFIC: {
+                        "networkmanager": {
+                            "connection.id": NM_TEST_ID,
+                            "connection.uuid": NM_TEST_UUID,
+                        }
+                    },
+                }
+            ]
+        }
+    )
+    cmdlib.exec_cmd(f"nmcli c show {NM_TEST_ID}".split(), check=True)
+    cmdlib.exec_cmd(f"nmcli c show {NM_TEST_UUID}".split(), check=True)
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "may_fail_value", TEST_TRUE_VALUES + TEST_FALSE_VALUES
+)
+def test_nm_backend_specific_may_fail(eth1_up, may_fail_value):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                    },
+                    Interface.BACKEND_SPECIFIC: {
+                        "networkmanager": {
+                            "ipv4.may-fail": may_fail_value,
+                            "ipv6.may-fail": may_fail_value,
+                        }
+                    },
+                }
+            ]
+        }
+    )
+    if may_fail_value in TEST_TRUE_VALUES:
+        expected_nm_value = "yes"
+    else:
+        expected_nm_value = "no"
+
+    assert (
+        cmdlib.exec_cmd(
+            f"nmcli -g ipv4.may-fail c show eth1".split(), check=True
+        )[1].strip()
+        == expected_nm_value
+    )
+    assert (
+        cmdlib.exec_cmd(
+            f"nmcli -g ipv6.may-fail c show eth1".split(), check=True
+        )[1].strip()
+        == expected_nm_value
+    )


### PR DESCRIPTION
Introducing backend specific configuration allowing user to define
specific settings in nmstate schema.

The `get_json_value_difference()` has been modified to accept
stringlized boolean or integer.

Add support of these NM configures:
    * connection.id
    * connection.uuid
    * ipv4.may-fail
    * ipv6.may-fail

Example yaml:

```yaml
---
interfaces:
  - name: eth1
    type: ethernet
    backend-specific:
      networkmanager:
        connection.id: WAN
        ipv4.may-fail: false
    ipv4:
      enabled: true
      dhcp: true
```

Unit test case included to check `get_json_value_difference()`.
Integration test cased included to test NM specific settings, one of
test case is marked as tier 1 due as it is required by openshift
machine-config-operator[1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=2082042
