### PR TITLE
nm: Fix dbus value type of coalesce-adaptive RX/TX

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
@@ -128,13 +128,15 @@ impl TryFrom<DbusDictionary> for NmSettingEthtool {
             coalesce_adaptive_rx: _from_map!(
                 v,
                 "coalesce-adaptive-rx",
-                bool::try_from
-            )?,
+                u32::try_from
+            )?
+            .map(|i| i > 0),
             coalesce_adaptive_tx: _from_map!(
                 v,
                 "coalesce-adaptive-tx",
-                bool::try_from
-            )?,
+                u32::try_from
+            )?
+            .map(|i| i > 0),
             coalesce_pkt_rate_high: _from_map!(
                 v,
                 "coalesce-pkt-rate-high",
@@ -274,10 +276,10 @@ impl ToDbusValue for NmSettingEthtool {
             ret.insert("pause-autoneg", zvariant::Value::new(v));
         }
         if let Some(v) = &self.coalesce_adaptive_rx {
-            ret.insert("coalesce-adaptive-rx", zvariant::Value::new(v));
+            ret.insert("coalesce-adaptive-rx", zvariant::Value::new(*v as u32));
         }
         if let Some(v) = &self.coalesce_adaptive_tx {
-            ret.insert("coalesce-adaptive-tx", zvariant::Value::new(v));
+            ret.insert("coalesce-adaptive-tx", zvariant::Value::new(*v as u32));
         }
         if let Some(v) = &self.coalesce_pkt_rate_high {
             ret.insert("coalesce-pkt-rate-high", zvariant::Value::new(v));

--- a/tests/integration/nm/ethtool_test.py
+++ b/tests/integration/nm/ethtool_test.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import libnmstate
+from libnmstate.schema import Ethtool
+from libnmstate.schema import Interface
+
+from ..testlib import cmdlib
+
+
+def test_coalesce_rx_tx_no_verify(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Ethtool.CONFIG_SUBTREE: {
+                        Ethtool.Coalesce.CONFIG_SUBTREE: {
+                            Ethtool.Coalesce.ADAPTIVE_RX: True,
+                            Ethtool.Coalesce.ADAPTIVE_TX: True,
+                        }
+                    },
+                }
+            ]
+        },
+        verify_change=False,
+    )
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g ethtool.coalesce-adaptive-rx c show eth1".split()
+        )[1].strip()
+        == "1"
+    )
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g ethtool.coalesce-adaptive-tx c show eth1".split()
+        )[1].strip()
+        == "1"
+    )


### PR DESCRIPTION
When modifying `adaptive-rx` of `coalesce` in ethtool, we will get failure:

    org.freedesktop.NetworkManager.Settings.Connection.InvalidProperty:
    ethtool.coalesce-adaptive-rx: setting has invalid variant type

The `coalesce-adaptive-rx` and `coalesce-adaptive-tx` in NM dbus is u32,
other than bool.

Special hardware required to test this, hence the integration test case
has verification disabled, but it still check the communication to
NetworkManager.