### PR TITLE
hostname: Fix applying different running and config hostname

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -283,12 +283,6 @@ impl NetworkState {
         debug!("Changing net state {:?}", &chg_net_state);
         debug!("Deleting net state {:?}", &del_net_state);
 
-        if let Some(running_hostname) =
-            self.hostname.as_ref().and_then(|c| c.running.as_ref())
-        {
-            set_running_hostname(running_hostname)?;
-        }
-
         if !self.kernel_only {
             let retry_count =
                 if desire_state_to_apply.interfaces.has_sriov_enabled() {
@@ -316,6 +310,11 @@ impl NetworkState {
                 if ovsdb_is_running() {
                     ovsdb_apply(&desire_state_to_apply, &cur_net_state)?;
                 }
+                if let Some(running_hostname) =
+                    self.hostname.as_ref().and_then(|c| c.running.as_ref())
+                {
+                    set_running_hostname(running_hostname)?;
+                }
                 nm_checkpoint_timeout_extend(&checkpoint, timeout)?;
                 if !self.no_verify {
                     with_retry(
@@ -340,6 +339,11 @@ impl NetworkState {
                 &del_net_state,
                 &cur_net_state,
             )?;
+            if let Some(running_hostname) =
+                self.hostname.as_ref().and_then(|c| c.running.as_ref())
+            {
+                set_running_hostname(running_hostname)?;
+            }
             if !self.no_verify {
                 with_retry(
                     VERIFY_RETRY_INTERVAL_MILLISECONDS,

--- a/tests/integration/hostname_test.py
+++ b/tests/integration/hostname_test.py
@@ -98,3 +98,24 @@ def test_hostname_set_in_memory_only(restore_hostname):
     )
     cur_host_name = cmdlib.exec_cmd(["hostname"], check=True)[1]
     assert cur_host_name.strip() == TEST_HOSTNAME2
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="NM cannot change hostname in container",
+)
+def test_hostname_set_different_running_and_config(restore_hostname):
+    libnmstate.apply(
+        {
+            HostNameState.KEY: {
+                HostNameState.RUNNING: TEST_HOSTNAME1,
+                HostNameState.CONFIG: TEST_HOSTNAME2,
+            }
+        },
+    )
+    cur_host_name = cmdlib.exec_cmd(["hostname"], check=True)[1]
+    assert cur_host_name.strip() == TEST_HOSTNAME1
+    assert (
+        cmdlib.exec_cmd(["cat", "/etc/hostname"], check=True)[1].strip()
+        == TEST_HOSTNAME2
+    )


### PR DESCRIPTION
When applying different running and config hostname, nmstate will fail
on verification. The root cause is NetworkManager override the running
hostname set by nispor. The fix is apply running hostname via nispor
__after__ NetworkManager.

Integration test case included.