### PR TITLE
ip: allow extra IP address found in verification stage

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -71,9 +71,15 @@ struct InterfaceIp {
     pub auto_table_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
     pub addr_gen_mode: Option<Ipv6AddrGenMode>,
+    #[serde(
+        default = "default_allow_extra_address",
+        skip_serializing,
+        rename = "allow-extra-address"
+    )]
+    pub allow_extra_address: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(into = "InterfaceIp")]
 #[non_exhaustive]
 pub struct InterfaceIpv4 {
@@ -87,6 +93,25 @@ pub struct InterfaceIpv4 {
     pub auto_gateway: Option<bool>,
     pub auto_routes: Option<bool>,
     pub auto_table_id: Option<u32>,
+    pub allow_extra_address: bool,
+}
+
+impl Default for InterfaceIpv4 {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            prop_list: Vec::new(),
+            dhcp: None,
+            dhcp_client_id: None,
+            addresses: None,
+            dns: None,
+            auto_dns: None,
+            auto_gateway: None,
+            auto_routes: None,
+            auto_table_id: None,
+            allow_extra_address: default_allow_extra_address(),
+        }
+    }
 }
 
 impl InterfaceIpv4 {
@@ -221,6 +246,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
             auto_routes: ip.auto_routes,
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
+            allow_extra_address: ip.allow_extra_address,
             ..Default::default()
         }
     }
@@ -242,12 +268,13 @@ impl From<InterfaceIpv4> for InterfaceIp {
             auto_routes: ip.auto_routes,
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
+            allow_extra_address: ip.allow_extra_address,
             ..Default::default()
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 #[serde(into = "InterfaceIp")]
 pub struct InterfaceIpv6 {
@@ -263,6 +290,27 @@ pub struct InterfaceIpv6 {
     pub auto_gateway: Option<bool>,
     pub auto_routes: Option<bool>,
     pub auto_table_id: Option<u32>,
+    pub allow_extra_address: bool,
+}
+
+impl Default for InterfaceIpv6 {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            prop_list: Vec::new(),
+            dhcp: None,
+            dhcp_duid: None,
+            autoconf: None,
+            addr_gen_mode: None,
+            addresses: None,
+            dns: None,
+            auto_dns: None,
+            auto_gateway: None,
+            auto_routes: None,
+            auto_table_id: None,
+            allow_extra_address: default_allow_extra_address(),
+        }
+    }
 }
 
 impl InterfaceIpv6 {
@@ -415,6 +463,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
             addr_gen_mode: ip.addr_gen_mode,
+            allow_extra_address: ip.allow_extra_address,
             ..Default::default()
         }
     }
@@ -438,6 +487,7 @@ impl From<InterfaceIpv6> for InterfaceIp {
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
             addr_gen_mode: ip.addr_gen_mode,
+            allow_extra_address: ip.allow_extra_address,
             ..Default::default()
         }
     }
@@ -772,4 +822,9 @@ fn is_none_or_empty_mptcp_flags(v: &Option<Vec<MptcpAddressFlag>>) -> bool {
     } else {
         true
     }
