### PR TITLE
ethernet: Support querying `min_mtu` and `max_mtu`

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -749,7 +749,8 @@ impl Interface {
         &self,
         current: Option<&Self>,
     ) -> Result<(), NmstateError> {
-        self.base_iface().validate()?;
+        self.base_iface()
+            .validate(current.map(|c| c.base_iface()))?;
         match self {
             Interface::LinuxBridge(iface) => iface.validate(),
             Interface::Bond(iface) => iface.validate(current),

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -59,6 +59,32 @@ pub(crate) fn np_iface_to_base_iface(
         } else {
             Some(0u64)
         },
+        min_mtu: if !running_config_only {
+            if let Some(mtu) = np_iface.min_mtu {
+                if mtu >= 0 {
+                    Some(mtu as u64)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        },
+        max_mtu: if !running_config_only {
+            if let Some(mtu) = np_iface.max_mtu {
+                if mtu >= 0 {
+                    Some(mtu as u64)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        },
         accept_all_mac_addresses: if np_iface
             .flags
             .contains(&nispor::IfaceFlags::Promisc)

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -31,6 +31,8 @@ class Interface:
 
     MAC = "mac-address"
     MTU = "mtu"
+    MIN_MTU = "min-mtu"
+    MAX_MTU = "max-mtu"
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
     WAIT_IP = "wait-ip"

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -87,18 +87,6 @@ def test_increase_more_than_jambo_iface_mtu():
     assertlib.assert_state(desired_state)
 
 
-def test_decrease_to_zero_iface_mtu():
-    desired_state = statelib.show_only(("eth1",))
-    origin_desired_state = copy.deepcopy(desired_state)
-    eth1_desired_state = desired_state[Interface.KEY][0]
-    eth1_desired_state[Interface.MTU] = 0
-
-    with pytest.raises(NmstateVerificationError) as err:
-        libnmstate.apply(desired_state)
-    assert "mtu" in err.value.args[0]
-    assertlib.assert_state(origin_desired_state)
-
-
 def test_decrease_to_ipv6_min_ethernet_frame_size_iface_mtu(eth1_with_ipv6):
     desired_state = statelib.show_only(("eth1",))
     eth1_desired_state = desired_state[Interface.KEY][0]

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -414,3 +414,33 @@ def test_new_veth_with_ipv6_only():
             },
             verify_change=False,
         )
+
+
+def test_veth_invalid_mtu_smaller_than_min(eth1_up):
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "eth1",
+                        Interface.TYPE: InterfaceType.VETH,
+                        Interface.MTU: 32,
+                    },
+                ]
+            }
+        )
+
+
+def test_veth_invalid_mtu_bigger_than_max(eth1_up):
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "eth1",
+                        Interface.TYPE: InterfaceType.VETH,
+                        Interface.MTU: 1500000,
+                    },
+                ]
+            }
+        )


### PR DESCRIPTION
Including `min_mtu` and `max_mtu` to `BaseInterface` when querying.
Ignore them when applying and verifying.

Raise pre-apply error when desired MTU not in the supported range.

Python binding updated by adding constants of `Interface.MIN_MTU` and
`Interface.MAX_MTU`.

Integration test cases included.