### PR TITLE
errors: Implement std::Error trait

### DIFF
--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ErrorKind {
@@ -22,6 +24,8 @@ impl std::fmt::Display for NmstateError {
         write!(f, "{}: {}", self.kind, self.msg)
     }
 }
+
+impl Error for NmstateError {}
 
 #[derive(Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
The NmstateError was not implementing the std::Error trait so it was not
usable at certain scenarios. This change implement the trait.