### PR TITLE
hostname: Add support of static hostname modification

### DIFF
--- a/examples/dynamic_hostname.yml
+++ b/examples/dynamic_hostname.yml
@@ -1,0 +1,3 @@
+---
+hostname:
+  config: ""

--- a/examples/static_hostname.yml
+++ b/examples/static_hostname.yml
@@ -1,0 +1,4 @@
+---
+hostname:
+  running: "nmstate-test.example.org"
+  config: "nmstate-test.example.org"

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -7,7 +7,10 @@ use std::process::{Command, Stdio};
 
 use env_logger::Builder;
 use log::LevelFilter;
-use nmstate::{DnsState, NetworkState, OvsDbGlobalConfig, RouteRules, Routes};
+use nmstate::{
+    DnsState, HostNameState, NetworkState, OvsDbGlobalConfig, RouteRules,
+    Routes,
+};
 use serde::Serialize;
 use serde_yaml::{self, Value};
 
@@ -319,6 +322,8 @@ fn gen_conf(file_path: &str) -> Result<String, CliError> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct SortedNetworkState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hostname: Option<HostNameState>,
     #[serde(rename = "dns-resolver", default)]
     dns: DnsState,
     #[serde(rename = "route-rules", default)]
@@ -365,6 +370,7 @@ fn sort_netstate(
             }
         }
         return Ok(SortedNetworkState {
+            hostname: net_state.hostname,
             interfaces: new_ifaces,
             routes: net_state.routes,
             rules: net_state.rules,
@@ -374,6 +380,7 @@ fn sort_netstate(
     }
 
     Ok(SortedNetworkState {
+        hostname: net_state.hostname,
         interfaces: Vec::new(),
         routes: net_state.routes,
         rules: net_state.rules,

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -18,6 +18,7 @@ path = "lib.rs"
 libc = "0.2.106"
 log = "0.4.14"
 nispor = "1.2.5"
+nix = "0.24.1"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.68"
 uuid = { version = "0.8.2", features = ["v4", "v5"] }

--- a/rust/src/lib/hostname.rs
+++ b/rust/src/lib/hostname.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(deny_unknown_fields)]
+pub struct HostNameState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub running: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<String>,
+}
+
+impl HostNameState {
+    pub(crate) fn update(&mut self, other: &Self) {
+        if other.running.is_some() {
+            self.running = other.running.clone();
+        }
+        if other.config.is_some() {
+            self.config = other.config.clone();
+        }
+    }
+
+    pub(crate) fn verify(
+        &self,
+        current: Option<&Self>,
+    ) -> Result<(), NmstateError> {
+        let current = if let Some(c) = current {
+            c
+        } else {
+            // Should never happen
+            let e = NmstateError::new(
+                ErrorKind::Bug,
+                "Got None HostNameState as current".to_string(),
+            );
+            log::error!("{}", e);
+            return Err(e);
+        };
+
+        if let Some(running) = self.running.as_ref() {
+            if Some(running) != current.running.as_ref() {
+                let e = NmstateError::new(
+                    ErrorKind::VerificationError,
+                    format!(
+                        "Verification fail, desire hostname.running: \
+                        {}, current: {:?}",
+                        running,
+                        current.running.as_ref()
+                    ),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
+        }
+        if let Some(config) = self.config.as_ref() {
+            if Some(config) != current.config.as_ref() {
+                let e = NmstateError::new(
+                    ErrorKind::VerificationError,
+                    format!(
+                        "Verification fail, desire hostname.config: \
+                        {}, current: {:?}",
+                        config,
+                        current.config.as_ref()
+                    ),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -1,6 +1,7 @@
 mod deserializer;
 mod dns;
 mod error;
+mod hostname;
 mod ieee8021x;
 mod iface;
 mod ifaces;
@@ -19,6 +20,7 @@ mod unit_tests;
 
 pub use crate::dns::{DnsClientState, DnsState};
 pub use crate::error::{ErrorKind, NmstateError};
+pub use crate::hostname::HostNameState;
 pub use crate::ieee8021x::Ieee8021XConfig;
 pub use crate::iface::{
     Interface, InterfaceState, InterfaceType, UnknownInterface,

--- a/rust/src/lib/nispor/hostname.rs
+++ b/rust/src/lib/nispor/hostname.rs
@@ -1,0 +1,92 @@
+use std::io::Read;
+
+use crate::{ErrorKind, HostNameState, NmstateError};
+
+const HOST_NAME_MAX: usize = 64;
+
+pub(crate) fn get_hostname_state() -> Option<HostNameState> {
+    let mut buffer = [0u8; HOST_NAME_MAX];
+    let running = match nix::unistd::gethostname(&mut buffer) {
+        Ok(hostname_cstr) => match hostname_cstr.to_str() {
+            Ok(h) => Some(h.to_string()),
+            Err(e) => {
+                log::error!("Failed to convert hostname to String: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            log::error!("Failed to get hostname: {}", e);
+            None
+        }
+    };
+    if running.is_some() {
+        Some(HostNameState {
+            running,
+            config: get_config_hostname(),
+        })
+    } else {
+        None
+    }
+}
+
+const HOSTNAME_CONFIG_PATH: &str = "/etc/hostname";
+
+fn get_config_hostname() -> Option<String> {
+    if !std::path::Path::new("/etc/hostname").exists() {
+        return Some("".to_string());
+    }
+
+    let mut fd = match std::fs::File::open(HOSTNAME_CONFIG_PATH) {
+        Ok(fd) => fd,
+        Err(_) => {
+            return None;
+        }
+    };
+
+    let mut contents = String::new();
+    if let Err(e) = fd.read_to_string(&mut contents) {
+        log::error!(
+            "Failed to read hostname config {}: {}",
+            HOSTNAME_CONFIG_PATH,
+            e
+        );
+        None
+    } else {
+        contents.truncate(contents.as_str().trim().len());
+        Some(contents)
+    }
+}
+
+pub(crate) fn set_running_hostname(hostname: &str) -> Result<(), NmstateError> {
+    if hostname.is_empty() {
+        let e = NmstateError::new(
+            ErrorKind::InvalidArgument,
+            "Cannot set empty runtime hostname".to_string(),
+        );
+        log::error!("{}", e);
+        return Err(e);
+    }
+    if hostname.len() >= HOST_NAME_MAX {
+        let e = NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!("hostname to long, should be less than {}", HOST_NAME_MAX),
+        );
+        log::error!("{}", e);
+        return Err(e);
+    }
+
+    let os_str = std::ffi::OsStr::new(hostname);
+    if nix::unistd::sethostname(&os_str).is_err() {
+        let e = NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Failed to set hostname {}, errno {}",
+                hostname,
+                nix::errno::errno()
+            ),
+        );
+        log::error!("{}", e);
+        return Err(e);
+    }
+    Ok(())
+}

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -4,6 +4,7 @@ mod bond;
 mod error;
 mod ethernet;
 mod ethtool;
+mod hostname;
 mod infiniband;
 mod ip;
 mod linux_bridge;
@@ -18,4 +19,5 @@ mod vrf;
 mod vxlan;
 
 pub(crate) use apply::nispor_apply;
+pub(crate) use hostname::set_running_hostname;
 pub(crate) use show::nispor_retrieve;

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -6,6 +6,7 @@ use crate::{
         bond::np_bond_to_nmstate,
         error::np_error_to_nmstate,
         ethernet::np_ethernet_to_nmstate,
+        hostname::get_hostname_state,
         infiniband::np_ib_to_nmstate,
         linux_bridge::{append_bridge_port_config, np_bridge_to_nmstate},
         mac_vlan::{np_mac_vlan_to_nmstate, np_mac_vtap_to_nmstate},
@@ -23,10 +24,9 @@ use crate::{
 pub(crate) fn nispor_retrieve(
     running_config_only: bool,
 ) -> Result<NetworkState, NmstateError> {
-    let mut net_state = NetworkState::new();
-    net_state.prop_list.push("interfaces");
-    net_state.prop_list.push("routes");
-    net_state.prop_list.push("rules");
+    let mut net_state = NetworkState::default();
+    net_state.hostname = get_hostname_state();
+    net_state.prop_list = vec!["interfaces", "routes", "rules", "hostname"];
     let np_state = nispor::NetState::retrieve().map_err(np_error_to_nmstate)?;
 
     for (_, np_iface) in np_state.ifaces.iter() {

--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -147,6 +147,19 @@ fn apply_single_state(
     checkpoint: &str,
     memory_only: bool,
 ) -> Result<(), NmstateError> {
+    if let Some(hostname) =
+        net_state.hostname.as_ref().and_then(|c| c.config.as_ref())
+    {
+        if memory_only {
+            log::warn!(
+                "Cannot change configure hostname in memory only mode, \
+                ignoring"
+            );
+        } else {
+            nm_api.hostname_set(hostname).map_err(nm_error_to_nmstate)?;
+        }
+    }
+
     if net_state.interfaces.to_vec().is_empty() {
         return Ok(());
     }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -55,6 +55,17 @@ pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
 ) -> Result<Vec<String>, NmstateError> {
     let mut ret = Vec::new();
+    if net_state
+        .hostname
+        .as_ref()
+        .and_then(|c| c.config.as_ref())
+        .is_some()
+    {
+        log::warn!(
+            "Cannot store hostname configuration to keyfile \
+            of NetworkManager, please edit /etc/hostname manually"
+        );
+    }
     let ifaces = net_state.interfaces.to_vec();
     for iface in &ifaces {
         let mut ctrl_iface: Option<&Interface> = None;

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -370,6 +370,10 @@ impl<'a> NmDbus<'a> {
     ) -> Result<Vec<HashMap<String, zvariant::OwnedValue>>, NmError> {
         Ok(self.dns_proxy.configuration()?)
     }
+
+    pub(crate) fn hostname_set(&self, hostname: &str) -> Result<(), NmError> {
+        Ok(self.setting_proxy.save_hostname(hostname)?)
+    }
 }
 
 fn str_to_obj_path(obj_path: &str) -> Result<zvariant::ObjectPath, NmError> {

--- a/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
@@ -112,6 +112,9 @@ trait NetworkManagerSetting {
 
     /// GetAllDevices method
     fn get_all_devices(&self) -> zbus::Result<Vec<zvariant::OwnedObjectPath>>;
+
+    /// SaveHostname method
+    fn save_hostname(&self, hostname: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -317,6 +317,22 @@ impl<'a> NmApi<'a> {
         }
         Ok(ret)
     }
+
+    pub fn hostname_set(&self, hostname: &str) -> Result<(), NmError> {
+        if hostname.is_empty() {
+            // Due to bug https://bugzilla.redhat.com/2090946
+            // NetworkManager daemon cannot remove static hostname, hence we
+            // just delete the /etc/hostname file
+            if std::path::Path::new("/etc/hostname").exists() {
+                if let Err(e) = std::fs::remove_file("/etc/hostname") {
+                    log::error!("Failed to remove static /etc/hostname: {}", e);
+                }
+            }
+            Ok(())
+        } else {
+            self.dbus.hostname_set(hostname)
+        }
+    }
 }
 
 fn get_nm_ac_obj_path_by_uuid(

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -442,3 +442,9 @@ class Ethtool:
         TX_USECS_HIGH = "tx-usecs-high"
         TX_USECS_IRQ = "tx-usecs-irq"
         TX_USECS_LOW = "tx-usecs-low"
+
+
+class HostNameState:
+    KEY = "hostname"
+    CONFIG = "config"
+    RUNNING = "running"

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -31,6 +31,7 @@ from libnmstate import netinfo
 from libnmstate.error import NmstateNotSupportedError
 from libnmstate.error import NmstateDependencyError
 from libnmstate.schema import DNS
+from libnmstate.schema import HostNameState
 
 from .testlib.env import is_k8s
 from .testlib.env import nm_major_minor_version
@@ -251,3 +252,15 @@ def test_gen_conf_for_examples():
                     load_example(example_file.name)
                 )
                 assert first_result == second_result
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="NM cannot change hostname in container",
+)
+def test_static_hostname_for_examples():
+    with example_state(
+        "static_hostname.yml", cleanup="dynamic_hostname.yml"
+    ) as desired_state:
+        cur_hostname = libnmstate.show()[HostNameState.KEY]
+        assert cur_hostname == desired_state[HostNameState.KEY]

--- a/tests/integration/hostname_test.py
+++ b/tests/integration/hostname_test.py
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+
+import pytest
+
+import libnmstate
+from libnmstate.error import NmstateVerificationError
+from libnmstate.schema import HostNameState
+
+from .testlib import cmdlib
+
+TEST_HOSTNAME1 = "nmstate-test1.example.org"
+TEST_HOSTNAME2 = "nmstate-test2.example.org"
+
+
+@pytest.fixture
+def restore_hostname():
+    cur_hostname_conf = libnmstate.show()[HostNameState.KEY]
+    yield
+    libnmstate.apply({HostNameState.KEY: cur_hostname_conf})
+
+
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="NM cannot change hostname in container",
+)
+def test_hostname_set_chg_and_clear(restore_hostname):
+    libnmstate.apply(
+        {
+            HostNameState.KEY: {
+                HostNameState.CONFIG: TEST_HOSTNAME1,
+            }
+        }
+    )
+    cur_host_name = cmdlib.exec_cmd(["hostname"], check=True)[1]
+    assert os.path.exists("/etc/hostname")
+    assert cur_host_name.strip() == TEST_HOSTNAME1
+    libnmstate.apply(
+        {
+            HostNameState.KEY: {
+                HostNameState.RUNNING: TEST_HOSTNAME2,
+                HostNameState.CONFIG: "",
+            }
+        }
+    )
+    cur_host_name = cmdlib.exec_cmd(["hostname"], check=True)[1]
+    assert cur_host_name.strip() == TEST_HOSTNAME2
+    assert not os.path.exists("/etc/hostname")
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="NM cannot change hostname in container",
+)
+def test_hostname_set_config_in_memory_only(restore_hostname):
+    with pytest.raises(NmstateVerificationError):
+        libnmstate.apply(
+            {
+                HostNameState.KEY: {
+                    HostNameState.RUNNING: TEST_HOSTNAME2,
+                    HostNameState.CONFIG: TEST_HOSTNAME2,
+                }
+            },
+            save_to_disk=False,
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="NM cannot change hostname in container",
+)
+def test_hostname_set_in_memory_only(restore_hostname):
+    libnmstate.apply(
+        {
+            HostNameState.KEY: {
+                HostNameState.RUNNING: TEST_HOSTNAME2,
+            }
+        },
+    )
+    cur_host_name = cmdlib.exec_cmd(["hostname"], check=True)[1]
+    assert cur_host_name.strip() == TEST_HOSTNAME2


### PR DESCRIPTION
Example yaml:

```yaml
---
hostname:
  running: "nmstate-test.example.org"
  config: "nmstate-test.example.org"
```

The `running` is the activating hostname. The `config` is the on-disk
hostname in /etc/hostname. Then setting empty string to `config`,
nmstate will remove on-disk hostname.

For query, the nispor plugin provide both running and config hostname.
For setting, nispor plugin set the running hostname and NetworkManager
set the on disk hostname via
`org.freedesktop.NetworkManager.Settings.SaveHostname`.

Example added: `static_hostname.yml`, `dynamic_hostname.yml`

Integration test case included but skipped in CI as NetworkManager
cannot change hostname insider of container with error:

        org.freedesktop.NetworkManager.Settings.Failed: Saving the hostname failed