### PR TITLE
vrf: Merge table ID from current

### DIFF
--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, InterfaceType};
+use crate::{BaseInterface, ErrorKind, Interface, InterfaceType, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -44,7 +44,18 @@ impl VrfInterface {
         }
     }
 
-    pub(crate) fn pre_verify_cleanup(&mut self) {
+    // Merge table ID from current if desired table ID is 0
+    pub(crate) fn pre_edit_cleanup(
+        &mut self,
+        current: Option<&Interface>,
+    ) -> Result<(), NmstateError> {
+        self.merge_table_id(current)
+    }
+
+    pub(crate) fn pre_verify_cleanup(
+        &mut self,
+        pre_apply_current: Option<&Interface>,
+    ) {
         self.base.mac_address = None;
         if self.base.accept_all_mac_addresses == Some(false) {
             self.base.accept_all_mac_addresses = None;
@@ -52,6 +63,40 @@ impl VrfInterface {
         if let Some(ports) = self.vrf.as_mut().and_then(|c| c.port.as_mut()) {
             ports.sort();
         }
+        self.merge_table_id(pre_apply_current).ok();
+    }
+
+    fn merge_table_id(
+        &mut self,
+        current: Option<&Interface>,
+    ) -> Result<(), NmstateError> {
+        if self.vrf.as_ref().map(|v| v.table_id) == Some(0) {
+            if let Some(&Interface::Vrf(VrfInterface {
+                vrf:
+                    Some(VrfConfig {
+                        table_id: cur_table_id,
+                        ..
+                    }),
+                ..
+            })) = current
+            {
+                if let Some(vrf_conf) = self.vrf.as_mut() {
+                    vrf_conf.table_id = cur_table_id;
+                }
+            } else {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Route table ID undefined or 0 is not allowed for \
+                        new VRF interface {}",
+                        self.base.name
+                    ),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -63,8 +108,11 @@ pub struct VrfConfig {
     pub port: Option<Vec<String>>,
     #[serde(
         rename = "route-table-id",
+        default,
         deserialize_with = "crate::deserializer::u32_or_string"
     )]
+    /// Route table ID of this VRF interface.
+    /// Use 0 to preserve current `table_id`.
     pub table_id: u32,
 }
 

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -100,7 +100,7 @@ fn test_linux_bridge_verify_ignore_port() {
     )
     .unwrap();
 
-    ifaces.verify(&cur_ifaces).unwrap();
+    ifaces.verify(&Interfaces::new(), &cur_ifaces).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -109,7 +109,7 @@ fn test_ovs_bridge_verify_ignore_port() {
     )
     .unwrap();
 
-    ifaces.verify(&cur_ifaces).unwrap();
+    ifaces.verify(&Interfaces::new(), &cur_ifaces).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -37,7 +37,7 @@ fn test_sriov_vf_mac_mix_case() {
     }
     des_ifaces.push(des_iface);
 
-    des_ifaces.verify(&cur_ifaces).unwrap();
+    des_ifaces.verify(&Interfaces::new(), &cur_ifaces).unwrap();
 }
 
 #[test]
@@ -73,5 +73,5 @@ fn test_ignore_sriov_if_not_desired() {
     )
     .unwrap();
 
-    desired.verify(&current).unwrap();
+    desired.verify(&Interfaces::new(), &current).unwrap();
 }

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -24,6 +24,7 @@ import yaml
 
 import libnmstate
 
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -359,6 +360,35 @@ interfaces:
                             Interface.NAME: TEST_BOND0_VLAN,
                             Interface.STATE: InterfaceState.ABSENT,
                         },
+                    ]
+                }
+            )
+
+    def test_change_vrf_without_table_id(self, vrf0_with_port0):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VRF0,
+                        VRF.CONFIG_SUBTREE: {
+                            VRF.PORT_SUBTREE: [TEST_VRF_PORT0],
+                        },
+                    }
+                ]
+            }
+        )
+
+    def test_new_vrf_without_table_id(self):
+        with pytest.raises(NmstateValueError):
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: TEST_VRF0,
+                            VRF.CONFIG_SUBTREE: {
+                                VRF.PORT_SUBTREE: [TEST_VRF_PORT0],
+                            },
+                        }
                     ]
                 }
             )


### PR DESCRIPTION
When desire state does not contain table ID for existing VRF interface,
we merge it from current.

In code:
 * expand `pre_edit_cleanup()` to accept `current: Option<&Interface>`.
 * expand `pre_verify_cleanup()` to accept
   `pre_apply_current: Option<&Interface>`

Integration test case included.