### PR TITLE
bond: fix fail_over_mac follow mode

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -438,7 +438,7 @@ impl std::fmt::Display for BondFailOverMac {
             match self {
                 Self::None => "none",
                 Self::Active => "active",
-                Self::Follow => "follow ",
+                Self::Follow => "follow",
             }
         )
     }

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -580,6 +580,21 @@ def test_bond_mac_restriction_in_current_mac_in_desire(eth1_up, eth2_up):
 
 
 @pytest.mark.tier1
+def test_bond_fail_over_mac_follow(eth1_up, eth2_up):
+    with bond_interface(
+        name=BOND99,
+        port=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+                Bond.OPTIONS_SUBTREE: {"fail_over_mac": "follow"},
+            },
+        },
+    ) as state:
+        assertlib.assert_state_match(state)
+
+
+@pytest.mark.tier1
 def test_create_bond_with_mac(eth1_up, eth2_up):
     with bond_interface(
         name=BOND99,


### PR DESCRIPTION
There was a trailing whitespace on the Display implementation of the
BondFailOverMac enum.

Integration test case added.

https://bugzilla.redhat.com/show_bug.cgi?id=2091775

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>