### PR TITLE
[base] libnmstate: expose the 'state_match()' for different states comparison

### DIFF
--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -6,6 +6,8 @@ from .netapplier import rollback
 from .netinfo import show
 from .netinfo import show_running_config
 from .prettystate import PrettyState
+from collections.abc import Mapping
+from collections.abc import Sequence
 
 __all__ = [
     "NmstateError",
@@ -16,8 +18,25 @@ __all__ = [
     "rollback",
     "show",
     "show_running_config",
+    "state_match",
 ]
 
 __version__ = "2.1.4"
 
 BASE_ON_RUST = True
+
+
+def state_match(desire, current):
+    if isinstance(desire, Mapping):
+        return isinstance(current, Mapping) and all(
+            state_match(val, current.get(key)) for key, val in desire.items()
+        )
+    elif isinstance(desire, Sequence) and not isinstance(desire, str):
+        return (
+            isinstance(current, Sequence)
+            and not isinstance(current, str)
+            and len(current) == len(desire)
+            and all(state_match(d, c) for d, c in zip(desire, current))
+        )
+    else:
+        return desire == current


### PR DESCRIPTION
The network role needs such a api for determining if the network state
changes between the desired state and the current state.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>