### PR TITLE
[nmstate-1.3] libnmstate: expose the 'state_match()' for different states comparison

### DIFF
--- a/libnmstate/__init__.py
+++ b/libnmstate/__init__.py
@@ -27,6 +27,7 @@ from .netinfo import show
 from .netinfo import show_running_config
 from .nmstate import generate_configurations
 from .prettystate import PrettyState
+from .state import state_match
 from .version import get_version as _get_version
 
 __all__ = [
@@ -39,6 +40,7 @@ __all__ = [
     "schema",
     "show",
     "show_running_config",
+    "state_match",
 ]
 
 __version__ = _get_version()


### PR DESCRIPTION
The network role needs such a api for determining if the network state
changes between the desired state and the current state.