### PR TITLE
ifaces: Fix compile warning on Rust 1.61

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -314,7 +314,8 @@ pub(crate) fn set_ifaces_up_priority(ifaces: &mut Interfaces) -> bool {
                 continue;
             }
             if let Some(parent) = iface.parent() {
-                if let Some(parent_priority) = pending_changes.get(parent) {
+                let parent_priority = pending_changes.get(parent).cloned();
+                if let Some(parent_priority) = parent_priority {
                     pending_changes
                         .insert(iface_name.to_string(), parent_priority + 1);
                 } else if let Some(parent_iface) =


### PR DESCRIPTION
On Rust 1.61, we got warning complaining about

    cannot borrow `pending_changes` as mutable because it is also
    borrowed as immutable

On Rust nightly 1.64.0-nightly(4d6d601c8 2022-07-26) we don't have this
warning because the rust nightly can automaticlly convert the
`Option<&u32>` to `Option<u32>` which does not have above issue.

To fix the compile warning, we can just use `cloned()` to convert
`Option<&u32>` to `Option<u32>` explicitly.