### PR TITLE
nm ip: Fix IPv6 `addr-gen-mode`

### DIFF
--- a/rust/src/lib/nm/ip.rs
+++ b/rust/src/lib/nm/ip.rs
@@ -12,6 +12,8 @@ use crate::{
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
 const ADDR_GEN_MODE_STABLE_PRIVACY: i32 = 1;
+const ADDR_GEN_MODE_STABLE_DEFAULT_OR_EUI64: i32 = 2;
+const ADDR_GEN_MODE_STABLE_DEFAULT: i32 = 3;
 
 fn gen_nm_ipv4_setting(
     iface_ip: Option<&InterfaceIpv4>,
@@ -286,7 +288,13 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             ],
             dns: Some(nm_dns_to_nmstate(nm_ip_setting)),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
-            addr_gen_mode: nm_ipv6_addr_gen_mode_to_nmstate(nm_ip_setting),
+            addr_gen_mode: {
+                if enabled {
+                    nm_ipv6_addr_gen_mode_to_nmstate(nm_ip_setting)
+                } else {
+                    None
+                }
+            },
             ..Default::default()
         }
     } else {
@@ -366,6 +374,12 @@ fn nm_ipv6_addr_gen_mode_to_nmstate(
     match nm_setting.addr_gen_mode.as_ref() {
         Some(&ADDR_GEN_MODE_EUI64) => Some(Ipv6AddrGenMode::Eui64),
         Some(&ADDR_GEN_MODE_STABLE_PRIVACY) => {
+            Some(Ipv6AddrGenMode::StablePrivacy)
+        }
+        Some(&ADDR_GEN_MODE_STABLE_DEFAULT_OR_EUI64) => {
+            Some(Ipv6AddrGenMode::Eui64)
+        }
+        Some(&ADDR_GEN_MODE_STABLE_DEFAULT) => {
             Some(Ipv6AddrGenMode::StablePrivacy)
         }
         Some(s) => Some(Ipv6AddrGenMode::Other(format!("{}", s))),

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1337,6 +1337,26 @@ def test_auto6_addr_gen_mode(dhcpcli_up_with_dynamic_ip, addr_gen_mode):
     )
 
 
+def test_hide_addr_gen_mode_if_ipv6_disabled(dhcpcli_up_with_dynamic_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: False,
+                    },
+                }
+            ]
+        }
+    )
+    current_state = statelib.show_only((DHCP_CLI_NIC,))
+    assert (
+        InterfaceIPv6.ADDR_GEN_MODE
+        not in current_state[Interface.KEY][0][Interface.IPV6]
+    )
+
+
 @pytest.mark.tier1
 @pytest.mark.parametrize(
     "wait_ip",


### PR DESCRIPTION
* Hide `addr-gen-mode` if IPv6 is disabled.
 * Add support of the new libnm 1.40 value:
   NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE_DEFAULT_OR_EUI64 (2) and
   NM_SETTING_IP6_CONFIG_ADDR_GEN_MODE_DEFAULT (3).
   We are ignoring NM global setting(there is no API for that), so we
   treat them as EUI64 and `stable-privacy`

Integration test case enabled.