### PR TITLE
[nmstate-1.2] nm ovs: Fix race problem when attaching bond to OVS bridge

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -25,11 +25,11 @@ COPR_ARG=""
 if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util python3-jsonschema;'
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema python3-nispor python3dist\(ovs\);'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util python3-jsonschema;
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema python3-nispor;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'

--- a/libnmstate/nm/active_connection.py
+++ b/libnmstate/nm/active_connection.py
@@ -48,6 +48,13 @@ def is_activated(nm_ac, nm_dev):
     if state == NM.ActiveConnectionState.ACTIVATED:
         return True
     elif state == NM.ActiveConnectionState.ACTIVATING:
+        # OVS bridge and OVS port are not allowed to have IP, hence we wait it
+        # to reach ACTIVATED state.
+        if nm_dev.get_device_type() in (
+            NM.DeviceType.OVS_PORT,
+            NM.DeviceType.OVS_BRIDGE,
+        ):
+            return False
         ac_state_flags = nm_ac.get_state_flags()
         nm_flags = NM.ActivationStateFlags
         ip4_is_dynamic = is_ipv4_dynamic(nm_ac)

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -156,7 +156,7 @@ impl BaseInterface {
     }
 
     pub fn can_have_ip(&self) -> bool {
-        self.controller == None
+        self.controller.is_none()
             || self.iface_type == InterfaceType::OvsInterface
             || self.controller_type == Some(InterfaceType::Vrf)
     }

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -23,7 +23,7 @@ pub(crate) fn np_ipv4_to_nmstate(
         Some(ip)
     } else {
         // IP might just disabled
-        if np_iface.controller == None {
+        if np_iface.controller.is_none() {
             Some(InterfaceIpv4 {
                 enabled: false,
                 prop_list: vec!["enabled"],
@@ -58,7 +58,7 @@ pub(crate) fn np_ipv6_to_nmstate(
         Some(ip)
     } else {
         // IP might just disabled
-        if np_iface.controller == None {
+        if np_iface.controller.is_none() {
             Some(InterfaceIpv6 {
                 enabled: false,
                 prop_list: vec!["enabled"],


### PR DESCRIPTION
Got failure when attaching linux bond to ovs bridge:

    libnmstate.error.NmstateLibnmError: Activate profile
    uuid:cf81a923-5999-4a21-bd7e-dc96c7977451 iface:eth1 type: ethernet
    failed: reason=<enum
    NM_ACTIVE_CONNECTION_STATE_REASON_DEVICE_DISCONNECTED of type
    NM.ActiveConnectionStateReason><enum
    NM_DEVICE_STATE_REASON_DEPENDENCY_FAILED of type NM.DeviceStateReason>

This is caused by race between we activating OVS port profile manually and NettworkManager `autoconnect-slaves` function.

To fix the problem, for OVS bridge and OVS port, the `IP_CONFIG` state is not considered as activated as they are not allowed to have IP.

Integration test case included.

Signed-off-by: Gris Ge <fge@redhat.com>
(cherry picked from commit 0a58ac3fc3f74871f43337eaab8f7ef1acca4d21)