### PR TITLE
DHCPv6: Add support of DUID

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -174,6 +174,8 @@ pub struct InterfaceIpv6 {
         deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub dhcp: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "dhcp-duid")]
+    pub dhcp_duid: Option<Dhcpv6Duid>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
@@ -246,6 +248,9 @@ impl InterfaceIpv6 {
         }
         if other.prop_list.contains(&"dhcp") {
             self.dhcp = other.dhcp;
+        }
+        if other.prop_list.contains(&"dhcp_duid") {
+            self.dhcp_duid = other.dhcp_duid.clone();
         }
         if other.prop_list.contains(&"autoconf") {
             self.autoconf = other.autoconf;
@@ -458,6 +463,47 @@ pub(crate) fn include_current_ip_address_if_dhcp_on_to_off(
                     }
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(from = "String", into = "String")]
+pub enum Dhcpv6Duid {
+    LinkLayerAddressPlusTime,
+    EnterpriseNumber,
+    LinkLayerAddress,
+    Uuid,
+    Other(String),
+}
+
+impl std::fmt::Display for Dhcpv6Duid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from(self.clone()))
+    }
+}
+
+impl From<String> for Dhcpv6Duid {
+    fn from(s: String) -> Self {
+        return match s.as_str() {
+            "llt" | "LLT" => Self::LinkLayerAddressPlusTime,
+            "en" | "EN" => Self::EnterpriseNumber,
+            "ll" | "LL" => Self::LinkLayerAddress,
+            "uuid" | "UUID" => Self::Uuid,
+            _ => Self::Other(s),
+        };
+    }
+}
+
+impl From<Dhcpv6Duid> for String {
+    fn from(v: Dhcpv6Duid) -> Self {
+        match v {
+            Dhcpv6Duid::LinkLayerAddressPlusTime => "llt".to_string(),
+            Dhcpv6Duid::EnterpriseNumber => "en".to_string(),
+            Dhcpv6Duid::LinkLayerAddress => "ll".to_string(),
+            Dhcpv6Duid::Uuid => "uuid".to_string(),
+            Dhcpv6Duid::Other(s) => s,
         }
     }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -41,7 +41,9 @@ pub use crate::ifaces::{
     OvsPatchConfig, SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig,
     VlanInterface, VrfConfig, VrfInterface, VxlanConfig, VxlanInterface,
 };
-pub use crate::ip::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
+pub use crate::ip::{
+    Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
+};
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
     LldpMacPhyConf, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs,

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -138,6 +138,7 @@ class InterfaceIPv4(InterfaceIP):
 
 class InterfaceIPv6(InterfaceIP):
     AUTOCONF = "autoconf"
+    DHCP_DUID = "dhcp-duid"
 
 
 class Bond:

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1265,3 +1265,26 @@ def test_show_running_config_does_not_include_auto_config(
         for rt in running_config[RT.KEY][RT.CONFIG]
         if rt[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
     )
+
+
+@pytest.mark.parametrize(
+    "duid_type",
+    ["llt", "ll", "0f:66:55:BC:73:4D"],
+    ids=["llt", "ll", "raw"],
+)
+def test_dhcpv6_duid(dhcpcli_up_with_dynamic_ip, duid_type):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                        InterfaceIPv6.DHCP_DUID: duid_type,
+                    },
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
Add `dhcp-duid` to `InterfaceIpv6` per RFC 8415:

    Clients and servers MUST treat DUIDs as opaque values and MUST only
    compare DUIDs for equality.  Clients and servers SHOULD NOT in any

Introduced these DHCPv6 DUID types:
 * `Dhcpv6Duid::LinkLayerAddressPlusTime`: showing as 'llt'.
 * `Dhcpv6Duid::LinkLayerAddress`: showing as 'll'.
 * `Dhcpv6Duid::EnterpriseNumber`: showing as 'en'.
 * `Dhcpv6Duid::Uuid`: showing as 'uuid'.
 * `Dhcpv6Duid::Other(String)`: allow user to define arbitrary value for
   DUID in hex format or backend specific string.

Currently, NetworkManager only supports `llt`, `ll` and raw hex string.
Integration test case included.