### PR TITLE
ip: Introduce `BaseInterface.wait_ip` property

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -749,6 +749,7 @@ impl Interface {
         &self,
         current: Option<&Self>,
     ) -> Result<(), NmstateError> {
+        self.base_iface().validate()?;
         match self {
             Interface::LinuxBridge(iface) => iface.validate(),
             Interface::Bond(iface) => iface.validate(current),

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -101,7 +101,6 @@ impl BondInterface {
         &self,
         current: Option<&Interface>,
     ) -> Result<(), NmstateError> {
-        self.base.validate()?;
         self.validate_new_iface_with_no_mode(current)?;
         self.validate_mac_restricted_mode(current)?;
         if let Some(bond_conf) = &self.bond {

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -155,7 +155,6 @@ impl LinuxBridgeInterface {
     }
 
     pub(crate) fn validate(&self) -> Result<(), NmstateError> {
-        self.base.validate()?;
         self.bridge
             .as_ref()
             .map(LinuxBridgeConfig::validate)

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -46,7 +46,7 @@ pub use crate::ifaces::{
 };
 pub use crate::ip::{
     Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
-    Ipv6AddrGenMode,
+    Ipv6AddrGenMode, WaitIp,
 };
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -110,6 +110,7 @@ pub struct NmSettingIp {
     pub dhcp_client_id: Option<String>,
     pub dhcp_timeout: Option<i32>,
     pub gateway: Option<String>,
+    pub may_fail: Option<bool>,
     // IPv6 only
     pub ra_timeout: Option<i32>,
     // IPv6 only
@@ -150,6 +151,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             dhcp_iaid: _from_map!(v, "dhcp-iaid", String::try_from)?,
             route_table: _from_map!(v, "route-table", u32::try_from)?,
             gateway: _from_map!(v, "gateway", String::try_from)?,
+            may_fail: _from_map!(v, "may-fail", bool::try_from)?,
             ..Default::default()
         };
 
@@ -284,6 +286,9 @@ impl NmSettingIp {
         }
         if let Some(v) = &self.gateway {
             ret.insert("gateway", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.may_fail {
+            ret.insert("may-fail", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -22,7 +22,10 @@ use crate::{
     nm::dns::retrieve_dns_info,
     nm::error::nm_error_to_nmstate,
     nm::ieee8021x::nm_802_1x_to_nmstate,
-    nm::ip::{nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6},
+    nm::ip::{
+        nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6,
+        query_nmstate_wait_ip,
+    },
     nm::lldp::{get_lldp, is_lldp_enabled},
     nm::ovs::{
         get_ovs_dpdk_config, get_ovs_patch_config, nm_ovs_bridge_conf_get,
@@ -202,11 +205,14 @@ fn nm_conn_to_base_iface(
             "ieee8021x",
             "description",
             "lldp",
+            "wait_ip",
         ];
         base_iface.state = InterfaceState::Up;
         base_iface.iface_type = nm_dev_iface_type_to_nmstate(nm_dev);
         base_iface.ipv4 = ipv4;
         base_iface.ipv6 = ipv6;
+        base_iface.wait_ip =
+            query_nmstate_wait_ip(nm_conn.ipv4.as_ref(), nm_conn.ipv6.as_ref());
         base_iface.controller = nm_conn.controller().map(|c| c.to_string());
         base_iface.description = get_description(nm_conn);
         base_iface.lldp =

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -33,6 +33,7 @@ class Interface:
     MTU = "mtu"
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
+    WAIT_IP = "wait-ip"
 
 
 class Route:

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1335,3 +1335,35 @@ def test_auto6_addr_gen_mode(dhcpcli_up_with_dynamic_ip, addr_gen_mode):
             ]
         }
     )
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "wait_ip",
+    [
+        "any",
+        "ipv4",
+        "ipv6",
+        "ipv4+ipv6",
+    ],
+)
+def test_wait_ip(eth1_up, wait_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.WAIT_IP: wait_ip,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                    },
+                }
+            ],
+        }
+    )


### PR DESCRIPTION
This patch is introducing `BaseInterface.wait_ip` property with these
possible values:
 * "any": System will consider interface activated when any IP stack is
          configured(neither static or automatic).
 * "ipv4": System will wait IPv4 been configured.
 * "ipv6": System will wait IPv6 been configured.
 * "ipv4+ipv6": System will wait both IPv4 and IPv6 been configured.

Integration test case included.