### PR TITLE
cli: Add service subcommand

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -1,0 +1,20 @@
+.TH nmstate\&.service 8 "@DATE@" "@VERSION@" "nmstate.service man page"
+.SH "NAME"
+nmstate\&.service \- Apply /etc/nmstate network states
+.SH "SYNOPSIS"
+.PP
+nmstate\&.service
+.SH "DESCRIPTION"
+.PP
+nmstate\&.service invokes \fBnmstatectl service\fR command which
+apply all network state files ending with \fB.yml\fR in
+\fB/etc/nmstate\fR folder.
+The applied network state file will be renamed with postfix \fB.applied\fR
+to prevent repeated applied on next service start.
+.SH BUG REPORTS
+Report bugs on nmstate GitHub issues <https://github.com/nmstate/nmstate>.
+.SH COPYRIGHT
+License Apache 2.0 or any later version
+<https://www.apache.org/licenses/LICENSE-2.0.txt>
+.SH SEE ALSO
+.B nmstatectl\fP(8)

--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -19,6 +19,8 @@ nmstatectl \- A nmstate command line tool
 .br
 .B nmstatectl commit \fR[\fICHECKPOINT_PATH\fR]
 .br
+.B nmstatectl service \fR[\fI-c, --config <CONFIG_FOLDER>\fR]
+.br
 .B nmstatectl version
 .br
 .SH DESCRIPTION
@@ -111,6 +113,15 @@ checkpoint if not defined as argument.
 .RS
 displays nmstate version.
 .RE
+
+.B service
+.RS
+Apply all network state files ending with \fB.yml\fR in specified(
+default: \fB/etc/nmstate\fR) folder.
+The applied network state file will be renamed with postfix \fB.applied\fR
+to prevent repeated applied on next run.
+.RE
+
 .PP
 .RE
 .SH OPTIONS

--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Apply nmstate on-disk state
+Documentation=man:nmstate.service(8) https://www.nmstate.io
+After=NetworkManager.service
+Requires=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nmstatectl service
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -14,6 +14,7 @@ URL:            https://github.com/%{srcname}/%{srcname}
 Source0:        https://github.com/%{srcname}/%{srcname}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-devel
+BuildRequires:  systemd
 Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 %if 0%{?rhel}
 BuildRequires:  rust-toolset
@@ -91,10 +92,12 @@ env SKIP_PYTHON_INSTALL=1 PREFIX=%{_prefix} LIBDIR=%{_libdir} %make_install
 %files
 %doc README.md
 %doc examples/
+%{_mandir}/man8/nmstate.service.8*
 %{_mandir}/man8/nmstatectl.8*
 %{_mandir}/man8/nmstate-autoconf.8*
 %{_bindir}/nmstatectl
 %{_bindir}/nmstate-autoconf
+%{_unitdir}/nmstate.service
 
 %files libs
 %{_libdir}/libnmstate.so.*

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -1,5 +1,6 @@
 mod autoconf;
 mod error;
+mod service;
 
 use std::fs::File;
 use std::io::{self, stdin, stdout, Read, Write};
@@ -26,6 +27,7 @@ const SUB_CMD_ROLLBACK: &str = "rollback";
 const SUB_CMD_EDIT: &str = "edit";
 const SUB_CMD_VERSION: &str = "version";
 const SUB_CMD_AUTOCONF: &str = "autoconf";
+const SUB_CMD_SERVICE: &str = "service";
 
 const EX_DATAERR: i32 = 65;
 const EXIT_FAILURE: i32 = 1;
@@ -230,6 +232,19 @@ fn main() {
                 )
         )
         .subcommand(
+            clap::Command::new(SUB_CMD_SERVICE)
+                .about("Service mode: apply files from service folder")
+                .arg(
+                    clap::Arg::new(self::service::CONFIG_FOLDER_KEY)
+                        .long("config")
+                        .short('c')
+                        .required(false)
+                        .takes_value(true)
+                        .default_value(self::service::DEFAULT_SERVICE_FOLDER)
+                        .help("Folder hold network state files"),
+                ),
+        )
+        .subcommand(
             clap::Command::new(SUB_CMD_VERSION)
             .about("Show version")
        ).get_matches();
