### PR TITLE
clib: Fix SONAME

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2.1.0"
+rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2"


### PR DESCRIPTION
The SONAME should only contain major version number, hence changed
the compile flag to

    rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2"