### PR TITLE
cargo: Add gc, apply and show features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,27 @@ jobs:
     - name: Unit test
       run: cd rust && cargo test -- --test-threads=1 --show-output
 
+  rust_features:
+    strategy:
+      fail-fast: true
+      matrix:
+        rust_version: ["stable", "nightly", "beta"]
+        feature: ["offline", "online", "default"]
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Rust ${{ matrix.rust_version }}
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ matrix.rust_version }}
+          override: true
+
+    - name: Build feature ${{ matrix.feature }}
+      run: cd rust && cargo build --features ${{ matrix.feature }} --no-default-features
+ 
   rpm_build:
     runs-on: ubuntu-latest
     steps:

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -9,7 +9,7 @@ name = "nmstatectl"
 path = "ncl.rs"
 
 [dependencies]
-nmstate = {path = "../lib"}
+nmstate = { path = "../lib", features = ["offline"] }
 serde_yaml = "0.8"
 clap = { version = "3.1", features = ["cargo"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-nmstate = { path = "../lib" }
+nmstate = { path = "../lib", features = ["offline"]}
 libc = "0.2.74"
 serde_json = "1.0"
 log = "0.4.17"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -27,3 +27,8 @@ zvariant = "2.10.0"
 
 [dev-dependencies]
 serde_yaml = "0.8"
+
+[features]
+online = []
+offline = []
+default = ["online"]

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -8,6 +8,10 @@ mod ifaces;
 mod ip;
 mod lldp;
 mod net_state;
+#[cfg(feature = "offline")]
+mod net_state_offline;
+#[cfg(feature = "online")]
+mod net_state_online;
 mod nispor;
 mod nm;
 mod ovs;

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
+use log::warn;
 
-use log::{debug, info, warn};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
@@ -8,24 +7,9 @@ use crate::{
         get_cur_dns_ifaces, is_dns_changed, purge_dns_config,
         reselect_dns_ifaces,
     },
-    ifaces::get_ignored_ifaces,
-    nispor::{nispor_apply, nispor_retrieve, set_running_hostname},
-    nm::{
-        nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
-        nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_gen_conf,
-        nm_retrieve,
-    },
-    ovsdb::{ovsdb_apply, ovsdb_is_running, ovsdb_retrieve},
     DnsState, ErrorKind, HostNameState, Interface, InterfaceType, Interfaces,
     NmstateError, OvsDbGlobalConfig, RouteRules, Routes,
 };
-
-const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;
-const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
-const VERIFY_RETRY_COUNT: usize = 5;
-const VERIFY_RETRY_COUNT_SRIOV: usize = 60;
-const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
-const MAX_SUPPORTED_INTERFACES: usize = 1000;
 
 #[derive(Clone, Debug, Serialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -53,21 +37,21 @@ pub struct NetworkState {
     pub prop_list: Vec<&'static str>,
     #[serde(skip)]
     // TODO: Hide user space only info when serialize
-    kernel_only: bool,
+    pub kernel_only: bool,
     #[serde(skip)]
-    no_verify: bool,
+    pub no_verify: bool,
     #[serde(skip)]
-    no_commit: bool,
+    pub no_commit: bool,
     #[serde(skip)]
-    timeout: Option<u32>,
+    pub timeout: Option<u32>,
     #[serde(skip)]
-    include_secrets: bool,
+    pub include_secrets: bool,
     #[serde(skip)]
-    include_status_data: bool,
+    pub include_status_data: bool,
     #[serde(skip)]
-    running_config_only: bool,
+    pub running_config_only: bool,
     #[serde(skip)]
-    memory_only: bool,
+    pub memory_only: bool,
 }
 
 impl<'de> Deserialize<'de> for NetworkState {
@@ -157,6 +141,10 @@ impl NetworkState {
         self
     }
 
+    pub fn get_running_config_only(self) -> bool {
+        self.running_config_only
+    }
+
     pub fn set_memory_only(&mut self, value: bool) -> &mut Self {
         self.memory_only = value;
         self
@@ -178,228 +166,26 @@ impl NetworkState {
         }
     }
 
+    pub(crate) fn get_kernel_iface_with_route(
+        &self,
+        iface_name: &str,
+    ) -> Option<Interface> {
+        if let Some(iface) = self.interfaces.kernel_ifaces.get(iface_name) {
+            let mut ret = iface.clone();
+            ret.base_iface_mut().routes =
+                self.routes.get_config_routes_of_iface(iface_name);
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
     pub fn append_interface_data(&mut self, iface: Interface) {
         self.interfaces.push(iface);
     }
 
-    pub fn retrieve(&mut self) -> Result<&mut Self, NmstateError> {
-        let state = nispor_retrieve(self.running_config_only)?;
-        if state.prop_list.contains(&"hostname") {
-            self.hostname = state.hostname;
-        }
-        if state.prop_list.contains(&"interfaces") {
-            self.interfaces = state.interfaces;
-        }
-        if state.prop_list.contains(&"routes") {
-            self.routes = state.routes;
-        }
-        if state.prop_list.contains(&"rules") {
-            self.rules = state.rules;
-        }
-        if !self.kernel_only {
-            let nm_state = nm_retrieve(self.running_config_only)?;
-            // TODO: Priority handling
-            self.update_state(&nm_state);
-            if ovsdb_is_running() {
-                match ovsdb_retrieve() {
-                    Ok(ovsdb_state) => self.update_state(&ovsdb_state),
-                    Err(e) => {
-                        log::warn!("Failed to retrieve OVS DB state: {}", e);
-                    }
-                }
-            }
-        }
-        if !self.include_secrets {
-            self.hide_secrets();
-        }
-        Ok(self)
-    }
-
     pub fn hide_secrets(&mut self) {
         self.interfaces.hide_secrets();
-    }
-
-    pub fn apply(&self) -> Result<(), NmstateError> {
-        let mut desire_state_to_verify = self.clone();
-        let mut desire_state_to_apply = self.clone();
-        let mut cur_net_state = NetworkState::new();
-        cur_net_state.set_kernel_only(self.kernel_only);
-        cur_net_state.set_include_secrets(true);
-        cur_net_state.retrieve()?;
-
-        if desire_state_to_apply.interfaces.to_vec().len()
-            >= MAX_SUPPORTED_INTERFACES
-        {
-            log::warn!(
-                "Interfaces count exceeds the support limit {} in \
-                desired state",
-                MAX_SUPPORTED_INTERFACES,
-            );
-        }
-
-        let (ignored_kernel_ifaces, ignored_user_ifaces) =
-            get_ignored_ifaces(&self.interfaces, &cur_net_state.interfaces);
-
-        for iface_name in &ignored_kernel_ifaces {
-            log::info!("Ignoring kernel interface {}", iface_name)
-        }
-        for (iface_name, iface_type) in &ignored_user_ifaces {
-            log::info!(
-                "Ignoring user space interface {} with type {}",
-                iface_name,
-                iface_type
-            )
-        }
-
-        desire_state_to_apply.interfaces.remove_ignored_ifaces(
-            &ignored_kernel_ifaces,
-            &ignored_user_ifaces,
-        );
-        cur_net_state.interfaces.remove_ignored_ifaces(
-            &ignored_kernel_ifaces,
-            &ignored_user_ifaces,
-        );
-
-        desire_state_to_apply
-            .routes
-            .remove_ignored_iface_routes(ignored_kernel_ifaces.as_slice());
-        cur_net_state
-            .routes
-            .remove_ignored_iface_routes(ignored_kernel_ifaces.as_slice());
-
-        desire_state_to_verify
-            .interfaces
-            .resolve_unknown_ifaces(&cur_net_state.interfaces)?;
-        desire_state_to_apply
-            .interfaces
-            .resolve_unknown_ifaces(&cur_net_state.interfaces)?;
-
-        let (add_net_state, chg_net_state, del_net_state) =
-            desire_state_to_apply.gen_state_for_apply(&cur_net_state)?;
-
-        debug!("Adding net state {:?}", &add_net_state);
-        debug!("Changing net state {:?}", &chg_net_state);
-        debug!("Deleting net state {:?}", &del_net_state);
-
-        if let Some(running_hostname) =
-            self.hostname.as_ref().and_then(|c| c.running.as_ref())
-        {
-            set_running_hostname(running_hostname)?;
-        }
-
-        if !self.kernel_only {
-            let retry_count =
-                if desire_state_to_apply.interfaces.has_sriov_enabled() {
-                    VERIFY_RETRY_COUNT_SRIOV
-                } else {
-                    VERIFY_RETRY_COUNT
-                };
-
-            let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
-            let checkpoint = nm_checkpoint_create(timeout)?;
-            info!("Created checkpoint {}", &checkpoint);
-
-            with_nm_checkpoint(&checkpoint, self.no_commit, || {
-                nm_apply(
-                    &add_net_state,
-                    &chg_net_state,
-                    &del_net_state,
-                    // TODO: Passing full(desire + current) network state
-                    // instead of current,
-                    &cur_net_state,
-                    self,
-                    &checkpoint,
-                    self.memory_only,
-                )?;
-                if ovsdb_is_running() {
-                    ovsdb_apply(&desire_state_to_apply, &cur_net_state)?;
-                }
-                nm_checkpoint_timeout_extend(&checkpoint, timeout)?;
-                if !self.no_verify {
-                    with_retry(
-                        VERIFY_RETRY_INTERVAL_MILLISECONDS,
-                        retry_count,
-                        || {
-                            let mut new_cur_net_state = cur_net_state.clone();
-                            new_cur_net_state.set_include_secrets(true);
-                            new_cur_net_state.retrieve()?;
-                            desire_state_to_verify.verify(&new_cur_net_state)
-                        },
-                    )
-                } else {
-                    Ok(())
-                }
-            })
-        } else {
-            // TODO: Need checkpoint for kernel only mode
-            nispor_apply(
-                &add_net_state,
-                &chg_net_state,
-                &del_net_state,
-                &cur_net_state,
-            )?;
-            if !self.no_verify {
-                with_retry(
-                    VERIFY_RETRY_INTERVAL_MILLISECONDS,
-                    VERIFY_RETRY_COUNT_KERNEL_MODE,
-                    || {
-                        let mut new_cur_net_state = cur_net_state.clone();
-                        new_cur_net_state.retrieve()?;
-                        desire_state_to_verify.verify(&new_cur_net_state)
-                    },
-                )
-            } else {
-                Ok(())
-            }
-        }
-    }
-
-    fn update_state(&mut self, other: &Self) {
-        if other.prop_list.contains(&"hostname") {
-            if let Some(h) = self.hostname.as_mut() {
-                if let Some(other_h) = other.hostname.as_ref() {
-                    h.update(other_h);
-                }
-            } else {
-                self.hostname = other.hostname.clone();
-            }
-        }
-        if other.prop_list.contains(&"interfaces") {
-            self.interfaces.update(&other.interfaces);
-        }
-        if other.prop_list.contains(&"dns") {
-            self.dns = other.dns.clone();
-        }
-        if other.prop_list.contains(&"ovsdb") {
-            self.ovsdb = other.ovsdb.clone();
-        }
-    }
-
-    pub fn gen_conf(
-        &self,
-    ) -> Result<HashMap<String, Vec<(String, String)>>, NmstateError> {
-        let mut ret = HashMap::new();
-        let mut self_clone = self.clone();
-        self_clone.interfaces.set_unknown_iface_to_eth();
-        self_clone.interfaces.set_missing_port_to_eth();
-        let (add_net_state, _, _) =
-            self_clone.gen_state_for_apply(&Self::new())?;
-        ret.insert("NetworkManager".to_string(), nm_gen_conf(&add_net_state)?);
-        Ok(ret)
-    }
-
-    fn verify(&self, current: &Self) -> Result<(), NmstateError> {
-        if let Some(desired_hostname) = self.hostname.as_ref() {
-            desired_hostname.verify(current.hostname.as_ref())?;
-        }
-        self.interfaces.verify(&current.interfaces)?;
-        let (ignored_kernel_ifaces, _) =
-            get_ignored_ifaces(&self.interfaces, &current.interfaces);
-        self.routes
-            .verify(&current.routes, &ignored_kernel_ifaces)?;
-        self.rules.verify(&current.rules)?;
-        self.dns.verify(&current.dns)?;
-        self.ovsdb.verify(&current.ovsdb)
     }
 
     // Return three NetworkState:
@@ -726,82 +512,4 @@ impl NetworkState {
             }
         }
     }
-    pub fn checkpoint_rollback(checkpoint: &str) -> Result<(), NmstateError> {
-        nm_checkpoint_rollback(checkpoint)
-    }
-
-    pub fn checkpoint_commit(checkpoint: &str) -> Result<(), NmstateError> {
-        nm_checkpoint_destroy(checkpoint)
-    }
-
-    pub(crate) fn get_kernel_iface_with_route(
-        &self,
-        iface_name: &str,
-    ) -> Option<Interface> {
-        if let Some(iface) = self.interfaces.kernel_ifaces.get(iface_name) {
-            let mut ret = iface.clone();
-            ret.base_iface_mut().routes =
-                self.routes.get_config_routes_of_iface(iface_name);
-            Some(ret)
-        } else {
-            None
-        }
-    }
-}
-
-fn with_nm_checkpoint<T>(
-    checkpoint: &str,
-    no_commit: bool,
-    func: T,
-) -> Result<(), NmstateError>
-where
-    T: FnOnce() -> Result<(), NmstateError>,
-{
-    match func() {
-        Ok(()) => {
-            if !no_commit {
-                nm_checkpoint_destroy(checkpoint)?;
-
-                info!("Destroyed checkpoint {}", checkpoint);
-            } else {
-                info!("Skipping commit for checkpoint {}", checkpoint);
-            }
-            Ok(())
-        }
-        Err(e) => {
-            if let Err(e) = nm_checkpoint_rollback(checkpoint) {
-                warn!("nm_checkpoint_rollback() failed: {}", e);
-            }
-            info!("Rollbacked to checkpoint {}", checkpoint);
-            Err(e)
-        }
-    }
-}
-
-fn with_retry<T>(
-    interval_ms: u64,
-    count: usize,
-    func: T,
-) -> Result<(), NmstateError>
-where
-    T: FnOnce() -> Result<(), NmstateError> + Copy,
-{
-    let mut cur_count = 0usize;
-    while cur_count < count {
-        if let Err(e) = func() {
-            if cur_count == count - 1 {
-                return Err(e);
-            } else {
-                info!("Retrying on verification failure: {}", e);
-                std::thread::sleep(std::time::Duration::from_millis(
-                    interval_ms,
-                ));
-                cur_count += 1;
-                continue;
-            }
-        } else {
-            return Ok(());
-        }
-    }
-    Ok(())
 }

