### PR TITLE
test: Add test for applying STP setting even STP disabled

### DIFF
--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -341,3 +341,59 @@ def test_partially_consume_linux_bridge_port(
             f"nmcli -g GENERAL.STATE d show {DUMMY1}".split(), check=True
         )[1]
     )
+
+
+@pytest.mark.tier1
+def test_linux_bridge_store_stp_setting_even_disabled(
+    eth1_up,
+):
+    with linux_bridge(
+        BRIDGE0,
+        bridge_subtree_state={
+            LB.PORT_SUBTREE: [
+                {
+                    LB.Port.NAME: "eth1",
+                }
+            ],
+            LB.OPTIONS_SUBTREE: {
+                LB.STP_SUBTREE: {
+                    LB.STP.ENABLED: False,
+                    LB.STP.FORWARD_DELAY: 16,
+                    LB.STP.HELLO_TIME: 2,
+                    LB.STP.MAX_AGE: 20,
+                    LB.STP.PRIORITY: 20480,
+                }
+            },
+        },
+    ) as state:
+        assertlib.assert_state_match(state)
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.stp c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "no"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.forward-delay c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "16"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.hello-time c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "2"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.max-age c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "20"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.priority c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "20480"
+        )


### PR DESCRIPTION
Ovirt use case requires nmstate to apply STP settings even STP been
disabled. Adding test for this use case as tier1.

Integration test case included.