### PR TITLE
[nmstate-1.3] Add support of `ports` keyword

### DIFF
--- a/libnmstate/ifaces/bond.py
+++ b/libnmstate/ifaces/bond.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -43,6 +43,7 @@ class BondIface(BaseIface):
             self.raw[Bond.CONFIG_SUBTREE][Bond.PORT].sort()
 
     def __init__(self, info, save_to_disk=True):
+        _rename_ports_to_port(info)
         super().__init__(info, save_to_disk)
         self._normalize_options_values()
         self._fix_bond_option_arp_monitor()
@@ -187,6 +188,7 @@ class BondIface(BaseIface):
             _include_arp_ip_target_explictly_when_disable(
                 state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
             )
+        _rename_ports_to_port(state)
         return state
 
     def remove_port(self, port_name):
@@ -323,3 +325,10 @@ def _include_arp_ip_target_explictly_when_disable(bond_options):
         and "arp_ip_target" not in bond_options
     ):
         bond_options["arp_ip_target"] = ""
+
+
+def _rename_ports_to_port(info):
+    if info.get(Bond.CONFIG_SUBTREE, {}).get(Bond.PORTS):
+        info[Bond.CONFIG_SUBTREE][Bond.PORT] = info[Bond.CONFIG_SUBTREE].pop(
+            Bond.PORTS
+        )

--- a/libnmstate/ifaces/bridge.py
+++ b/libnmstate/ifaces/bridge.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -29,6 +29,15 @@ from .base_iface import BaseIface
 
 class BridgeIface(BaseIface):
     BRPORT_OPTIONS_METADATA = "_brport_options"
+
+    def __init__(self, info, save_to_disk=True):
+        _rename_ports_to_port(info)
+        super().__init__(info, save_to_disk)
+
+    def state_for_verify(self):
+        state = super().state_for_verify()
+        _rename_ports_to_port(state)
+        return state
 
     @property
     def is_controller(self):
@@ -105,3 +114,10 @@ class BridgeIface(BaseIface):
 
 def _index_port_configs(port_configs):
     return {port[Bridge.Port.NAME]: port for port in port_configs}
+
+
+def _rename_ports_to_port(info):
+    if info.get(Bridge.CONFIG_SUBTREE, {}).get(Bridge.PORTS_SUBTREE):
+        info[Bridge.CONFIG_SUBTREE][Bridge.PORT_SUBTREE] = info[
+            Bridge.CONFIG_SUBTREE
+        ].pop(Bridge.PORTS_SUBTREE)

--- a/libnmstate/ifaces/vrf.py
+++ b/libnmstate/ifaces/vrf.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -28,6 +28,15 @@ from .base_iface import BaseIface
 
 class VrfIface(BaseIface):
     TABLE_ID_CHANGED_METADATA = "_table_id_changed"
+
+    def __init__(self, info, save_to_disk=True):
+        _rename_ports_to_port(info)
+        super().__init__(info, save_to_disk)
+
+    def state_for_verify(self):
+        state = super().state_for_verify()
+        _rename_ports_to_port(state)
+        return state
 
     def sort_port(self):
         if self.port:
@@ -90,3 +99,10 @@ class VrfIface(BaseIface):
             s for s in self.port if s != port_name
         ]
         self.sort_port()
+
+
+def _rename_ports_to_port(info):
+    if info.get(VRF.CONFIG_SUBTREE, {}).get(VRF.PORTS_SUBTREE):
+        info[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] = info[
+            VRF.CONFIG_SUBTREE
+        ].pop(VRF.PORTS_SUBTREE)

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -208,6 +208,7 @@ class Bond(metaclass=_DeprecatorType):
 
     MODE = "mode"
     PORT = "port"
+    PORTS = "ports"
     OPTIONS_SUBTREE = "options"
 
 
@@ -225,6 +226,7 @@ class Bridge:
     CONFIG_SUBTREE = "bridge"
     OPTIONS_SUBTREE = "options"
     PORT_SUBTREE = "port"
+    PORTS_SUBTREE = "ports"
 
     class Port:
         NAME = "name"
@@ -381,6 +383,7 @@ class OVSBridge(Bridge, OvsDB):
         class LinkAggregation(metaclass=_DeprecatorType):
             MODE = "mode"
             PORT_SUBTREE = "port"
