### PR TITLE
nm: update connection for state:down interface

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -215,10 +215,13 @@ impl Interfaces {
             } else if let Some(cur_iface) =
                 cur_clone.get_iface(iface.name(), iface.iface_type())
             {
-                iface.verify(cur_iface)?;
-                if let Interface::Ethernet(eth_iface) = iface {
-                    if eth_iface.sriov_is_enabled() {
-                        eth_iface.verify_sriov(cur_ifaces)?;
+                // Do not verify physical interface with state:down
+                if !iface.is_down() {
+                    iface.verify(cur_iface)?;
+                    if let Interface::Ethernet(eth_iface) = iface {
+                        if eth_iface.sriov_is_enabled() {
+                            eth_iface.verify_sriov(cur_ifaces)?;
+                        }
                     }
                 }
             } else {

--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -162,6 +162,7 @@ fn apply_single_state(
     if net_state.interfaces.to_vec().is_empty() {
         return Ok(());
     }
+    let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
 
     let exist_nm_conns =
@@ -185,7 +186,7 @@ fn apply_single_state(
     let ifaces = net_state.interfaces.to_vec();
 
     for iface in ifaces.iter() {
-        if iface.iface_type() != InterfaceType::Unknown && iface.is_up() {
+        if iface.iface_type() != InterfaceType::Unknown && !iface.is_absent() {
             let mut ctrl_iface: Option<&Interface> = None;
             if let Some(ctrl_iface_name) = &iface.base_iface().controller {
                 if let Some(ctrl_type) = &iface.base_iface().controller_type {
@@ -212,7 +213,10 @@ fn apply_single_state(
                 is_veth_peer_in_desire(iface, ifaces.as_slice()),
                 cur_net_state,
             )? {
-                nm_conns_to_activate.push(nm_conn);
+                if iface.is_up() {
+                    nm_conns_to_activate.push(nm_conn.clone());
+                }
+                nm_conns_to_update.push(nm_conn);
             }
         }
     }
@@ -230,13 +234,13 @@ fn apply_single_state(
         .collect::<Vec<_>>();
 
     use_uuid_for_controller_reference(
-        &mut nm_conns_to_activate,
+        &mut nm_conns_to_update,
         &des_net_state.interfaces.user_ifaces,
         &cur_net_state.interfaces.user_ifaces,
         &exist_nm_conns,
     )?;
     use_uuid_for_parent_reference(
-        &mut nm_conns_to_activate,
+        &mut nm_conns_to_update,
         &des_net_state.interfaces.kernel_ifaces,
         &exist_nm_conns,
     );
@@ -252,7 +256,7 @@ fn apply_single_state(
     )?;
     save_nm_profiles(
         nm_api,
-        nm_conns_to_activate.as_slice(),
+        nm_conns_to_update.as_slice(),
         checkpoint,
         memory_only,
     )?;


### PR DESCRIPTION
When certain interface been marked as `state:down`, nmstate does not
update its connection/profile even desire state requested.

Fixed by storing pending update connections to `nm_conns_to_update`.
Also ignore verification on down physical interface as DHCP and other
kernel state will not match.

Integration test case included.