### PR TITLE
[nmstate-1.3] nm linux bridge: Apply STP setting even STP disabled

### DIFF
--- a/libnmstate/nm/bridge.py
+++ b/libnmstate/nm/bridge.py
@@ -99,16 +99,15 @@ def _set_bridge_properties(bridge_setting, options):
 
 def _set_bridge_stp_properties(bridge_setting, bridge_stp):
     bridge_setting.props.stp = bridge_stp[LB.STP.ENABLED]
-    if bridge_stp[LB.STP.ENABLED] is True:
-        for stp_key, stp_val in bridge_stp.items():
-            if stp_key == LB.STP.PRIORITY:
-                bridge_setting.props.priority = stp_val
-            elif stp_key == LB.STP.FORWARD_DELAY:
-                bridge_setting.props.forward_delay = stp_val
-            elif stp_key == LB.STP.HELLO_TIME:
-                bridge_setting.props.hello_time = stp_val
-            elif stp_key == LB.STP.MAX_AGE:
-                bridge_setting.props.max_age = stp_val
+    for stp_key, stp_val in bridge_stp.items():
+        if stp_key == LB.STP.PRIORITY:
+            bridge_setting.props.priority = stp_val
+        elif stp_key == LB.STP.FORWARD_DELAY:
+            bridge_setting.props.forward_delay = stp_val
+        elif stp_key == LB.STP.HELLO_TIME:
+            bridge_setting.props.hello_time = stp_val
+        elif stp_key == LB.STP.MAX_AGE:
+            bridge_setting.props.max_age = stp_val
 
 
 def _is_vlan_filter_active(bridge_state):

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -341,3 +341,59 @@ def test_partially_consume_linux_bridge_port(
             f"nmcli -g GENERAL.STATE d show {DUMMY1}".split(), check=True
         )[1]
     )
+
+
+@pytest.mark.tier1
+def test_linux_bridge_store_stp_setting_even_disabled(
+    eth1_up,
+):
+    with linux_bridge(
+        BRIDGE0,
+        bridge_subtree_state={
+            LB.PORT_SUBTREE: [
+                {
+                    LB.Port.NAME: "eth1",
+                }
+            ],
+            LB.OPTIONS_SUBTREE: {
+                LB.STP_SUBTREE: {
+                    LB.STP.ENABLED: False,
+                    LB.STP.FORWARD_DELAY: 16,
+                    LB.STP.HELLO_TIME: 2,
+                    LB.STP.MAX_AGE: 20,
+                    LB.STP.PRIORITY: 20480,
+                }
+            },
+        },
+    ) as state:
+        assertlib.assert_state_match(state)
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.stp c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "no"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.forward-delay c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "16"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.hello-time c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "2"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.max-age c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "20"
+        )
+        assert (
+            exec_cmd(
+                f"nmcli -g bridge.priority c show {BRIDGE0}".split(),
+            )[1].strip()
+            == "20480"
+        )


### PR DESCRIPTION
Ovirt use case requires nmstate to apply STP settings even STP been
disabled. Kernel allows so and no hard to other user, hence we change
nmstate to apply STP settings regardless.

Integration test case included.