### PR TITLE
[nmstate-1.0] ovs: Do not validate on non-desired interface

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -160,7 +160,8 @@ class Ifaces:
             self._apply_copy_mac_from()
             self.gen_metadata()
             for iface in self.all_ifaces():
-                iface.pre_edit_validation_and_cleanup()
+                if iface.is_desired and iface.is_up:
+                    iface.pre_edit_validation_and_cleanup()
 
             self._pre_edit_validation_and_cleanup()
 
@@ -271,7 +272,11 @@ class Ifaces:
         When OVS patch peer does not exist or is down, raise an error.
         """
         for iface in self._kernel_ifaces.values():
-            if iface.type == InterfaceType.OVS_INTERFACE and iface.is_up:
+            if (
+                iface.type == InterfaceType.OVS_INTERFACE
+                and iface.is_up
+                and iface.is_desired
+            ):
                 if iface.peer:
                     peer_iface = self._kernel_ifaces.get(iface.peer)
                     if not peer_iface or not peer_iface.is_up:
@@ -296,6 +301,7 @@ class Ifaces:
 
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
+                and iface.is_desired
                 and iface.is_up
             ):
                 if (
@@ -319,6 +325,7 @@ class Ifaces:
 
             if (
                 iface.type in [InterfaceType.VLAN, InterfaceType.VXLAN]
+                and iface.is_desired
                 and iface.is_up
                 and iface.mtu
             ):

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -97,9 +97,6 @@ class _ConnectionSetting:
             self._setting.props.master = controller
             self._setting.props.slave_type = port_type
 
-    def set_profile_name(self, con_name):
-        self._setting.props.id = con_name
-
     @property
     def setting(self):
         return self._setting
@@ -115,7 +112,6 @@ def create_new_nm_simple_conn(iface, nm_profile):
     con_setting = _ConnectionSetting()
     if nm_profile and not is_multiconnect_profile(nm_profile):
         con_setting.import_by_profile(nm_profile, iface.is_controller)
-        con_setting.set_profile_name(iface.name)
     else:
         # OVS bridge and interfaces could sharing the same interface name, to
         # distinguish them at NM connection level, instead of using interface

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -49,6 +49,8 @@ RUN dnf update -y && \
 
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
+COPY network_manager_keyfile.conf \
+     /etc/NetworkManager/conf.d/96-keyfile.conf
 
 RUN systemctl enable dbus systemd-udevd NetworkManager
 

--- a/packaging/network_manager_keyfile.conf
+++ b/packaging/network_manager_keyfile.conf
@@ -1,0 +1,2 @@
+[main]
+plugins=keyfile

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -97,8 +97,6 @@ NMCLI_CON_UP_TEST_PROFILE_CMD = [
 
 NM_PROFILE_DIRECTORY = "/etc/NetworkManager/system-connections/"
 
-ETH_PROFILE_DIRECTORY = "/etc/sysconfig/network-scripts/"
-
 MEMORY_ONLY_PROFILE_DIRECTORY = "/run/NetworkManager/system-connections/"
 
 MAC0 = "02:FF:FF:FF:FF:00"
@@ -118,10 +116,7 @@ def test_delete_existing_interface_inactive_profiles(eth1_up):
     with create_inactive_profile(eth1_up[Interface.KEY][0][Interface.NAME]):
         eth1_up[Interface.KEY][0][Interface.MTU] = 2000
         libnmstate.apply(eth1_up)
-        profile_exists = _profile_exists(
-            ETH_PROFILE_DIRECTORY + "ifcfg-testProfile"
-        )
-        assert not profile_exists
+        assert not _nm_connection_exists("testProfile")
 
 
 def test_rename_existing_interface_active_profile(eth1_up):
@@ -131,7 +126,7 @@ def test_rename_existing_interface_active_profile(eth1_up):
     ):
         eth1_up[Interface.KEY][0][Interface.MTU] = 2000
         libnmstate.apply(eth1_up)
-        assert _profile_exists(ETH_PROFILE_DIRECTORY + "ifcfg-testProfile")
+        assert _nm_connection_exists("testProfile")
 
 
 @contextmanager
@@ -187,10 +182,7 @@ def cloned_active_profile(con_name, source):
     cmdlib.exec_cmd(["nmcli", "con", "clone", "id", source, con_name])
     cmdlib.exec_cmd(_nmcli_delete_connection(source))
     cmdlib.exec_cmd(NMCLI_CON_UP_TEST_PROFILE_CMD)
-    profile_exists = _profile_exists(
-        ETH_PROFILE_DIRECTORY + f"ifcfg-{con_name}"
-    )
-    assert profile_exists
+    assert _nm_connection_exists(con_name)
     try:
         yield
     finally:
@@ -201,10 +193,7 @@ def cloned_active_profile(con_name, source):
 def create_inactive_profile(con_name):
     cmdlib.exec_cmd(_nmcli_deactivate_connection(con_name))
     cmdlib.exec_cmd(NMCLI_CON_ADD_ETH_CMD)
-    profile_exists = _profile_exists(
-        ETH_PROFILE_DIRECTORY + "ifcfg-testProfile"
-    )
-    assert profile_exists
+    assert _nm_connection_exists("testProfile")
     try:
         yield
     finally:
@@ -365,6 +354,13 @@ def _nmcli_delete_connection(con_name):
 
 def _profile_exists(profile_name):
     return os.path.isfile(profile_name)
+
+
+def _nm_connection_exists(conn_name):
+    rc, _, _ = cmdlib.exec_cmd(
+        f"nmcli -g connection.id c show {conn_name}".split()
+    )
+    return rc == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently nmstate is showing unmanaged ovs vxlan with empty parent which
failure the apply() even it is not mentioned in desire state.

The fix is skip all the validations on non-desired interfaces.

Integration test case included.