### PR TITLE
nm ovs: Fix issue when OVS bridge port not mentioned

### DIFF
--- a/rust/src/lib/nm/ovs.rs
+++ b/rust/src/lib/nm/ovs.rs
@@ -240,8 +240,18 @@ pub(crate) fn create_ovs_port_nm_conn(
 pub(crate) fn get_ovs_port_name(
     ovs_br_iface: &OvsBridgeInterface,
     ovs_iface_name: &str,
+    cur_ovs_br_iface: Option<&Interface>,
 ) -> Option<String> {
-    for port_conf in ovs_br_iface.port_confs() {
+    let port_confs = if ovs_br_iface.ports().is_none() {
+        if let Some(Interface::OvsBridge(cur_ovs_br_iface)) = cur_ovs_br_iface {
+            cur_ovs_br_iface.port_confs()
+        } else {
+            ovs_br_iface.port_confs()
+        }
+    } else {
+        ovs_br_iface.port_confs()
+    };
+    for port_conf in port_confs {
         if let Some(bond_conf) = &port_conf.bond {
             for bond_port_name in bond_conf.ports() {
                 if bond_port_name == ovs_iface_name {

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -326,20 +326,19 @@ pub(crate) fn use_uuid_for_controller_reference(
         }
 
         if ctrl_type == "ovs-port" {
+            let cur_ovs_br_iface = cur_user_space_ifaces
+                .get(&(ctrl_name.to_string(), InterfaceType::OvsBridge));
             if let Some(Interface::OvsBridge(ovs_br_iface)) =
                 des_user_space_ifaces
                     .get(&(ctrl_name.to_string(), InterfaceType::OvsBridge))
-                    .or_else(|| {
-                        cur_user_space_ifaces.get(&(
-                            ctrl_name.to_string(),
-                            InterfaceType::OvsBridge,
-                        ))
-                    })
+                    .or(cur_ovs_br_iface)
             {
                 if let Some(iface_name) = nm_conn.iface_name() {
-                    if let Some(ovs_port_name) =
-                        get_ovs_port_name(ovs_br_iface, iface_name)
-                    {
+                    if let Some(ovs_port_name) = get_ovs_port_name(
+                        ovs_br_iface,
+                        iface_name,
+                        cur_ovs_br_iface,
+                    ) {
                         ctrl_name = ovs_port_name.to_string();
                     } else {
                         let e = NmstateError::new(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1209,3 +1209,25 @@ def test_ovsdb_global_remove_all_other_config(ovsdb_global_db):
     assert not current[OvsDB.OTHER_CONFIG]
     assert current[OvsDB.EXTERNAL_IDS]["opt1"] == "value1"
     assert current[OvsDB.EXTERNAL_IDS]["opt2"] == "value2"
+
+
+def test_change_ovs_intenral_iface_ext_id_with_br_port_not_mentioned(
+    bridge_with_ports,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: BRIDGE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+            },
+            {
+                Interface.NAME: PORT1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                OvsDB.OVS_DB_SUBTREE: {
+                    OvsDB.EXTERNAL_IDS: {"foo": "abc", "bak": 1}
+                },
+            },
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
When modifying OVS internal interface with its OVS bridge included in
desire state without port section, nmstate complains about:

    Failed to find OVS port name for NmConnection NmConnection {
    connection: Some(NmSettingConnection { id: Some("ovs0-if")

The root cause is we don't look on current port list when desired state
has OVS bridge defined.

Fixed by checking current port list if desire state has no port list
mentioned.

Integration test case included.