### PR TITLE
nm: Fix the handle of external managed interface

### DIFF
--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -24,7 +24,9 @@ mod keyfile;
 mod lldp;
 mod nm_api;
 
-pub use self::active_connection::NmActiveConnection;
+pub use self::active_connection::{
+    NmActiveConnection, NM_ACTIVATION_STATE_FLAG_EXTERNAL,
+};
 pub use self::connection::{
     NmConnection, NmIpRoute, NmIpRouteRule, NmSetting8021X, NmSettingBond,
     NmSettingBridge, NmSettingBridgeVlanRange, NmSettingConnection,


### PR DESCRIPTION
When an interface is marked as external managed by NM, it means that
interface has configuration not created by NM and holding
NmActiveConnection auto generated by NM. Current nmstate code will treat
it IPv6 disabled even it has IPv6 address.

To fix that, NM plugin should not report any IP status for external
managed interface.

Integration test case included.