### PR TITLE
[nmstate-1.3] nm ovs: Fix race problem when attaching bond to OVS bridge

### DIFF
--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -48,6 +48,13 @@ def is_activated(nm_ac, nm_dev):
     if state == NM.ActiveConnectionState.ACTIVATED:
         return True
     elif state == NM.ActiveConnectionState.ACTIVATING:
+        # OVS bridge and OVS port are not allowed to have IP, hence we wait it
+        # to reach ACTIVATED state.
+        if nm_dev.get_device_type() in (
+            NM.DeviceType.OVS_PORT,
+            NM.DeviceType.OVS_BRIDGE,
+        ):
+            return False
         ac_state_flags = nm_ac.get_state_flags()
         nm_flags = NM.ActivationStateFlags
         ip4_is_dynamic = is_ipv4_dynamic(nm_ac)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -20,6 +20,7 @@
 from contextlib import contextmanager
 import os
 import pytest
+import yaml
 
 import libnmstate
 from libnmstate.prettystate import PrettyState
@@ -933,6 +934,58 @@ def test_add_route_rule_to_ovs_interface_dhcp_auto_route_table(
         route_rule.get(RouteRule.PRIORITY),
         route_rule.get(RouteRule.ROUTE_TABLE),
     )
+
+
+@pytest.fixture
+def cleanup_ovs_bridge_and_bond():
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BRIDGE0,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+                {
+                    Interface.NAME: BOND1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
+
+
+@pytest.mark.tier1
+def test_attach_linux_bond_to_ovs_bridge(
+    cleanup_ovs_bridge_and_bond, eth1_up, eth2_up
+):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+          - name: bond1
+            state: up
+            type: bond
+            link-aggregation:
+              mode: active-backup
+              options:
+                miimon: 140
+                primary: eth1
+              port:
+                - eth1
+                - eth2
+          - name: br0
+            type: ovs-bridge
+            state: up
+            bridge:
+              options:
+                stp: false
+              port:
+                - name: bond1
+            """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Got failure when attaching linux bond to ovs bridge:

    libnmstate.error.NmstateLibnmError: Activate profile
    uuid:cf81a923-5999-4a21-bd7e-dc96c7977451 iface:eth1 type: ethernet
    failed: reason=<enum
    NM_ACTIVE_CONNECTION_STATE_REASON_DEVICE_DISCONNECTED of type
    NM.ActiveConnectionStateReason><enum
    NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED of type NM.DeviceStateReason>

This is caused by race between we activating OVS port profile manually
and NettworkManager `autoconnect-slaves` function.

To fix the problem, for OVS bridge and OVS port, the `IP_CONFIG` state
is not considered as activated as they are not allowed to have IP.

Integration test case included.