+}
+
+// Allow extra IP by default
+fn default_allow_extra_address() -> bool {
+    true
 }

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -89,6 +89,7 @@ impl BaseInterface {
     pub(crate) fn pre_verify_cleanup(
         &mut self,
         pre_apply_current: Option<&Self>,
+        mut current: Option<&mut Self>,
     ) {
         // Ignore min_mtu and max_mtu as they are not changeable
         self.min_mtu = None;
@@ -103,12 +104,14 @@ impl BaseInterface {
         if let Some(ref mut ipv4) = self.ipv4 {
             ipv4.pre_verify_cleanup(
                 pre_apply_current.and_then(|i| i.ipv4.as_ref()),
+                current.as_mut().and_then(|i| i.ipv4.as_mut()),
             );
         }
 
         if let Some(ref mut ipv6) = self.ipv6 {
             ipv6.pre_verify_cleanup(
                 pre_apply_current.and_then(|i| i.ipv6.as_ref()),
+                current.as_mut().and_then(|i| i.ipv6.as_mut()),
             );
         }
         // Change all veth interface to ethernet for simpler verification

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -19,9 +19,12 @@ impl Interface {
     pub(crate) fn pre_verify_cleanup(
         &mut self,
         pre_apply_current: Option<&Self>,
+        current: Option<&mut Self>,
     ) {
-        self.base_iface_mut()
-            .pre_verify_cleanup(pre_apply_current.map(|i| i.base_iface()));
+        self.base_iface_mut().pre_verify_cleanup(
+            pre_apply_current.map(|i| i.base_iface()),
+            current.map(|c| c.base_iface_mut()),
+        );
         match self {
             Self::LinuxBridge(ref mut iface) => {
                 iface.pre_verify_cleanup();
@@ -61,8 +64,9 @@ impl Interface {
             self_clone.base_iface_mut().controller_type =
                 current_clone.base_iface().controller_type.clone();
         }
-        current_clone.pre_verify_cleanup(None);
-        self_clone.pre_verify_cleanup(pre_apply_cur_iface);
+        current_clone.pre_verify_cleanup(None, None);
+        self_clone
+            .pre_verify_cleanup(pre_apply_cur_iface, Some(&mut current_clone));
         if self_clone.iface_type() == InterfaceType::Unknown {
             current_clone.base_iface_mut().iface_type = InterfaceType::Unknown;
         }

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -23,6 +23,6 @@ mac-address: "d4:ee:07:25:42:5a"
 "#,
     )
     .unwrap();
-    iface.pre_verify_cleanup(None);
+    iface.pre_verify_cleanup(None, None);
     assert_eq!(iface.mac_address, Some(String::from("D4:EE:07:25:42:5A")));
 }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,4 +1,4 @@
-use crate::{BaseInterface, Interface, InterfaceState};
+use crate::{BaseInterface, ErrorKind, Interface, InterfaceState, Interfaces};
 
 #[test]
 fn test_ip_stringlized_attributes() {
@@ -66,4 +66,136 @@ ipv6:
     assert_eq!(iface.name(), "eth1");
     assert_eq!(iface.base_iface().ipv4, None);
     assert_eq!(iface.base_iface().ipv6, None);
+}
+
+#[test]
+fn test_ip_allow_extra_address_by_default() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "192.168.1.1"
+      prefix-length: "24"
+  ipv6:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+      prefix-length: "64"
+"#,
+    )
+    .unwrap();
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "192.168.1.1"
+      prefix-length: "24"
+    - ip: "192.168.1.2"
+      prefix-length: "24"
+  ipv6:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+      prefix-length: "64"
+    - ip: "2001:0db8:85a3:0000:0001:8a2e:0370:7331"
+      prefix-length: "64"
+"#,
+    )
+    .unwrap();
+
+    desired.verify(&Interfaces::new(), &current).unwrap();
+}
+
+#[test]
+fn test_ipv4_not_allow_extra_address() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: "true"
+    dhcp: "false"
+    allow-extra-address: false
+    address:
+    - ip: "192.168.1.1"
+      prefix-length: "24"
+"#,
+    )
+    .unwrap();
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "192.168.1.1"
+      prefix-length: "24"
+    - ip: "192.168.1.2"
+      prefix-length: "24"
+"#,
+    )
+    .unwrap();
+
+    let result = desired.verify(&Interfaces::new(), &current);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::VerificationError);
+    }
+}
+
+#[test]
+fn test_ipv6_not_allow_extra_address() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv6:
+    enabled: "true"
+    dhcp: "false"
+    allow-extra-address: false
+    address:
+    - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+      prefix-length: "64"
+"#,
+    )
+    .unwrap();
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: up
+  ipv6:
+    enabled: "true"
+    dhcp: "false"
+    address:
+    - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+      prefix-length: "64"
+    - ip: "2001:0db8:85a3:0000:0001:8a2e:0370:7331"
+      prefix-length: "64"
+"#,
+    )
+    .unwrap();
+
+    let result = desired.verify(&Interfaces::new(), &current);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::VerificationError);
+    }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -135,6 +135,7 @@ class InterfaceIP:
     AUTO_ROUTES = "auto-routes"
     AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
     MPTCP_FLAGS = "mptcp-flags"
+    ALLOW_EXTRA_ADDRESS = "allow-extra-address"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -538,6 +538,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcpcli_up):
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV6] = _create_ipv6_state(enabled=True)
 
+    print(desired_state)
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)


### PR DESCRIPTION
When nmstate applying the network state, there might be another tool
changing the IP addresses of interface, which lead to verification error
as extra IP address found. This is valid use case in kubernetes-nmstate
where keepalived is trying to add VIP(192.168.111.4) to certain interface.

To support that, we introduce `InterfaceIpv4.allow_extra_ip` and
`InterfaceIpv6.allow_extra_ip` with default set to true, nmstate
verification will ignore extra IP address after applied.

Considering this is a very corner case, and could make the life of of
OpenshiftSDN engineer easier, I would suggest we accept this breaker of
API behavior.

It is hard to reproduce it in integration test case, hence only added
unit test cases.