### PR TITLE
ifaces: Do not verify absent real NIC

### DIFF
--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -375,21 +375,8 @@ fn verify_desire_absent_but_found_in_current(
         );
         log::error!("{}", e);
         Err(e)
-    } else if cur_iface.is_up() {
-        // Real hardware should be marked as down by absent action
-        let e = NmstateError::new(
-            ErrorKind::VerificationError,
-            format!(
-                "Absent interface {}/{} still found as \
-                state up: {:?}",
-                des_iface.name(),
-                des_iface.iface_type(),
-                cur_iface
-            ),
-        );
-        log::error!("{}", e);
-        Err(e)
     } else {
+        // Hard to predict real hardware state due to backend variety.
         Ok(())
     }
 }

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -76,3 +76,25 @@ fn test_veth_change_peer_away_from_ignored_peer() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_eth_verify_absent_ignore_current_up() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: absent
+"#,
+    )
+    .unwrap();
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+"#,
+    )
+    .unwrap();
+
+    desired.verify(&Interfaces::new(), &current).unwrap();
+}


### PR DESCRIPTION
When NetworkManager has inactive connection referring to a real NIC via
MAC address other than interface name, nmstate will not able to remove
that profile/connection which fail the verification for absent action:

    VerificationError: Absent interface ens3f0np0/ethernet still found as
    state up

It is complex to match such profile to interface when performing profile
deletion(the inactivate mac-referring profile only link to interface
after we delete its active profile).

Considering this is corner case, we just loose the absent verification on
real hardware.

Unit test case included.