### PR TITLE
libnmstate: expose the 'state_match()' for different states comparison

### DIFF
--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -26,6 +26,7 @@ from .netapplier import apply
 from .netapplier import commit
 from .netapplier import rollback
 from .netinfo import show
+from .state import state_match
 
 from .prettystate import PrettyState
 
@@ -39,6 +40,7 @@ __all__ = [
     "rollback",
     "error",
     "schema",
+    "state_match",
     "PrettyState",
 ]
 


### PR DESCRIPTION
The network role needs such a api for determining if the network state
changes between the desired state and the current state.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>