+            PORTS_SUBTREE = "ports"
 
             class Port:
                 NAME = "name"
@@ -428,6 +431,7 @@ class LLDP:
 class VRF:
     CONFIG_SUBTREE = "vrf"
     PORT_SUBTREE = "port"
+    PORTS_SUBTREE = "ports"
     ROUTE_TABLE_ID = "route-table-id"
 
 

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -285,6 +285,10 @@ definitions:
               type: array
               items:
                 type: string
+            ports:
+              type: array
+              items:
+                type: string
             options:
               type: object
   interface-linux-bridge:
@@ -315,6 +319,35 @@ definitions:
         bridge:
           type: object
           properties:
+            ports:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  stp-priority:
+                    type: integer
+                  stp-path-cost:
+                    type: integer
+                  stp-hairpin-mode:
+                    type: boolean
+                  vlan:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum:
+                          - trunk
+                          - access
+                      trunk-tags:
+                        type: array
+                        items:
+                          $ref: "#/definitions/bridge-port-vlan"
+                      tag:
+                        $ref: "#/definitions/types/bridge-vlan-tag"
+                      enable-native:
+                        type: boolean
             port:
               type: array
               items:
@@ -408,6 +441,55 @@ definitions:
         bridge:
           type: object
           properties:
+            ports:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  vlan:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum:
+                          - trunk
+                          - access
+                      trunk-tags:
+                        type: array
+                        items:
+                          $ref: "#/definitions/bridge-port-vlan"
+                      tag:
+                        $ref: "#/definitions/types/bridge-vlan-tag"
+                      enable-native:
+                        type: boolean
+                  link-aggregation:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                      slaves:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      ports:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      port:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
             port:
               type: array
               items:
@@ -437,6 +519,13 @@ definitions:
                       mode:
                         type: string
                       slaves:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      ports:
                         type: array
                         items:
                           type: object
@@ -754,6 +843,10 @@ definitions:
         vrf:
           type: object
           properties:
+            port:
+              type: array
+              items:
+                type: string
             ports:
               type: array
               items:

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -240,7 +240,7 @@ pub struct BondConfig {
     pub mode: Option<BondMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<BondOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     pub port: Option<Vec<String>>,
 }
 

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -241,7 +241,7 @@ impl LinuxBridgeInterface {
 pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<LinuxBridgeOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     pub port: Option<Vec<LinuxBridgePortConfig>>,
 }
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -104,7 +104,11 @@ impl OvsBridgeInterface {
 pub struct OvsBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "port",
+        alias = "ports"
+    )]
     pub ports: Option<Vec<OvsBridgePortConfig>>,
 }
 
@@ -246,7 +250,11 @@ impl OvsInterface {
 pub struct OvsBridgeBondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<OvsBridgeBondMode>,
-    #[serde(skip_serializing_if = "Option::is_none", rename = "port")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "port",
+        alias = "ports"
+    )]
     pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -59,6 +59,7 @@ impl VrfInterface {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct VrfConfig {
+    #[serde(alias = "ports")]
     pub port: Option<Vec<String>>,
     #[serde(
         rename = "route-table-id",

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -1,7 +1,7 @@
 use crate::{
     BondAdSelect, BondAllPortsActive, BondArpValidate, BondFailOverMac,
     BondInterface, BondLacpRate, BondMode, BondPrimaryReselect, ErrorKind,
-    Interface,
+    Interface, Interfaces,
 };
 
 #[test]
@@ -351,4 +351,22 @@ fn test_integer_bond_mode() {
             &ifaces[i * 2 + 1].bond.as_ref().unwrap().mode.unwrap()
         );
     }
+}
+
+#[test]
+fn test_bond_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: bond99
+  type: bond
+  state: up
+  link-aggregation:
+    mode: balance-rr
+    ports:
+    - eth1
+    - eth2
+"#,
+    )
+    .unwrap();
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
 }

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -278,3 +278,20 @@ bridge:
         Some(LinuxBridgeMulticastRouterType::Disabled)
     );
 }
