### PR TITLE
route rule: Sanitize IP network

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -548,7 +548,7 @@ impl NetworkState {
         current: &Self,
     ) -> Result<(), NmstateError> {
         let mut changed_rules =
-            self.rules.gen_rule_changed_table_ids(&current.rules);
+            self.rules.gen_rule_changed_table_ids(&current.rules)?;
 
         // Convert table id to interface name
         for (table_id, rules) in changed_rules.drain() {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1168,3 +1168,22 @@ def test_sanitize_route_destination(eth1_static_ip):
 
     cur_state = libnmstate.show()
     _assert_routes(expected_routes, cur_state)
+
+
+def test_sanitize_route_rule_from_to(route_rule_test_env):
+    state = route_rule_test_env
+    rules = [
+        {RouteRule.IP_FROM: "203.0.113.1", RouteRule.IP_TO: "192.0.2.4/24"},
+        {RouteRule.IP_FROM: "2001:db8::1", RouteRule.IP_TO: "2001:db8::f/64"},
+    ]
+    state[RouteRule.KEY] = {RouteRule.CONFIG: rules}
+    libnmstate.apply(state)
+
+    expected_rules = [
+        {RouteRule.IP_FROM: "203.0.113.1/32", RouteRule.IP_TO: "192.0.2.0/24"},
+        {
+            RouteRule.IP_FROM: "2001:db8::1/128",
+            RouteRule.IP_TO: "2001:db8::/64",
+        },
+    ]
+    _check_ip_rules(expected_rules)


### PR DESCRIPTION
Supporting these IP format for route rule `ip-from` and `ip-to`:
* `192.0.2.1/24` == `192.0.2.0/24`
* `192.0.2.1` == `192.0.2.1/32`
* `2001:db8:1::1/64` == `2001:db8:1::0/64`
* `2001:db8:1::1` = `2001:db8:1::1/128`
* `2001:db8:1:0000:000::1` == `2001:db8:1::1/128`

Unit test cases and integration test case included.