### PR TITLE
show: Hide ignored user space interface

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -743,3 +743,7 @@ pub(crate) fn get_ignored_ifaces(
         ignored_user_ifaces.drain().collect();
     (k_ifaces, u_ifaces)
 }
+
+pub(crate) fn purge_userspace_ignored_ifaces(state: &mut Interfaces) {
+    state.user_ifaces.retain(|_, iface| !iface.is_ignore())
+}

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -36,6 +36,7 @@ pub use ethtool::{
     EthtoolPauseConfig, EthtoolRingConfig,
 };
 pub use infiniband::{InfiniBandConfig, InfiniBandInterface, InfiniBandMode};
+pub(crate) use inter_ifaces::purge_userspace_ignored_ifaces;
 pub use inter_ifaces::*;
 pub use linux_bridge::{
     LinuxBridgeConfig, LinuxBridgeInterface, LinuxBridgeMulticastRouterType,

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -8,7 +8,7 @@ use crate::{
         get_cur_dns_ifaces, is_dns_changed, purge_dns_config,
         reselect_dns_ifaces,
     },
-    ifaces::get_ignored_ifaces,
+    ifaces::{get_ignored_ifaces, purge_userspace_ignored_ifaces},
     nispor::{nispor_apply, nispor_retrieve, set_running_hostname},
     nm::{
         nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
@@ -212,6 +212,8 @@ impl NetworkState {
         if !self.include_secrets {
             self.hide_secrets();
         }
+        purge_userspace_ignored_ifaces(&mut self.interfaces);
+
         Ok(self)
     }
 

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -428,6 +428,11 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
             iface.base = base_iface;
             iface
         }),
+        InterfaceType::OvsBridge => Interface::OvsBridge({
+            let mut iface = OvsBridgeInterface::new();
+            iface.base = base_iface;
+            iface
+        }),
         InterfaceType::Bond => Interface::Bond({
             let mut iface = BondInterface::new();
             iface.base = base_iface;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -464,10 +464,19 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
                 ..Default::default()
             }
         }),
-        _ => Interface::Unknown({
+        iface_type
+            if iface_type == &InterfaceType::Other("ovs-port".to_string()) =>
+        {
+            log::debug!(
+                "Skipping unmanaged/disconnected NM speicifc OVS-port {}",
+                base_iface.name
+            );
+            return None;
+        }
+        iface_type => Interface::Unknown({
             log::info!(
                 "Got unsupported interface type {}: {}, ignoring",
-                base_iface.iface_type,
+                iface_type,
                 base_iface.name
             );
             let mut iface = UnknownInterface::new();

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -447,3 +447,13 @@ def test_remove_same_name_ovs_bridge_clean_up_system_port_also(
         "nmcli -g connection.master c show eth1".split()
     )
     assert not output.strip()
+
+
+@pytest.mark.tier1
+def test_purge_unmanged_ovs_bridge_in_show(ovs_unmanaged_bridge):
+    state = statelib.show_only((BRIDGE0,))
+    assert len(state[Interface.KEY]) == 1
+    assert state[Interface.KEY][0][Interface.NAME] == BRIDGE0
+    assert (
+        state[Interface.KEY][0][Interface.TYPE] == InterfaceType.OVS_INTERFACE
+    )


### PR DESCRIPTION
The `NetworkState::retrieve()` should hide the ignored user space interface
so that we don't provide partial data.

Integration test case created to make sure we don't report OVS bridge
created by `ovs-vsctl`.