### PR TITLE
gc: Use nm connection id as key

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -377,7 +377,7 @@ impl NetworkState {
 
     pub fn gen_conf(
         &self,
-    ) -> Result<HashMap<String, Vec<String>>, NmstateError> {
+    ) -> Result<HashMap<String, HashMap<String, String>>, NmstateError> {
         let mut ret = HashMap::new();
         let mut self_clone = self.clone();
         self_clone.interfaces.set_unknown_iface_to_eth();

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -53,8 +53,8 @@ pub(crate) const NM_SETTING_USER_SPACES: [&str; 2] = [
 
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
-) -> Result<Vec<String>, NmstateError> {
-    let mut ret = Vec::new();
+) -> Result<HashMap<String, String>, NmstateError> {
+    let mut ret = HashMap::new();
     if net_state
         .hostname
         .as_ref()
@@ -85,18 +85,21 @@ pub(crate) fn nm_gen_conf(
             false,
             &NetworkState::new(),
         )? {
-            ret.push(match nm_conn.to_keyfile() {
-                Ok(s) => s,
-                Err(e) => {
-                    return Err(NmstateError::new(
-                        ErrorKind::PluginFailure,
-                        format!(
+            ret.insert(
+                nm_conn.id().unwrap().to_string(),
+                match nm_conn.to_keyfile() {
+                    Ok(s) => s,
+                    Err(e) => {
+                        return Err(NmstateError::new(
+                            ErrorKind::PluginFailure,
+                            format!(
                         "Bug in NM plugin, failed to generate configure: {}",
                         e
                     ),
-                    ));
-                }
-            })
+                        ));
+                    }
+                },
+            );
         }
     }
     Ok(ret)


### PR DESCRIPTION
At some scenarios is convenient to save nm keyfiles with the same name
as the one expected from nmstate, this change convert Vec<String> as
HashMap<String, String> for other backends it can be still used.

Signed-off-by: Enrique Llorente <ellorent@redhat.com>