### PR TITLE
ip: Improve pre-edit and pre-verify code

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -646,7 +646,8 @@ impl Interface {
         &mut self,
         pre_apply_current: Option<&Self>,
     ) {
-        self.base_iface_mut().pre_verify_cleanup();
+        self.base_iface_mut()
+            .pre_verify_cleanup(pre_apply_current.map(|i| i.base_iface()));
         match self {
             Self::LinuxBridge(ref mut iface) => {
                 iface.pre_verify_cleanup();
@@ -671,7 +672,8 @@ impl Interface {
         &mut self,
         current: Option<&Self>,
     ) -> Result<(), NmstateError> {
-        self.base_iface_mut().pre_edit_cleanup()?;
+        self.base_iface_mut()
+            .pre_edit_cleanup(current.map(|i| i.base_iface()))?;
         if let Interface::Ethernet(iface) = self {
             iface.pre_edit_cleanup()?;
         }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -162,7 +162,10 @@ impl BaseInterface {
         }
     }
 
-    pub(crate) fn pre_edit_cleanup(&mut self) -> Result<(), NmstateError> {
+    pub(crate) fn pre_edit_cleanup(
+        &mut self,
+        current: Option<&Self>,
+    ) -> Result<(), NmstateError> {
         // Do not allow changing min_mtu and max_mtu
         self.max_mtu = None;
         self.min_mtu = None;
@@ -183,10 +186,10 @@ impl BaseInterface {
         }
 
         if let Some(ref mut ipv4) = self.ipv4 {
-            ipv4.pre_edit_cleanup();
+            ipv4.pre_edit_cleanup(current.and_then(|i| i.ipv4.as_ref()));
         }
         if let Some(ref mut ipv6) = self.ipv6 {
-            ipv6.pre_edit_cleanup();
+            ipv6.pre_edit_cleanup(current.and_then(|i| i.ipv6.as_ref()));
         }
         if let Some(ref mut ethtool_conf) = self.ethtool {
             ethtool_conf.pre_edit_cleanup();
@@ -197,7 +200,10 @@ impl BaseInterface {
         Ok(())
     }
 
-    pub(crate) fn pre_verify_cleanup(&mut self) {
+    pub(crate) fn pre_verify_cleanup(
+        &mut self,
+        pre_apply_current: Option<&Self>,
+    ) {
         // Ignore min_mtu and max_mtu as they are not changeable
         self.min_mtu = None;
         self.max_mtu = None;
@@ -209,11 +215,15 @@ impl BaseInterface {
         }
 
         if let Some(ref mut ipv4) = self.ipv4 {
-            ipv4.pre_verify_cleanup();
+            ipv4.pre_verify_cleanup(
+                pre_apply_current.and_then(|i| i.ipv4.as_ref()),
+            );
         }
 
         if let Some(ref mut ipv6) = self.ipv6 {
-            ipv6.pre_verify_cleanup()
+            ipv6.pre_verify_cleanup(
+                pre_apply_current.and_then(|i| i.ipv6.as_ref()),
+            );
         }
         // Change all veth interface to ethernet for simpler verification
         if self.iface_type == InterfaceType::Veth {

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -23,6 +23,6 @@ mac-address: "d4:ee:07:25:42:5a"
 "#,
     )
     .unwrap();
-    iface.pre_verify_cleanup();
+    iface.pre_verify_cleanup(None);
     assert_eq!(iface.mac_address, Some(String::from("D4:EE:07:25:42:5A")));
 }

--- a/rust/src/lib/unit_tests/mptcp.rs
+++ b/rust/src/lib/unit_tests/mptcp.rs
@@ -84,6 +84,6 @@ ipv6:
     )
     .unwrap();
 
-    desire_iface.pre_edit_cleanup().unwrap();
+    desire_iface.pre_edit_cleanup(None).unwrap();
     assert_eq!(desire_iface, expected_iface);
 }


### PR DESCRIPTION
With recent improvement of `pre_edit_cleanup` and `pre_verify_cleanup`, we
can modify the `InterfaceIp` base on current state(or pre-applied current
state).  So there is no need to invoke these two functions at
`Interfaces` level:
 * `merge_ip_stack`
 * `include_current_ip_address_if_dhcp_on_to_off`

Both of them not is handled by `pre_edit_cleanup()` and
`pre_verify_cleanup()`.

No integration test case included as these test case will confirm the old
behaviour is unchanged:
 * `test_ipv4_dhcp_switch_on_to_off`
 * `test_ipv6_dhcp_switch_on_to_off`
 * `test_merge_ip_enabled_property_from_current`