### PR TITLE
[nmstate-1.0] nm sriov: Do not touch SR-IOV if not desired

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -26,11 +26,11 @@ if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     COPR_ARG="--copr networkmanager/NetworkManager-1.30"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util python3-jsonschema;'
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema python3-nispor python3dist\(ovs\);'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
-        dnf install -y python3-varlink libvarlink-util python3-jsonschema;
+        dnf install -y python3-varlink libvarlink-util python3-jsonschema python3-nispor;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'

--- a/libnmstate/ifaces/ethernet.py
+++ b/libnmstate/ifaces/ethernet.py
@@ -139,6 +139,9 @@ def verify_sriov_vf(iface, cur_ifaces):
         and (iface.is_desired or iface.is_changed)
         and iface.type == InterfaceType.ETHERNET
         and iface.sriov_total_vfs > 0
+        and iface.original_dict.get(Ethernet.CONFIG_SUBTREE, {}).get(
+            Ethernet.SRIOV_SUBTREE
+        )
     ):
         return
     cur_iface = cur_ifaces.get_iface(iface.name, iface.type)

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -204,7 +204,7 @@ def create_new_nm_simple_conn(iface, nm_profile):
     if vxlan_setting:
         settings.append(vxlan_setting)
 
-    sriov_setting = create_sriov_setting(iface_info, nm_profile)
+    sriov_setting = create_sriov_setting(iface, nm_profile)
     if sriov_setting:
         settings.append(sriov_setting)
 

--- a/libnmstate/nm/sriov.py
+++ b/libnmstate/nm/sriov.py
@@ -47,9 +47,9 @@ SRIOV_NMSTATE_TO_NM_MAP = {
 }
 
 
-def create_setting(iface_state, base_con_profile):
+def create_setting(iface, base_con_profile):
     sriov_setting = None
-    sriov_config = iface_state.get(Ethernet.CONFIG_SUBTREE, {}).get(
+    sriov_config = iface.original_dict.get(Ethernet.CONFIG_SUBTREE, {}).get(
         Ethernet.SRIOV_SUBTREE
     )
 

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -509,3 +509,33 @@ class TestIfacesSriov:
         )
         assert absent_iface.is_desired
         assert absent_iface.is_absent
+
+    def test_ignore_sriov_vfs_if_not_desired(self):
+        pre_apply_cur_iface_infos = [
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+        ]
+        pre_apply_cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        pre_apply_cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 3}
+        }
+        pre_apply_cur_iface_infos[1][Interface.NAME] = f"{FOO1_IFACE_NAME}v0"
+        pre_apply_cur_iface_infos[2][Interface.NAME] = f"{FOO1_IFACE_NAME}v1"
+        pre_apply_cur_iface_infos[3][Interface.NAME] = f"{FOO1_IFACE_NAME}v2"
+
+        des_iface_infos = [gen_foo_iface_info(InterfaceType.ETHERNET)]
+        des_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+
+        des_ifaces = Ifaces(des_iface_infos, pre_apply_cur_iface_infos)
+
+        cur_iface_infos = [
+            gen_foo_iface_info(InterfaceType.ETHERNET),
+        ]
+        cur_iface_infos[0][Interface.NAME] = FOO1_IFACE_NAME
+        cur_iface_infos[0][Ethernet.CONFIG_SUBTREE] = {
+            Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 0}
+        }
+
+        des_ifaces.verify(cur_iface_infos)


### PR DESCRIPTION
We should not create SRIOV settings in NetworkManager if that is not
desired.

In the verification stage, we do not verify SR-IOV VFS if not desired.

Unit test case added to confirm verification will not check SRIOV if
not desired.

Manual test been done on Intel X710.