### PR TITLE
[nmstate-1.3] gc: Refer to controller using UUID

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -148,13 +148,10 @@ class NmProfile:
         )
 
     def to_key_file_string(self):
-        nm_simple_conn = create_new_nm_simple_conn(
-            self._iface, nm_profile=None
-        )
-        nm_simple_conn.normalize()
+        self._nm_simple_conn.normalize()
         # pylint: disable=no-member
         key_file = NM.keyfile_write(
-            nm_simple_conn, NM.KeyfileHandlerFlags.NONE, None, None
+            self._nm_simple_conn, NM.KeyfileHandlerFlags.NONE, None, None
         )
         # pylint: enable=no-member
         return key_file.to_data()[0]

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -56,6 +56,7 @@ class NmProfiles:
                 profile.prepare_config(save_to_disk=False, gen_conf_mode=True)
                 all_profiles.append(profile)
 
+        _use_uuid_as_controller_and_parent(all_profiles)
         return [
             (profile.config_file_name, profile.to_key_file_string())
             for profile in all_profiles

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -350,7 +350,7 @@ impl NetworkState {
 
     pub fn gen_conf(
         &self,
-    ) -> Result<HashMap<String, Vec<String>>, NmstateError> {
+    ) -> Result<HashMap<String, Vec<(String, String)>>, NmstateError> {
         let mut ret = HashMap::new();
         let mut self_clone = self.clone();
         self_clone.interfaces.set_unknown_iface_to_eth();

--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -21,8 +21,7 @@ use crate::{
     nm::vlan::is_vlan_id_changed,
     nm::vrf::is_vrf_table_id_changed,
     nm::vxlan::is_vxlan_id_changed,
-    Interface, InterfaceType, NetworkState, NmstateError, OvsBridgeInterface,
-    RouteEntry,
+    Interface, InterfaceType, NetworkState, NmstateError, RouteEntry,
 };
 
 const ACTIVATION_RETRY_COUNT: usize = 5;
@@ -216,13 +215,6 @@ fn apply_single_state(
             )
         })
         .collect::<Vec<_>>();
-
-    let mut ovs_br_ifaces: Vec<&OvsBridgeInterface> = Vec::new();
-    for iface in net_state.interfaces.user_ifaces.values() {
-        if let Interface::OvsBridge(ref br_iface) = iface {
-            ovs_br_ifaces.push(br_iface);
-        }
-    }
 
     use_uuid_for_controller_reference(
         &mut nm_conns_to_activate,

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -4,7 +4,6 @@ use crate::nm::nm_dbus::{
     NmApi, NmConnection, NmSettingConnection, NmSettingMacVlan, NmSettingVeth,
     NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
 };
-
 use crate::{
     nm::bond::gen_nm_bond_setting,
     nm::bridge::{gen_nm_br_port_setting, gen_nm_br_setting},
@@ -16,7 +15,7 @@ use crate::{
         create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
         gen_nm_ovs_ext_ids_setting, gen_nm_ovs_iface_setting,
     },
-    nm::profile::get_exist_profile,
+    nm::profile::{get_exist_profile, use_uuid_for_controller_reference},
     nm::sriov::gen_nm_sriov_setting,
     nm::user::gen_nm_user_setting,
     nm::veth::create_veth_peer_profile_if_not_found,
@@ -77,6 +76,13 @@ pub(crate) fn nm_gen_conf(
             nm_conns.push(nm_conn);
         }
     }
+
+    use_uuid_for_controller_reference(
+        &mut nm_conns,
+        &net_state.interfaces.user_ifaces,
+        &HashMap::new(),
+        &[],
+    )?;
 
     let mut ret = Vec::new();
     for nm_conn in nm_conns {

--- a/rust/src/python/libnmstate/gen_conf.py
+++ b/rust/src/python/libnmstate/gen_conf.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from .clib_wrapper import gen_conf
 
 
 def generate_configurations(desired_state):
-    return gen_conf(desired_state)
+    return json.loads(gen_conf(desired_state))

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -1,0 +1,125 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+import time
+
+import pytest
+import yaml
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import OVSBridge
+
+from ..testlib.nmplugin import nm_service_restart
+from ..testlib.statelib import show_only
+
+
+NM_CONFIG_FOLDER = "/etc/NetworkManager/system-connections"
+MAX_RETRY_COUNT = 20
+
+
+@pytest.fixture
+def cleanup_ovs_same_name():
+    yield
+    libnmstate.apply(
+        load_yaml(
+            """
+interfaces:
+- name: br0
+  type: ovs-bridge
+  state: absent
+"""
+        ),
+        verify_change=False,
+    )
+
+
+@pytest.mark.tier1
+def test_gen_conf_ovs_same_name(eth1_up, cleanup_ovs_same_name):
+    desired_state = load_yaml(
+        """
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: br0
+- name: br0
+  type: ovs-interface
+  state: up
+"""
+    )
+    result = libnmstate.generate_configurations(desired_state)[
+        "NetworkManager"
+    ]
+    with nm_service_restart():
+        for file_name, file_content in result:
+            save_nm_config(file_name, file_content)
+
+    retry_verify_ovs_ports("br0", sorted(["eth1", "br0"]))
+
+
+def save_nm_config(file_name, file_content):
+    file_path = f"{NM_CONFIG_FOLDER}/{file_name}"
+    with open(file_path, "w") as fd:
+        fd.write(file_content)
+    os.chown(file_path, 0, 0)
+    os.chmod(file_path, 0o600)
+
+
+def load_yaml(content):
+    return yaml.load(content, Loader=yaml.SafeLoader)
+
+
+# the assert_state_match does not works well on OVS same name
+# manual checking
+def retry_verify_ovs_ports(bridge_name, port_names):
+    retry_count = 0
+    while retry_count < MAX_RETRY_COUNT:
+        try:
+            verify_ovs_ports(bridge_name, port_names)
+            break
+        except AssertionError:
+            retry_count += 1
+            time.sleep(1)
+
+    verify_ovs_ports(bridge_name, port_names)
+
+
+def verify_ovs_ports(bridge_name, port_names):
+    cur_iface = None
+    for iface in show_only((bridge_name,))[Interface.KEY]:
+        if iface[Interface.TYPE] == InterfaceType.OVS_BRIDGE:
+            cur_iface = iface
+            break
+    assert cur_iface
+
+    cur_ports = [
+        p[OVSBridge.Port.NAME]
+        for p in cur_iface[OVSBridge.CONFIG_SUBTREE][OVSBridge.PORT_SUBTREE]
+    ]
+    cur_ports.sort()
+    assert cur_ports == port_names


### PR DESCRIPTION
When OVS bridge is holding the same name as OVS interface, we should
refer it using UUID instead of the duplicated name.

Integration test case included and marked as tier1 as openshift require
so.