### PR TITLE
rust/clib: build both cdylib and staticlib

### DIFF
--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [lib]
 name = "nmstate"
 path = "lib.rs"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
 nmstate = { path = "../lib" }


### PR DESCRIPTION
For applications wishing to embed libnmstate without having to
distribute all its dependencies, it is useful to build the static
library alongside the dynamic one.