### PR TITLE
gc: do not show interfaces with down/absent state

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -67,6 +67,13 @@ pub(crate) fn nm_gen_conf(
     }
     let ifaces = net_state.interfaces.to_vec();
     for iface in &ifaces {
+        if !iface.is_up() {
+            log::warn!(
+                "ignoring iface {} because is down or absent",
+                iface.name(),
+            );
+            continue;
+        }
         let mut ctrl_iface: Option<&Interface> = None;
         if let Some(ctrl_iface_name) = &iface.base_iface().controller {
             if let Some(ctrl_type) = &iface.base_iface().controller_type {


### PR DESCRIPTION
When an interface is down or absent, generate config mode of Nmstate
should not generate the config for them.

https://bugzilla.redhat.com/show_bug.cgi?id=2095173

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>