### PR TITLE
DHCPv4: Add support of client ID

### DIFF
--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -42,7 +42,7 @@ pub use crate::ifaces::{
     VlanInterface, VrfConfig, VrfInterface, VxlanConfig, VxlanInterface,
 };
 pub use crate::ip::{
-    Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
+    Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
 };
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -133,7 +133,7 @@ class InterfaceIP:
 
 
 class InterfaceIPv4(InterfaceIP):
-    pass
+    DHCP_CLIENT_ID = "dhcp-client-id"
 
 
 class InterfaceIPv6(InterfaceIP):

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1288,3 +1288,25 @@ def test_dhcpv6_duid(dhcpcli_up_with_dynamic_ip, duid_type):
             ]
         }
     )
+
+
+@pytest.mark.parametrize(
+    "client_id_type",
+    ["ll", "iaid+duid", "0f:66:55:BC:73:4D"],
+    ids=["ll", "iaid+duid", "raw"],
+)
+def test_dhcpv4_client_id(dhcpcli_up_with_dynamic_ip, client_id_type):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                        InterfaceIPv4.DHCP_CLIENT_ID: client_id_type,
+                    },
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
Per RFC 2132 and 4361, we add `Dhcpv4ClientId` to `InterfaceIpv4`:
 * `Dhcpv4ClientId::LinkLayerAddress`, shown as `ll`.
 * `Dhcpv4ClientId::IaidPlusDuid`, show as `iaid+duid`.
 * `Dhcpv4ClientId::Other(String)` for hex string or backend specific
   client id type.

For NetworkManager, `ll` is converted to `mac`, the `iaid+duis` is converted to
`duid`.

Integration test case included.