### PR TITLE
[nmstate-2.1] bond,bridge,ovs: Add support of `ports` keyword

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -266,7 +266,7 @@ pub struct BondConfig {
     pub mode: Option<BondMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<BondOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     pub port: Option<Vec<String>>,
 }
 

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -241,7 +241,7 @@ impl LinuxBridgeInterface {
 pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<LinuxBridgeOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     pub port: Option<Vec<LinuxBridgePortConfig>>,
 }
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -104,7 +104,11 @@ impl OvsBridgeInterface {
 pub struct OvsBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "port",
+        alias = "ports"
+    )]
     pub ports: Option<Vec<OvsBridgePortConfig>>,
 }
 
@@ -246,7 +250,11 @@ impl OvsInterface {
 pub struct OvsBridgeBondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<OvsBridgeBondMode>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "port",
+        alias = "ports"
+    )]
     pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -59,6 +59,7 @@ impl VrfInterface {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct VrfConfig {
+    #[serde(alias = "ports")]
     pub port: Option<Vec<String>>,
     #[serde(
         rename = "route-table-id",

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -412,3 +412,21 @@ fn test_integer_bond_opts() {
         panic!("Failed to find bond interface")
     }
 }
+
+#[test]
+fn test_bond_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: bond99
+  type: bond
+  state: up
+  link-aggregation:
+    mode: balance-rr
+    ports:
+    - eth1
+    - eth2
+"#,
+    )
+    .unwrap();
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
+}

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -278,3 +278,20 @@ bridge:
         Some(LinuxBridgeMulticastRouterType::Disabled)
     );
 }
+
+#[test]
+fn test_linux_bridge_ports() {
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r#"---
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    ports:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
+}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -218,3 +218,29 @@ fn test_ovs_bridge_resolve_user_space_iface_type() {
     assert!(br_iface.is_absent());
     assert_eq!(desired.kernel_ifaces.get("ovs-br1"), None);
 }
+
+#[test]
+fn test_ovs_bridge_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    ports:
+    - name: eth1
+    - name: eth2
+    - name: bond1
+      link-aggregation:
+        mode: balance-slb
+        ports:
+          - name: eth3
+          - name: eth4
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        ifaces.to_vec()[0].ports(),
+        Some(vec!["eth1", "eth2", "eth3", "eth4"])
+    );
+}

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -1,4 +1,4 @@
-use crate::VrfInterface;
+use crate::{Interfaces, VrfInterface};
 
 #[test]
 fn test_vrf_stringlized_attributes() {
@@ -14,4 +14,23 @@ vrf:
     .unwrap();
 
     assert_eq!(iface.vrf.unwrap().table_id, 101);
+}
+
+#[test]
+fn test_vrf_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: vrf1
+  type: vrf
+  state: up
+  vrf:
+    route-table-id: "101"
+    ports:
+      - eth1
+      - eth2
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -151,6 +151,7 @@ class Bond:
 
     MODE = "mode"
     PORT = "port"
+    PORTS = "ports"
     OPTIONS_SUBTREE = "options"
 
 
@@ -168,6 +169,7 @@ class Bridge:
     CONFIG_SUBTREE = "bridge"
     OPTIONS_SUBTREE = "options"
     PORT_SUBTREE = "port"
+    PORTS_SUBTREE = "ports"
 
     class Port:
         NAME = "name"


### PR DESCRIPTION
In old python API, we use `slaves` keyword which been replaced by `port`
keyword. Some user complained about `plural` vs `singular`, hence we add
support of `ports` here.

Unit test case included.