### PR TITLE
ovs: Fix genconf mode for OVS `external_ids`

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -275,6 +275,9 @@ impl NmConnection {
         if let Some(ib) = &self.infiniband {
             sections.push(("infiniband", ib.to_keyfile()?));
         }
+        if let Some(ovs_eids) = &self.ovs_ext_ids {
+            sections.push(("ovs-external-ids", ovs_eids.to_keyfile()?));
+        }
 
         keyfile_sections_to_string(&sections)
     }

--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -237,6 +237,18 @@ impl NmSettingOvsExtIds {
         }));
         Ok(ret)
     }
+
+    pub(crate) fn to_keyfile(
+        &self,
+    ) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(data) = self.data.as_ref() {
+            for (k, v) in data {
+                ret.insert(format!("data.{}", k), zvariant::Value::new(v));
+            }
+        }
+        Ok(ret)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]

--- a/tests/integration/testlib/genconf.py
+++ b/tests/integration/testlib/genconf.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+from contextlib import contextmanager
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+
+from .cmdlib import exec_cmd
+
+NM_CONN_FOLDER = "/etc/NetworkManager/system-connections"
+
+
+@contextmanager
+def gen_conf_apply(desire_state):
+    iface_names = [
+        iface[Interface.NAME] for iface in desire_state.get(Interface.KEY, [])
+    ]
+    file_paths = []
+    try:
+        conns = libnmstate.generate_configurations(desire_state).get(
+            "NetworkManager", []
+        )
+        for conn in conns:
+            file_paths.append(save_nmconnection(conn[0], conn[1]))
+        reload_nm_connection()
+        yield
+    finally:
+        absent_state = {Interface.KEY: []}
+        for iface_name in iface_names:
+            absent_state[Interface.KEY].append(
+                {
+                    Interface.NAME: iface_name,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            )
+        libnmstate.apply(absent_state, verify_change=False)
+        for file_path in file_paths:
+            try:
+                os.unlink(file_path)
+            except Exception:
+                pass
+
+
+def save_nmconnection(file_name, content):
+    file_path = f"{NM_CONN_FOLDER}/{file_name}"
+    with open(file_path, "w") as fd:
+        fd.write(content)
+
+    os.chmod(file_path, 0o600)
+    os.chown(file_path, 0, 0)
+    return file_path
+
+
+def reload_nm_connection():
+    exec_cmd("nmcli c reload".split(), check=True)


### PR DESCRIPTION
Add support of ovs external ids for genconf mode.

Integration test case included.