### PR TITLE
Add MPTCP initial support

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -18,7 +18,8 @@ path = "lib.rs"
 ipnet = "2.5.0"
 libc = "0.2.106"
 log = "0.4.14"
-nispor = "1.2.7"
+# nispor = "1.2.7"
+nispor = { git = "https://github.com/nispor/nispor" }
 nix = "0.24.1"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.68"

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -7,6 +7,7 @@ mod iface;
 mod ifaces;
 mod ip;
 mod lldp;
+mod mptcp;
 mod net_state;
 mod nispor;
 mod nm;
@@ -55,6 +56,7 @@ pub use crate::lldp::{
     LldpSystemCapabilities, LldpSystemCapability, LldpSystemDescription,
     LldpSystemName, LldpVlan, LldpVlans,
 };
+pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
 pub use crate::net_state::NetworkState;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 pub use crate::route::{RouteEntry, RouteState, Routes};

--- a/rust/src/lib/mptcp.rs
+++ b/rust/src/lib/mptcp.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// The document string for MptcpAddressFlag is copy from manpage of
+// `IP-MPTCP(8)` which is licensed under GPLv2.0+
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BaseInterface, ErrorKind, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct MptcpConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Automatically assign MPTCP flags to all valid IP addresses of this
+    /// interface including both static and dynamic ones.
+    pub address_flags: Option<Vec<MptcpAddressFlag>>,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum MptcpAddressFlag {
+    /// The endpoint will be announced/signaled to each peer via an MPTCP
+    /// ADD_ADDR sub-option. Upon reception of an ADD_ADDR sub-option, the
+    /// peer can try to create additional subflows. Cannot used along with
+    /// MptcpAddressFlag::Fullmesh as Linux kernel enforced.
+    Signal,
+    /// If additional subflow creation is allowed by the MPTCP limits, the
+    /// MPTCP path manager will try to create an additional subflow using
+    /// this endpoint as the source address after the MPTCP connection is
+    /// established.
+    Subflow,
+    /// If this is a subflow endpoint, the subflows created using this endpoint
+    /// will have the backup flag set during the connection process. This flag
+    /// instructs the peer to only send data on a given subflow when all
+    /// non-backup subflows are unavailable. This does not affect outgoing
+    /// data, where subflow priority is determined by the backup/non-backup
+    /// flag received from the peer.
+    Backup,
+    /// If this is a subflow endpoint and additional subflow creation is
+    /// allowed by the MPTCP limits, the MPTCP path manager will try to
+    /// create an additional subflow for each known peer address, using
+    /// this endpoint as the source address. This will occur after the
+    /// MPTCP connection is established. If the peer did not announce any
+    /// additional addresses using the MPTCP ADD_ADDR sub-option, this will
+    /// behave the same as a plain subflow endpoint.  When the peer does
+    /// announce addresses, each received ADD_ADDR sub-option will trigger
+    /// creation of an additional subflow to generate a full mesh topology.
+    Fullmesh,
+}
+
+impl std::convert::TryFrom<nispor::MptcpAddressFlag> for MptcpAddressFlag {
+    type Error = NmstateError;
+    fn try_from(value: nispor::MptcpAddressFlag) -> Result<Self, NmstateError> {
+        match value {
+            nispor::MptcpAddressFlag::Signal => Ok(MptcpAddressFlag::Signal),
+            nispor::MptcpAddressFlag::Subflow => Ok(MptcpAddressFlag::Subflow),
+            nispor::MptcpAddressFlag::Backup => Ok(MptcpAddressFlag::Backup),
+            nispor::MptcpAddressFlag::Fullmesh => {
+                Ok(MptcpAddressFlag::Fullmesh)
+            }
+            _ => Err(NmstateError::new(
+                ErrorKind::NotSupportedError,
+                format!(
+                    "MPTCP address flag {:?} is not supported by nmstate yet",
+                    value
+                ),
+            )),
+        }
+    }
+}
+
+pub(crate) fn mptcp_pre_edit_cleanup(iface: &mut BaseInterface) {
+    remove_per_addr_mptcp_flags(iface);
+}
+
+pub(crate) fn mptcp_pre_verify_cleanup(iface: &mut BaseInterface) {
+    remove_per_addr_mptcp_flags(iface);
+    if let Some(addrs) =
+        iface.mptcp.as_mut().and_then(|m| m.address_flags.as_mut())
+    {
+        addrs.sort_unstable();
+    }
+}
+
+fn remove_per_addr_mptcp_flags(iface: &mut BaseInterface) {
+    let mut empty_ipv4_addrs = Vec::new();
+    let mut empty_ipv6_addrs = Vec::new();
+
+    for ip_addr in iface
+        .ipv4
+        .as_mut()
+        .and_then(|i| i.addresses.as_mut())
+        .unwrap_or(&mut empty_ipv4_addrs)
+        .iter_mut()
+        .chain(
+            iface
+                .ipv6
+                .as_mut()
+                .and_then(|i| i.addresses.as_mut())
+                .unwrap_or(&mut empty_ipv6_addrs)
+                .iter_mut(),
+        )
+    {
+        ip_addr.mptcp_flags = None;
+    }
+}
+
+pub(crate) fn validate_mptcp(
+    iface: &BaseInterface,
+) -> Result<(), NmstateError> {
+    if let Some(iface_flags) =
+        iface.mptcp.as_ref().and_then(|m| m.address_flags.as_ref())
+    {
+        if iface_flags.contains(&MptcpAddressFlag::Signal)
+            && iface_flags.contains(&MptcpAddressFlag::Fullmesh)
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "MPTCP flags mustn't have both signal and fullmesh".to_string(),
+            );
+            log::error!("{}", e);
+            return Err(e);
+        }
+    }
+    validate_iface_mptcp_and_addr_mptcp_flags(iface);
+
+    Ok(())
+}
+
+fn validate_iface_mptcp_and_addr_mptcp_flags(iface: &BaseInterface) {
+    let mut iface_flags =
+        match iface.mptcp.as_ref().and_then(|m| m.address_flags.as_ref()) {
+            Some(f) => f.clone(),
+            None => Vec::new(),
+        };
+    iface_flags.sort_unstable();
+
+    let empty_ip_addrs = Vec::new();
+
+    for ip_addr in iface
+        .ipv4
+        .as_ref()
+        .and_then(|i| i.addresses.as_ref())
+        .unwrap_or(&empty_ip_addrs)
+        .iter()
+        .chain(
+            iface
+                .ipv6
+                .as_ref()
+                .and_then(|i| i.addresses.as_ref())
+                .unwrap_or(&empty_ip_addrs)
+                .iter(),
+        )
+    {
+        if let Some(mut addr_flags) = ip_addr.mptcp_flags.as_ref().cloned() {
+            addr_flags.sort_unstable();
+            if iface_flags != addr_flags {
+                log::warn!(
+                    "Nmstate does not support setting different MPTCP flags \
+                    within the interface. Ignoring MPTCP flags {:?} of IP \
+                    address {}/{} as it is different from interface level \
+                    MPTCP flags {:?}",
+                    addr_flags,
+                    ip_addr.ip,
+                    ip_addr.prefix_length,
+                    iface_flags
+                );
+            }
+        }
+    }
+}

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -1,6 +1,7 @@
 use crate::{
     nispor::ethtool::np_ethtool_to_nmstate,
     nispor::ip::{np_ipv4_to_nmstate, np_ipv6_to_nmstate},
+    nispor::mptcp::get_iface_mptcp_conf,
     BaseInterface, InterfaceState, InterfaceType,
 };
 
