### PR TITLE
copr: Fix build failure caused by git version upgrade

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,10 @@
 python_major_version=$(shell command -v python3 &>/dev/null && echo 3 || echo 2)
 SRPM_DEPENDENCIES=python$(python_major_version)-setuptools git
+PROJECT_DIR:=$(realpath $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../)
 
 srpm:
 	rpm -q --whatprovides $(SRPM_DEPENDENCIES) || \
 		dnf -y install $(SRPM_DEPENDENCIES)
+	git config --global --add safe.directory $(PROJECT_DIR)
 	env SKIP_VENDOR_CREATION=1 outdir=$(outdir) \
-		make srpm -C \
-		$(dir $(realpath $(firstword $(MAKEFILE_LIST))))../
+		make srpm -C $(PROJECT_DIR)


### PR DESCRIPTION
The srpm build system of copr just upgrade their git which enforce
`safe.directory` check.

https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory

This command fixed copr issue:

    git config --global --add safe.directory $(PROJECT_DIR)