--- a/rust/src/lib/net_state_offline.rs
+++ b/rust/src/lib/net_state_offline.rs
@@ -1,0 +1,18 @@
+use std::collections::HashMap;
+
+use crate::{net_state::NetworkState, nm::nm_gen_conf, NmstateError};
+
+impl NetworkState {
+    pub fn gen_conf(
+        &self,
+    ) -> Result<HashMap<String, Vec<(String, String)>>, NmstateError> {
+        let mut ret = HashMap::new();
+        let mut self_clone = self.clone();
+        self_clone.interfaces.set_unknown_iface_to_eth();
+        self_clone.interfaces.set_missing_port_to_eth();
+        let (add_net_state, _, _) =
+            self_clone.gen_state_for_apply(&Self::new())?;
+        ret.insert("NetworkManager".to_string(), nm_gen_conf(&add_net_state)?);
+        Ok(ret)
+    }
+}

--- a/rust/src/lib/net_state_online.rs
+++ b/rust/src/lib/net_state_online.rs
@@ -1,0 +1,291 @@
+use log::{debug, info, warn};
+
+use crate::{
+    ifaces::get_ignored_ifaces,
+    net_state::NetworkState,
+    nispor::{nispor_apply, nispor_retrieve, set_running_hostname},
+    nm::{
+        nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
+        nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_retrieve,
+    },
+    ovsdb::{ovsdb_apply, ovsdb_is_running, ovsdb_retrieve},
+    DnsState, HostNameState, Interfaces, NmstateError, OvsDbGlobalConfig,
+    RouteRules, Routes,
+};
+
+const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;
+const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
+const VERIFY_RETRY_COUNT: usize = 5;
+const VERIFY_RETRY_COUNT_SRIOV: usize = 60;
+const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
+const MAX_SUPPORTED_INTERFACES: usize = 1000;
+
+impl NetworkState {
+    pub fn retrieve(&mut self) -> Result<&mut Self, NmstateError> {
+        let state = nispor_retrieve(self.running_config_only)?;
+        if state.prop_list.contains(&"hostname") {
+            self.hostname = state.hostname;
+        }
+        if state.prop_list.contains(&"interfaces") {
+            self.interfaces = state.interfaces;
+        }
+        if state.prop_list.contains(&"routes") {
+            self.routes = state.routes;
+        }
+        if state.prop_list.contains(&"rules") {
+            self.rules = state.rules;
+        }
+        if !self.kernel_only {
+            let nm_state = nm_retrieve(self.running_config_only)?;
+            // TODO: Priority handling
+            self.update_state(&nm_state);
+            if ovsdb_is_running() {
+                match ovsdb_retrieve() {
+                    Ok(ovsdb_state) => self.update_state(&ovsdb_state),
+                    Err(e) => {
+                        log::warn!("Failed to retrieve OVS DB state: {}", e);
+                    }
+                }
+            }
+        }
+        if !self.include_secrets {
+            self.hide_secrets();
+        }
+        Ok(self)
+    }
+
+    pub fn apply(&self) -> Result<(), NmstateError> {
+        let mut desire_state_to_verify = self.clone();
+        let mut desire_state_to_apply = self.clone();
+        let mut cur_net_state = NetworkState::new();
+        cur_net_state.set_kernel_only(self.kernel_only);
+        cur_net_state.set_include_secrets(true);
+        cur_net_state.retrieve()?;
+
+        if desire_state_to_apply.interfaces.to_vec().len()
+            >= MAX_SUPPORTED_INTERFACES
+        {
+            log::warn!(
+                "Interfaces count exceeds the support limit {} in \
+                desired state",
+                MAX_SUPPORTED_INTERFACES,
+            );
+        }
+
+        let (ignored_kernel_ifaces, ignored_user_ifaces) =
+            get_ignored_ifaces(&self.interfaces, &cur_net_state.interfaces);
+
+        for iface_name in &ignored_kernel_ifaces {
+            log::info!("Ignoring kernel interface {}", iface_name)
+        }
+        for (iface_name, iface_type) in &ignored_user_ifaces {
+            log::info!(
+                "Ignoring user space interface {} with type {}",
+                iface_name,
+                iface_type
+            )
+        }
+
+        desire_state_to_apply.interfaces.remove_ignored_ifaces(
+            &ignored_kernel_ifaces,
+            &ignored_user_ifaces,
+        );
+        cur_net_state.interfaces.remove_ignored_ifaces(
+            &ignored_kernel_ifaces,
+            &ignored_user_ifaces,
+        );
+
+        desire_state_to_apply
+            .routes
+            .remove_ignored_iface_routes(ignored_kernel_ifaces.as_slice());
+        cur_net_state
+            .routes
+            .remove_ignored_iface_routes(ignored_kernel_ifaces.as_slice());
+
+        desire_state_to_verify
+            .interfaces
+            .resolve_unknown_ifaces(&cur_net_state.interfaces)?;
+        desire_state_to_apply
+            .interfaces
+            .resolve_unknown_ifaces(&cur_net_state.interfaces)?;
+
+        let (add_net_state, chg_net_state, del_net_state) =
+            desire_state_to_apply.gen_state_for_apply(&cur_net_state)?;
+
+        debug!("Adding net state {:?}", &add_net_state);
+        debug!("Changing net state {:?}", &chg_net_state);
+        debug!("Deleting net state {:?}", &del_net_state);
+
+        if let Some(running_hostname) =
+            self.hostname.as_ref().and_then(|c| c.running.as_ref())
+        {
+            set_running_hostname(running_hostname)?;
+        }
+
+        if !self.kernel_only {
+            let retry_count =
+                if desire_state_to_apply.interfaces.has_sriov_enabled() {
+                    VERIFY_RETRY_COUNT_SRIOV
+                } else {
+                    VERIFY_RETRY_COUNT
+                };
+
+            let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
+            let checkpoint = nm_checkpoint_create(timeout)?;
+            info!("Created checkpoint {}", &checkpoint);
+
+            with_nm_checkpoint(&checkpoint, self.no_commit, || {
+                nm_apply(
+                    &add_net_state,
+                    &chg_net_state,
+                    &del_net_state,
+                    // TODO: Passing full(desire + current) network state
+                    // instead of current,
+                    &cur_net_state,
+                    self,
+                    &checkpoint,
+                    self.memory_only,
+                )?;
+                if ovsdb_is_running() {
+                    ovsdb_apply(&desire_state_to_apply, &cur_net_state)?;
+                }
+                nm_checkpoint_timeout_extend(&checkpoint, timeout)?;
+                if !self.no_verify {
+                    with_retry(
+                        VERIFY_RETRY_INTERVAL_MILLISECONDS,
+                        retry_count,
+                        || {
+                            let mut new_cur_net_state = cur_net_state.clone();
+                            new_cur_net_state.set_include_secrets(true);
+                            new_cur_net_state.retrieve()?;
+                            desire_state_to_verify.verify(&new_cur_net_state)
+                        },
+                    )
+                } else {
+                    Ok(())
+                }
+            })
+        } else {
+            // TODO: Need checkpoint for kernel only mode
+            nispor_apply(
+                &add_net_state,
+                &chg_net_state,
+                &del_net_state,
+                &cur_net_state,
+            )?;
+            if !self.no_verify {
+                with_retry(
+                    VERIFY_RETRY_INTERVAL_MILLISECONDS,
+                    VERIFY_RETRY_COUNT_KERNEL_MODE,
+                    || {
+                        let mut new_cur_net_state = cur_net_state.clone();
+                        new_cur_net_state.retrieve()?;
+                        desire_state_to_verify.verify(&new_cur_net_state)
+                    },
+                )
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn update_state(&mut self, other: &Self) {
+        if other.prop_list.contains(&"hostname") {
+            if let Some(h) = self.hostname.as_mut() {
+                if let Some(other_h) = other.hostname.as_ref() {
+                    h.update(other_h);
+                }
+            } else {
+                self.hostname = other.hostname.clone();
+            }
+        }
+        if other.prop_list.contains(&"interfaces") {
+            self.interfaces.update(&other.interfaces);
+        }
+        if other.prop_list.contains(&"dns") {
+            self.dns = other.dns.clone();
+        }
+        if other.prop_list.contains(&"ovsdb") {
+            self.ovsdb = other.ovsdb.clone();
+        }
+    }
+
+    fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+        if let Some(desired_hostname) = self.hostname.as_ref() {
+            desired_hostname.verify(current.hostname.as_ref())?;
+        }
+        self.interfaces.verify(&current.interfaces)?;
+        let (ignored_kernel_ifaces, _) =
+            get_ignored_ifaces(&self.interfaces, &current.interfaces);
+        self.routes
+            .verify(&current.routes, &ignored_kernel_ifaces)?;
+        self.rules.verify(&current.rules)?;
+        self.dns.verify(&current.dns)?;
+        self.ovsdb.verify(&current.ovsdb)
+    }
+
+    pub fn checkpoint_rollback(checkpoint: &str) -> Result<(), NmstateError> {
+        nm_checkpoint_rollback(checkpoint)
+    }
+
+    pub fn checkpoint_commit(checkpoint: &str) -> Result<(), NmstateError> {
+        nm_checkpoint_destroy(checkpoint)
+    }
+}
+
+fn with_nm_checkpoint<T>(
+    checkpoint: &str,
+    no_commit: bool,
+    func: T,
+) -> Result<(), NmstateError>
+where
+    T: FnOnce() -> Result<(), NmstateError>,
+{
+    match func() {
+        Ok(()) => {
+            if !no_commit {
+                nm_checkpoint_destroy(checkpoint)?;
+
+                info!("Destroyed checkpoint {}", checkpoint);
+            } else {
+                info!("Skipping commit for checkpoint {}", checkpoint);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if let Err(e) = nm_checkpoint_rollback(checkpoint) {
+                warn!("nm_checkpoint_rollback() failed: {}", e);
+            }
+            info!("Rollbacked to checkpoint {}", checkpoint);
+            Err(e)
+        }
+    }
+}
+
+fn with_retry<T>(
+    interval_ms: u64,
+    count: usize,
+    func: T,
+) -> Result<(), NmstateError>
+where
+    T: FnOnce() -> Result<(), NmstateError> + Copy,
+{
+    let mut cur_count = 0usize;
+    while cur_count < count {
+        if let Err(e) = func() {
+            if cur_count == count - 1 {
+                return Err(e);
+            } else {
+                info!("Retrying on verification failure: {}", e);
+                std::thread::sleep(std::time::Duration::from_millis(
+                    interval_ms,
+                ));
+                cur_count += 1;
+                continue;
+            }
+        } else {
+            return Ok(());
+        }
+    }
+    Ok(())
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -50,6 +50,7 @@ pub(crate) const NM_SETTING_USER_SPACES: [&str; 2] = [
     NM_SETTING_OVS_PORT_SETTING_NAME,
 ];
 
+#[cfg(feature = "offline")]
 pub(crate) fn nm_gen_conf(
     net_state: &NetworkState,
 ) -> Result<Vec<(String, String)>, NmstateError> {

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -30,10 +30,14 @@ mod vrf;
 mod vxlan;
 mod wired;
 
+#[cfg(feature = "online")]
 pub(crate) use apply::nm_apply;
+#[cfg(feature = "online")]
 pub(crate) use checkpoint::{
     nm_checkpoint_create, nm_checkpoint_destroy, nm_checkpoint_rollback,
     nm_checkpoint_timeout_extend,
 };
+#[cfg(feature = "offline")]
 pub(crate) use connection::nm_gen_conf;
+#[cfg(feature = "online")]
 pub(crate) use show::nm_retrieve;

--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -205,6 +205,7 @@ impl NmConnection {
         _connection_inner_string_member!(self, controller_type)
     }
 
+    #[cfg(feature = "offline")]
     pub fn to_keyfile(&self) -> Result<String, NmError> {
         let mut sections: Vec<(&str, HashMap<String, zvariant::Value>)> =
             Vec::new();

--- a/rust/src/lib/nm/nm_dbus/connection/wired.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/wired.rs
@@ -63,6 +63,7 @@ impl TryFrom<DbusDictionary> for NmSettingWired {
 }
 
 impl NmSettingWired {
+    #[cfg(feature = "offline")]
     pub(crate) fn to_keyfile(
         &self,
     ) -> Result<HashMap<String, zvariant::Value>, NmError> {


### PR DESCRIPTION
When consuming nmstate as a library is good to be able to compile only
the needed bits. This change split lib/net_state into features:
- show: show func
- apply: retrieve func
- gc: gen_conf func