+
+#[test]
+fn test_linux_bridge_ports() {
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r#"---
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    ports:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
+}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -218,3 +218,29 @@ fn test_ovs_bridge_resolve_user_space_iface_type() {
     assert!(br_iface.is_absent());
     assert_eq!(desired.kernel_ifaces.get("ovs-br1"), None);
 }
+
+#[test]
+fn test_ovs_bridge_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    ports:
+    - name: eth1
+    - name: eth2
+    - name: bond1
+      link-aggregation:
+        mode: balance-slb
+        ports:
+          - name: eth3
+          - name: eth4
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        ifaces.to_vec()[0].ports(),
+        Some(vec!["eth1", "eth2", "eth3", "eth4"])
+    );
+}

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -1,4 +1,4 @@
-use crate::VrfInterface;
+use crate::{Interfaces, VrfInterface};
 
 #[test]
 fn test_vrf_stringlized_attributes() {
@@ -14,4 +14,23 @@ vrf:
     .unwrap();
 
     assert_eq!(iface.vrf.unwrap().table_id, 101);
+}
+
+#[test]
+fn test_vrf_ports() {
+    let ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: vrf1
+  type: vrf
+  state: up
+  vrf:
+    route-table-id: "101"
+    ports:
+      - eth1
+      - eth2
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -151,6 +151,7 @@ class Bond:
 
     MODE = "mode"
     PORT = "port"
+    PORTS = "ports"
     OPTIONS_SUBTREE = "options"
 
 
@@ -168,6 +169,7 @@ class Bridge:
     CONFIG_SUBTREE = "bridge"
     OPTIONS_SUBTREE = "options"
     PORT_SUBTREE = "port"
+    PORTS_SUBTREE = "ports"
 
     class Port:
         NAME = "name"

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -977,3 +977,17 @@ def test_linux_bridge_show_port_ip_as_disabled(bridge0_with_port0):
 
     assert not state[Interface.KEY][0][Interface.IPV4][InterfaceIPv4.ENABLED]
     assert not state[Interface.KEY][0][Interface.IPV6][InterfaceIPv6.ENABLED]
+
+
+def test_linux_bridge_using_ports_keyword(port0_up):
+    port_name = port0_up[Interface.KEY][0][Interface.NAME]
+    bridge_state = _create_bridge_subtree_config((port_name,))
+    # Disable STP to avoid topology changes and the consequence link change.
+    options_subtree = bridge_state[LinuxBridge.OPTIONS_SUBTREE]
+    options_subtree[LinuxBridge.STP_SUBTREE][LinuxBridge.STP.ENABLED] = False
+    with linux_bridge(TEST_BRIDGE0, bridge_state, create=False) as state:
+        bridge_conf = state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE]
+        bridge_conf[LinuxBridge.PORTS_SUBTREE] = bridge_conf.pop(
+            LinuxBridge.PORT_SUBTREE
+        )
+        libnmstate.apply(state)

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -127,9 +127,10 @@ class Bridge:
                 port_option.update(new_option)
 
     @contextmanager
-    def create(self):
+    def create(self, apply=True):
         desired_state = self.state
-        libnmstate.apply(desired_state)
+        if apply:
+            libnmstate.apply(desired_state)
         try:
             yield desired_state
         finally:

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -313,3 +313,27 @@ class TestVrf:
                 ]
             }
         )
+
+    def test_vrf_using_ports_keyworks(self, eth1_up):
+        vrf_iface_info = {
+            Interface.NAME: TEST_VRF0,
+            Interface.TYPE: InterfaceType.VRF,
+            VRF.CONFIG_SUBTREE: {
+                VRF.PORTS_SUBTREE: [TEST_VRF_PORT0],
+                VRF.ROUTE_TABLE_ID: TEST_ROUTE_TABLE_ID0,
+            },
+        }
+        try:
+            libnmstate.apply({Interface.KEY: [vrf_iface_info]})
+        finally:
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: TEST_VRF0,
+                            Interface.STATE: InterfaceState.ABSENT,
+                        }
+                    ]
+                }
+            )
+            assertlib.assert_absent(TEST_VRF0)


### PR DESCRIPTION
In old python API, we use `slaves` keyword which been replaced by `port`
keyword. Some user complained about `plural` vs `singular`, hence we add
support of `ports` for vrf, linux bridge, ovs bridge, ovs bond, bond.

Integration test cases included.