### PR TITLE
ncl: Unescaped the `\n` for `gc` mode

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -337,7 +337,8 @@ fn gen_conf(file_path: &str) -> Result<String, CliError> {
     let fd = std::fs::File::open(file_path)?;
     let net_state: NetworkState = serde_yaml::from_reader(fd)?;
     let confs = net_state.gen_conf()?;
-    Ok(serde_yaml::to_string(&confs)?)
+    let escaped_string = serde_yaml::to_string(&confs)?;
+    Ok(escaped_string.replace("\\n", "\n\n"))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]


### PR DESCRIPTION
In old python command line, we show output of `nmstatectl gc` with `\n`
unescaped like:

```
---
NetworkManager:
- - eth1.nmconnection
  - '[connection]

    id=eth1

    uuid=a05ca4c1-0d08-4c43-a02f-7a784007c86a

    type=ethernet

    interface-name=eth1

    [ethernet]

    [ipv4]

    dhcp-client-id=mac

    method=disabled

    [ipv6]

    addr-gen-mode=eui64

    dhcp-duid=ll

    dhcp-iaid=mac

    method=disabled

    [proxy]

    '
```

Fixing the rust nmstatectl to behave the same.