### PR TITLE
dns: Fix DNS store in `genconf` mode

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -280,12 +280,14 @@ fn is_iface_valid_for_dns(is_ipv6: bool, iface: &Interface) -> Option<bool> {
     if is_ipv6 {
         iface.base_iface().ipv6.as_ref().map(|ip_conf| {
             ip_conf.enabled
-                && (!ip_conf.is_auto() || (ip_conf.auto_dns == Some(false)))
+                && (ip_conf.is_static()
+                    || (ip_conf.is_auto() && ip_conf.auto_dns == Some(false)))
         })
     } else {
         iface.base_iface().ipv4.as_ref().map(|ip_conf| {
             ip_conf.enabled
-                && (!ip_conf.is_auto() || ip_conf.auto_dns == Some(false))
+                && (ip_conf.is_static()
+                    || (ip_conf.is_auto() && ip_conf.auto_dns == Some(false)))
         })
     }
 }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -99,6 +99,12 @@ impl InterfaceIpv4 {
         self.enabled && self.dhcp == Some(true)
     }
 
+    pub(crate) fn is_static(&self) -> bool {
+        self.enabled
+            && !self.is_auto()
+            && !self.addresses.as_deref().unwrap_or_default().is_empty()
+    }
+
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;
@@ -298,6 +304,12 @@ impl InterfaceIpv6 {
 
     pub(crate) fn is_auto(&self) -> bool {
         self.enabled && (self.dhcp == Some(true) || self.autoconf == Some(true))
+    }
+
+    pub(crate) fn is_static(&self) -> bool {
+        self.enabled
+            && !self.is_auto()
+            && !self.addresses.as_deref().unwrap_or_default().is_empty()
     }
 
     // * Disable DHCP and remove address if enabled: false

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -32,6 +32,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
 
 from .testlib import cmdlib
+from .testlib.genconf import gen_conf_apply
 
 IPV4_DNS_NAMESERVERS = ["8.8.8.8", "1.1.1.1"]
 EXTRA_IPV4_DNS_NAMESERVER = "9.9.9.9"
@@ -447,3 +448,16 @@ def test_nmstatectl_show_dns(static_dns):
     assert (
         current_state[DNS.KEY][DNS.CONFIG] == static_dns[DNS.KEY][DNS.CONFIG]
     )
+
+
+@pytest.mark.tier1
+@parametrize_ip_ver
+def test_dns_edit_nameserver_with_static_gateway_genconf(dns_config):
+    desired_state = {
+        Interface.KEY: _get_test_iface_states(),
+        Route.KEY: {Route.CONFIG: _gen_default_gateway_route()},
+        DNS.KEY: {DNS.CONFIG: dns_config},
+    }
+    with gen_conf_apply(desired_state):
+        current_state = libnmstate.show()
+        assert dns_config == current_state[DNS.KEY][DNS.CONFIG]


### PR DESCRIPTION
Previously, `genconf` is incorrectly select interface to store the DNS
information caused by this line in `is_iface_valid_for_dns()`:

```rust
    ip_conf.enabled
    && (!ip_conf.is_auto() || (ip_conf.auto_dns == Some(false)))
```

We missed the case where `enabled: true`, `dhcp: None` and empty IP
address.

Fixed by adding `is_static()` to `InterfaceIpv4` and `InterfaceIpv6` to
make sure we select IP interface with static IP adress for DNS.

Integration test cases included.