### PR TITLE
ovsdb: Support partial editing on ovs-db global config

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -315,7 +315,9 @@ impl NetworkState {
                             &checkpoint,
                             self.memory_only,
                         )?;
-                        if ovsdb_is_running() {
+                        if desire_state_to_apply.prop_list.contains(&"ovsdb")
+                            && ovsdb_is_running()
+                        {
                             ovsdb_apply(
                                 &desire_state_to_apply,
                                 &cur_net_state,

--- a/rust/src/lib/ovsdb/apply.rs
+++ b/rust/src/lib/ovsdb/apply.rs
@@ -4,14 +4,8 @@ pub(crate) fn ovsdb_apply(
     desired: &NetworkState,
     current: &NetworkState,
 ) -> Result<(), NmstateError> {
-    if desired.ovsdb.external_ids.is_some()
-        || desired.ovsdb.other_config.is_some()
-    {
-        let mut cli = OvsDbConnection::new()?;
-        let mut desired = desired.ovsdb.clone();
-        desired.merge(&current.ovsdb);
-        cli.apply_global_conf(&desired)
-    } else {
-        Ok(())
-    }
+    let mut cli = OvsDbConnection::new()?;
+    let mut desired = desired.ovsdb.clone();
+    desired.merge(&current.ovsdb);
+    cli.apply_global_conf(&desired)
 }

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -27,6 +27,8 @@ mod mac_vtap;
 #[cfg(test)]
 mod ovs;
 #[cfg(test)]
+mod ovsdb;
+#[cfg(test)]
 mod route;
 #[cfg(test)]
 mod route_rule;

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -1,0 +1,133 @@
+use crate::OvsDbGlobalConfig;
+
+fn get_current_ovsdb_config() -> OvsDbGlobalConfig {
+    serde_yaml::from_str(
+        r#"---
+external_ids:
+  a: A0
+  b: B0
+  c: C0
+  h: H0
+other_config:
+  d: D0
+  e: E0
+  f: F0
+  g: G0
+"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_ovsdb_merge_with_override_and_delete() {
+    let mut desired: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids:
+  a: A
+  b: B
+  c: null
+other_config:
+  d: null
+  e: E
+  f: F
+"#,
+    )
+    .unwrap();
+
+    let current = get_current_ovsdb_config();
+
+    let mut expect: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids:
+  a: A
+  b: B
+  h: H0
+other_config:
+  e: E
+  f: F
+  g: G0
+"#,
+    )
+    .unwrap();
+
+    desired.merge(&current);
+    desired.prop_list = Vec::new();
+    expect.prop_list = Vec::new();
+    assert_eq!(desired, expect);
+}
+
+#[test]
+fn test_ovsdb_merge_delete_all() {
+    let mut desired: OvsDbGlobalConfig = serde_yaml::from_str("{}").unwrap();
+    let current = get_current_ovsdb_config();
+
+    let mut expect: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids: {}
+other_config: {}
+"#,
+    )
+    .unwrap();
+
+    desired.merge(&current);
+    desired.prop_list = Vec::new();
+    expect.prop_list = Vec::new();
+    assert_eq!(desired, expect);
+}
+
+#[test]
+fn test_ovsdb_merge_delete_all_external_ids() {
+    let mut desired: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids: {}
+"#,
+    )
+    .unwrap();
+    let current = get_current_ovsdb_config();
+
+    let mut expect: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids: {}
+other_config:
+  d: D0
+  e: E0
+  f: F0
+  g: G0
+"#,
+    )
+    .unwrap();
+
+    desired.merge(&current);
+    desired.prop_list = Vec::new();
+    expect.prop_list = Vec::new();
+
+    assert_eq!(desired, expect);
+}
+
+#[test]
+fn test_ovsdb_merge_delete_all_other_config() {
+    let mut desired: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+other_config: {}
+"#,
+    )
+    .unwrap();
+    let current = get_current_ovsdb_config();
+
+    let mut expect: OvsDbGlobalConfig = serde_yaml::from_str(
+        r#"---
+external_ids:
+  a: A0
+  b: B0
+  c: C0
+  h: H0
+other_config: {}
+"#,
+    )
+    .unwrap();
+
+    desired.merge(&current);
+    desired.prop_list = Vec::new();
+    expect.prop_list = Vec::new();
+    assert_eq!(desired, expect);
+}


### PR DESCRIPTION
Allowing partial editing on ovs-db global config:
 * Merging desire from current.
 * Will remove all ovs-db global configure for `ovs-db: {}`.
 * To remove single entry, use `foo: null` in yaml or `foo: None` in
   rust.

Unit test case and Integration test cases included.