### PR TITLE
veth: Show veth interface as `type: veth`

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -201,6 +201,7 @@ function prepare_network_environment {
             exec_cmd "ip link set ${peer} up"
             exec_cmd "ip link set ${device} up"
             exec_cmd "nmcli device set ${device} managed yes"
+            exec_cmd "nmcli device set ${peer} managed no"
         fi
     done
     set -e

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -353,6 +353,8 @@ impl Interface {
             Self::Ethernet(iface) => {
                 let mut new_iface = EthernetInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
+                // Do not use veth interface type when clone internally
+                new_iface.base.iface_type = InterfaceType::Ethernet;
                 Self::Ethernet(new_iface)
             }
             Self::Vlan(iface) => {
@@ -665,9 +667,7 @@ impl Interface {
     pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
         self.base_iface_mut().pre_edit_cleanup()?;
         if let Interface::Ethernet(iface) = self {
-            if iface.veth.is_some() {
-                iface.base.iface_type = InterfaceType::Veth;
-            }
+            iface.pre_edit_cleanup()?;
         }
         if let Interface::OvsInterface(iface) = self {
             iface.pre_edit_cleanup()?;

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -254,6 +254,11 @@ impl NetworkState {
             )
         }
 
+        desire_state_to_apply.interfaces.pre_ignore_check(
+            &cur_net_state.interfaces,
+            &ignored_kernel_ifaces,
+        )?;
+
         desire_state_to_apply.interfaces.remove_ignored_ifaces(
             &ignored_kernel_ifaces,
             &ignored_user_ifaces,

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -47,7 +47,6 @@ fn net_state_to_nispor(
             }
             np_ifaces.push(nmstate_iface_to_np(iface, np_iface_type)?);
         } else if iface.is_absent() {
-            println!("del {:?} {:?}", iface.name(), iface.iface_type());
             let mut iface_conf = nispor::IfaceConf::default();
             iface_conf.name = iface.name().to_string();
             iface_conf.iface_type =

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -30,8 +30,7 @@ pub(crate) fn nispor_retrieve(
     let np_state = nispor::NetState::retrieve().map_err(np_error_to_nmstate)?;
 
     for (_, np_iface) in np_state.ifaces.iter() {
-        let mut base_iface =
-            np_iface_to_base_iface(np_iface, running_config_only);
+        let base_iface = np_iface_to_base_iface(np_iface, running_config_only);
         // The `ovs-system` is reserved for OVS kernel datapath
         if np_iface.name == "ovs-system" {
             continue;
@@ -60,7 +59,6 @@ pub(crate) fn nispor_retrieve(
                 np_ethernet_to_nmstate(np_iface, base_iface),
             ),
             InterfaceType::Veth => {
-                base_iface.iface_type = InterfaceType::Ethernet;
                 Interface::Ethernet(np_veth_to_nmstate(np_iface, base_iface))
             }
             InterfaceType::Vlan => {

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -7,8 +7,7 @@ pub(crate) fn np_veth_to_nmstate(
     let veth_conf = np_iface.veth.as_ref().and_then(|np_veth_info| {
         if np_veth_info.peer.as_str().parse::<u32>().is_ok() {
             // If veth peer is interface index, it means its veth peer is in
-            // another network namespace, we should treat this interface
-            // as ethernet
+            // another network namespace, we hide the veth section
             None
         } else {
             Some(VethConfig {

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -27,8 +27,6 @@ pub(crate) fn get_exist_profile<'a>(
     let mut found_nm_conns: Vec<&NmConnection> = Vec::new();
     for exist_nm_conn in exist_nm_conns {
         let nm_iface_type = if let Ok(t) = iface_type_to_nm(iface_type) {
-            // The iface_type will never be veth as top level code
-            // `pre_edit_clean()` has confirmed so.
             t
         } else {
             continue;

--- a/tests/integration/nm/veth_test.py
+++ b/tests/integration/nm/veth_test.py
@@ -20,8 +20,11 @@
 import pytest
 
 import libnmstate
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import Veth
 
 from ..testlib.env import nm_major_minor_version
 from ..testlib import cmdlib
@@ -30,6 +33,7 @@ from ..testlib.veth import veth_interface
 
 VETH1 = "veth1"
 VETH1PEER = "veth1peer"
+VETH1PEER2 = "veth1ep"
 
 
 @pytest.mark.skipif(
@@ -46,3 +50,67 @@ def test_remove_peer_connection():
             cmdlib.exec_cmd(f"nmcli connection show {VETH1PEER}".split())[0]
             != 0
         )
+
+
+@pytest.fixture
+def veth1_with_ignored_peer():
+    cmdlib.exec_cmd(
+        f"ip link add {VETH1} type veth peer {VETH1PEER}".split(), check=True
+    )
+    cmdlib.exec_cmd(f"ip link set {VETH1} up".split(), check=True)
+    cmdlib.exec_cmd(f"ip link set {VETH1PEER} up".split(), check=True)
+    cmdlib.exec_cmd(f"nmcli d set {VETH1} managed true".split(), check=True)
+    cmdlib.exec_cmd(
+        f"nmcli d set {VETH1PEER} managed false".split(), check=True
+    )
+    yield
+    cmdlib.exec_cmd(f"nmcli c del {VETH1}".split())
+    cmdlib.exec_cmd(f"nmcli c del {VETH1PEER}".split())
+    cmdlib.exec_cmd(f"ip link del {VETH1}".split())
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() <= 1.28,
+    reason="Modifying veth interfaces is not supported on NetworkManager.",
+)
+def test_veth_with_ignored_peer(veth1_with_ignored_peer):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VETH1,
+                Interface.TYPE: InterfaceType.VETH,
+                Interface.STATE: InterfaceState.UP,
+                Veth.CONFIG_SUBTREE: {
+                    Veth.PEER: VETH1PEER,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assert (
+        "unmanaged"
+        in cmdlib.exec_cmd(
+            f"nmcli -g GENERAL.STATE d show {VETH1PEER}".split()
+        )[1]
+    )
+
+
+@pytest.mark.skipif(
+    nm_major_minor_version() <= 1.28,
+    reason="Modifying veth interfaces is not supported on NetworkManager.",
+)
+def test_veth_with_ignored_peer_changed_to_new_peer(veth1_with_ignored_peer):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VETH1,
+                Interface.TYPE: InterfaceType.VETH,
+                Interface.STATE: InterfaceState.UP,
+                Veth.CONFIG_SUBTREE: {
+                    Veth.PEER: VETH1PEER2,
+                },
+            }
+        ]
+    }
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(desired_state)

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -53,7 +53,7 @@ def remove_veth_pair(nic, peer_ns):
 
 
 @contextmanager
-def veth_interface(ifname, peer):
+def veth_interface(ifname, peer, kernel_mode=False):
     d_state = {
         Interface.KEY: [
             {
@@ -67,7 +67,7 @@ def veth_interface(ifname, peer):
         ]
     }
     try:
-        libnmstate.apply(d_state)
+        libnmstate.apply(d_state, kernel_only=kernel_mode)
         yield d_state
     finally:
         d_state[Interface.KEY][0][Interface.STATE] = InterfaceState.ABSENT
@@ -78,4 +78,4 @@ def veth_interface(ifname, peer):
                 Interface.STATE: InterfaceState.ABSENT,
             }
         )
-        libnmstate.apply(d_state)
+        libnmstate.apply(d_state, kernel_only=kernel_mode, verify_change=False)


### PR DESCRIPTION
Previously, in order to simplify the code workflow, we are showing both
veth and normal ethernet as `type: ethernet`. This has break kubernetes
use case where they need it to identify the veth interfaces.

Changed to show veth interface as `type: veth`. When its peer is in
another network namespace, hide the `veth` section.

Expand the integration test cases to cover these use cases:

 * `test_eth_with_veth_conf`
   Desire state is desiring ethernet interface with veth configuration.
   Raise InvalidArgument error (NmstateValueError exception in python)

 * `test_add_veth_with_ethernet_peer`
   Desire state contains both veth and veth peer interface. But veth
   peer interface is set as `type: ethernet`.

 * `test_add_veth_with_veth_peer_in_desire`
   Desire state contains both veth and veth peer interface. Both veth
   and peer interfaces are set as `type: veth` with `veth` configure
   pointing to each other.

 * `test_modify_veth_peer`
   Change veth peer. The old peer should be removed.

 * `test_veth_without_peer_fails`
   When adding new veth(not exist) without veth peer defined in veth
   configure, raise InvalidArgument error (NmstateValueError exception
   in python).

 * `test_change_veth_with_veth_type_without_veth_conf`
   With pre-exist veth, changing other configure with `type: veth` and
   no veth configure.

 * `test_change_veth_with_eth_type_without_veth_conf`
   With pre-exist veth, changing other configure with `type: ethernet` and
   no veth configure.

 * `test_veth_with_ignored_peer`
   With pre-exist veth and its peer marked as ignored (unmanaged by NM).
   Applying desire state with `type: veth` and veth configuration should
   not fail. And the veth configuration should be ignored.

 * `test_veth_with_ignored_peer_changed_to_new_peer`
   With pre-exist veth and its peer marked as ignored (unmanaged by NM).
   Nmstate will raise InvalidArgument error (NmstateValueError exception
   in python) when user try to change its peer. Also have unit test case
   for this.