### PR TITLE
route: Sanitize IP address/network

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 path = "lib.rs"
 
 [dependencies]
+ipnet = "2.5.0"
 libc = "0.2.106"
 log = "0.4.14"
 nispor = "1.2.7"

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -65,3 +65,12 @@ impl From<std::net::AddrParseError> for NmstateError {
         )
     }
 }
+
+impl From<ipnet::AddrParseError> for NmstateError {
+    fn from(e: ipnet::AddrParseError) -> Self {
+        NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!("Invalid IP network: {}", e),
+        )
+    }
+}

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -458,7 +458,7 @@ impl NetworkState {
             &mut chg_net_state,
             &del_net_state,
             current,
-        );
+        )?;
 
         self.include_rule_changes(
             &mut add_net_state,
@@ -482,9 +482,9 @@ impl NetworkState {
         chg_net_state: &mut Self,
         del_net_state: &Self,
         current: &Self,
-    ) {
+    ) -> Result<(), NmstateError> {
         let mut changed_iface_routes =
-            self.routes.gen_changed_ifaces_and_routes(&current.routes);
+            self.routes.gen_changed_ifaces_and_routes(&current.routes)?;
 
         for (iface_name, routes) in changed_iface_routes.drain() {
             let cur_iface = current
@@ -537,6 +537,7 @@ impl NetworkState {
                 );
             }
         }
+        Ok(())
     }
 
     fn include_rule_changes(

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1127,7 +1127,7 @@ def test_delete_both_route_rule_and_interface(br_with_static_route_rule):
     assertlib.assert_absent(TEST_BRIDGE0)
 
 
-def test_ignore_metric_difference(eth1_static_gateway_dns):
+def test_ignore_route_metric_difference(eth1_static_gateway_dns):
     dup_routes = [_get_ipv4_test_routes()[0], _get_ipv6_test_routes()[0]]
     dup_routes[0][Route.METRIC] += 1
     dup_routes[1][Route.METRIC] += 1
@@ -1142,3 +1142,29 @@ def test_ignore_metric_difference(eth1_static_gateway_dns):
         or route[Route.DESTINATION] == dup_routes[1][Route.DESTINATION]
     ]
     assert len(cur_routes) == 2
+
+
+@pytest.fixture
+def eth1_static_ip(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+        }
+    )
+    yield
+
+
+def test_sanitize_route_destination(eth1_static_ip):
+    desired_routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    desired_routes[0][Route.DESTINATION] = "198.51.100.1/24"
+    desired_routes[1][Route.DESTINATION] = "203.0.113.1"
+    desired_routes[2][Route.DESTINATION] = "2001:db8:a::1/64"
+    desired_routes[3][Route.DESTINATION] = "2001:db8:b::0001"
+    libnmstate.apply({Route.KEY: {Route.CONFIG: desired_routes}})
+
+    expected_routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
+    expected_routes[1][Route.DESTINATION] = "203.0.113.1/32"
+    expected_routes[3][Route.DESTINATION] = "2001:db8:b::1/128"
+
+    cur_state = libnmstate.show()
+    _assert_routes(expected_routes, cur_state)


### PR DESCRIPTION
Supporting these IP format for route destination:
 * `192.0.2.1/24` == `192.0.2.0/24`
 * `192.0.2.1` == `192.0.2.1/32`
 * `2001:db8:1::1/64` == `2001:db8:1::0/64`
 * `2001:db8:1::1` = `2001:db8:1::1/128`
 * `2001:db8:1:0000:000::1` == `2001:db8:1::1/128`

Supporting non-compact IPv6 address for route next hop address:
 * `2001:db8:1:0000:000::1` == `2001:db8:1::1`

Introduce new rust dependency crate -- ipnet.

Unit test cases and integration test case included.