### PR TITLE
nm: Upgrade to uuid 1.1 crate

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -17,4 +17,4 @@ env_logger = "0.9.0"
 log = "0.4.14"
 serde_json = "1.0.75"
 ctrlc = "3.2.1"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.1", features = ["v4"] }

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -21,7 +21,7 @@ nispor = "1.2.7"
 nix = "0.24.1"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.68"
-uuid = { version = "0.8.2", features = ["v4", "v5"] }
+uuid = { version = "1.1", features = ["v4", "v5"] }
 zbus = "1.9.2"
 zvariant = "2.10.0"
 

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -516,6 +516,6 @@ fn uuid_from_name_and_type(
         &uuid::Uuid::NAMESPACE_URL,
         format!("{}://{}", iface_type, iface_name).as_bytes(),
     )
-    .to_hyphenated()
+    .hyphenated()
     .to_string()
 }

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -205,7 +205,7 @@ impl<'a> NmApi<'a> {
 
     pub fn uuid_gen() -> String {
         // Use Linux random number generator (RNG) to generate UUID
-        uuid::Uuid::new_v4().to_hyphenated().to_string()
+        uuid::Uuid::new_v4().hyphenated().to_string()
     }
 
     pub fn active_connections_get(


### PR DESCRIPTION
The uuid crate is upgrade from 0.8 to 1.1. Per Fedora request, we should
upgrade to latest version.