### PR TITLE
test: Remove test with OVS daemon masked/disabled

### DIFF
--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -48,7 +48,6 @@ from .testlib import iprule
 from .testlib import statelib
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
-from .testlib.nmplugin import mount_devnull_to_path
 from .testlib.statelib import state_match
 from .testlib.ovslib import Bridge
 from .testlib.vlan import vlan_interface
@@ -252,32 +251,6 @@ def test_nm_ovs_plugin_missing():
                     ]
                 }
             )
-
-
-@pytest.mark.xfail(
-    reason="https://bugzilla.redhat.com/2052441",
-)
-def test_ovs_service_missing_with_system_port_only(eth1_up):
-    bridge = Bridge(BRIDGE1)
-    bridge.add_system_port(ETH1)
-
-    with mount_devnull_to_path("/var/run/openvswitch/db.sock"):
-        with pytest.raises(NmstateDependencyError):
-            with bridge.create():
-                pass
-
-
-@pytest.mark.xfail(
-    reason="The design of rust code cannot detect this mis-configure"
-)
-def test_ovs_service_missing_with_internal_port_only():
-    bridge = Bridge(BRIDGE1)
-    bridge.add_internal_port(PORT1)
-
-    with mount_devnull_to_path("/var/run/openvswitch/db.sock"):
-        with pytest.raises(NmstateDependencyError):
-            with bridge.create():
-                pass
 
 
 @pytest.fixture


### PR DESCRIPTION
When OVS daemon not started, the activation call to NetworkManager daemon
will not fail, only the `NM.Device.StateReason.OVSDB_FAILED` can
indicate the root cause.

To support querying on `NM.Device.StateReason.OVSDB_FAILED`, nmstate
rust could need to async checking after activation command finished,
this is against current nmstate rust nm plugin sync design and also
bring race problem because `NM.Device.StateReason.OVSDB_FAILED` will
change to `NM.Device.StateReason.USER_REQUESTED` after the activation
failure.

Unless NetworkManager API fix their problem, workaround it in nmstate is
waste of time considering this use case is rare.

Hence removed iteration test case.