### PR TITLE
Fix problem on VRF over new bond vlan.

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -336,9 +336,11 @@ impl Interfaces {
                         chg_iface.set_iface_type(cur_iface.iface_type());
                         chg_iface.pre_edit_cleanup()?;
                         info!(
-                            "Changing interface {} with type {}",
+                            "Changing interface {} with type {}, \
+                            up priority {}",
                             chg_iface.name(),
-                            chg_iface.iface_type()
+                            chg_iface.iface_type(),
+                            chg_iface.base_iface().up_priority
                         );
                         chg_ifaces.push(chg_iface);
                     }
@@ -346,9 +348,11 @@ impl Interfaces {
                         let mut new_iface = iface.clone();
                         new_iface.pre_edit_cleanup()?;
                         info!(
-                            "Adding interface {} with type {}",
+                            "Adding interface {} with type {}, \
+                            up priority {}",
                             new_iface.name(),
-                            new_iface.iface_type()
+                            new_iface.iface_type(),
+                            new_iface.base_iface().up_priority
                         );
                         add_ifaces.push(new_iface);
                     }

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -1,4 +1,4 @@
-use crate::VlanInterface;
+use crate::{Interfaces, VlanInterface};
 
 #[test]
 fn test_vlan_stringlized_attributes() {
@@ -15,4 +15,46 @@ vlan:
     .unwrap();
 
     assert_eq!(iface.vlan.unwrap().id, 101);
+}
+
+#[test]
+fn test_vlan_get_parent_up_priority_plus_one() {
+    let mut desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: bond0.100
+  type: vlan
+  vlan:
+    base-iface: bond0
+    id: 100
+- name: bond0
+  type: bond
+  link-aggregation:
+    mode: balance-rr
+- name: vrf0
+  type: vrf
+  state: up
+  vrf:
+    port:
+    - bond0
+    - bond0.100
+    route-table-id: 1000"#,
+    )
+    .unwrap();
+
+    let (add_ifaces, _, _) = desired
+        .gen_state_for_apply(&Interfaces::new(), false)
+        .unwrap();
+
+    assert_eq!(desired.kernel_ifaces["vrf0"].base_iface().up_priority, 0);
+    assert_eq!(desired.kernel_ifaces["bond0"].base_iface().up_priority, 1);
+    assert_eq!(
+        desired.kernel_ifaces["bond0.100"].base_iface().up_priority,
+        2
+    );
+
+    let ordered_ifaces = add_ifaces.to_vec();
+
+    assert_eq!(ordered_ifaces[0].name(), "vrf0".to_string());
+    assert_eq!(ordered_ifaces[1].name(), "bond0".to_string());
+    assert_eq!(ordered_ifaces[2].name(), "bond0.100".to_string());
 }


### PR DESCRIPTION
We got failure on this yaml:

```yaml
---
interfaces:
- name: bond0.100
  type: vlan
  vlan:
    base-iface: bond0
    id: 100
- name: bond0
  type: bond
  link-aggregation:
    mode: balance-rr
- name: vrf0
  type: vrf
  state: up
  vrf:
    port:
    - bond0
    - bond0.100
    route-table-id: 1000
```

To fix it, we need to two commits:
 * Activate VLAN after its parent.
 * Retry on NM race problem on autoconnection.

You can check the commit comment for detail.

Unit test case and integration test case included.