### PR TITLE
New release 2.1.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 # Changelog
+## [2.1.4] - 2022-08-10
+### Breaking changes
+ - N/A
+
+### New features
+ - Add suppoprt to `ports` keyword for bond, bridge and VRF. (919b1166)
+
+### Bug fixes
+ - Fix compile warning on Rust 1.61. (d9fe1aea)
+ - Fix SONAME of c binding to `libnmstate.so.2`. (7fb28f46)
+ - Fix bond integer option. (3a1453c1)
+ - Ignored interface is still ignored even mentioned in port list.
+   (1299223f, 275d9a57)
+
 ## [2.1.3] - 2022-07-27
 ### Breaking changes
  - N/A


### PR DESCRIPTION
* Breaking changes
  * N/A

* New features
  * Add suppoprt to `ports` keyword for bond, bridge and VRF. (919b1166)

* Bug fixes
  * Fix compile warning on Rust 1.61. (d9fe1aea)
  * Fix SONAME of c binding to `libnmstate.so.2`. (7fb28f46)
  * Fix bond integer option. (3a1453c1)
  * Ignored interface is still ignored even mentioned in port list.
    (1299223f, 275d9a57)