### PR TITLE
Upgrade nispor dependency to 1.2.7

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 [dependencies]
 libc = "0.2.106"
 log = "0.4.14"
-nispor = "1.2.5"
+nispor = "1.2.7"
 nix = "0.24.1"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.68"


### PR DESCRIPTION
The nispor 1.2.7 fixed the linux bridge bug:

    https://github.com/little-dude/netlink/pull/247

Which is important to nmstate