@@ -286,6 +301,11 @@ fn main() {
         }
     } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_EDIT) {
         print_result_and_exit(state_edit(matches), EX_DATAERR);
+    } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_SERVICE) {
+        print_result_and_exit(
+            self::service::ncl_service(matches),
+            EXIT_FAILURE,
+        );
     } else if matches.subcommand_matches(SUB_CMD_VERSION).is_some() {
         print_string_and_exit(format!(
             "{} {}",

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -1,0 +1,86 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use nmstate::NetworkState;
+
+use crate::error::CliError;
+
+pub(crate) const DEFAULT_SERVICE_FOLDER: &str = "/etc/nmstate";
+pub(crate) const CONFIG_FOLDER_KEY: &str = "CONFIG_FOLDER";
+
+const CONFIG_FILE_EXTENTION: &str = "yml";
+const RELOCATE_FILE_EXTENTION: &str = "applied";
+
+pub(crate) fn ncl_service(
+    matches: &clap::ArgMatches,
+) -> Result<String, CliError> {
+    let folder = matches
+        .value_of(CONFIG_FOLDER_KEY)
+        .unwrap_or(DEFAULT_SERVICE_FOLDER);
+
+    let config_files = get_config_files(folder)?;
+    if config_files.is_empty() {
+        log::info!(
+            "No nmstate config(end with .{}) found in config folder {}",
+            CONFIG_FILE_EXTENTION,
+            folder
+        );
+    }
+
+    for file_path in config_files {
+        match apply_file(&file_path) {
+            Ok(()) => {
+                log::info!("Applied nmstate config: {}", file_path.display());
+                if let Err(e) = relocate_file(&file_path) {
+                    log::error!(
+                        "Failed to rename applied state file: {} {}",
+                        file_path.display(),
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "Failed to apply state file {}: {}",
+                    file_path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    Ok("".to_string())
+}
+
+// All file ending with `.yml` will be included.
+fn get_config_files(folder: &str) -> Result<Vec<PathBuf>, CliError> {
+    let folder = Path::new(folder);
+    let mut ret = Vec::new();
+    for entry in folder.read_dir()? {
+        let file = entry?.path();
+        if file.extension() == Some(OsStr::new(CONFIG_FILE_EXTENTION)) {
+            ret.push(folder.join(file));
+        }
+    }
+    ret.sort_unstable();
+    Ok(ret)
+}
+
+// rename file by adding a suffix `.applied`.
+fn relocate_file(file_path: &Path) -> Result<(), CliError> {
+    let new_path = file_path.with_extension(RELOCATE_FILE_EXTENTION);
+    std::fs::rename(file_path, &new_path)?;
+    log::info!(
+        "Renamed applied config {} to {}",
+        file_path.display(),
+        new_path.display()
+    );
+    Ok(())
+}
+
+fn apply_file(file_path: &Path) -> Result<(), CliError> {
+    let fd = std::fs::File::open(file_path)?;
+    let net_state: NetworkState = serde_yaml::from_reader(fd)?;
+    net_state.apply()?;
+    Ok(())
+}

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+
+import yaml
+import pytest
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+
+from .testlib.cmdlib import exec_cmd
+from .testlib.assertlib import assert_state_match
+
+TEST_YAML1_CONTENT = """
+---
+interfaces:
+- name: dummy0
+  type: dummy
+  state: up
+  ipv4:
+    enabled: false
+  ipv6:
+    enabled: false
+"""
+
+TEST_YAML2_CONTENT = """
+---
+interfaces:
+- name: dummy0
+  type: dummy
+  state: up
+  ipv4:
+    address:
+    - ip: 192.0.2.252
+      prefix-length: 24
+    - ip: 192.0.2.251
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  ipv6:
+    address:
+      - ip: 2001:db8:2::1
+        prefix-length: 64
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+    autoconf: false
+    dhcp: false
+    enabled: true
+"""
+
+CONFIG_DIR = "/etc/nmstate"
+TEST_CONFIG1_FILE_PATH = f"{CONFIG_DIR}/01-nmstate-test.yml"
+TEST_CONFIG1_APPLIED_FILE_PATH = f"{CONFIG_DIR}/01-nmstate-test.applied"
+TEST_CONFIG2_FILE_PATH = f"{CONFIG_DIR}/02-nmstate-test.yml"
+TEST_CONFIG2_APPLIED_FILE_PATH = f"{CONFIG_DIR}/02-nmstate-test.applied"
+
+
+@pytest.fixture
+def nmstate_etc_config():
+    if not os.path.isdir(CONFIG_DIR):
+        os.mkdir(CONFIG_DIR)
+
+    for file_path, content in [
+        (
+            TEST_CONFIG1_FILE_PATH,
+            TEST_YAML1_CONTENT,
+        ),
+        (
+            TEST_CONFIG2_FILE_PATH,
+            TEST_YAML2_CONTENT,
+        ),
+    ]:
+        with open(file_path, "w") as fd:
+            fd.write(content)
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "dummy0",
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    os.remove(TEST_CONFIG1_APPLIED_FILE_PATH)
+    os.remove(TEST_CONFIG2_APPLIED_FILE_PATH)
+
+
+def test_nmstate_service_apply(nmstate_etc_config):
+    exec_cmd("systemctl start nmstate".split(), check=True)
+
+    desire_state = yaml.load(TEST_YAML2_CONTENT, Loader=yaml.SafeLoader)
+    assert_state_match(desire_state)
+
+    assert not os.path.exists(TEST_CONFIG1_FILE_PATH)
+    assert os.path.isfile(TEST_CONFIG1_APPLIED_FILE_PATH)
+    assert not os.path.exists(TEST_CONFIG2_FILE_PATH)
+    assert os.path.isfile(TEST_CONFIG2_APPLIED_FILE_PATH)


### PR DESCRIPTION
With command `sudo nmstatectl service -c <config_folder>`, nmstatectl
will search all `.yml` files in specified folder(default to
`/etc/nmstate`), and apply those state files. Any applied state file
will be then renamed to `.applied` suffix.

The config files are sorted by rust native lexicographical order.

Man page for `nmstatectl` updated.
Add new man page `nmstate.service(8)`.
Systemd unit file included.
RPM spec file updated.
Integration test case included.