### PR TITLE
gc: Add flag to skip con UUID generation

### DIFF
--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -31,6 +31,7 @@ mod vxlan;
 mod wired;
 
 pub(crate) use apply::nm_apply;
+pub(crate) use apply::NetworkStates;
 pub(crate) use checkpoint::{
     nm_checkpoint_create, nm_checkpoint_destroy, nm_checkpoint_rollback,
     nm_checkpoint_timeout_extend,

--- a/rust/src/lib/nm/ovs.rs
+++ b/rust/src/lib/nm/ovs.rs
@@ -184,6 +184,7 @@ pub(crate) fn create_ovs_port_nm_conn(
     br_name: &str,
     port_conf: &OvsBridgePortConfig,
     exist_nm_conn: Option<&NmConnection>,
+    skip_uuid_gen: bool,
 ) -> Result<NmConnection, NmstateError> {
     let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
     let mut base_iface = BaseInterface::new();
@@ -193,7 +194,11 @@ pub(crate) fn create_ovs_port_nm_conn(
     base_iface.controller_type = Some(InterfaceType::OvsBridge);
     let mut iface = UnknownInterface::new();
     iface.base = base_iface;
-    gen_nm_conn_setting(&Interface::Unknown(iface), &mut nm_conn)?;
+    gen_nm_conn_setting(
+        &Interface::Unknown(iface),
+        &mut nm_conn,
+        skip_uuid_gen,
+    )?;
 
     let mut nm_ovs_port_set =
         nm_conn.ovs_port.as_ref().cloned().unwrap_or_default();

--- a/rust/src/lib/nm/veth.rs
+++ b/rust/src/lib/nm/veth.rs
@@ -35,6 +35,7 @@ pub(crate) fn create_veth_peer_profile_if_not_found(
     peer_name: &str,
     end_name: &str,
     exist_nm_conns: &[NmConnection],
+    skip_uuid_gen: bool,
 ) -> Result<NmConnection, NmstateError> {
     for nm_conn in exist_nm_conns {
         if let Some(iface_type) = nm_conn.iface_type() {
@@ -58,7 +59,7 @@ pub(crate) fn create_veth_peer_profile_if_not_found(
     };
     let iface = Interface::Ethernet(eth_iface);
     let mut nm_conn = NmConnection::default();
-    gen_nm_conn_setting(&iface, &mut nm_conn)?;
+    gen_nm_conn_setting(&iface, &mut nm_conn, skip_uuid_gen)?;
     gen_nm_ip_setting(&iface, None, None, &mut nm_conn)?;
     nm_conn.veth = Some(NmSettingVeth::from(&VethConfig {
         peer: end_name.to_string(),


### PR DESCRIPTION
At certain scenarios is important to generate the same configuration
from the same nmstate when running "gc" multiple times, also the UUID is
not mandatory since NetworkManager can generate one for you. This change
add the flag "--skip-uuid-gen" to be able to skip the UUID generation.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>