@@ -116,6 +117,8 @@ pub(crate) fn np_iface_to_base_iface(
         );
         base_iface.state = InterfaceState::Ignore;
     }
+
+    base_iface.mptcp = get_iface_mptcp_conf(&base_iface);
 
     base_iface
 }

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 
-use crate::{InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
+use crate::{
+    nispor::mptcp::get_mptcp_flags, InterfaceIpAddr, InterfaceIpv4,
+    InterfaceIpv6,
+};
 
 pub(crate) fn np_ipv4_to_nmstate(
     np_iface: &nispor::Iface,
@@ -28,6 +31,11 @@ pub(crate) fn np_ipv4_to_nmstate(
                 Ok(i) => addresses.push(InterfaceIpAddr {
                     ip: i,
                     prefix_length: np_addr.prefix_len,
+                    mptcp_flags: Some(get_mptcp_flags(
+                        np_iface,
+                        np_addr.address.as_str(),
+                    )),
+                    ..Default::default()
                 }),
                 Err(e) => {
                     log::warn!(
@@ -76,6 +84,11 @@ pub(crate) fn np_ipv6_to_nmstate(
                 Ok(i) => addresses.push(InterfaceIpAddr {
                     ip: i,
                     prefix_length: np_addr.prefix_len,
+                    mptcp_flags: Some(get_mptcp_flags(
+                        np_iface,
+                        np_addr.address.as_str(),
+                    )),
+                    ..Default::default()
                 }),
                 Err(e) => {
                     log::warn!(

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -10,6 +10,7 @@ mod ip;
 mod linux_bridge;
 mod linux_bridge_port_vlan;
 mod mac_vlan;
+mod mptcp;
 mod route;
 mod route_rule;
 mod show;

--- a/rust/src/lib/nispor/mptcp.rs
+++ b/rust/src/lib/nispor/mptcp.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+
+use crate::{
+    ip::{is_ipv6_unicast_link_local, is_ipv6_unicast_local},
+    BaseInterface, MptcpAddressFlag, MptcpConfig,
+};
+
+pub(crate) fn get_mptcp_flags(
+    np_iface: &nispor::Iface,
+    ip_addr: &str,
+) -> Vec<MptcpAddressFlag> {
+    let mut flags = Vec::new();
+    if let Some(mptcp_addrs) = np_iface.mptcp.as_ref() {
+        for mptcp_addr in mptcp_addrs {
+            if mptcp_addr.address.to_string().as_str() == ip_addr {
+                if let Some(np_flags) = mptcp_addr.flags.as_ref() {
+                    for np_flag in np_flags {
+                        match MptcpAddressFlag::try_from(*np_flag) {
+                            Ok(f) => flags.push(f),
+                            Err(e) => {
+                                log::warn!("{}", e);
+                                continue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    flags
+}
+
+pub(crate) fn get_iface_mptcp_conf(
+    iface: &BaseInterface,
+) -> Option<MptcpConfig> {
+    let mut flags: Vec<MptcpAddressFlag> = Vec::new();
+    let mut has_mptcp_valid_ip_addr = false;
+
+    if let Some(addrs) = iface.ipv4.as_ref().and_then(|i| i.addresses.as_ref())
+    {
+        for addr in addrs {
+            if let std::net::IpAddr::V4(ip_addr) = &addr.ip {
+                if ip_addr.is_loopback()
+                    || ip_addr.is_link_local()
+                    || ip_addr.is_multicast()
+                {
+                    continue;
+                }
+            }
+            has_mptcp_valid_ip_addr = true;
+            if let Some(mptcp_flags) = addr.mptcp_flags.as_ref() {
+                if flags.is_empty() {
+                    flags = mptcp_flags.clone();
+                } else if &flags != mptcp_flags {
+                    return None;
+                }
+            }
+        }
+    }
+    if let Some(addrs) = iface.ipv6.as_ref().and_then(|i| i.addresses.as_ref())
+    {
+        for addr in addrs {
+            if let std::net::IpAddr::V6(ip_addr) = &addr.ip {
+                // TODO: Skip IPv6 privacy extensions address also.
+                if ip_addr.is_loopback()
+                    || ip_addr.is_multicast()
+                    || is_ipv6_unicast_local(ip_addr)
+                    || is_ipv6_unicast_link_local(ip_addr)
+                {
+                    continue;
+                }
+            }
+            has_mptcp_valid_ip_addr = true;
+            if let Some(mptcp_flags) = addr.mptcp_flags.as_ref() {
+                if flags.is_empty() {
+                    flags = mptcp_flags.clone();
+                } else if &flags != mptcp_flags {
+                    return None;
+                }
+            }
+        }
+    }
+
+    if has_mptcp_valid_ip_addr {
+        Some(MptcpConfig {
+            address_flags: Some(flags),
+        })
+    } else {
+        None
+    }
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -11,6 +11,7 @@ use crate::{
     nm::ieee8021x::gen_nm_802_1x_setting,
     nm::infiniband::gen_nm_ib_setting,
     nm::ip::gen_nm_ip_setting,
+    nm::mptcp::apply_mptcp_conf,
     nm::ovs::{
         create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
         gen_nm_ovs_ext_ids_setting, gen_nm_ovs_iface_setting,
@@ -181,6 +182,7 @@ pub(crate) fn iface_to_nm_connections(
         }
     }
     let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
+    nm_conn.flags = Vec::new();
 
     // Use stable UUID if there is no existing NM connections where
     // we don't have possible UUID overlap there.
@@ -512,7 +514,12 @@ pub(crate) fn gen_nm_conn_setting(
     if let Some(lldp_conf) = iface.base_iface().lldp.as_ref() {
         nm_conn_set.lldp = Some(lldp_conf.enabled);
     }
+    if let Some(mptcp_conf) = iface.base_iface().mptcp.as_ref() {
+        apply_mptcp_conf(&mut nm_conn_set, mptcp_conf)?;
+    }
+
     nm_conn.connection = Some(nm_conn_set);
+
     Ok(())
 }
 

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -13,6 +13,7 @@ mod infiniband;
 mod ip;
 mod lldp;
 mod mac_vlan;
+mod mptcp;
 mod nm_dbus;
 mod ovs;
 mod profile;

--- a/rust/src/lib/nm/mptcp.rs
+++ b/rust/src/lib/nm/mptcp.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+
+use crate::{
+    nm::nm_dbus::NmSettingConnection,
+    nm::nm_dbus::{NmApi, NmConnection},
+    ErrorKind, MptcpAddressFlag, MptcpConfig, NmstateError,
+};
+
+const NM_MPTCP_FLAG_ALSO_WITHOUT_DEFAULT_ROUTE: u32 = 0x08;
+const NM_MPTCP_FLAG_DISABLE: u32 = 0x01;
+const NM_MPTCP_FLAG_SIGNAL: u32 = 0x10;
+const NM_MPTCP_FLAG_SUBFLOW: u32 = 0x20;
+const NM_MPTCP_FLAG_BACKUP: u32 = 0x40;
+const NM_MPTCP_FLAG_FULLMESH: u32 = 0x80;
+
+const MPTCP_SYSCTL_PATH: &str = "/proc/sys/net/mptcp/enabled";
+
+pub(crate) fn apply_mptcp_conf(
+    nm_conn_set: &mut NmSettingConnection,
+    mptcp_conf: &MptcpConfig,
+) -> Result<(), NmstateError> {
+    if let Some(flags) = mptcp_conf.address_flags.as_ref() {
+        if flags.is_empty() {
+            nm_conn_set.mptcp_flags = Some(NM_MPTCP_FLAG_DISABLE);
+        } else {
+            if !is_mptcp_enabled() {
+                let e = NmstateError::new(
+                    ErrorKind::NotSupportedError,
+                    "NetworkManager cannot enable MPTCP via sysctl yet, \
+                     please use sysctl to set net.mptcp.enabled as 1 or other \
+                     tools before applying MPTCP flags"
+                        .to_string(),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
+            let mut nm_mptcp_flags: u32 = 0;
+            for flag in flags {
+                nm_mptcp_flags |= match flag {
+                    MptcpAddressFlag::Signal => NM_MPTCP_FLAG_SIGNAL,
+                    MptcpAddressFlag::Subflow => NM_MPTCP_FLAG_SUBFLOW,
+                    MptcpAddressFlag::Backup => NM_MPTCP_FLAG_BACKUP,
+                    MptcpAddressFlag::Fullmesh => NM_MPTCP_FLAG_FULLMESH,
+                }
+            }
+            if nm_mptcp_flags != 0 {
+                // NetworkManager only apply MPTCP flags when default gateway
+                // presents. Nmstate do not want to expose that hidden
+                // restriction to API, hence we force NM to apply MPTCP flags
+                // via NM_MPTCP_FLAG_ALSO_WITHOUT_DEFAULT_ROUTE.
+                nm_mptcp_flags |= NM_MPTCP_FLAG_ALSO_WITHOUT_DEFAULT_ROUTE;
+            }
+            nm_conn_set.mptcp_flags = Some(nm_mptcp_flags);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn is_mptcp_flags_changed(
+    nm_conn: &NmConnection,
+    activated_nm_con: &NmConnection,
+) -> bool {
+    match (
+        nm_conn.connection.as_ref().and_then(|c| c.mptcp_flags),
+        activated_nm_con
+            .connection
+            .as_ref()
+            .and_then(|c| c.mptcp_flags),
+    ) {
+        (Some(flags), Some(cur_flags)) => flags == cur_flags,
+        _ => false,
+    }
+}
+
+fn is_mptcp_enabled() -> bool {
+    if let Ok(mut fd) = std::fs::File::open(MPTCP_SYSCTL_PATH) {
+        let mut content = [0u8; 1];
+        if fd.read_exact(&mut content).is_err() {
+            false
+        } else {
+            content[0] == b'1'
+        }
+    } else {
+        false
+    }
+}
+
+pub(crate) fn is_mptcp_supported(nm_api: &NmApi) -> bool {
+    let version_str = nm_api.version().unwrap_or_default();
+    let versions: Vec<&str> = version_str.split('.').collect();
+    if versions.len() < 2 {
+        return false;
+    }
+    if let (Ok(major), Ok(minor)) =
+        (versions[0].parse::<i32>(), versions[1].parse::<i32>())
+    {
+        major >= 1 && minor >= 40
+    } else {
+        false
+    }
+}
+
+pub(crate) fn remove_nm_mptcp_set(nm_conn: &mut NmConnection) {
+    if let Some(nm_conn_set) = nm_conn.connection.as_mut() {
+        nm_conn_set.mptcp_flags = None;
+    }
+}

--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2021 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -401,6 +402,7 @@ pub struct NmSettingConnection {
     pub autoconnect: Option<bool>,
     pub autoconnect_ports: Option<bool>,
     pub lldp: Option<bool>,
+    pub mptcp_flags: Option<u32>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -420,6 +422,7 @@ impl TryFrom<DbusDictionary> for NmSettingConnection {
                 _from_map!(v, "autoconnect-slaves", i32::try_from)?,
             ),
             lldp: _from_map!(v, "lldp", i32::try_from)?.map(|i| i == 1),
+            mptcp_flags: _from_map!(v, "mptcp-flags", u32::try_from)?,
             _other: v,
         })
     }
@@ -473,6 +476,9 @@ impl NmSettingConnection {
         }
         if let Some(v) = &self.lldp {
             ret.insert("lldp", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.mptcp_flags {
+            ret.insert("mptcp-flags", zvariant::Value::new(v));
         }
 
         ret.insert(

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::Entry, HashMap};
 use std::str::FromStr;
 use std::time::Instant;
 
-use super::nm_dbus::{NmApi, NmConnection};
+use super::nm_dbus::{NmApi, NmConnection, NmSettingsConnectionFlag};
 
 use crate::{
     nm::checkpoint::{
@@ -86,6 +86,14 @@ pub(crate) fn delete_exist_profiles(
         } else {
             continue;
         };
+        // Volatile nm_conn will be automatically removed once deactivated.
+        // Hence no need to deactivate.
+        if exist_nm_conn
+            .flags
+            .contains(&NmSettingsConnectionFlag::Volatile)
+        {
+            continue;
+        }
         if !excluded_uuids.contains(&uuid)
             && changed_iface_name_types.contains(&(iface_name, nm_iface_type))
         {

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -25,6 +25,8 @@ mod mac_vlan;
 #[cfg(test)]
 mod mac_vtap;
 #[cfg(test)]
+mod mptcp;
+#[cfg(test)]
 mod ovs;
 #[cfg(test)]
 mod ovsdb;

--- a/rust/src/lib/unit_tests/mptcp.rs
+++ b/rust/src/lib/unit_tests/mptcp.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{BaseInterface, ErrorKind};
+
+#[test]
+fn test_valid_mptcp_flags() {
+    let iface: BaseInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+mptcp:
+  address-flags:
+  - signal
+  - fullmesh
+"#,
+    )
+    .unwrap();
+    let result = iface.validate(Some(&BaseInterface::new()));
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_mptcp_pre_edit_cleanup() {
+    let mut desire_iface: BaseInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+mptcp:
+  address-flags:
+  - signal
+  - backup
+  - fullmesh
+ipv4:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "192.168.1.1"
+    prefix-length: "24"
+    mptcp-flags:
+    - signal
+    - backup
+    - fullmesh
+ipv6:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+    prefix-length: "64"
+    mptcp-flags:
+    - signal
+    - backup
+    - fullmesh
+"#,
+    )
+    .unwrap();
+    let expected_iface: BaseInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+mptcp:
+  address-flags:
+  - signal
+  - backup
+  - fullmesh
+ipv4:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "192.168.1.1"
+    prefix-length: "24"
+ipv6:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+    prefix-length: "64"
+"#,
+    )
+    .unwrap();
+
+    desire_iface.pre_edit_cleanup().unwrap();
+    assert_eq!(desire_iface, expected_iface);
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -28,6 +28,7 @@ class Interface:
 
     IPV4 = "ipv4"
     IPV6 = "ipv6"
+    MPTCP = "mptcp"
 
     MAC = "mac-address"
     MTU = "mtu"
@@ -133,6 +134,7 @@ class InterfaceIP:
     AUTO_GATEWAY = "auto-gateway"
     AUTO_ROUTES = "auto-routes"
     AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
+    MPTCP_FLAGS = "mptcp-flags"
 
 
 class InterfaceIPv4(InterfaceIP):
@@ -456,3 +458,11 @@ class HostNameState:
     KEY = "hostname"
     CONFIG = "config"
     RUNNING = "running"
+
+
+class Mptcp:
+    ADDRESS_FLAGS = "address-flags"
+    FLAG_SIGNAL = "signal"
+    FLAG_SUBFLOW = "subflow"
+    FLAG_BACKUP = "backup"
+    FLAG_FULLMESH = "fullmesh"

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -123,7 +123,7 @@ def test_dns_edit(eth1_up):
     with example_state(
         "dns_edit_eth1.yml", cleanup="dns_remove.yml"
     ) as desired_state:
-        assertlib.assert_state(desired_state)
+        assertlib.assert_state_match(desired_state)
 
     current_state = netinfo.show()
     assert current_state.get(DNS.KEY, {}).get(DNS.CONFIG, {}) == {}

--- a/tests/integration/mptcp_test.py
+++ b/tests/integration/mptcp_test.py
@@ -1,0 +1,198 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This file is part of nmstate
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import pytest
+
+import libnmstate
+
+from libnmstate.error import NmstateValueError
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import Mptcp
+
+from .testlib import assertlib
+from .testlib import cmdlib
+from .testlib.env import nm_minor_version
+
+
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV6_ADDRESS1 = "2001:db8:1::1"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_mptcp_in_sysctl():
+    ori_value = cmdlib.exec_cmd("sysctl net.mptcp.enabled".split())[1].strip()[
+        -1
+    ]
+    cmdlib.exec_cmd("sysctl -w net.mptcp.enabled=1".split(), check=True)
+    yield
+    cmdlib.exec_cmd(
+        f"sysctl -w net.mptcp.enabled={ori_value}".split(), check=True
+    )
+
+
+@pytest.fixture
+def eth1_with_static_ip(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+@pytest.mark.parametrize(
+    "mptcp_flags",
+    [
+        [Mptcp.FLAG_SIGNAL],
+        [Mptcp.FLAG_SUBFLOW],
+        [Mptcp.FLAG_BACKUP],
+        [Mptcp.FLAG_FULLMESH],
+        [Mptcp.FLAG_SIGNAL, Mptcp.FLAG_SUBFLOW],
+        [Mptcp.FLAG_SIGNAL, Mptcp.FLAG_BACKUP],
+        [Mptcp.FLAG_SUBFLOW, Mptcp.FLAG_BACKUP],
+        [Mptcp.FLAG_SUBFLOW, Mptcp.FLAG_FULLMESH],
+        [Mptcp.FLAG_SIGNAL, Mptcp.FLAG_SUBFLOW, Mptcp.FLAG_BACKUP],
+        [
+            Mptcp.FLAG_SUBFLOW,
+            Mptcp.FLAG_BACKUP,
+            Mptcp.FLAG_FULLMESH,
+        ],
+        [
+            Mptcp.FLAG_FULLMESH,
+            Mptcp.FLAG_SUBFLOW,
+            Mptcp.FLAG_BACKUP,
+        ],
+    ],
+    ids=[
+        "signal",
+        "subflow",
+        "backup",
+        "fullmesh",
+        "signal&subflow",
+        "signal&backup",
+        "subflow@backup",
+        "subflow@fullmesh",
+        "signal@subflow@backup",
+        "subflow@backup@fullmesh",
+        "fullmesh@subflow@backup",
+    ],
+)
+@pytest.mark.skipif(
+    nm_minor_version() < 40, reason="MPTCP is not supported by NetworkManager"
+)
+def test_enable_mptcp_flags_and_remove(eth1_with_static_ip, mptcp_flags):
+    expected_state = eth1_with_static_ip
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MPTCP: {
+                    Mptcp.ADDRESS_FLAGS: mptcp_flags,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    expected_state[Interface.KEY][0][Interface.MPTCP] = {
+        Mptcp.ADDRESS_FLAGS: mptcp_flags
+    }
+    expected_state[Interface.KEY][0][Interface.IPV4][InterfaceIPv4.ADDRESS][0][
+        InterfaceIPv4.MPTCP_FLAGS
+    ] = mptcp_flags
+    expected_state[Interface.KEY][0][Interface.IPV6][InterfaceIPv6.ADDRESS][0][
+        InterfaceIPv6.MPTCP_FLAGS
+    ] = mptcp_flags
+    assertlib.assert_state_match(expected_state)
+
+
+@pytest.mark.parametrize(
+    "mptcp_flags",
+    [
+        [Mptcp.FLAG_SIGNAL, Mptcp.FLAG_FULLMESH],
+        [Mptcp.FLAG_FULLMESH, Mptcp.FLAG_SIGNAL],
+        [Mptcp.FLAG_SIGNAL, Mptcp.FLAG_SUBFLOW, Mptcp.FLAG_FULLMESH],
+        [
+            Mptcp.FLAG_SIGNAL,
+            Mptcp.FLAG_BACKUP,
+            Mptcp.FLAG_FULLMESH,
+        ],
+        [
+            Mptcp.FLAG_FULLMESH,
+            Mptcp.FLAG_SUBFLOW,
+            Mptcp.FLAG_BACKUP,
+            Mptcp.FLAG_SIGNAL,
+        ],
+    ],
+    ids=[
+        "signal&fullmesh",
+        "fullmesh@signal",
+        "signal@subflow@fullmesh",
+        "signal@backup@fullmesh",
+        "fullmesh@subflow@backup@signal",
+    ],
+)
+@pytest.mark.skipif(
+    nm_minor_version() < 40, reason="MPTCP is not supported by NetworkManager"
+)
+def test_invalid_mptcp_flags(eth1_with_static_ip, mptcp_flags):
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "eth1",
+                        Interface.TYPE: InterfaceType.ETHERNET,
+                        Interface.STATE: InterfaceState.UP,
+                        Interface.MPTCP: {
+                            Mptcp.ADDRESS_FLAGS: mptcp_flags,
+                        },
+                    }
+                ]
+            }
+        )

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -63,9 +63,12 @@ def assert_state_match(desired_state_data):
         )
         if not desired_state.match(current_state):
             print(
-                "desired miss match with current, retrying:",
-                desired_state.state,
-                current_state.state,
+                "desired miss match with current, retrying, "
+                f"desire {desired_state.state}"
+            )
+            print(
+                "desired miss match with current, retrying, "
+                f"current {current_state.state}"
             )
             time.sleep(0.5)
     desired_state, current_state = _prepare_state_for_verify(

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -25,13 +25,14 @@ from ipaddress import ip_address
 from operator import itemgetter
 
 import libnmstate
+from libnmstate.schema import Bond
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
-from libnmstate.schema import Bond
 from libnmstate.schema import LinuxBridge
+from libnmstate.schema import Mptcp
 from libnmstate.schema import OVSBridge
 
 
@@ -125,6 +126,8 @@ class State:
         self._normalize_linux_bridge_port_vlan()
         self._upper_linux_bridge_group_addr()
         self._sort_ovs_lag_ports()
+        self._sort_mptcp_flags()
+        self._remove_mptcp_flags_of_ip_addr()
 
     def match(self, other):
         return state_match(self.state, other.state)
@@ -277,6 +280,31 @@ class State:
                 ).get(OVSBridge.Port.LinkAggregation.PORT_SUBTREE, []).sort(
                     key=itemgetter(OVSBridge.Port.LinkAggregation.Port.NAME)
                 )
+
+    def _sort_mptcp_flags(self):
+        for iface_state in self._state[Interface.KEY]:
+            iface_state.get(Interface.MPTCP, {}).get(
+                Mptcp.ADDRESS_FLAGS, []
+            ).sort()
+            for addr in iface_state.get(Interface.IPV4, {}).get(
+                InterfaceIPv4.ADDRESS, []
+            ):
+                addr.get(InterfaceIPv4.MPTCP_FLAGS, []).sort()
+            for addr in iface_state.get(Interface.IPV6, {}).get(
+                InterfaceIPv6.ADDRESS, []
+            ):
+                addr.get(InterfaceIPv6.MPTCP_FLAGS, []).sort()
+
+    def _remove_mptcp_flags_of_ip_addr(self):
+        for iface_state in self._state[Interface.KEY]:
+            for addr in iface_state.get(Interface.IPV4, {}).get(
+                InterfaceIPv4.ADDRESS, []
+            ):
+                addr.pop(InterfaceIPv4.MPTCP_FLAGS, None)
+            for addr in iface_state.get(Interface.IPV6, {}).get(
+                InterfaceIPv6.ADDRESS, []
+            ):
+                addr.pop(InterfaceIPv6.MPTCP_FLAGS, None)
 
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):


### PR DESCRIPTION
Support configure interface level MPTCP flags:

```yml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    mptcp:
      address-flags:
      - subflow
      - backup
      - fullmesh
```

When querying, also include MPTCP flags per IP address:

```yml
address:
  - ip: 192.0.2.2
    prefix-length: 24
    mptcp-flags:
      - signal
      - subflow
```

For interface level MPTCP flags, will apply flags to all valid IP
addresses(both static and dynamic). Plugin might has their own rule on
excusing special scope of IP address, e.g. IPv6 multicast address.

Limitations:
 * Per IP address MPTCP flags is ignored with an warning message when
   different from interface level MPTCP flags.
 * Cannot set `signal` along with `fullmesh` due to kernel restriction.
 * If sysctl has `net.mptcp.enabled` set to 0, NetworkManager cannot
   apply MPTCP flags. User will get an failure suggest them to use
   third-party tools.
 * Cannot reapply on MPTCP changes, full activation will invoked when
   MPTCP flags changed.
 * When MPTCP not supported by NetworkManager, the query will hide
   interface level MPTCP flags even it been enabled by third party
   tool.



Changed to nispor dependency to git as the latest release of nispor does
not have `nispor::MptcpAddressFlag` exposed.

Removed `testlib.assert_state()` and replaced by
`testlib.assert_state_match()`

Unit test cases and integration test cases are included.