### PR TITLE
ip: Merge ip stack from current

### DIFF
--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -784,3 +784,28 @@ def test_static_ip_kernel_mode():
             },
             kernel_only=True,
         )
+
+
+def test_merge_ip_enabled_property_from_current(setup_eth1_static_ip):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.IPV4: {
+                    InterfaceIPv4.DHCP: True,
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.DHCP: True,
+                    InterfaceIPv6.AUTOCONF: True,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    desired_state[Interface.KEY][0][Interface.IPV4][
+        InterfaceIPv4.ENABLED
+    ] = True
+    desired_state[Interface.KEY][0][Interface.IPV6][
+        InterfaceIPv6.ENABLED
+    ] = True
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
Since the `InterfaceIpv4` and `InterfaceIpv6` are using `enabled: false`
by default, this prevent user from applying this desire state:

```yml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    mtu: 1500
    ipv4:
      dhcp: true
    ipv6:
      dhcp: true
      autoconf: true
```

We should merge ip stack as we did for python API.

Implementation detail:
 * Introducing private struct `InterfaceIp` using serde build-in
   Deserializer and Serializer.
 * Implement `Deserialize` for `InterfaceIpv4` and `InterfaceIpv6`
   preserving the `prop_list` which will used to determined whether user
   desired `enabled` property or not.
 * At `Interfaces` struct, we merge ip stack `enabled`, `dhcp`,
   `autoconf` properties before applying and verifying.

Design choice:
 * Why not just convert `enabled: bool` to `enabled: Option<bool>`?
    1. This break rust API of nmstate.
    2. A lot lines need to changed and handle `enabled: None` case which
       might be interpreted in differently in the future or by other
       developer. The best approach should be do special merge action
       and follow up code don't need to worry about `enabled: None`
       use case.

Integration test case included.