### PR TITLE
ovs: Fix adding ovs system interface to exist bridge

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -359,6 +359,8 @@ impl Interfaces {
                         // existing OVS bridge, we should place this new OVS
                         // interface along with its controller -- chg_ifaces.
                         if new_iface.iface_type() == InterfaceType::OvsInterface
+                            || new_iface.base_iface().controller_type
+                                == Some(InterfaceType::OvsBridge)
                         {
                             new_ovs_ifaces.push(new_iface.clone());
                             if new_iface


### PR DESCRIPTION
When attaching new veth as OVS system interface into existing OVS bridge,
nmstate will fail with error:

    BUG: Failed to find UUID of controller connection: ovn-veth,
    ovs-port

This is because we place this new veth interface into `new_ifaces` while
its controller OVS bridge into `chg_ifaces`, this then lead to NM plugin
does not create new OVS port connection.

The fix is just place new OVS system interface to changed interface list
when its controller OVS bridge is found in current state.

Integration test case included.