### PR TITLE
ipv6: Add support of `addr_gen_mode`

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -189,6 +189,8 @@ pub struct InterfaceIpv6 {
         deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub autoconf: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
+    pub addr_gen_mode: Option<Ipv6AddrGenMode>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "address")]
     pub addresses: Option<Vec<InterfaceIpAddr>>,
     #[serde(skip)]
@@ -262,6 +264,9 @@ impl InterfaceIpv6 {
         if other.prop_list.contains(&"autoconf") {
             self.autoconf = other.autoconf;
         }
+        if other.prop_list.contains(&"addr_gen_mode") {
+            self.addr_gen_mode = other.addr_gen_mode.clone();
+        }
         if other.prop_list.contains(&"addresses") {
             self.addresses = other.addresses.clone();
         }
@@ -279,6 +284,9 @@ impl InterfaceIpv6 {
         }
         if other.prop_list.contains(&"dns") {
             self.dns = other.dns.clone();
+        }
+        if other.prop_list.contains(&"addr_gen_mode") {
+            self.addr_gen_mode = other.addr_gen_mode.clone();
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
@@ -548,6 +556,36 @@ impl From<Dhcpv6Duid> for String {
             Dhcpv6Duid::LinkLayerAddress => "ll".to_string(),
             Dhcpv6Duid::Uuid => "uuid".to_string(),
             Dhcpv6Duid::Other(s) => s,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(from = "String", into = "String")]
+pub enum Ipv6AddrGenMode {
+    Eui64,
+    // RFC 7217
+    StablePrivacy,
+    Other(String),
+}
+
+impl From<String> for Ipv6AddrGenMode {
+    fn from(s: String) -> Self {
+        return match s.as_str() {
+            "eui64" | "EUI64" => Self::Eui64,
+            "stable-privacy" | "STABLE-PRIVACY" => Self::StablePrivacy,
+            _ => Self::Other(s),
+        };
+    }
+}
+
+impl From<Ipv6AddrGenMode> for String {
+    fn from(v: Ipv6AddrGenMode) -> Self {
+        match v {
+            Ipv6AddrGenMode::Eui64 => "eui64".to_string(),
+            Ipv6AddrGenMode::StablePrivacy => "stable-privacy".to_string(),
+            Ipv6AddrGenMode::Other(s) => s,
         }
     }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -43,6 +43,7 @@ pub use crate::ifaces::{
 };
 pub use crate::ip::{
     Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
+    Ipv6AddrGenMode,
 };
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -139,6 +139,9 @@ class InterfaceIPv4(InterfaceIP):
 class InterfaceIPv6(InterfaceIP):
     AUTOCONF = "autoconf"
     DHCP_DUID = "dhcp-duid"
+    ADDR_GEN_MODE = "addr-gen-mode"
+    ADDR_GEN_MODE_EUI64 = "eui64"
+    ADDR_GEN_MODE_STABLE_PRIVACY = "stable-privacy"
 
 
 class Bond:

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1310,3 +1310,28 @@ def test_dhcpv4_client_id(dhcpcli_up_with_dynamic_ip, client_id_type):
             ]
         }
     )
+
+
+@pytest.mark.parametrize(
+    "addr_gen_mode",
+    [
+        InterfaceIPv6.ADDR_GEN_MODE_EUI64,
+        InterfaceIPv6.ADDR_GEN_MODE_STABLE_PRIVACY,
+    ],
+)
+def test_auto6_addr_gen_mode(dhcpcli_up_with_dynamic_ip, addr_gen_mode):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                        InterfaceIPv6.ADDR_GEN_MODE: addr_gen_mode,
+                    },
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
Add support of IPv6 address generation mode:
 * "eui64" -- RFC4862
 * "stable-privacy" -- RFC 7217

NetworkManager is using `IN6_ADDR_GEN_MODE_NONE` to instruct kernel do not
generate link local address, but let user space control. Hence there is no
need to use nispor on querying kernel state on this.

Integration test case included.