### PR TITLE
linux bridge: Mark port as changed if desire `vlan: {}`

### DIFF
--- a/rust/src/lib/ifaces/bridge_vlan.rs
+++ b/rust/src/lib/ifaces/bridge_vlan.rs
@@ -71,6 +71,13 @@ impl BridgePortVlanConfig {
             || (self.trunk_tags.is_some()
                 && self.trunk_tags != current.trunk_tags)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.enable_native.is_none()
+            && self.mode.is_none()
+            && self.tag.is_none()
+            && self.trunk_tags.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -307,7 +307,8 @@ impl LinuxBridgePortConfig {
                 && self.stp_priority != current.stp_priority)
             || match (self.vlan.as_ref(), current.vlan.as_ref()) {
                 (Some(des_vlan_conf), Some(cur_vlan_conf)) => {
-                    des_vlan_conf.is_changed(cur_vlan_conf)
+                    (des_vlan_conf.is_empty() && !cur_vlan_conf.is_empty())
+                        || des_vlan_conf.is_changed(cur_vlan_conf)
                 }
                 (Some(_), None) => true,
                 _ => false,

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -295,3 +295,42 @@ fn test_linux_bridge_ports() {
     .unwrap();
     assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
 }
+
+#[test]
+fn test_linux_bridge_partially_disable_vlan_filtering() {
+    let current = serde_yaml::from_str::<LinuxBridgeInterface>(
+        r#"---
+name: br0
+type: linux-bridge
+state: up
+bridge:
+  port:
+    - name: eth1
+      vlan:
+        mode: access
+        trunk-tags: []
+        tag: 305
+    - name: eth2
+      vlan:
+        mode: trunk
+        trunk-tags:
+        - id: 500
+"#,
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<LinuxBridgeInterface>(
+        r#"---
+name: br0
+type: linux-bridge
+state: up
+bridge:
+  port:
+    - name: eth1
+      vlan: {}
+    - name: eth2
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(desired.get_config_changed_ports(&current), vec!["eth1"])
+}


### PR DESCRIPTION
When applying desire state in order to partially disable VLAN filtering
on port eth1

```yml
---
interfaces:
- name: br0
  type: linux-bridge
  state: up
  bridge:
    port:
      - name: eth1
        vlan: {}
      - name: eth2
```

nmstate will fail as `LinuxBridgePortConfig.is_changed()` thinks eth1 is
unchanged port.

To fix it, introduce `BridgePortVlanConfig.is_empty()` for `vlan: {}`
and consider it as user would like to remove all VLAN settings.

Unit and integration test case included.