### PR TITLE
vrf: Sort the ports before verify

### DIFF
--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -49,6 +49,9 @@ impl VrfInterface {
         if self.base.accept_all_mac_addresses == Some(false) {
             self.base.accept_all_mac_addresses = None;
         }
+        if let Some(ports) = self.vrf.as_mut().and_then(|c| c.port.as_mut()) {
+            ports.sort();
+        }
     }
 }
 

--- a/rust/src/lib/nispor/vrf.rs
+++ b/rust/src/lib/nispor/vrf.rs
@@ -6,7 +6,11 @@ pub(crate) fn np_vrf_to_nmstate(
 ) -> VrfInterface {
     let vrf_conf = np_iface.vrf.as_ref().map(|np_vrf_info| VrfConfig {
         table_id: np_vrf_info.table_id,
-        port: Some(np_vrf_info.subordinates.clone()),
+        port: {
+            let mut ports = np_vrf_info.subordinates.clone();
+            ports.sort_unstable();
+            Some(ports)
+        },
     });
 
     VrfInterface {


### PR DESCRIPTION
The order of VRF ports should be ignored during verification stage.

Integration test case included.