### PR TITLE
bond: Support integer bond mode

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -189,19 +189,19 @@ impl BondInterface {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 pub enum BondMode {
-    #[serde(rename = "balance-rr")]
+    #[serde(rename = "balance-rr", alias = "0")]
     RoundRobin,
-    #[serde(rename = "active-backup")]
+    #[serde(rename = "active-backup", alias = "1")]
     ActiveBackup,
-    #[serde(rename = "balance-xor")]
+    #[serde(rename = "balance-xor", alias = "2")]
     XOR,
-    #[serde(rename = "broadcast")]
+    #[serde(rename = "broadcast", alias = "3")]
     Broadcast,
-    #[serde(rename = "802.3ad")]
+    #[serde(rename = "802.3ad", alias = "4")]
     LACP,
-    #[serde(rename = "balance-tlb")]
+    #[serde(rename = "balance-tlb", alias = "5")]
     TLB,
-    #[serde(rename = "balance-alb")]
+    #[serde(rename = "balance-alb", alias = "6")]
     ALB,
     #[serde(rename = "unknown")]
     Unknown,

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -1,6 +1,7 @@
 use crate::{
     BondAdSelect, BondAllPortsActive, BondArpValidate, BondFailOverMac,
-    BondInterface, BondLacpRate, BondPrimaryReselect, ErrorKind, Interface,
+    BondInterface, BondLacpRate, BondMode, BondPrimaryReselect, ErrorKind,
+    Interface,
 };
 
 #[test]
@@ -250,4 +251,104 @@ link-aggregation:
     assert_eq!(bond_opts.tlb_dynamic_lb, Some(true));
     assert_eq!(bond_opts.updelay, Some(104));
     assert_eq!(bond_opts.use_carrier, Some(false));
+}
+
+#[test]
+fn test_integer_bond_mode() {
+    let ifaces: Vec<BondInterface> = serde_yaml::from_str(
+        r#"---
+- name: bond0
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 0
+- name: bond00
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "0"
+- name: bond1
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 1
+- name: bond10
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "1"
+- name: bond2
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 2
+- name: bond20
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "2"
+- name: bond3
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 3
+- name: bond30
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "3"
+- name: bond4
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 4
+- name: bond40
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "4"
+- name: bond5
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 5
+- name: bond50
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "5"
+- name: bond6
+  type: bond
+  state: up
+  link-aggregation:
+    mode: 6
+- name: bond60
+  type: bond
+  state: up
+  link-aggregation:
+    mode: "6"
+"#,
+    )
+    .unwrap();
+    for (i, expected_bond_mode) in [
+        BondMode::RoundRobin,
+        BondMode::ActiveBackup,
+        BondMode::XOR,
+        BondMode::Broadcast,
+        BondMode::LACP,
+        BondMode::TLB,
+        BondMode::ALB,
+    ]
+    .iter()
+    .enumerate()
+    {
+        assert_eq!(
+            expected_bond_mode,
+            &ifaces[i * 2].bond.as_ref().unwrap().mode.unwrap()
+        );
+        assert_eq!(
+            expected_bond_mode,
+            &ifaces[i * 2 + 1].bond.as_ref().unwrap().mode.unwrap()
+        );
+    }
 }


### PR DESCRIPTION
The kernel allows specifying the bond mode using integer from 0 to 6, so
we do the same. Using `serde` `alias` macro could do the magic.

Unit test case created.