### PR TITLE
[nmstate-1.2] ovsdb: Raise exception if no ovsdb plugin when required

### DIFF
--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -32,6 +32,7 @@ class NmstatePlugin(metaclass=ABCMeta):
     PLUGIN_CAPABILITY_ROUTE = "route"
     PLUGIN_CAPABILITY_ROUTE_RULE = "route_rule"
     PLUGIN_CAPABILITY_DNS = "dns"
+    PLUGIN_CAPABILITY_OVSDB_GLOBAL = "ovsdb_global"
 
     DEFAULT_PRIORITY = 10
 

--- a/libnmstate/plugins/nmstate_plugin_ovsdb.py
+++ b/libnmstate/plugins/nmstate_plugin_ovsdb.py
@@ -156,8 +156,16 @@ class NmstateOvsdbPlugin(NmstatePlugin):
         return NmstatePlugin.DEFAULT_PRIORITY + 1
 
     @property
+    def capabilities(self):
+        return [
+            NmstatePlugin.PLUGIN_CAPABILITY_OVSDB_GLOBAL,
+        ]
+
+    @property
     def plugin_capabilities(self):
-        return NmstatePlugin.PLUGIN_CAPABILITY_IFACE
+        return [
+            NmstatePlugin.PLUGIN_CAPABILITY_IFACE,
+        ]
 
     def get_interfaces(self):
         ifaces = []

--- a/libnmstate/validator.py
+++ b/libnmstate/validator.py
@@ -23,6 +23,7 @@ import logging
 import jsonschema as js
 
 from libnmstate.schema import Interface
+from libnmstate.schema import OvsDB
 from libnmstate.schema import InterfaceType
 from libnmstate.error import NmstateDependencyError
 
@@ -43,6 +44,7 @@ def schema_validate(data, validation_schema=schema.ifaces_schema):
 
 def validate_capabilities(state, capabilities):
     validate_interface_capabilities(state.get(Interface.KEY, []), capabilities)
+    validate_ovsdb_global_cap(state.get(OvsDB.KEY, {}), capabilities)
 
 
 def validate_interface_capabilities(ifaces_state, capabilities):
@@ -77,4 +79,16 @@ def _validate_max_supported_intface_count(data):
         logging.warning(
             "Interfaces count exceeds the limit %s in desired state",
             MAX_SUPPORTED_INTERFACES,
+        )
+
+
+def validate_ovsdb_global_cap(ovsdb_global_conf, capabilities):
+    if (
+        ovsdb_global_conf
+        and NmstatePlugin.PLUGIN_CAPABILITY_OVSDB_GLOBAL not in capabilities
+    ):
+        raise NmstateDependencyError(
+            "Missing plugin for ovs-db global configuration, "
+            "please try to install 'nmstate-plugin-ovsdb' or other plugin "
+            "provides NmstatePlugin.PLUGIN_CAPABILITY_OVSDB_GLOBAL"
         )

--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -15,3 +15,5 @@ __all__ = [
 ]
 
 __version__ = "1.2.2"
+
+BASE_ON_RUST = True

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -45,11 +45,13 @@ from .testlib import assertlib
 from .testlib import cmdlib
 from .testlib import iprule
 from .testlib import statelib
+from .testlib.env import is_rust_nmstate
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.nmplugin import mount_devnull_to_path
-from .testlib.statelib import state_match
 from .testlib.ovslib import Bridge
+from .testlib.plugin import tmp_plugin_dir
+from .testlib.statelib import state_match
 from .testlib.vlan import vlan_interface
 
 
@@ -1049,3 +1051,19 @@ def test_ovs_vxlan_in_current_not_impact_others(unmanged_ovs_vxlan):
         assertlib.assert_state_match(state)
 
     assertlib.assert_absent(BRIDGE1)
+
+
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    is_rust_nmstate(),
+    reason="Nmstate rust support ovsdb without external dependency",
+)
+def test_global_ovsdb_without_ovsdb_plugin():
+    with tmp_plugin_dir():
+        desired_ovs_config = {
+            OvsDB.EXTERNAL_IDS: {
+                TEST_EXTERNAL_IDS_KEY: TEST_EXTERNAL_IDS_VALUE
+            }
+        }
+        with pytest.raises(NmstateDependencyError):
+            libnmstate.apply({OvsDB.KEY: desired_ovs_config})

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import libnmstate
 import os
 
 import gi
@@ -42,3 +43,9 @@ def nm_major_minor_version():
 
 def is_k8s():
     return os.getenv("RUN_K8S") == "true"
+
+
+def is_rust_nmstate():
+    return hasattr(libnmstate, "BASE_ON_RUST") and getattr(
+        libnmstate, "BASE_ON_RUST"
+    )


### PR DESCRIPTION
Raise `NmstateDependencyError` when no plugin is providing
`NmstatePlugin.PLUGIN_CAPABILITY_OVSDB_GLOBAL` but with ovsdb global
config desired.

Integration test case included and marked as tier1 as OpenShift require
this use case.