### PR TITLE
Introduce support of nmpolicy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _kubevirtci
 rust/Cargo.lock
 rust/target
 rust/src/clib/test/nmstate_test
+rust/src/clib/test/nmpolicy_test
 rust/src/clib/test/vgcore*
 rust/src/clib/nmstate.h
 rust/vendor/

--- a/Makefile
+++ b/Makefile
@@ -178,10 +178,16 @@ clib_check: $(CLIB_SO_DEV_DEBUG) $(CLIB_HEADER)
 	cp $(CLIB_HEADER) $(TMPDIR)/$(shell basename $(CLIB_HEADER))
 	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
 		-o $(TMPDIR)/nmstate_test rust/src/clib/test/nmstate_test.c
+	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
+		-o $(TMPDIR)/nmpolicy_test rust/src/clib/test/nmpolicy_test.c
 	LD_LIBRARY_PATH=$(TMPDIR) \
 		valgrind --trace-children=yes --leak-check=full \
 		--error-exitcode=1 \
 		$(TMPDIR)/nmstate_test 1>/dev/null
+	LD_LIBRARY_PATH=$(TMPDIR) \
+		valgrind --trace-children=yes --leak-check=full \
+		--error-exitcode=1 \
+		$(TMPDIR)/nmpolicy_test 1>/dev/null
 	rm -rf $(TMPDIR)
 
 .PHONY: go_check

--- a/examples/policy/all-ethernet-up/current.yml
+++ b/examples/policy/all-ethernet-up/current.yml
@@ -1,0 +1,26 @@
+---
+interfaces:
+  - accept-all-mac-addresses: false
+    lldp:
+      enabled: false
+    mac-address: 52:55:00:D1:55:01
+    name: eth0
+    state: up
+    type: ethernet
+  - accept-all-mac-addresses: false
+    lldp:
+      enabled: false
+    mac-address: 52:55:00:D1:56:02
+    name: eth1
+    state: down
+    type: ethernet
+  - accept-all-mac-addresses: false
+    mac-address: 52:55:00:D1:57:03
+    name: eth4
+    state: up
+    type: ethernet
+  - accept-all-mac-addresses: false
+    mac-address: 52:55:00:D1:56:04
+    name: eth2
+    state: down
+    type: ethernet

--- a/examples/policy/all-ethernet-up/expected.yml
+++ b/examples/policy/all-ethernet-up/expected.yml
@@ -1,0 +1,16 @@
+---
+interfaces:
+  - accept-all-mac-addresses: false
+    lldp:
+      enabled: true
+    mac-address: 52:55:00:D1:55:01
+    name: eth0
+    state: up
+    type: ethernet
+  - accept-all-mac-addresses: false
+    lldp:
+      enabled: true
+    mac-address: 52:55:00:D1:57:03
+    name: eth4
+    state: up
+    type: ethernet

--- a/examples/policy/all-ethernet-up/policy.yml
+++ b/examples/policy/all-ethernet-up/policy.yml
@@ -1,0 +1,8 @@
+---
+capture:
+  ethernets: interfaces.type=="ethernet"
+  ethernets-up: capture.ethernets.interfaces.state=="up"
+  ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
+
+desiredState:
+  interfaces: "{{ capture.ethernets-lldp.interfaces }}"

--- a/examples/policy/all-linux-bridges-down/current.yml
+++ b/examples/policy/all-linux-bridges-down/current.yml
@@ -1,0 +1,13 @@
+---
+interfaces:
+  - name: eth0
+    type: ethernet
+  - name: br1
+    type: linux-bridge
+    state: up
+  - name: br2
+    type: linux-bridge
+    state: up
+  - name: br3
+    type: linux-bridge
+    state: up

--- a/examples/policy/all-linux-bridges-down/expected.yml
+++ b/examples/policy/all-linux-bridges-down/expected.yml
@@ -1,0 +1,11 @@
+---
+interfaces:
+  - name: br1
+    type: linux-bridge
+    state: down
+  - name: br2
+    type: linux-bridge
+    state: down
+  - name: br3
+    type: linux-bridge
+    state: down

--- a/examples/policy/all-linux-bridges-down/policy.yml
+++ b/examples/policy/all-linux-bridges-down/policy.yml
@@ -1,0 +1,7 @@
+---
+capture:
+  linux-bridges: interfaces.type=="linux-bridge"
+  linux-bridges-down: capture.linux-bridges | interfaces.state:="down"
+
+desiredState:
+  interfaces: "{{ capture.linux-bridges-down.interfaces }}"

--- a/examples/policy/bridge-interfaces-by-description/current.yml
+++ b/examples/policy/bridge-interfaces-by-description/current.yml
@@ -1,0 +1,12 @@
+---
+interfaces:
+  - name: eth0
+    description: primary
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:01
+  - name: eth1
+    description: secondary
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:02

--- a/examples/policy/bridge-interfaces-by-description/expected.yml
+++ b/examples/policy/bridge-interfaces-by-description/expected.yml
@@ -1,0 +1,16 @@
+---
+interfaces:
+  - bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth0
+        - name: eth1
+    ipv4:
+      dhcp: true
+      enabled: true
+    mac-address: 00:00:5E:00:00:01
+    name: br1
+    state: up
+    type: linux-bridge

--- a/examples/policy/bridge-interfaces-by-description/policy.yml
+++ b/examples/policy/bridge-interfaces-by-description/policy.yml
@@ -1,0 +1,20 @@
+---
+capture:
+  primary-nic: interfaces.description == "primary"
+  secondary-nic: interfaces.description == "secondary"
+desiredState:
+  interfaces:
+    - name: br1
+      type: linux-bridge
+      state: up
+      mac-address: "{{ capture.primary-nic.interfaces.0.mac-address }}"
+      ipv4:
+        dhcp: true
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: "{{ capture.primary-nic.interfaces.0.name }}"
+          - name: "{{ capture.secondary-nic.interfaces.0.name }}"

--- a/examples/policy/bridge-on-default-gw-dhcp/current.yml
+++ b/examples/policy/bridge-on-default-gw-dhcp/current.yml
@@ -1,0 +1,24 @@
+---
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: true
+      enabled: true

--- a/examples/policy/bridge-on-default-gw-dhcp/expected.yml
+++ b/examples/policy/bridge-on-default-gw-dhcp/expected.yml
@@ -1,0 +1,18 @@
+---
+interfaces:
+  - name: br1
+    description: >-
+      DHCP aware Linux bridge to connect a nic that is
+      referenced by a default gateway
+    type: linux-bridge
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      dhcp: true
+      enabled: true
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth1

--- a/examples/policy/bridge-on-default-gw-dhcp/policy.yml
+++ b/examples/policy/bridge-on-default-gw-dhcp/policy.yml
@@ -1,0 +1,23 @@
+---
+capture:
+  default-gw: routes.running.destination=="0.0.0.0/0"
+  base-iface: >-
+    interfaces.name==capture.default-gw.routes.running.0.next-hop-interface
+desiredState:
+  interfaces:
+    - name: br1
+      description: >-
+        DHCP aware Linux bridge to connect a nic that is referenced by a
+        default gateway
+      type: linux-bridge
+      state: up
+      mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
+      ipv4:
+        dhcp: true
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: "{{ capture.base-iface.interfaces.0.name }}"

--- a/examples/policy/bridge-on-default-gw-no-dhcp/current.yml
+++ b/examples/policy/bridge-on-default-gw-no-dhcp/current.yml
@@ -1,0 +1,24 @@
+---
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: false
+      enabled: true

--- a/examples/policy/bridge-on-default-gw-no-dhcp/expected.yml
+++ b/examples/policy/bridge-on-default-gw-no-dhcp/expected.yml
@@ -1,0 +1,31 @@
+---
+interfaces:
+  - name: br1
+    description: Linux bridge with base interface as a port
+    type: linux-bridge
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: false
+      enabled: true
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth1
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: br1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: br1
+      table-id: 254

--- a/examples/policy/bridge-on-default-gw-no-dhcp/policy.yml
+++ b/examples/policy/bridge-on-default-gw-no-dhcp/policy.yml
@@ -1,0 +1,25 @@
+---
+capture:
+  default-gw: routes.running.destination=="0.0.0.0/0"
+  base-iface: >-
+    interfaces.name==capture.default-gw.routes.running.0.next-hop-interface
+  base-iface-routes: >-
+    routes.running.next-hop-interface==capture.base-iface.interfaces.0.name
+  bridge-routes: >-
+    capture.base-iface-routes | routes.running.next-hop-interface:="br1"
+desiredState:
+  interfaces:
+    - name: br1
+      description: Linux bridge with base interface as a port
+      type: linux-bridge
+      state: up
+      mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
+      ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: "{{ capture.base-iface.interfaces.0.name }}"
+  routes:
+    config: "{{ capture.bridge-routes.routes.running }}"

--- a/examples/policy/convert-dhcp-to-static/current.yml
+++ b/examples/policy/convert-dhcp-to-static/current.yml
@@ -1,0 +1,31 @@
+---
+dns-resolver:
+  running:
+    search:
+      - example.com
+      - example.org
+    server:
+      - 8.8.8.8
+      - 2001:4860:4860::8888
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: true
+      enabled: true

--- a/examples/policy/convert-dhcp-to-static/expected.yml
+++ b/examples/policy/convert-dhcp-to-static/expected.yml
@@ -1,0 +1,31 @@
+---
+dns-resolver:
+  config:
+    search:
+      - example.com
+      - example.org
+    server:
+      - 8.8.8.8
+      - 2001:4860:4860::8888
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: false
+      enabled: true

--- a/examples/policy/convert-dhcp-to-static/policy.yml
+++ b/examples/policy/convert-dhcp-to-static/policy.yml
@@ -1,0 +1,18 @@
+---
+capture:
+  eth1-iface: interfaces.name == "eth1"
+  eth1-routes: routes.running.next-hop-interface == "eth1"
+  dns: dns-resolver.running
+desiredState:
+  interfaces:
+    - name: eth1
+      type: ethernet
+      state: up
+      ipv4:
+        address: "{{ capture.eth1-iface.interfaces.0.ipv4.address }}"
+        dhcp: false
+        enabled: true
+  routes:
+    config: "{{ capture.eth1-routes.routes.running }}"
+  dns-resolver:
+    config: "{{ capture.dns.dns-resolver.running }}"

--- a/examples/policy/ovs-slb-bond-primary-secondary/current.yml
+++ b/examples/policy/ovs-slb-bond-primary-secondary/current.yml
@@ -1,0 +1,18 @@
+---
+interfaces:
+  - name: eth1
+    description: primary
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      dhcp: true
+      enabled: true
+  - name: eth2
+    description: secondary
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:02
+    ipv4:
+      dhcp: true
+      enabled: true

--- a/examples/policy/ovs-slb-bond-primary-secondary/expected.yml
+++ b/examples/policy/ovs-slb-bond-primary-secondary/expected.yml
@@ -1,0 +1,25 @@
+---
+interfaces:
+  - name: br1-iface
+    type: ovs-interface
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      dhcp: true
+      enabled: true
+  - name: br1
+    type: ovs-bridge
+    state: up
+    bridge:
+      options:
+        stp: false
+        mcast-snooping-enable: false
+        rstp: false
+      port:
+        - name: bond0
+          link-aggregation:
+            mode: balance-slb
+            port:
+              - name: eth1
+              - name: eth2
+        - name: br1-iface

--- a/examples/policy/ovs-slb-bond-primary-secondary/policy.yml
+++ b/examples/policy/ovs-slb-bond-primary-secondary/policy.yml
@@ -1,0 +1,27 @@
+---
+capture:
+  primary-nic: interfaces.description == "primary"
+  secondary-nic: interfaces.description == "secondary"
+desiredState:
+  interfaces:
+    - name: br1-iface
+      type: ovs-interface
+      state: up
+      mac-address: "{{ capture.primary-nic.interfaces.0.mac-address }}"
+      ipv4: "{{ capture.primary-nic.interfaces.0.ipv4 }}"
+    - name: br1
+      type: ovs-bridge
+      state: up
+      bridge:
+        options:
+          stp: false
+          mcast-snooping-enable: false
+          rstp: false
+        port:
+          - name: bond0
+            link-aggregation:
+              mode: balance-slb
+              port:
+                - name: "{{ capture.primary-nic.interfaces.0.name }}"
+                - name: "{{ capture.secondary-nic.interfaces.0.name }}"
+          - name: br1-iface

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.14"
 serde_json = "1.0.75"
 ctrlc = { version = "3.2.1", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
+chrono = "0.4"
 
 [features]
 default = ["query_apply", "gen_conf"]

--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+
+use nmstate::{NetworkPolicy, NetworkState};
+use serde::{Deserialize, Serialize};
+
+use crate::error::CliError;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+struct CliNmpolicyCaptureState {
+    #[serde(rename = "metaInfo")]
+    meta_info: CliNmpolicyCaptureMetaInfo,
+    state: NetworkState,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+struct CliNmpolicyCaptureMetaInfo {
+    time: String,
+    version: String,
+}
+
+pub(crate) fn policy(matches: &clap::ArgMatches) -> Result<String, CliError> {
+    let net_policy = deserilize_from_file::<NetworkPolicy>(
+        // clap already confirmed POLICY_FILE is always defined,
+        // so unwrap() here is safe.
+        matches.value_of("POLICY_FILE").unwrap(),
+    )?;
+    if net_policy.is_empty() {
+        return Ok(String::new());
+    }
+    let current_state =
+        if let Some(current_state_file) = matches.value_of("CURRENT_STATE") {
+            deserilize_from_file::<NetworkState>(current_state_file)?
+        } else {
+            let mut state = NetworkState::new();
+            state.retrieve()?;
+            state
+        };
+
+    let captured_states = if let Some(captured_state_file) =
+        matches.value_of("CAPTURED_STATES")
+    {
+        load_capture_states_from_file(captured_state_file)?
+    } else {
+        net_policy.capture.execute(&current_state)?
+    };
+
+    if let Some(output_capture_file) = matches.value_of("OUTPUT_CAPTURED") {
+        store_capture_states_from_file(
+            output_capture_file,
+            &captured_states,
+            matches.is_present("JSON"),
+        )?;
+    }
+
+    let new_net_state = net_policy
+        .desired
+        .fill_with_captured_data(&captured_states)?;
+
+    if new_net_state.is_empty() {
+        return Ok("".to_string());
+    }
+
+    Ok(if matches.is_present("JSON") {
+        serde_json::to_string_pretty(&new_net_state)?
+    } else {
+        serde_yaml::to_string(&new_net_state)?
+    })
+}
+
+fn deserilize_from_file<T>(file_path: &str) -> Result<T, CliError>
+where
+    T: for<'de> serde::Deserialize<'de> + Default,
+{
+    let mut fd = std::fs::File::open(file_path)?;
+    let mut content = String::new();
+    fd.read_to_string(&mut content)?;
+    if content.is_empty() {
+        return Ok(T::default());
+    }
+    match serde_yaml::from_str(&content) {
+        Ok(n) => Ok(n),
+        Err(yaml_error) => match serde_json::from_str(&content) {
+            Ok(n) => Ok(n),
+            Err(json_error) => Err(format!(
+                "Failed to load from file, \
+                     tried both YAML and JSON format. Errors: {}, {}",
+                yaml_error, json_error
+            )
+            .into()),
+        },
+    }
+}
+
+fn load_capture_states_from_file(
+    captured_state_file: &str,
+) -> Result<HashMap<String, NetworkState>, CliError> {
+    let mut states = HashMap::new();
+    let mut cli_cap_states = deserilize_from_file::<
+        HashMap<String, CliNmpolicyCaptureState>,
+    >(captured_state_file)?;
+    for (name, cli_cap_state) in cli_cap_states.drain() {
+        states.insert(name, cli_cap_state.state);
+    }
+
+    Ok(states)
+}
+
+fn store_capture_states_from_file(
+    file_path: &str,
+    states: &HashMap<String, NetworkState>,
+    use_json_format: bool,
+) -> Result<(), CliError> {
+    let mut cli_cap_states = HashMap::new();
+    for (name, state) in states.iter() {
+        cli_cap_states.insert(
+            name.to_string(),
+            CliNmpolicyCaptureState {
+                meta_info: CliNmpolicyCaptureMetaInfo {
+                    time: get_utc_time_in_rfc3339_format(),
+                    version: "0".to_string(),
+                },
+                state: state.clone(),
+            },
+        );
+    }
+    let states_string = if use_json_format {
+        serde_json::to_string_pretty(&cli_cap_states)?
+    } else {
+        serde_yaml::to_string(&cli_cap_states)?
+    };
+    let mut fd = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(file_path)
+        .map_err(|e| {
+            CliError::from(format!(
+                "Failed to store captured states to file {}: {}",
+                file_path, e
+            ))
+        })?;
+    fd.write_all(states_string.as_bytes())?;
+    Ok(())
+}
+
+fn get_utc_time_in_rfc3339_format() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -8,6 +8,8 @@ mod checkpoint;
 mod gen_conf;
 mod logger;
 #[cfg(feature = "query_apply")]
+mod policy;
+#[cfg(feature = "query_apply")]
 mod query;
 
 use std::ffi::CString;
@@ -26,6 +28,8 @@ pub use crate::checkpoint::{
 };
 #[cfg(feature = "gen_conf")]
 pub use crate::gen_conf::nmstate_generate_configurations;
+#[cfg(feature = "query_apply")]
+pub use crate::policy::nmstate_net_state_from_policy;
 #[cfg(feature = "query_apply")]
 pub use crate::query::nmstate_net_state_retrieve;
 

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -129,8 +129,8 @@ int nmstate_net_state_apply(uint32_t flags, const char *state, uint32_t rollback
  *      0.1
  *
  * Description:
- *      Destroy the checkpoint, if no checkpoint 
- *      is passed it will destroy last active checkpoint 
+ *      Destroy the checkpoint, if no checkpoint
+ *      is passed it will destroy last active checkpoint
  *
  * @checkpoint:
  *      Checkpoint to destroy or empty to select the last active one.
@@ -161,8 +161,8 @@ int nmstate_checkpoint_commit(const char *checkpoint, char **log, char **err_kin
  *      0.1
  *
  * Description:
- *      Rollack the checkpoint, if no checkpoint 
- *      is passed it will rollback last active checkpoint 
+ *      Rollack the checkpoint, if no checkpoint
+ *      is passed it will rollback last active checkpoint
  *
  * @checkpoint:
  *      Checkpoint to rollback or empty to select the last active one.
@@ -224,6 +224,45 @@ int nmstate_generate_configurations(const char *state, char **configs,
                                     char **log, char **err_kind,
                                     char **err_msg);
 
+/**
+ * nmstate_net_state_from_policy - Generate network state from policy
+ *
+ * Version:
+ *      2.2
+ *
+ * Description:
+ *      Generate new network state from policy again specifed state
+ *
+ * @policy:
+ *      Pointer of char array for network policy in json format.
+ * @current_state:
+ *      Pointer of char array for current network state.
+ * @state:
+ *      Output pointer of char array for network state in json format.
+ *      The memory should be freed by nmstate_net_state_free().
+ * @log:
+ *      Output pointer of char array for logging.
+ *      The memory should be freed by nmstate_log_free().
+ * @err_kind:
+ *      Output pointer of char array for error kind.
+ *      The memory should be freed by nmstate_err_kind_free().
+ * @err_msg:
+ *      Output pointer of char array for error message.
+ *      The memory should be freed by nmstate_err_msg_free().
+ *
+ * Return:
+ *      Error code:
+ *          * NMSTATE_PASS
+ *              On success.
+ *          * NMSTATE_FAIL
+ *              On failure.
+ */
+int nmstate_net_state_from_policy(const char *policy,
+                                  const char *current_state,
+                                  char **state,
+                                  char **log,
+                                  char **err_kind,
+                                  char **err_msg);
 /**
  * nmstate_cstring_free - free the memory of C string
  *

--- a/rust/src/clib/policy.rs
+++ b/rust/src/clib/policy.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use std::ffi::{CStr, CString};
+use std::time::SystemTime;
+
+use libc::{c_char, c_int};
+use nmstate::{NetworkPolicy, NetworkState};
+
+use crate::{init_logger, NMSTATE_FAIL, NMSTATE_PASS};
+
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+#[no_mangle]
+pub extern "C" fn nmstate_net_state_from_policy(
+    policy: *const c_char,
+    current_state: *const c_char,
+    state: *mut *mut c_char,
+    log: *mut *mut c_char,
+    err_kind: *mut *mut c_char,
+    err_msg: *mut *mut c_char,
+) -> c_int {
+    assert!(!policy.is_null());
+    assert!(!state.is_null());
+    assert!(!log.is_null());
+    assert!(!err_kind.is_null());
+    assert!(!err_msg.is_null());
+
+    unsafe {
+        *state = std::ptr::null_mut();
+        *log = std::ptr::null_mut();
+        *err_kind = std::ptr::null_mut();
+        *err_msg = std::ptr::null_mut();
+    }
+
+    if state.is_null() {
+        return NMSTATE_PASS;
+    }
+
+    let logger = match init_logger() {
+        Ok(l) => l,
+        Err(e) => {
+            unsafe {
+                *err_msg =
+                    CString::new(format!("Failed to setup logger: {}", e))
+                        .unwrap()
+                        .into_raw();
+            }
+            return NMSTATE_FAIL;
+        }
+    };
+    let now = SystemTime::now();
+
+    let current = if current_state.is_null() {
+        None
+    } else {
+        match deserilize_from_c_char::<NetworkState>(
+            current_state,
+            err_kind,
+            err_msg,
+        ) {
+            Some(c) => Some(c),
+            None => {
+                unsafe {
+                    *log = CString::new(logger.drain(now)).unwrap().into_raw();
+                }
+                return NMSTATE_FAIL;
+            }
+        }
+    };
+
+    let mut policy = match deserilize_from_c_char::<NetworkPolicy>(
+        policy, err_kind, err_msg,
+    ) {
+        Some(p) => p,
+        None => {
+            unsafe {
+                *log = CString::new(logger.drain(now)).unwrap().into_raw();
+            }
+            return NMSTATE_FAIL;
+        }
+    };
+    policy.current = current;
+
+    let result = NetworkState::try_from(policy);
+    unsafe {
+        *log = CString::new(logger.drain(now)).unwrap().into_raw();
+    }
+
+    match result {
+        Ok(s) => match serde_json::to_string(&s) {
+            Ok(state_str) => unsafe {
+                *state = CString::new(state_str).unwrap().into_raw();
+                NMSTATE_PASS
+            },
+            Err(e) => unsafe {
+                *err_msg = CString::new(format!(
+                    "serde_json::to_string failure: {}",
+                    e
+                ))
+                .unwrap()
+                .into_raw();
+                *err_kind =
+                    CString::new(format!("{}", nmstate::ErrorKind::Bug))
+                        .unwrap()
+                        .into_raw();
+                NMSTATE_FAIL
+            },
+        },
+        Err(e) => {
+            unsafe {
+                *err_msg = CString::new(e.msg()).unwrap().into_raw();
+                *err_kind =
+                    CString::new(format!("{}", &e.kind())).unwrap().into_raw();
+            }
+            NMSTATE_FAIL
+        }
+    }
+}
+
+fn deserilize_from_c_char<T>(
+    content: *const c_char,
+    err_kind: *mut *mut c_char,
+    err_msg: *mut *mut c_char,
+) -> Option<T>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    let content_cstr = unsafe { CStr::from_ptr(content) };
+
+    let content_str = match content_cstr.to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            unsafe {
+                *err_msg = CString::new(format!(
+                    "Error on converting C char to rust str: {}",
+                    e
+                ))
+                .unwrap()
+                .into_raw();
+                *err_kind = CString::new(format!(
+                    "{}",
+                    nmstate::ErrorKind::InvalidArgument
+                ))
+                .unwrap()
+                .into_raw();
+            }
+            return None;
+        }
+    };
+
+    match serde_json::from_str(content_str) {
+        Ok(n) => Some(n),
+        Err(e) => {
+            unsafe {
+                *err_msg = CString::new(e.to_string()).unwrap().into_raw();
+                *err_kind = CString::new("InvalidArgument").unwrap().into_raw();
+            }
+            None
+        }
+    }
+}

--- a/rust/src/clib/test/nmpolicy_test.c
+++ b/rust/src/clib/test/nmpolicy_test.c
@@ -1,0 +1,99 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <nmstate.h>
+
+int main(void) {
+	int rc = EXIT_SUCCESS;
+	const char *policy = "{"
+"  \"capture\": {"
+"    \"default-gw\": \"override me with the cache\","
+"    \"base-iface\": \"interfaces.name== capture.default-gw.routes.running.0.next-hop-interface\","
+"    \"base-iface-routes\": \"routes.running.next-hop-interface== capture.default-gw.routes.running.0.next-hop-interface\","
+"    \"bridge-routes\": \"capture.base-iface-routes | routes.running.next-hop-interface:=\\\"br1\\\"\""
+"  },"
+"  \"desiredState\": {"
+"    \"interfaces\": ["
+"      {"
+"        \"name\": \"br1\","
+"        \"description\": \"Linux bridge with base interface as a port\","
+"        \"type\": \"linux-bridge\","
+"        \"state\": \"up\","
+"        \"ipv4\": \"{{ capture.base-iface.interfaces.0.ipv4 }}\","
+"        \"bridge\": {"
+"          \"options\": {"
+"            \"stp\": {"
+"              \"enabled\": false"
+"            }"
+"          },"
+"          \"port\": ["
+"            {"
+"              \"name\": \"{{ capture.base-iface.interfaces.0.name }}\""
+"            }"
+"          ]"
+"        }"
+"      }"
+"    ],"
+"    \"routes\": {"
+"      \"config\": \"{{ capture.bridge-routes.routes.running }}\""
+"    }"
+"  }"
+"}";
+	const char *current_state = "{"
+"  \"interfaces\": ["
+"    {"
+"      \"name\": \"eth1\","
+"      \"type\": \"ethernet\","
+"      \"state\": \"up\","
+"      \"mac-address\": \"1c:c1:0c:32:3b:ff\","
+"      \"ipv4\": {"
+"        \"address\": ["
+"          {"
+"            \"ip\": \"192.0.2.251\","
+"            \"prefix-length\": 24"
+"          }"
+"        ],"
+"        \"dhcp\": false,"
+"        \"enabled\": true"
+"      }"
+"    }"
+"  ],"
+"  \"routes\": {"
+"    \"running\": ["
+"      {"
+"        \"destination\": \"0.0.0.0/0\","
+"        \"next-hop-address\": \"192.0.2.1\","
+"        \"next-hop-interface\": \"eth1\""
+"      }"
+"    ],"
+"    \"config\": ["
+"      {"
+"        \"destination\": \"0.0.0.0/0\","
+"        \"next-hop-address\": \"192.0.2.1\","
+"        \"next-hop-interface\": \"eth1\""
+"      }"
+"    ]"
+"  }"
+"}";
+	char *state = NULL;
+	char *err_kind = NULL;
+	char *err_msg = NULL;
+	char *log = NULL;
+
+	if (nmstate_net_state_from_policy(policy, current_state, &state, &log,
+					  &err_kind, &err_msg) == NMSTATE_PASS)
+	{
+		printf("%s\n", state);
+	} else {
+		printf("%s: %s\n", err_kind, err_msg);
+		rc = EXIT_FAILURE;
+	}
+
+	nmstate_cstring_free(state);
+	nmstate_cstring_free(err_kind);
+	nmstate_cstring_free(err_msg);
+	nmstate_cstring_free(log);
+	exit(rc);
+}

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.14"
 nispor = { version = "1.2.8" , optional = true}
 nix = { version = "0.24.1", optional = true}
 serde = { version = "1.0.132", features = ["derive"] }
-serde_json = "1.0.68"
+serde_json = { version = "1.0.68", features = [ "preserve_order" ] }
 uuid = { version = "1.1", features = ["v4", "v5"] }
 zbus = { version ="1.9.2", optional = true}
 zvariant = "2.10.0"

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -52,6 +52,10 @@ impl DnsState {
         Self::default()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.running.is_none() && self.config.is_none()
+    }
+
     pub(crate) fn validate(&self) -> Result<(), NmstateError> {
         if let Some(dns_conf) = self.config.as_ref() {
             if let Some(config_srvs) = dns_conf.server.as_ref() {
@@ -117,6 +121,10 @@ pub struct DnsClientState {
 impl DnsClientState {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.server.is_none() && self.search.is_none()
     }
 
     // Whether user want to purge all DNS settings

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -12,6 +12,13 @@ pub enum ErrorKind {
     NotSupportedError,
     KernelIntegerRoundedError,
     DependencyError,
+    PolicyError,
+}
+
+impl Default for ErrorKind {
+    fn default() -> Self {
+        Self::Bug
+    }
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -22,22 +29,45 @@ impl std::fmt::Display for ErrorKind {
 
 impl std::fmt::Display for NmstateError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.kind, self.msg)
+        if self.kind == ErrorKind::PolicyError {
+            write!(
+                f,
+                "{}: {}\n| {}\n| {:.<4$}^",
+                self.kind, self.msg, self.line, "", self.position
+            )
+        } else {
+            write!(f, "{}: {}", self.kind, self.msg)
+        }
     }
 }
 
 impl Error for NmstateError {}
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct NmstateError {
     kind: ErrorKind,
     msg: String,
+    line: String,
+    position: usize,
 }
 
 impl NmstateError {
     pub fn new(kind: ErrorKind, msg: String) -> Self {
-        Self { kind, msg }
+        Self {
+            kind,
+            msg,
+            ..Default::default()
+        }
+    }
+
+    pub fn new_policy_error(msg: String, line: &str, position: usize) -> Self {
+        Self {
+            kind: ErrorKind::PolicyError,
+            line: line.to_string(),
+            msg,
+            position,
+        }
     }
 
     pub fn kind(&self) -> ErrorKind {
@@ -46,6 +76,16 @@ impl NmstateError {
 
     pub fn msg(&self) -> &str {
         self.msg.as_str()
+    }
+
+    pub fn line(&self) -> &str {
+        self.line.as_str()
+    }
+
+    /// The position of character in line which cause the PolicyError, the
+    /// first character is position 0.
+    pub fn position(&self) -> usize {
+        self.position
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -80,6 +80,10 @@ impl Interfaces {
         Self::default()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.kernel_ifaces.is_empty() && self.user_ifaces.is_empty()
+    }
+
     /// Extract internal interfaces to `Vec()`.
     pub fn to_vec(&self) -> Vec<&Interface> {
         let mut ifaces = Vec::new();

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -103,6 +103,8 @@ mod ovs;
 #[cfg(feature = "query_apply")]
 mod ovsdb;
 #[cfg(feature = "query_apply")]
+mod policy;
+#[cfg(feature = "query_apply")]
 mod query_apply;
 mod route;
 mod route_rule;
@@ -151,5 +153,9 @@ pub use crate::lldp::{
 pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
 pub use crate::net_state::NetworkState;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
+#[cfg(feature = "query_apply")]
+pub use crate::policy::{
+    NetworkCaptureRules, NetworkPolicy, NetworkStateTemplate,
+};
 pub use crate::route::{RouteEntry, RouteState, Routes};
 pub use crate::route_rule::{RouteRuleEntry, RouteRuleState, RouteRules};

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -185,6 +185,15 @@ impl<'de> Deserialize<'de> for NetworkState {
 }
 
 impl NetworkState {
+    pub fn is_empty(&self) -> bool {
+        self.hostname.is_none()
+            && self.dns.is_empty()
+            && self.rules.is_empty()
+            && self.routes.is_empty()
+            && self.interfaces.is_empty()
+            && self.ovsdb.is_none()
+    }
+
     pub(crate) const PASSWORD_HID_BY_NMSTATE: &'static str =
         "<_password_hid_by_nmstate>";
 

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{
+    ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::{ErrorKind, NetworkState, NmstateError};
+
+use super::{
+    iface::{get_iface_match, update_ifaces},
+    json::{get_value_from_json, value_retain_only, value_to_string},
+    route::{get_route_match, update_routes},
+    route_rule::{get_route_rule_match, update_route_rules},
+    token::{parse_str_to_capture_tokens, NetworkCaptureToken},
+};
+
+pub(crate) const PROPERTY_SPLITTER: &str = ".";
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NetworkCaptureRules {
+    pub cmds: Vec<(String, NetworkCaptureCommand)>,
+}
+
+impl<'de> Deserialize<'de> for NetworkCaptureRules {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map = serde_json::Map::<String, serde_json::Value>::deserialize(
+            deserializer,
+        )?;
+        let mut cmds: Vec<(String, NetworkCaptureCommand)> = Vec::new();
+
+        for (k, v) in map.iter() {
+            if let serde_json::Value::String(s) = v {
+                cmds.push((
+                    k.to_string(),
+                    NetworkCaptureCommand::parse(s.as_str())
+                        .map_err(serde::de::Error::custom)?,
+                ));
+            } else {
+                return Err(serde::de::Error::custom(format!(
+                    "Expecting a string, but got {}",
+                    v
+                )));
+            }
+        }
+        log::debug!("Parsed into commands {:?}", cmds);
+        Ok(NetworkCaptureRules { cmds })
+    }
+}
+
+impl Serialize for NetworkCaptureRules {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.cmds.len()))?;
+        for (name, value) in &self.cmds {
+            map.serialize_entry(&name, &value)?;
+        }
+        map.end()
+    }
+}
+
+impl NetworkCaptureRules {
+    pub fn execute(
+        &self,
+        current: &NetworkState,
+    ) -> Result<HashMap<String, NetworkState>, NmstateError> {
+        let mut ret = HashMap::new();
+        for (var_name, cmd) in self.cmds.as_slice() {
+            let matched_state = cmd.execute(current, &ret)?;
+            log::debug!(
+                "Found match state for {}: {:?}",
+                var_name,
+                matched_state
+            );
+            ret.insert(var_name.to_string(), matched_state);
+        }
+        Ok(ret)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.cmds.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NetworkCaptureCommand {
+    pub(crate) key: NetworkCaptureToken,
+    pub(crate) key_capture: Option<String>,
+    pub(crate) key_capture_pos: usize,
+    pub(crate) action: NetworkCaptureAction,
+    pub(crate) value: NetworkCaptureToken,
+    pub(crate) value_capture: Option<String>,
+    pub(crate) value_capture_pos: usize,
+    pub(crate) line: String,
+}
+
+impl NetworkCaptureCommand {
+    pub(crate) fn parse(line: &str) -> Result<Self, NmstateError> {
+        let line = line
+            .trim()
+            .replace(
+                '\u{A0}', // Non-breaking space
+                " ",
+            )
+            .trim()
+            .to_string();
+
+        let mut ret = Self {
+            line,
+            ..Default::default()
+        };
+        let tokens = parse_str_to_capture_tokens(ret.line.as_str())?;
+        let tokens = tokens.as_slice();
+
+        if let Some(pos) = tokens
+            .iter()
+            .position(|c| matches!(c, NetworkCaptureToken::Pipe(_)))
+        {
+            ret.key_capture = Some(get_input_capture_source(
+                &tokens[..pos],
+                ret.line.as_str(),
+                &tokens[pos],
+            )?);
+            if pos + 1 < tokens.len() {
+                process_tokens_without_pipe(&mut ret, &tokens[pos + 1..])?;
+            }
+        } else {
+            process_tokens_without_pipe(&mut ret, tokens)?;
+        }
+
+        Ok(ret)
+    }
+}
+
+impl Serialize for NetworkCaptureCommand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.line.as_str())
+    }
+}
+
+impl NetworkCaptureCommand {
+    pub(crate) fn execute(
+        &self,
+        current: &NetworkState,
+        captures: &HashMap<String, NetworkState>,
+    ) -> Result<NetworkState, NmstateError> {
+        let input = if let Some(cap_name) = self.key_capture.as_ref() {
+            if let Some(cap) = captures.get(cap_name) {
+                cap.clone()
+            } else {
+                return Err(NmstateError::new_policy_error(
+                    format!("Capture {} not found", cap_name),
+                    self.line.as_str(),
+                    self.key_capture_pos,
+                ));
+            }
+        } else {
+            current.clone()
+        };
+        if self.action == NetworkCaptureAction::None {
+            if let NetworkCaptureToken::Path(keys, _) = &self.key {
+                if keys.is_empty() {
+                    return Ok(NetworkState::new());
+                }
+                let mut input_value =
+                    serde_json::to_value(&input).map_err(|e| {
+                        NmstateError::new(
+                            ErrorKind::Bug,
+                            format!(
+                                "Failed to convert NetworkState {:?} \
+                                 to serde_json value: {}",
+                                input, e
+                            ),
+                        )
+                    })?;
+                value_retain_only(&mut input_value, keys.as_slice());
+                return NetworkState::deserialize(&input_value).map_err(|e| {
+                    NmstateError::new(
+                        ErrorKind::Bug,
+                        format!(
+                            "Failed to convert NetworkState {:?} \
+                             from serde_json value: {:?}",
+                            input_value, e
+                        ),
+                    )
+                });
+            } else {
+                return Ok(NetworkState::new());
+            }
+        }
+
+        let matching_value = value_to_string(&get_value(
+            &self.value,
+            &input,
+            self.line.as_str(),
+        )?);
+
+        let mut ret = NetworkState::new();
+
+        let (keys, key_pos) =
+            if let NetworkCaptureToken::Path(keys, pos) = &self.key {
+                (keys.as_slice(), pos)
+            } else {
+                return Err(NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "The NetworkCaptureCommand.key is not Path but {:?}",
+                        &self.key
+                    ),
+                ));
+            };
+
+        match keys.get(0).map(String::as_str) {
+            Some("routes") => {
+                ret.routes = match self.action {
+                    NetworkCaptureAction::Equal => get_route_match(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "routes.".len(),
+                    )?,
+                    NetworkCaptureAction::Replace => update_routes(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "routes.".len(),
+                    )?,
+                    NetworkCaptureAction::None => unreachable!(),
+                }
+            }
+            Some("route-rules") => {
+                ret.rules = match self.action {
+                    NetworkCaptureAction::Equal => get_route_rule_match(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "route-rules.".len(),
+                    )?,
+                    NetworkCaptureAction::Replace => update_route_rules(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "route-rules.".len(),
+                    )?,
+                    NetworkCaptureAction::None => unreachable!(),
+                }
+            }
+            Some("interfaces") => {
+                ret.interfaces = match self.action {
+                    NetworkCaptureAction::Equal => get_iface_match(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "interfaces.".len(),
+                    )?,
+                    NetworkCaptureAction::Replace => update_ifaces(
+                        &keys[1..],
+                        matching_value.as_str(),
+                        &input,
+                        self.line.as_str(),
+                        key_pos + "interfaces.".len(),
+                    )?,
+                    NetworkCaptureAction::None => unreachable!(),
+                }
+            }
+            Some(v) => {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Unsupported capture keyword '{}'", v),
+                ));
+            }
+            None => {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Invalid empty keyword".to_string(),
+                ));
+            }
+        }
+        Ok(ret)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NetworkCaptureAction {
+    None,
+    Equal,
+    Replace,
+}
+
+impl Default for NetworkCaptureAction {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl std::fmt::Display for NetworkCaptureAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Equal => "==",
+                Self::Replace => ":=",
+                Self::None => "",
+            }
+        )
+    }
+}
+
+pub(crate) fn get_value(
+    prop_path: &NetworkCaptureToken,
+    state: &NetworkState,
+    line: &str,
+) -> Result<serde_json::Value, NmstateError> {
+    match prop_path {
+        NetworkCaptureToken::Path(prop_path, pos) => {
+            match serde_json::to_value(state)
+                .map_err(|e| {
+                    NmstateError::new(
+                        ErrorKind::Bug,
+                        format!(
+                            "Failed to convert NetworkState {:?} \
+                            to serde_json value: {}",
+                            state, e
+                        ),
+                    )
+                })?
+                .as_object()
+            {
+                Some(state_value) => {
+                    get_value_from_json(prop_path, state_value, line, *pos)
+                }
+                None => Err(NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "Failed to convert NetworkState {:?} to serde_json map",
+                        state,
+                    ),
+                )),
+            }
+        }
+
+        NetworkCaptureToken::Value(v, _) => {
+            Ok(serde_json::Value::String(v.clone()))
+        }
+        _ => todo!(),
+    }
+}
+
+fn get_input_capture_source(
+    tokens: &[NetworkCaptureToken],
+    line: &str,
+    pipe_token: &NetworkCaptureToken,
+) -> Result<String, NmstateError> {
+    match tokens.get(0) {
+        Some(NetworkCaptureToken::Path(path, pos)) => {
+            if path.len() != 2 || path[0] != "capture" {
+                Err(NmstateError::new_policy_error(
+                    "The pipe action should always in format of \
+                    'capture.<capture_name>'"
+                        .to_string(),
+                    line,
+                    *pos,
+                ))
+            } else {
+                Ok(path[1].to_string())
+            }
+        }
+        Some(NetworkCaptureToken::Value(_, pos)) => {
+            Err(NmstateError::new_policy_error(
+                "The pipe action should always in format of \
+                'capture.<capture_name>'"
+                    .to_string(),
+                line,
+                *pos,
+            ))
+        }
+        Some(token) => Err(NmstateError::new_policy_error(
+            "The pipe action should always in format of \
+                'capture.<capture_name>'"
+                .to_string(),
+            line,
+            token.pos(),
+        )),
+        None => Err(NmstateError::new_policy_error(
+            "The pipe action should always in format of \
+                'capture.<capture_name>'"
+                .to_string(),
+            line,
+            pipe_token.pos(),
+        )),
+    }
+}
+
+fn get_condition_key(
+    tokens: &[NetworkCaptureToken],
+    line: &str,
+    action_token: &NetworkCaptureToken,
+) -> Result<(NetworkCaptureToken, Option<(String, usize)>), NmstateError> {
+    if tokens.len() == 1 {
+        if let Some(NetworkCaptureToken::Path(path, pos)) = tokens.get(0) {
+            if path.get(0) == Some(&"capture".to_string()) {
+                if path.len() <= 2 {
+                    return Err(NmstateError::new_policy_error(
+                        "No property path after capture name".to_string(),
+                        line,
+                        *pos,
+                    ));
+                }
+                Ok((
+                    NetworkCaptureToken::Path(
+                        path[2..].to_vec(),
+                        pos + "capture.".len() + path[1].len(),
+                    ),
+                    Some((path[1].to_string(), pos + "capture.".len())),
+                ))
+            } else {
+                Ok((tokens[0].clone(), None))
+            }
+        } else {
+            Err(NmstateError::new_policy_error(
+                "The equal or replace action should always start with \
+                property path"
+                    .to_string(),
+                line,
+                tokens[0].pos(),
+            ))
+        }
+    } else {
+        Err(NmstateError::new_policy_error(
+            "The equal or replace action should always start with \
+            property path"
+                .to_string(),
+            line,
+            action_token.pos(),
+        ))
+    }
+}
+
+fn get_condition_value(
+    tokens: &[NetworkCaptureToken],
+    line: &str,
+    action_token: &NetworkCaptureToken,
+) -> Result<(NetworkCaptureToken, Option<(String, usize)>), NmstateError> {
+    if tokens.len() != 1 {
+        return Err(NmstateError::new_policy_error(
+            "The equal or replace action should end with single value or \
+            property path"
+                .to_string(),
+            line,
+            if tokens.len() >= 2 {
+                tokens[0].pos()
+            } else {
+                action_token.pos()
+            },
+        ));
+    }
+
+    match tokens[0] {
+        NetworkCaptureToken::Path(ref path, pos) => {
+            Ok(if path.get(0) == Some(&"capture".to_string()) {
+                if path.len() < 3 {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "When using equal action to match against \
+                            captured data, the correct format should be \
+                            'interfaces.name == \
+                            capture.default-gw.interfaces.0.name', \
+                            but got: {}",
+                            line
+                        ),
+                    ));
+                }
+                (
+                    NetworkCaptureToken::Path(
+                        path[2..].to_vec(),
+                        pos + format!("capture.{}.", path[1]).chars().count(),
+                    ),
+                    Some((path[1].to_string(), pos + "capture.".len())),
+                )
+            } else {
+                (tokens[0].clone(), None)
+            })
+        }
+        NetworkCaptureToken::Value(_, _) => Ok((tokens[0].clone(), None)),
+        _ => Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "The equal action should end with single value or \
+                property path but got: {}",
+                line
+            ),
+        )),
+    }
+}
+
+fn process_tokens_without_pipe(
+    ret: &mut NetworkCaptureCommand,
+    tokens: &[NetworkCaptureToken],
+) -> Result<(), NmstateError> {
+    let line = ret.line.as_str();
+    if let Some(pos) = tokens
+        .iter()
+        .position(|c| matches!(c, &NetworkCaptureToken::Equal(_)))
+    {
+        if pos + 1 >= tokens.len() {
+            return Err(NmstateError::new_policy_error(
+                "The equal action got no value defined afterwards".to_string(),
+                line,
+                tokens[pos].pos(),
+            ));
+        }
+        ret.action = NetworkCaptureAction::Equal;
+        let (key, key_capture) =
+            get_condition_key(&tokens[..pos], line, &tokens[pos])?;
+        if ret.key_capture.is_none() {
+            if let Some((cap_name, pos)) = key_capture {
+                ret.key_capture = Some(cap_name);
+                ret.key_capture_pos = pos;
+            }
+        }
+        ret.key = key;
+        let (value, value_capture) =
+            get_condition_value(&tokens[pos + 1..], line, &tokens[pos])?;
+        ret.value = value;
+        if let Some((cap_name, pos)) = value_capture {
+            ret.value_capture = Some(cap_name);
+            ret.value_capture_pos = pos;
+        }
+    } else if let Some(pos) = tokens
+        .iter()
+        .position(|c| matches!(c, &NetworkCaptureToken::Replace(_)))
+    {
+        if pos + 1 > tokens.len() {
+            return Err(NmstateError::new_policy_error(
+                "The replace action got no value defined afterwards"
+                    .to_string(),
+                line,
+                tokens[pos].pos(),
+            ));
+        }
+        ret.action = NetworkCaptureAction::Replace;
+        let (key, key_capture) =
+            get_condition_key(&tokens[..pos], line, &tokens[pos])?;
+        if ret.key_capture.is_none() {
+            if let Some((cap_name, pos)) = key_capture {
+                ret.key_capture = Some(cap_name);
+                ret.key_capture_pos = pos;
+            }
+        }
+        ret.key = key;
+        let (value, value_capture) =
+            get_condition_value(&tokens[pos + 1..], line, &tokens[pos])?;
+        ret.value = value;
+        if let Some((cap_name, pos)) = value_capture {
+            ret.value_capture = Some(cap_name);
+            ret.value_capture_pos = pos;
+        }
+    } else if let Some(NetworkCaptureToken::Path(_, _)) = tokens.get(0) {
+        // User just want to remove all information except the defined one
+        ret.action = NetworkCaptureAction::None;
+        ret.key = tokens[0].clone()
+    }
+    Ok(())
+}

--- a/rust/src/lib/policy/iface.rs
+++ b/rust/src/lib/policy/iface.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Interface, Interfaces, NetworkState, NmstateError};
+
+use super::json::{search_item, update_items};
+
+pub(crate) fn get_iface_match(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<Interfaces, NmstateError> {
+    let mut ret = Interfaces::new();
+    for iface in search_item(
+        "interface",
+        prop_path,
+        value,
+        state.interfaces.to_vec().as_slice(),
+        line,
+        pos,
+    )? {
+        ret.push(iface.clone());
+    }
+
+    Ok(ret)
+}
+
+pub(crate) fn update_ifaces(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<Interfaces, NmstateError> {
+    let ifaces: Vec<Interface> = state
+        .interfaces
+        .to_vec()
+        .as_slice()
+        .iter()
+        .cloned()
+        .cloned()
+        .collect();
+
+    let mut ret = Interfaces::new();
+    for iface in
+        update_items("interface", prop_path, value, &ifaces, line, pos)?
+    {
+        ret.push(iface);
+    }
+    Ok(ret)
+}

--- a/rust/src/lib/policy/json.rs
+++ b/rust/src/lib/policy/json.rs
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, NmstateError};
+
+use super::capture::PROPERTY_SPLITTER;
+
+pub(crate) fn get_value_from_json(
+    prop_path: &[String],
+    data: &serde_json::Map<String, serde_json::Value>,
+    line: &str,
+    pos: usize,
+) -> Result<serde_json::Value, NmstateError> {
+    match prop_path.len().cmp(&1) {
+        std::cmp::Ordering::Less => Err(NmstateError::new(
+            ErrorKind::Bug,
+            "Got zero length prop_path".to_string(),
+        )),
+        // Reached the final
+        std::cmp::Ordering::Equal => match data.get(&prop_path[0]) {
+            Some(v) => Ok(v.clone()),
+            None => Err(NmstateError::new_policy_error(
+                format!(
+                    "Failed to find property {}, exists properties are {}",
+                    prop_path[0],
+                    data.keys()
+                        .map(|k| k.as_str())
+                        .collect::<Vec<&str>>()
+                        .join(",")
+                ),
+                line,
+                pos,
+            )),
+        },
+        // Still have leaf
+        std::cmp::Ordering::Greater => match data.get(&prop_path[0]) {
+            Some(v) => {
+                if let Some(index) = prop_path
+                    .get(1)
+                    .and_then(|index_str| index_str.parse::<usize>().ok())
+                {
+                    get_leaf_array_value(
+                        prop_path[0].as_str(),
+                        &prop_path[2..],
+                        v,
+                        index,
+                        line,
+                        pos + format!("{}.{}.", prop_path[0], prop_path[1])
+                            .chars()
+                            .count(),
+                    )
+                } else if let Some(leaf) = v.as_object() {
+                    get_value_from_json(
+                        &prop_path[1..],
+                        leaf,
+                        line,
+                        pos + prop_path[0].to_string().chars().count(),
+                    )
+                } else {
+                    Err(NmstateError::new_policy_error(
+                        format!(
+                            "The {} leaf data is not a object",
+                            prop_path[0]
+                        ),
+                        line,
+                        pos,
+                    ))
+                }
+            }
+            None => Err(NmstateError::new_policy_error(
+                format!(
+                    "Failed to find leaf {} data, allowed keys are {}",
+                    prop_path[0],
+                    data.keys()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<&str>>()
+                        .join(",")
+                ),
+                line,
+                pos,
+            )),
+        },
+    }
+}
+
+pub(crate) fn value_to_string(v: &serde_json::Value) -> String {
+    match v.as_str() {
+        Some(v) => v.to_string(),
+        None => v.to_string(),
+    }
+}
+
+pub(crate) fn search_item<T>(
+    item_name: &str,
+    prop_path: &[String],
+    value: &str,
+    items: &[T],
+    line: &str,
+    pos: usize,
+) -> Result<Vec<T>, NmstateError>
+where
+    T: Clone + serde::Serialize,
+{
+    let mut ret = Vec::new();
+    for item in items {
+        let item_value = match serde_json::to_value(item) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let item_value = match item_value.as_object() {
+            Some(v) => v,
+            None => continue,
+        };
+
+        let cur_value =
+            match get_value_from_json(prop_path, item_value, line, pos) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+        if value_to_string(&cur_value).as_str() == value {
+            ret.push(item.clone());
+        }
+    }
+    if ret.is_empty() {
+        Err(NmstateError::new_policy_error(
+            format!(
+                "{} with '{}={}' not found",
+                item_name,
+                prop_path.join(PROPERTY_SPLITTER),
+                value
+            ),
+            line,
+            pos,
+        ))
+    } else {
+        Ok(ret)
+    }
+}
+
+fn get_leaf_array_value(
+    item_name: &str,
+    prop_path: &[String],
+    value: &serde_json::Value,
+    index: usize,
+    line: &str,
+    pos: usize,
+) -> Result<serde_json::Value, NmstateError> {
+    let leaf = match value.as_array().and_then(|items| items.get(index)) {
+        Some(l) => l,
+        None => {
+            return Err(NmstateError::new_policy_error(
+                format!("Failed to find index {} from {}", index, item_name),
+                line,
+                pos,
+            ));
+        }
+    };
+    if prop_path.is_empty() {
+        Ok(leaf.clone())
+    } else if let Some(leaf) = leaf.as_object() {
+        get_value_from_json(
+            prop_path,
+            leaf,
+            line,
+            pos + format!("{}.", index).chars().count(),
+        )
+    } else {
+        Err(NmstateError::new_policy_error(
+            format!(
+                "The {} index {} leaf data is not a object",
+                item_name, index
+            ),
+            line,
+            pos,
+        ))
+    }
+}
+
+pub(crate) fn update_json_value(
+    item_name: &str,
+    prop_path: &[String],
+    value: &str,
+    data: &mut serde_json::Map<String, serde_json::Value>,
+) -> Result<(), NmstateError> {
+    match prop_path.len().cmp(&1) {
+        std::cmp::Ordering::Less => Err(NmstateError::new(
+            ErrorKind::Bug,
+            "Got zero length prop_path".to_string(),
+        )),
+        // Reached the final
+        std::cmp::Ordering::Equal => {
+            if let Some(old_value) = data.get(&prop_path[0]) {
+                log::debug!(
+                    "Changing {} property of {} from {} to {}",
+                    &prop_path[0],
+                    item_name,
+                    old_value,
+                    value
+                );
+                data.insert(
+                    prop_path[0].to_string(),
+                    serde_json::Value::String(value.to_string()),
+                );
+                Ok(())
+            } else {
+                log::debug!(
+                    "Inserting new property {}:{} to {}",
+                    &prop_path[0],
+                    value,
+                    item_name
+                );
+                data.insert(
+                    prop_path[0].to_string(),
+                    serde_json::Value::String(value.to_string()),
+                );
+                Ok(())
+            }
+        }
+        // Still have left
+        std::cmp::Ordering::Greater => match data.get_mut(&prop_path[0]) {
+            Some(v) => {
+                if let Some(leaf) = v.as_object_mut() {
+                    update_json_value(item_name, &prop_path[1..], value, leaf)
+                } else {
+                    Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "The {} leaf data {:?} is not a object",
+                            prop_path[0], v
+                        ),
+                    ))
+                }
+            }
+            None => {
+                // We should create new Map and move on
+                data.insert(
+                    prop_path[0].to_string(),
+                    serde_json::Value::Object(serde_json::Map::new()),
+                );
+                if let Some(v) = data.get_mut(&prop_path[0]) {
+                    if let Some(leaf) = v.as_object_mut() {
+                        update_json_value(
+                            item_name,
+                            &prop_path[1..],
+                            value,
+                            leaf,
+                        )
+                    } else {
+                        Err(NmstateError::new(
+                            ErrorKind::Bug,
+                            format!(
+                                "Failed to get newly inserted map in {:?} \
+                                for {}",
+                                data, prop_path[0],
+                            ),
+                        ))
+                    }
+                } else {
+                    Err(NmstateError::new(
+                        ErrorKind::Bug,
+                        format!(
+                            "Failed to get newly inserted map in {:?} for {}",
+                            data, prop_path[0],
+                        ),
+                    ))
+                }
+            }
+        },
+    }
+}
+
+pub(crate) fn update_items<T>(
+    item_name: &str,
+    prop_path: &[String],
+    value: &str,
+    items: &[T],
+    line: &str,
+    pos: usize,
+) -> Result<Vec<T>, NmstateError>
+where
+    T: std::fmt::Debug
+        + Clone
+        + serde::Serialize
+        + for<'de> serde::Deserialize<'de>,
+{
+    let mut ret = Vec::new();
+    for item in items {
+        let mut item_value = serde_json::to_value(item).map_err(|e| {
+            NmstateError::new_policy_error(
+                format!(
+                    "Failed to convert {:?} item into serde_json value: {}",
+                    item, e
+                ),
+                line,
+                pos,
+            )
+        })?;
+        if let Some(item_value) = item_value.as_object_mut() {
+            update_json_value(item_name, prop_path, value, item_value)?;
+            ret.push(
+                serde_json::from_value(serde_json::Value::Object(
+                    item_value.clone(),
+                ))
+                .map_err(|e| {
+                    NmstateError::new(
+                        ErrorKind::Bug,
+                        format!(
+                            "Failed to deserialize {:?} into {}: {}",
+                            item_value, item_name, e
+                        ),
+                    )
+                })?,
+            );
+        }
+    }
+    Ok(ret)
+}
+
+pub(crate) fn value_retain_only(
+    data: &mut serde_json::Value,
+    prop_path: &[String],
+) {
+    if let Some(data) = data.as_object_mut() {
+        if !prop_path.is_empty() {
+            data.retain(|k, _| k == &prop_path[0]);
+            if prop_path.len() >= 2 {
+                if let Some(leaf) = data.get_mut(&prop_path[0]) {
+                    value_retain_only(leaf, &prop_path[1..]);
+                }
+            }
+        }
+    }
+}

--- a/rust/src/lib/policy/mod.rs
+++ b/rust/src/lib/policy/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod capture;
+mod iface;
+mod json;
+mod net_policy;
+mod route;
+mod route_rule;
+mod template;
+pub(crate) mod token;
+
+pub use self::capture::NetworkCaptureRules;
+pub use self::net_policy::NetworkPolicy;
+pub use self::template::NetworkStateTemplate;

--- a/rust/src/lib/policy/net_policy.rs
+++ b/rust/src/lib/policy/net_policy.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{NetworkState, NmstateError};
+
+use super::{NetworkCaptureRules, NetworkStateTemplate};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct NetworkPolicy {
+    #[serde(skip_serializing_if = "NetworkCaptureRules::is_empty", default)]
+    /// Capture rules for matching current network state
+    pub capture: NetworkCaptureRules,
+    /// Template of desired state, will apply capture results
+    #[serde(alias = "desiredState", default)]
+    pub desired: NetworkStateTemplate,
+    /// Current network state which the capture rules should run against
+    #[serde(default)]
+    pub current: Option<NetworkState>,
+}
+
+impl TryFrom<NetworkPolicy> for NetworkState {
+    type Error = NmstateError;
+
+    fn try_from(policy: NetworkPolicy) -> Result<Self, NmstateError> {
+        if policy.is_empty() {
+            return Ok(NetworkState::new());
+        }
+
+        if !policy.capture.is_empty() {
+            let capture_results = match policy.current.as_ref() {
+                Some(current) => policy.capture.execute(current)?,
+                None => {
+                    let mut current = NetworkState::new();
+                    current.retrieve()?;
+                    policy.capture.execute(&current)?
+                }
+            };
+            policy.desired.fill_with_captured_data(&capture_results)
+        } else {
+            policy.desired.fill_with_captured_data(&HashMap::new())
+        }
+    }
+}
+
+impl NetworkPolicy {
+    pub fn is_empty(&self) -> bool {
+        self.capture.is_empty() && self.desired.is_empty()
+    }
+}

--- a/rust/src/lib/policy/route.rs
+++ b/rust/src/lib/policy/route.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{NetworkState, NmstateError, RouteEntry, Routes};
+
+use super::json::{search_item, update_items};
+
+pub(crate) fn get_route_match(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<Routes, NmstateError> {
+    let mut ret = Routes::new();
+    let empty_vec: Vec<RouteEntry> = Vec::new();
+    if prop_path.len() != 2 {
+        return Err(NmstateError::new_policy_error(
+            "No route search pattern found".to_string(),
+            line,
+            pos,
+        ));
+    }
+    match prop_path[0].as_str() {
+        "running" => {
+            ret.running = Some(search_item(
+                "route",
+                &prop_path[1..],
+                value,
+                state.routes.running.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        "config" => {
+            ret.config = Some(search_item(
+                "route",
+                &prop_path[1..],
+                value,
+                state.routes.config.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        _ => {
+            return Err(NmstateError::new_policy_error(
+                "Only support 'running' or 'config' keyword for \
+                route searching"
+                    .to_string(),
+                line,
+                pos,
+            ));
+        }
+    };
+    Ok(ret)
+}
+
+pub(crate) fn update_routes(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<Routes, NmstateError> {
+    let mut ret = Routes::new();
+    let empty_vec: Vec<RouteEntry> = Vec::new();
+    if prop_path.len() != 2 {
+        return Err(NmstateError::new_policy_error(
+            "No route replace pattern found".to_string(),
+            line,
+            pos,
+        ));
+    }
+    match prop_path[0].as_str() {
+        "running" => {
+            ret.running = Some(update_items(
+                "route",
+                &prop_path[1..],
+                value,
+                state.routes.running.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        "config" => {
+            ret.config = Some(update_items(
+                "route",
+                &prop_path[1..],
+                value,
+                state.routes.config.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        _ => {
+            return Err(NmstateError::new_policy_error(
+                "Only support 'running' or 'config' keyword for \
+                    replacing routes"
+                    .to_string(),
+                line,
+                pos,
+            ));
+        }
+    };
+    Ok(ret)
+}

--- a/rust/src/lib/policy/route_rule.rs
+++ b/rust/src/lib/policy/route_rule.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{NetworkState, NmstateError, RouteRuleEntry, RouteRules};
+
+use super::json::{search_item, update_items};
+
+pub(crate) fn get_route_rule_match(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<RouteRules, NmstateError> {
+    let mut ret = RouteRules::new();
+    let empty_vec: Vec<RouteRuleEntry> = Vec::new();
+    if prop_path.len() != 2 {
+        return Err(NmstateError::new_policy_error(
+            "No route rule search pattern found".to_string(),
+            line,
+            pos,
+        ));
+    }
+    match prop_path[0].as_str() {
+        "config" => {
+            ret.config = Some(search_item(
+                "route_rule",
+                &prop_path[1..],
+                value,
+                state.rules.config.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        _ => {
+            return Err(NmstateError::new_policy_error(
+                "Only support 'config' keyword for searching route rules"
+                    .to_string(),
+                line,
+                pos,
+            ));
+        }
+    };
+    Ok(ret)
+}
+
+pub(crate) fn update_route_rules(
+    prop_path: &[String],
+    value: &str,
+    state: &NetworkState,
+    line: &str,
+    pos: usize,
+) -> Result<RouteRules, NmstateError> {
+    let mut ret = RouteRules::new();
+    let empty_vec: Vec<RouteRuleEntry> = Vec::new();
+    if prop_path.len() != 2 {
+        return Err(NmstateError::new_policy_error(
+            "No route rule search pattern found".to_string(),
+            line,
+            pos,
+        ));
+    }
+    match prop_path[0].as_str() {
+        "config" => {
+            ret.config = Some(update_items(
+                "route_rule",
+                &prop_path[1..],
+                value,
+                state.rules.config.as_ref().unwrap_or(&empty_vec),
+                line,
+                pos,
+            )?);
+        }
+        _ => {
+            return Err(NmstateError::new_policy_error(
+                "Only support 'config' keyword for \
+                replacing route rules"
+                    .to_string(),
+                line,
+                pos,
+            ));
+        }
+    };
+    Ok(ret)
+}

--- a/rust/src/lib/policy/template.rs
+++ b/rust/src/lib/policy/template.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::iter::FromIterator;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, NetworkState, NmstateError};
+
+use super::{
+    capture::get_value,
+    token::{
+        parse_str_to_template_tokens, NetworkCaptureToken, NetworkTemplateToken,
+    },
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NetworkStateTemplate(HashMap<String, serde_json::Value>);
+
+impl NetworkStateTemplate {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn fill_with_captured_data(
+        &self,
+        capture_results: &HashMap<String, NetworkState>,
+    ) -> Result<NetworkState, NmstateError> {
+        log::debug!("fill_with_captured_data {:?} {:?}", self, capture_results);
+
+        let mut desire_state_value = self.0.clone();
+        let mut new_values = HashMap::new();
+        for (k, v) in desire_state_value.iter_mut() {
+            if let Some(new_value) = resolve_capture_data(v, capture_results)? {
+                new_values.insert(k.to_string(), new_value);
+            }
+        }
+        for (k, v) in new_values.drain() {
+            desire_state_value.insert(k, v);
+        }
+
+        serde_json::from_value(serde_json::Value::from_iter(
+            desire_state_value.drain(),
+        ))
+        .map_err(|e| {
+            NmstateError::new(ErrorKind::InvalidArgument, format!("{}", e))
+        })
+    }
+}
+
+fn resolve_capture_data(
+    value: &mut serde_json::Value,
+    capture_results: &HashMap<String, NetworkState>,
+) -> Result<Option<serde_json::Value>, NmstateError> {
+    if let serde_json::Value::String(value) = value {
+        let line = value.as_str().trim();
+        let tokens = parse_str_to_template_tokens(line)?;
+
+        if let (Some(token_start_pos), Some(token_end_pos)) = (
+            tokens.as_slice().iter().position(|t| {
+                matches!(t, &NetworkTemplateToken::ReferenceStart(_))
+            }),
+            tokens.as_slice().iter().position(|t| {
+                matches!(t, &NetworkTemplateToken::ReferenceEnd(_))
+            }),
+        ) {
+            let cap_prop_token = &tokens[token_start_pos + 1];
+            if let NetworkTemplateToken::Path(cap_props, pos) = cap_prop_token {
+                let resolved = get_capture_value(
+                    cap_props.as_slice(),
+                    capture_results,
+                    line,
+                    cap_prop_token.pos(),
+                )?;
+                if (!resolved.is_string())
+                    && (token_start_pos != 0
+                        || token_end_pos != tokens.len() - 1)
+                {
+                    return Err(NmstateError::new_policy_error(
+                        "The resolved reference result is object or array, \
+                        hence you cannot add prefix or postfix"
+                            .to_string(),
+                        line,
+                        *pos,
+                    ));
+                }
+                if let serde_json::Value::String(resolved) = resolved {
+                    let mut new_value = String::new();
+                    // Append resolved to original string
+                    if token_start_pos != 0 {
+                        for token in &tokens[..token_start_pos] {
+                            if let NetworkTemplateToken::Value(s, _) = token {
+                                write!(new_value, "{}", s.as_str()).ok();
+                            } else {
+                                return Err(NmstateError::new_policy_error(
+                                    "Only allows string before reference"
+                                        .to_string(),
+                                    line,
+                                    token.pos(),
+                                ));
+                            }
+                        }
+                    }
+                    write!(new_value, "{}", resolved).ok();
+                    if token_end_pos < tokens.len() - 1 {
+                        println!("HAHA {:?}", &tokens);
+                        for token in &tokens[token_end_pos + 1..] {
+                            if let NetworkTemplateToken::Value(s, _) = token {
+                                write!(new_value, "{}", s.as_str()).ok();
+                            } else {
+                                return Err(NmstateError::new_policy_error(
+                                    "Only allows string after reference"
+                                        .to_string(),
+                                    line,
+                                    token.pos(),
+                                ));
+                            }
+                        }
+                    }
+                    return Ok(Some(serde_json::Value::String(new_value)));
+                } else {
+                    return Ok(Some(resolved));
+                }
+            } else {
+                return Err(NmstateError::new_policy_error(
+                    "Only allow property path between reference \
+                        start {{ and reference end }}"
+                        .to_string(),
+                    line,
+                    tokens[token_start_pos].pos(),
+                ));
+            }
+        } else {
+            return Ok(None);
+        }
+    } else if let Some(value) = value.as_object_mut() {
+        let mut pending_changes: HashMap<String, serde_json::Value> =
+            HashMap::new();
+        for (k, v) in value.iter_mut() {
+            if let Some(new_value) = resolve_capture_data(v, capture_results)? {
+                log::debug!("Changing {} to {} for {}", v, new_value, k);
+                pending_changes.insert(k.to_string(), new_value);
+            }
+        }
+        for (k, v) in pending_changes.drain() {
+            value.insert(k, v);
+        }
+    } else if let Some(items) = value.as_array_mut() {
+        for item in items {
+            resolve_capture_data(item, capture_results)?;
+        }
+    }
+    Ok(None)
+}
+
+fn get_capture_value(
+    prop_path: &[String],
+    captures: &HashMap<String, NetworkState>,
+    line: &str,
+    pos: usize,
+) -> Result<serde_json::Value, NmstateError> {
+    if prop_path.len() < 2 {
+        return Err(NmstateError::new_policy_error(
+            "Invalid capture reference string, should be in the format \
+            capture.<capture_name>.<property_path>"
+                .to_string(),
+            line,
+            pos,
+        ));
+    }
+    if &prop_path[0] != "capture" {
+        return Err(NmstateError::new_policy_error(
+            "Can only refer to captured data".to_string(),
+            line,
+            pos,
+        ));
+    }
+    let capture = match captures.get(&prop_path[1].to_string()) {
+        Some(c) => {
+            log::debug!("Found capture {} {:?}", &prop_path[1], c);
+            c
+        }
+        None => {
+            return Err(NmstateError::new_policy_error(
+                format!("Failed to find capture {}", &prop_path[1],),
+                line,
+                pos + "capture.".len(),
+            ));
+        }
+    };
+    get_value(
+        &NetworkCaptureToken::Path(
+            prop_path[2..].to_vec(),
+            pos + format!("capture.{}.", &prop_path[1]).chars().count(),
+        ),
+        capture,
+        line,
+    )
+}

--- a/rust/src/lib/policy/token.rs
+++ b/rust/src/lib/policy/token.rs
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::iter::FromIterator;
+
+use crate::NmstateError;
+
+const NEXT_TOKEN_START_CHARS: [char; 6] = [' ', '=', '!', '|', '"', ':'];
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub(crate) enum NetworkCaptureToken {
+    Path(Vec<String>, usize), // Example: routes.running.destination
+    Value(String, usize),     // Example: 13 or "Abc"
+    Pipe(usize),              // |
+    Replace(usize),           // :=
+    Equal(usize),             // ==
+}
+
+impl Default for NetworkCaptureToken {
+    fn default() -> Self {
+        Self::Value(String::new(), 0)
+    }
+}
+
+impl NetworkCaptureToken {
+    pub(crate) fn pos(&self) -> usize {
+        match self {
+            Self::Path(_, p)
+            | Self::Value(_, p)
+            | Self::Pipe(p)
+            | Self::Replace(p)
+            | Self::Equal(p) => *p,
+        }
+    }
+}
+
+pub(crate) fn parse_str_to_capture_tokens(
+    line: &str,
+) -> Result<Vec<NetworkCaptureToken>, NmstateError> {
+    let mut ret: Vec<NetworkCaptureToken> = Vec::new();
+    let line_chars: Vec<char> = line.chars().collect();
+    let mut line_iter = line.char_indices().peekable();
+
+    while let Some((pos, c)) = line_iter.next() {
+        log::debug!(
+            "Token processing {:?}, got {:?}, cur: {}",
+            String::from_iter(&line_chars[pos..]),
+            ret,
+            c
+        );
+        match c {
+            '=' => {
+                if let Some((_, c)) = line_iter.next() {
+                    if c == '=' {
+                        if ret.as_slice().iter().any(|c| {
+                            matches!(c, &NetworkCaptureToken::Equal(_))
+                        }) {
+                            return Err(NmstateError::new_policy_error(
+                                "Nmpolicy does not allows two equal action"
+                                    .to_string(),
+                                line,
+                                pos,
+                            ));
+                        }
+                        ret.push(NetworkCaptureToken::Equal(pos));
+                    } else {
+                        return Err(NmstateError::new_policy_error(
+                            "Invalid equal action string after =, \
+                            expecting another '='"
+                                .to_string(),
+                            line,
+                            pos + 1,
+                        ));
+                    }
+                } else {
+                    return Err(NmstateError::new_policy_error(
+                        "Invalid equal action string after =, \
+                        expecting another '=', but got nothing"
+                            .to_string(),
+                        line,
+                        pos,
+                    ));
+                }
+            }
+            '|' => {
+                if ret
+                    .as_slice()
+                    .iter()
+                    .any(|t| matches!(t, &NetworkCaptureToken::Pipe(_)))
+                {
+                    return Err(NmstateError::new_policy_error(
+                        "Nmpolicy does not allows two pipe action".to_string(),
+                        line,
+                        pos,
+                    ));
+                } else {
+                    ret.push(NetworkCaptureToken::Pipe(pos));
+                }
+            }
+            ':' => {
+                if let Some((_, c)) = line_iter.next() {
+                    if c == '=' {
+                        if ret.as_slice().iter().any(|t| {
+                            matches!(t, &NetworkCaptureToken::Replace(_))
+                        }) {
+                            return Err(NmstateError::new_policy_error(
+                                "Nmpolicy does not allows two replace action"
+                                    .to_string(),
+                                line,
+                                pos,
+                            ));
+                        } else {
+                            ret.push(NetworkCaptureToken::Replace(pos));
+                        }
+                    } else {
+                        return Err(NmstateError::new_policy_error(
+                            "Invalid replace action string after =, \
+                            expecting another '='"
+                                .to_string(),
+                            line,
+                            pos + 1,
+                        ));
+                    }
+                } else {
+                    return Err(NmstateError::new_policy_error(
+                        "Invalid replace action string after =, \
+                        expecting another '=', but got nothing"
+                            .to_string(),
+                        line,
+                        pos,
+                    ));
+                }
+            }
+            '"' => {
+                // Continue till next double quote
+                if pos + 1 >= line_chars.len()
+                    || !&line_chars[pos + 1..].contains(&'"')
+                {
+                    return Err(NmstateError::new_policy_error(
+                        "No ending double quote".to_string(),
+                        line,
+                        pos,
+                    ));
+                }
+                let mut quoted_string_chars = Vec::new();
+                for (_, c) in line_iter.by_ref() {
+                    if c != '"' {
+                        quoted_string_chars.push(c);
+                    } else {
+                        break;
+                    }
+                }
+                if !quoted_string_chars.is_empty() {
+                    ret.push(NetworkCaptureToken::Value(
+                        String::from_iter(quoted_string_chars.as_slice()),
+                        pos + 1,
+                    ));
+                }
+            }
+            _ => {
+                if c.is_whitespace() {
+                    continue;
+                }
+                let block = consume_till_next_token(c, &mut line_iter);
+                if block.contains('.') {
+                    ret.push(NetworkCaptureToken::Path(
+                        block.split('.').map(|c| c.to_string()).collect(),
+                        pos,
+                    ));
+                } else if !block.is_empty() {
+                    ret.push(NetworkCaptureToken::Value(block, pos));
+                }
+            }
+        }
+    }
+
+    if let Some(pos) = ret
+        .as_slice()
+        .iter()
+        .position(|c| matches!(c, &NetworkCaptureToken::Pipe(_)))
+    {
+        if ret.len() == pos + 1 {
+            return Err(NmstateError::new_policy_error(
+                "Invalid pipe action: no property path defined".to_string(),
+                line,
+                ret[pos].pos(),
+            ));
+        }
+        if !matches!(&ret[pos + 1], &NetworkCaptureToken::Path(_, _)) {
+            return Err(NmstateError::new_policy_error(
+                "Invalid pipe action: only property path allowed after pipe"
+                    .to_string(),
+                line,
+                ret[pos + 1].pos(),
+            ));
+        }
+    }
+
+    Ok(ret)
+}
+
+fn consume_till_next_token(
+    leading_char: char,
+    line_iter: &mut std::iter::Peekable<std::str::CharIndices>,
+) -> String {
+    let mut block = vec![leading_char];
+    while let Some((_, c)) = line_iter.peek() {
+        if NEXT_TOKEN_START_CHARS.contains(c) {
+            break;
+        } else if let Some((_, c)) = line_iter.next() {
+            block.push(c);
+        } else {
+            break;
+        }
+    }
+    String::from_iter(block.as_slice()).trim().to_string()
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub(crate) enum NetworkTemplateToken {
+    Value(String, usize),
+    ReferenceStart(usize),    // {{
+    Path(Vec<String>, usize), // Example: routes.running.destination
+    ReferenceEnd(usize),      // }}
+}
+
+impl NetworkTemplateToken {
+    pub(crate) fn pos(&self) -> usize {
+        match self {
+            Self::Path(_, p)
+            | Self::Value(_, p)
+            | Self::ReferenceStart(p)
+            | Self::ReferenceEnd(p) => *p,
+        }
+    }
+}
+
+pub(crate) fn parse_str_to_template_tokens(
+    line: &str,
+) -> Result<Vec<NetworkTemplateToken>, NmstateError> {
+    let mut ret: Vec<NetworkTemplateToken> = Vec::new();
+    let line_chars: Vec<char> = line.chars().collect();
+    let mut line_iter = line.char_indices().peekable();
+
+    while let Some((pos, c)) = line_iter.next() {
+        log::debug!(
+            "Token processing {:?}, got {:?}, cur: {}",
+            String::from_iter(&line_chars[pos..]),
+            ret,
+            c
+        );
+        match c {
+            '{' => {
+                if let Some((_, c)) = line_iter.next() {
+                    if c == '{' {
+                        if ret.as_slice().iter().any(|c| {
+                            matches!(
+                                c,
+                                &NetworkTemplateToken::ReferenceStart(_)
+                            )
+                        }) {
+                            return Err(NmstateError::new_policy_error(
+                                "Nmpolicy does not allow multiple references \
+                                {{}}"
+                                    .to_string(),
+                                line,
+                                pos,
+                            ));
+                        }
+                        ret.push(NetworkTemplateToken::ReferenceStart(pos));
+                        // Normally we have a white space after '}', let's
+                        // remove it and move on the pos
+                        while let Some((_, c)) = line_iter.peek() {
+                            if c.is_whitespace() {
+                                line_iter.next();
+                            } else {
+                                break;
+                            }
+                        }
+                    } else {
+                        return Err(NmstateError::new_policy_error(
+                            "Invalid reference action string after {, \
+                            expecting another '{'"
+                                .to_string(),
+                            line,
+                            pos,
+                        ));
+                    }
+                } else {
+                    return Err(NmstateError::new_policy_error(
+                        "Invalid reference action string after =, \
+                        expecting another '{', but got nothing"
+                            .to_string(),
+                        line,
+                        pos,
+                    ));
+                }
+            }
+            '}' => {
+                if let Some((_, c)) = line_iter.next() {
+                    if c == '}' {
+                        if ret.as_slice().iter().any(|c| {
+                            matches!(c, &NetworkTemplateToken::ReferenceEnd(_))
+                        }) {
+                            return Err(NmstateError::new_policy_error(
+                                "Nmpolicy does not allow multiple references \
+                                {{}}"
+                                    .to_string(),
+                                line,
+                                pos,
+                            ));
+                        }
+                        ret.push(NetworkTemplateToken::ReferenceEnd(pos));
+                    } else {
+                        return Err(NmstateError::new_policy_error(
+                            "Invalid reference action string after }, \
+                            expecting another '}'"
+                                .to_string(),
+                            line,
+                            pos,
+                        ));
+                    }
+                } else {
+                    return Err(NmstateError::new_policy_error(
+                        "Invalid reference action string after }, \
+                        expecting another '}', but got nothing"
+                            .to_string(),
+                        line,
+                        pos,
+                    ));
+                }
+            }
+            _ => {
+                let mut chars = vec![c];
+                while let Some((_, c)) = line_iter.peek() {
+                    if ['{', '}'].contains(c) {
+                        break;
+                    } else if let Some((_, c)) = line_iter.next() {
+                        if c.is_whitespace() {
+                            break;
+                        }
+                        chars.push(c);
+                    } else {
+                        break;
+                    }
+                }
+                // position should be first char after trimmed
+                let subline =
+                    String::from_iter(chars.as_slice()).trim().to_string();
+                if subline.is_empty() {
+                    continue;
+                }
+                if subline.contains('.') && !subline.starts_with('.') {
+                    ret.push(NetworkTemplateToken::Path(
+                        subline.split('.').map(|c| c.to_string()).collect(),
+                        pos,
+                    ));
+                } else {
+                    ret.push(NetworkTemplateToken::Value(subline, pos));
+                }
+            }
+        }
+    }
+
+    // The reference start and end should be paired.
+    if let Some(token_start) = ret
+        .as_slice()
+        .iter()
+        .find(|c| matches!(c, &NetworkTemplateToken::ReferenceStart(_)))
+    {
+        if !ret
+            .as_slice()
+            .iter()
+            .any(|c| matches!(c, &NetworkTemplateToken::ReferenceEnd(_)))
+        {
+            return Err(NmstateError::new_policy_error(
+                "No reference end }} found".to_string(),
+                line,
+                token_start.pos(),
+            ));
+        }
+    }
+
+    if let Some(token_end) = ret
+        .as_slice()
+        .iter()
+        .find(|c| matches!(c, &NetworkTemplateToken::ReferenceEnd(_)))
+    {
+        if !ret
+            .as_slice()
+            .iter()
+            .any(|c| matches!(c, &NetworkTemplateToken::ReferenceStart(_)))
+        {
+            return Err(NmstateError::new_policy_error(
+                "No reference start {{ found".to_string(),
+                line,
+                token_end.pos(),
+            ));
+        }
+    }
+
+    if let (Some(token_start_pos), Some(token_end_pos)) = (
+        ret.as_slice().iter().position(|t| {
+            matches!(t, &NetworkTemplateToken::ReferenceStart(_))
+        }),
+        ret.as_slice()
+            .iter()
+            .position(|t| matches!(t, &NetworkTemplateToken::ReferenceEnd(_))),
+    ) {
+        if token_start_pos >= token_end_pos {
+            return Err(NmstateError::new_policy_error(
+                "The reference start {{ can not be placed before \
+                reference end }}"
+                    .to_string(),
+                line,
+                ret[token_end_pos].pos(),
+            ));
+        }
+        if token_start_pos + 1 >= token_end_pos {
+            return Err(NmstateError::new_policy_error(
+                "No property path between reference start {{ and \
+                reference end }}"
+                    .to_string(),
+                line,
+                ret[token_end_pos].pos() - 1,
+            ));
+        }
+        if token_start_pos + 2 != token_end_pos {
+            return Err(NmstateError::new_policy_error(
+                "Only allows single property path between reference \
+                start {{ and reference end }}"
+                    .to_string(),
+                line,
+                ret[token_start_pos + 2].pos(),
+            ));
+        }
+    }
+
+    Ok(ret)
+}

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -58,6 +58,10 @@ impl Routes {
     }
 
     /// TODO: hide it, internal only
+    pub fn is_empty(&self) -> bool {
+        self.running.is_none() && self.config.is_none()
+    }
+
     pub fn validate(&self) -> Result<(), NmstateError> {
         // All desire non-absent route should have next hop interface
         if let Some(config_routes) = self.config.as_ref() {

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -36,6 +36,10 @@ impl RouteRules {
         Self::default()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.config.is_none()
+    }
+
     // * Neither ip_from nor ip_to should be defined
     pub(crate) fn validate(&self) -> Result<(), NmstateError> {
         if let Some(rules) = self.config.as_ref() {

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -33,6 +33,8 @@ mod ovs;
 #[cfg(test)]
 mod ovsdb;
 #[cfg(test)]
+mod policy;
+#[cfg(test)]
 mod route;
 #[cfg(test)]
 mod route_rule;

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{
+    policy::{
+        capture::{NetworkCaptureAction, NetworkCaptureCommand},
+        token::NetworkCaptureToken,
+    },
+    NetworkState,
+};
+
+#[test]
+fn test_policy_capture_with_replace() {
+    let cap_con = NetworkCaptureCommand::parse(
+        r#"
+        capture.base-iface-routes | routes.running.next-hop-interface:="br1"
+        "#
+        .trim(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        cap_con.key_capture.as_ref(),
+        Some(&"base-iface-routes".to_string())
+    );
+    assert_eq!(cap_con.action, NetworkCaptureAction::Replace);
+    assert_eq!(
+        cap_con.key,
+        NetworkCaptureToken::Path(
+            vec![
+                "routes".to_string(),
+                "running".to_string(),
+                "next-hop-interface".to_string(),
+            ],
+            "capture.base-iface-routes | r".len() - 1,
+        )
+    );
+    assert_eq!(
+        cap_con.value,
+        NetworkCaptureToken::Value(
+            "br1".to_string(),
+            "capture.base-iface-routes | \
+            routes.running.next-hop-interface:=\"b"
+                .len()
+                - 1
+        )
+    );
+    assert!(cap_con.value_capture.is_none());
+}
+
+#[test]
+fn test_policy_capture_with_equal() {
+    let cap_con = NetworkCaptureCommand::parse(
+        r#"
+        capture.base-iface-routes | routes.running.next-hop-interface=="br1"
+        "#
+        .trim(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        cap_con.key_capture.as_ref(),
+        Some(&"base-iface-routes".to_string())
+    );
+    assert_eq!(cap_con.action, NetworkCaptureAction::Equal);
+    assert_eq!(
+        cap_con.key,
+        NetworkCaptureToken::Path(
+            vec![
+                "routes".to_string(),
+                "running".to_string(),
+                "next-hop-interface".to_string(),
+            ],
+            "capture.base-iface-routes | r".len() - 1,
+        )
+    );
+    assert_eq!(
+        cap_con.value,
+        NetworkCaptureToken::Value(
+            "br1".to_string(),
+            "capture.base-iface-routes | \
+            routes.running.next-hop-interface==\"b"
+                .len()
+                - 1,
+        ),
+    );
+    assert!(cap_con.value_capture.is_none());
+}
+
+#[test]
+fn test_policy_capture_simple_store() {
+    let cap_con = NetworkCaptureCommand::parse(
+        r#"
+        just store it
+        "#
+        .trim(),
+    )
+    .unwrap();
+
+    assert!(cap_con.key_capture.is_none());
+    assert_eq!(cap_con.action, NetworkCaptureAction::None);
+    assert!(cap_con.key == NetworkCaptureToken::default());
+    assert!(cap_con.value == NetworkCaptureToken::default());
+    assert!(cap_con.value_capture.is_none());
+}
+
+#[test]
+fn test_policy_capture_equal_to_prop_path() {
+    let cap_con = NetworkCaptureCommand::parse(
+        "routes.running.next-hop-interface == \
+        capture.primary-nic.interfaces.0.name",
+    )
+    .unwrap();
+
+    assert!(cap_con.key_capture.is_none());
+    assert_eq!(cap_con.action, NetworkCaptureAction::Equal);
+    assert_eq!(
+        cap_con.key,
+        NetworkCaptureToken::Path(
+            vec![
+                "routes".to_string(),
+                "running".to_string(),
+                "next-hop-interface".to_string(),
+            ],
+            0
+        )
+    );
+    assert_eq!(
+        cap_con.value,
+        NetworkCaptureToken::Path(
+            vec![
+                "interfaces".to_string(),
+                "0".to_string(),
+                "name".to_string(),
+            ],
+            "routes.running.next-hop-interface == \
+            capture.primary-nic.i"
+                .len()
+                - 1
+        )
+    );
+    assert_eq!(cap_con.value_capture, Some("primary-nic".to_string()));
+}
+
+#[test]
+fn test_policy_capture_retain_only() {
+    let cap_con =
+        NetworkCaptureCommand::parse(" dns-resolver.running").unwrap();
+
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mac-address: 11:22:33:44:55:66
+            ipv4:
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          running:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+        dns-resolver:
+          running:
+            search:
+            - example.com
+            - example.org
+            server:
+            - 192.51.100.99
+            - 2001:db8:1::99
+        "#,
+    )
+    .unwrap();
+
+    let mut state = cap_con.execute(&current, &HashMap::new()).unwrap();
+    let empty_state = NetworkState::new();
+
+    assert!(cap_con.key_capture.is_none());
+    assert_eq!(cap_con.action, NetworkCaptureAction::None);
+    assert_eq!(
+        cap_con.key,
+        NetworkCaptureToken::Path(
+            vec!["dns-resolver".to_string(), "running".to_string(),],
+            0
+        )
+    );
+    assert!(cap_con.value == NetworkCaptureToken::default());
+    assert!(cap_con.value_capture.is_none());
+
+    assert_eq!(state.dns, current.dns);
+
+    state.dns = empty_state.dns.clone();
+    state.prop_list = Vec::new();
+    assert_eq!(state, empty_state);
+}
+
+#[test]
+fn test_policy_capture_route_rule() {
+    let cap_con =
+        NetworkCaptureCommand::parse("route-rules.config.route-table==500")
+            .unwrap();
+
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        routes:
+          config:
+          - destination: 192.168.2.0/24
+            metric: 108
+            next-hop-address: 192.168.1.3
+            next-hop-interface: eth1
+            table-id: 200
+          - destination: 2001:db8:a::/64
+            metric: 108
+            next-hop-address: 2001:db8:1::2
+            next-hop-interface: eth1
+            table-id: 500
+        route-rules:
+          config:
+            - ip-from: 192.168.3.2/32
+              route-table: 200
+            - ip-from: 2001:db8:b::/64
+              route-table: 500
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mtu: 1500
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.168.1.1
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        "#,
+    )
+    .unwrap();
+
+    let state = cap_con.execute(&current, &HashMap::new()).unwrap();
+
+    let rules = state.rules.config.as_ref().unwrap();
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0].ip_from, Some("2001:db8:b::/64".to_string()));
+    assert_eq!(rules[0].table_id, Some(500));
+}

--- a/rust/src/lib/unit_tests/policy/error.rs
+++ b/rust/src/lib/unit_tests/policy/error.rs
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{
+    policy::{
+        capture::NetworkCaptureCommand, token::parse_str_to_template_tokens,
+    },
+    ErrorKind, NetworkState, NetworkStateTemplate,
+};
+
+#[test]
+fn test_policy_invalid_equal_action_not_two_equal() {
+    let line = r#"routes.running.next-hop-interface=!"br1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "routes.running.next-hop-interface=!".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_single_equal_at_end() {
+    let line = "routes.running.next-hop-interface=";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "routes.running.next-hop-interface=".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_invalid_replace_action_no_equal_after() {
+    let line = r#"routes.running.next-hop-interface::"br1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "routes.running.next-hop-interface::".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_single_colon_at_end() {
+    let line = "routes.running.next-hop-interface:";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "routes.running.next-hop-interface:".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_no_ending_quote() {
+    let line = r#"routes.running.next-hop-interface=="br1"""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "routes.running.next-hop-interface==\"br1\"\"".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_two_pipes() {
+    let line = r#"capture.abc | capture.abc | interface.name="eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.abc | capture.abc |".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_two_replaces() {
+    let line = r#"capture.abc | capture.abc := interface.name := "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "capture.abc | capture.abc := interface.name :".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_two_equals() {
+    let line = r#"capture.abc | capture.abc == interface.name == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(
+            e.position(),
+            "capture.abc | capture.abc == interface.name =".len() - 1
+        );
+    }
+}
+
+#[test]
+fn test_policy_pipe_not_started_with_capture() {
+    let line = r#"kapture.abc | interface.name == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_pipe_invalid_capture_two_capture_name() {
+    let line = r#"capture.abc.abd | interface.name == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_pipe_invalid_capture_no_capture() {
+    let line = r#"interfaces | interface.name == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_equal_got_no_value_defined() {
+    let line = "interface.name ==";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "interface.name =".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_equal_got_2_values() {
+    let line = r#"interface.name == "eth1" interface.name"#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        println!("HAHA {}", e);
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "interface.name == \"e".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_equal_capture_no_path_afterwards() {
+    let line = r#"capture.abc == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_equal_capture_no_name_afterwards() {
+    let line = r#"capture == "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_replace_got_no_value_defined() {
+    let line = "interface.name :=";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "interface.name :".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_replace_got_2_value() {
+    let line = r#"interface.name := "eth1" interface.name"#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "interface.name := \"e".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_replace_capture_no_path_afterwards() {
+    let line = r#"capture.abc := "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_replace_capture_no_name_afterwards() {
+    let line = r#"capture := "eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_capture_not_found() {
+    let line = r#"capture.void.interface.name == "eth1""#;
+    let cmd = NetworkCaptureCommand::parse(line).unwrap();
+    let result = cmd.execute(&NetworkState::new(), &HashMap::new());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.v".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_reference_no_ending() {
+    let line = "{{ capture.void.interface.0.name";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0);
+    }
+}
+
+#[test]
+fn test_policy_reference_no_start() {
+    let line = "capture.void.interface.0.name }}";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.void.interface.0.name }".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_reference_end_before_start() {
+    let line = "}} capture.void.interface.0.name {{";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), 0)
+    }
+}
+
+#[test]
+fn test_policy_two_references() {
+    let line = "{{ {{ capture.void.interface.0.name }} }}";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "{{ {".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_empty_reference() {
+    let line = "{{ }}";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "{{ ".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_reference_with_two_paths() {
+    let line = "{{ capture.void.interface.0.name \
+        capture.void.interface.1.name }}";
+    let result = parse_str_to_template_tokens(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "{{ capture.void.interface.0.name c".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_reference_capture_not_found() {
+    let template: NetworkStateTemplate = serde_yaml::from_str(
+        r#"---
+interfaces:
+  - name: "{{ capture.void.interface.0.name }}""#,
+    )
+    .unwrap();
+    let capture_results = HashMap::new();
+    let result = template.fill_with_captured_data(&capture_results);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), "{{ capture.void.interface.0.name }}");
+        assert_eq!(e.position(), "{{ capture.v".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_reference_capture_concatenate_with_prefix() {
+    let template: NetworkStateTemplate = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: "{{ capture.void.interfaces.0.name }}.1""#,
+    )
+    .unwrap();
+    let mut capture_results: HashMap<String, NetworkState> = HashMap::new();
+    capture_results.insert(
+        "void".to_string(),
+        serde_yaml::from_str(
+            r#"
+            interfaces:
+              - name: eth1"#,
+        )
+        .unwrap(),
+    );
+    let state = template.fill_with_captured_data(&capture_results).unwrap();
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].base_iface().name, "eth1.1");
+}
+
+#[test]
+fn test_policy_reference_capture_property_not_found() {
+    let template: NetworkStateTemplate = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: "{{ capture.void.interface.0.name }}""#,
+    )
+    .unwrap();
+    let mut capture_results: HashMap<String, NetworkState> = HashMap::new();
+    capture_results.insert(
+        "void".to_string(),
+        serde_yaml::from_str(
+            r#"
+            interfaces:
+              - name: eth1"#,
+        )
+        .unwrap(),
+    );
+    let result = template.fill_with_captured_data(&capture_results);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), "{{ capture.void.interface.0.name }}");
+        assert_eq!(e.position(), "{{ capture.void.i".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_reference_capture_property_not_array() {
+    let template: NetworkStateTemplate = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: "{{ capture.void.0.name }}""#,
+    )
+    .unwrap();
+    let mut capture_results: HashMap<String, NetworkState> = HashMap::new();
+    capture_results.insert(
+        "void".to_string(),
+        serde_yaml::from_str(
+            r#"
+            interfaces:
+              - name: eth1"#,
+        )
+        .unwrap(),
+    );
+    let result = template.fill_with_captured_data(&capture_results);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), "{{ capture.void.0.name }}");
+        assert_eq!(e.position(), "{{ capture.void.0".len() - 1)
+    }
+}
+
+#[test]
+fn test_policy_ilegal_char() {
+    let line = r#"capture.abc | interface.name==-"eth1""#;
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        println!("HAHA {}", e);
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.abc | interface.name==-".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_pipe_at_end() {
+    let line = "capture.abc |";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.abc |".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_value_after_pipe() {
+    let line = "capture.abc | \"eth1\"";
+    let result = NetworkCaptureCommand::parse(line);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), line);
+        assert_eq!(e.position(), "capture.abc | \"e".len() - 1);
+    }
+}
+
+#[test]
+fn test_policy_template_no_capture() {
+    let template: NetworkStateTemplate = serde_yaml::from_str(
+        r#"---
+interfaces:
+  - name: "{{ interface.0.name }}""#,
+    )
+    .unwrap();
+    let capture_results = HashMap::new();
+    let result = template.fill_with_captured_data(&capture_results);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), "{{ interface.0.name }}");
+        assert_eq!(e.position(), "{{ i".len() - 1)
+    }
+}

--- a/rust/src/lib/unit_tests/policy/example.rs
+++ b/rust/src/lib/unit_tests/policy/example.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use std::path::Path;
+
+use crate::{NetworkPolicy, NetworkState};
+
+const EXAMPLE_FOLDER: &str = "../../../examples/policy";
+const CURRENT_YAML_FILENAME: &str = "current.yml";
+const POLICY_YAML_FILENAME: &str = "policy.yml";
+const EXPECTED_YAML_FILENAME: &str = "expected.yml";
+
+#[test]
+fn test_policy_examples() {
+    let folded_path = std::fs::canonicalize(
+        std::env::current_dir().unwrap().join(EXAMPLE_FOLDER),
+    )
+    .unwrap();
+
+    for entry in std::fs::read_dir(folded_path).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        println!("Testing {:?}", path);
+        let current_state = load_state(&path.join(CURRENT_YAML_FILENAME));
+        let mut policy = load_policy(&path.join(POLICY_YAML_FILENAME));
+        let expected_state = load_state(&path.join(EXPECTED_YAML_FILENAME));
+
+        policy.current = Some(current_state);
+        let state = NetworkState::try_from(policy).unwrap();
+        assert_eq!(state, expected_state);
+        println!("Pass    {:?}", path);
+    }
+}
+
+fn load_policy(file_path: &Path) -> NetworkPolicy {
+    println!("Loading NetworkPolicy from {:?}", file_path);
+    let fd = std::fs::File::open(file_path).unwrap();
+    serde_yaml::from_reader(fd).unwrap()
+}
+
+fn load_state(file_path: &Path) -> NetworkState {
+    println!("Loading NetworkState from {:?}", file_path);
+    let fd = std::fs::File::open(file_path).unwrap();
+    serde_yaml::from_reader(fd).unwrap()
+}

--- a/rust/src/lib/unit_tests/policy/mod.rs
+++ b/rust/src/lib/unit_tests/policy/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod capture;
+#[cfg(test)]
+mod error;
+#[cfg(test)]
+mod example;
+#[cfg(test)]
+mod net_policy;
+#[cfg(test)]
+mod token;

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+use crate::{NetworkPolicy, NetworkState};
+
+#[test]
+fn test_policy_move_dhcp_gw_eth_to_bridge() {
+    let mut policy: NetworkPolicy = serde_yaml::from_str(
+        r#"
+capture:
+  gw: routes.running.destination=="0.0.0.0/0"
+  base-iface: >-
+    interfaces.name==capture.gw.routes.running.0.next-hop-interface
+desiredState:
+  interfaces:
+  - name: br1
+    type: linux-bridge
+    state: up
+    mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
+    ipv4:
+      dhcp: true
+      enabled: true
+    bridge:
+        port:
+        - name: "{{ capture.base-iface.interfaces.0.name }}"
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mac-address: 11:22:33:44:55:66
+            ipv4:
+              dhcp: true
+              enabled: true
+
+        routes:
+          running:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          config: []
+        "#,
+    )
+    .unwrap();
+
+    policy.current = Some(current);
+
+    let state = NetworkState::try_from(policy).unwrap();
+
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].name(), "br1");
+    assert_eq!(ifaces[0].ports(), Some(vec!["eth1"]));
+    assert_eq!(
+        ifaces[0].base_iface().mac_address,
+        Some("11:22:33:44:55:66".to_string())
+    );
+}
+
+#[test]
+fn test_policy_move_static_gw_eth_to_bridge() {
+    let mut policy: NetworkPolicy = serde_yaml::from_str(
+        r#"
+capture:
+  void: this capture will just clone current without modification
+  default-gw: routes.running.destination=="0.0.0.0/0"
+  base-iface: >-
+    interfaces.name==
+    capture.default-gw.routes.running.0.next-hop-interface
+  base-iface-routes: >-
+    routes.running.next-hop-interface==
+    capture.default-gw.routes.running.0.next-hop-interface
+  bridge-routes: >-
+    capture.base-iface-routes | routes.running.next-hop-interface:="br1"
+desiredState:
+  interfaces:
+  - name: br1
+    description: Linux bridge with base interface as a port
+    type: linux-bridge
+    state: up
+    ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+      - name: "{{ capture.base-iface.interfaces.0.name }}"
+  routes:
+    config: "{{ capture.bridge-routes.routes.running }}"
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mac-address: 11:22:33:44:55:66
+            ipv4:
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          running:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+        "#,
+    )
+    .unwrap();
+
+    policy.current = Some(current);
+
+    let state = NetworkState::try_from(policy).unwrap();
+
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].name(), "br1");
+    assert_eq!(ifaces[0].ports(), Some(vec!["eth1"]));
+    assert!(ifaces[0].base_iface().ipv4.as_ref().unwrap().enabled);
+    let ip_addrs = ifaces[0]
+        .base_iface()
+        .ipv4
+        .as_ref()
+        .unwrap()
+        .addresses
+        .as_ref()
+        .unwrap();
+    assert_eq!(ip_addrs.len(), 1);
+    assert_eq!(
+        ip_addrs[0].ip,
+        std::net::IpAddr::from_str("192.0.2.251").unwrap()
+    );
+    let routes = state.routes.config.as_ref().unwrap();
+    assert_eq!(routes.len(), 2);
+    assert_eq!(routes[0].destination, Some("0.0.0.0/0".to_string()));
+    assert_eq!(routes[0].next_hop_iface, Some("br1".to_string()));
+    assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
+    assert_eq!(routes[1].next_hop_iface, Some("br1".to_string()));
+}
+
+#[test]
+fn test_policy_convert_dhcp_to_static_with_dns() {
+    let mut policy: NetworkPolicy = serde_yaml::from_str(
+        r#"
+        capture:
+          eth1-iface: interfaces.name == "eth1"
+          eth1-routes: routes.running.next-hop-interface == "eth1"
+          dns: dns-resolver.running
+        desiredState:
+          interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              address: "{{ capture.eth1-iface.interfaces.0.ipv4.address }}"
+              dhcp: false
+              enabled: true
+          routes:
+            config: "{{ capture.eth1-routes.routes.running }}"
+          dns-resolver:
+            config: "{{ capture.dns.dns-resolver.running }}"
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mac-address: 11:22:33:44:55:66
+            ipv4:
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          running:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+          - destination: 192.51.100.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+        dns-resolver:
+          running:
+            search:
+            - example.com
+            - example.org
+            server:
+            - 192.51.100.99
+            - 2001:db8:1::99
+        "#,
+    )
+    .unwrap();
+
+    policy.current = Some(current);
+
+    let state = NetworkState::try_from(policy).unwrap();
+
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].name(), "eth1");
+    assert!(ifaces[0].base_iface().ipv4.as_ref().unwrap().enabled);
+    let ip_addrs = ifaces[0]
+        .base_iface()
+        .ipv4
+        .as_ref()
+        .unwrap()
+        .addresses
+        .as_ref()
+        .unwrap();
+    assert_eq!(ip_addrs.len(), 1);
+    assert_eq!(
+        ip_addrs[0].ip,
+        std::net::IpAddr::from_str("192.0.2.251").unwrap()
+    );
+    let routes = state.routes.config.as_ref().unwrap();
+    assert_eq!(routes.len(), 2);
+    assert_eq!(routes[0].destination, Some("0.0.0.0/0".to_string()));
+    assert_eq!(routes[0].next_hop_iface, Some("eth1".to_string()));
+    assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
+    assert_eq!(routes[1].next_hop_iface, Some("eth1".to_string()));
+    let dns_config = state.dns.config.as_ref().unwrap();
+    assert_eq!(
+        dns_config.server,
+        Some(vec![
+            "192.51.100.99".to_string(),
+            "2001:db8:1::99".to_string()
+        ])
+    );
+    assert_eq!(
+        dns_config.search,
+        Some(vec!["example.com".to_string(), "example.org".to_string()])
+    );
+}
+
+#[test]
+fn test_policy_empty_policy() {
+    let policy: NetworkPolicy = serde_yaml::from_str("").unwrap();
+    let state = NetworkState::try_from(policy).unwrap();
+    assert_eq!(state, NetworkState::new());
+}
+
+#[test]
+fn test_policy_no_capture() {
+    let policy: NetworkPolicy = serde_yaml::from_str(
+        r#"
+        desiredState:
+          interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+        "#,
+    )
+    .unwrap();
+
+    let state = NetworkState::try_from(policy).unwrap();
+    let expected_state: NetworkState = serde_yaml::from_str(
+        r#"
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+        "#,
+    )
+    .unwrap();
+    assert_eq!(state, expected_state);
+}

--- a/rust/src/lib/unit_tests/policy/token.rs
+++ b/rust/src/lib/unit_tests/policy/token.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::policy::token::{parse_str_to_capture_tokens, NetworkCaptureToken};
+
+#[test]
+fn test_policy_token_quoted_string() {
+    assert_eq!(
+        parse_str_to_capture_tokens(r#""quoted string""#).unwrap(),
+        vec![NetworkCaptureToken::Value("quoted string".into(), 1)]
+    )
+}
+
+#[test]
+fn test_policy_token_equal_number() {
+    assert_eq!(
+        parse_str_to_capture_tokens("interfaces.mtu==1280").unwrap(),
+        vec![
+            NetworkCaptureToken::Path(
+                vec!["interfaces".into(), "mtu".into()],
+                0
+            ),
+            NetworkCaptureToken::Equal("interfaces.mtu=".len() - 1),
+            NetworkCaptureToken::Value(
+                "1280".into(),
+                "interfaces.mtu==1".len() - 1
+            )
+        ]
+    )
+}
+
+#[test]
+fn test_policy_token_path_equal_double_quoted_string() {
+    assert_eq!(
+        parse_str_to_capture_tokens(r#"interfaces.name=="eth1""#).unwrap(),
+        vec![
+            NetworkCaptureToken::Path(
+                vec!["interfaces".into(), "name".into()],
+                0
+            ),
+            NetworkCaptureToken::Equal("interfaces.name=".len() - 1),
+            NetworkCaptureToken::Value(
+                "eth1".into(),
+                "interfaces.name==\"e".len() - 1,
+            )
+        ]
+    )
+}
+
+#[test]
+fn test_policy_token_path_equal_unquoted_string() {
+    assert_eq!(
+        parse_str_to_capture_tokens("interfaces.name==eth1").unwrap(),
+        vec![
+            NetworkCaptureToken::Path(
+                vec!["interfaces".into(), "name".into()],
+                0
+            ),
+            NetworkCaptureToken::Equal("interfaces.name=".len() - 1),
+            NetworkCaptureToken::Value(
+                "eth1".into(),
+                "interfaces.name==e".len() - 1
+            )
+        ]
+    )
+}
+
+#[test]
+fn test_policy_token_path_equal_path() {
+    assert_eq!(
+        parse_str_to_capture_tokens(
+            "interfaces.name==\
+                capture.default-gw.routes.running.0.next-hop-interface"
+        )
+        .unwrap(),
+        vec![
+            NetworkCaptureToken::Path(
+                vec!["interfaces".into(), "name".into(),],
+                0
+            ),
+            NetworkCaptureToken::Equal("interfaces.name=".len() - 1),
+            NetworkCaptureToken::Path(
+                vec![
+                    "capture".into(),
+                    "default-gw".into(),
+                    "routes".into(),
+                    "running".into(),
+                    "0".into(),
+                    "next-hop-interface".into(),
+                ],
+                "interfaces.name==c".len() - 1
+            )
+        ]
+    )
+}
+
+#[test]
+fn test_policy_token_path_pipe() {
+    assert_eq!(
+        parse_str_to_capture_tokens(
+            r#"capture.base-iface-routes | running.a := "br1""#
+        )
+        .unwrap(),
+        vec![
+            NetworkCaptureToken::Path(
+                vec!["capture".into(), "base-iface-routes".into(),],
+                0,
+            ),
+            NetworkCaptureToken::Pipe("capture.base-iface-routes |".len() - 1),
+            NetworkCaptureToken::Path(
+                vec!["running".into(), "a".into()],
+                "capture.base-iface-routes | r".len() - 1
+            ),
+            NetworkCaptureToken::Replace(
+                "capture.base-iface-routes | running.a :".len() - 1
+            ),
+            NetworkCaptureToken::Value(
+                "br1".into(),
+                "capture.base-iface-routes | running.a := \"b".len() - 1
+            ),
+        ]
+    )
+}

--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -6,6 +6,7 @@ from .netapplier import rollback
 from .netinfo import show
 from .netinfo import show_running_config
 from .prettystate import PrettyState
+from .nmpolicy import gen_net_state_from_policy
 
 __all__ = [
     "NmstateError",
@@ -13,6 +14,7 @@ __all__ = [
     "apply",
     "commit",
     "generate_configurations",
+    "gen_net_state_from_policy",
     "rollback",
     "show",
     "show_running_config",

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -211,6 +211,35 @@ def gen_conf(state):
     # pylint: enable=no-member
 
 
+def net_state_from_policy(policy, cur_state):
+    c_err_msg = c_char_p()
+    c_err_kind = c_char_p()
+    c_policy = c_char_p(json.dumps(policy).encode("utf-8"))
+    c_cur_state = c_char_p(json.dumps(cur_state).encode("utf-8"))
+    c_state = c_char_p()
+    c_log = c_char_p()
+    rc = lib.nmstate_net_state_from_policy(
+        c_policy,
+        c_cur_state,
+        byref(c_state),
+        byref(c_log),
+        byref(c_err_kind),
+        byref(c_err_msg),
+    )
+    state = c_state.value
+    err_msg = c_err_msg.value
+    err_kind = c_err_kind.value
+    parse_log(c_log.value)
+    lib.nmstate_cstring_free(c_log)
+    lib.nmstate_cstring_free(c_err_kind)
+    lib.nmstate_cstring_free(c_err_msg)
+    if rc != NMSTATE_PASS:
+        raise map_error(err_kind, err_msg)
+    # pylint: disable=no-member
+    return state.decode("utf-8")
+    # pylint: enable=no-member
+
+
 def map_error(err_kind, err_msg):
     err_msg = err_msg.decode("utf-8")
     err_kind = err_kind.decode("utf-8")

--- a/rust/src/python/libnmstate/nmpolicy.py
+++ b/rust/src/python/libnmstate/nmpolicy.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+
+import json
+
+from .clib_wrapper import net_state_from_policy
+
+
+def gen_net_state_from_policy(policy, cur_state):
+    return json.loads(net_state_from_policy(policy, cur_state))

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -229,7 +229,7 @@ def test_change_gateway(eth1_up):
     _assert_routes(routes, cur_state)
 
 
-def _assert_routes(routes, state):
+def _assert_routes(routes, state, nic="eth1"):
     """
     Assuming we are all operating eth1 routes
     """
@@ -242,7 +242,7 @@ def _assert_routes(routes, state):
     routes.sort(key=_route_sort_key)
     config_routes = []
     for config_route in state[Route.KEY][Route.CONFIG]:
-        if config_route[Route.NEXT_HOP_INTERFACE] == "eth1":
+        if config_route[Route.NEXT_HOP_INTERFACE] == nic:
             config_routes.append(config_route)
 
     # The kernel routes contains more route entries than desired config

--- a/tests/integration/testlib/yaml.py
+++ b/tests/integration/testlib/yaml.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import yaml
+
+
+def load_yaml(content):
+    return yaml.load(content, Loader=yaml.SafeLoader)


### PR DESCRIPTION
Introducing support of nmpolicy syntax[1] including rust, python and C
bindings.

Implementation workflow:
 * `NetworkPolicy` could deserialize from existing nmpolicy file.
 * Each of capture line will produce a new `NetworkState` and stored for
   follow up capture line processing.
 * Each capture line will be converted to `Vec<NetworkCaptureToken>`,
   then fill into `NetworkCaptureCommand` for filtering or updating
   matched `NetworkState`.
 * We use `serde_json::Map` to walk through the property defined in the
   format of `routes.running.next-hop-interface`.

The cli tools could be used also:

    nmstatectl p <policy.yml> [-c current_state.yml] \
        [-s saved_capture.yml] [-o /path/to/output_capture.yml]


API:

 * Using running current to generate `NetworkState`:

   ```rust
   let policy: NetworkPolicy = serde_yaml::from_str(policy_content)?;
   let state = NetworkState::try_from(policy)?
   ```

 * Use saved current to generate `NetworkState`:

   ```rust
   let mut policy: NetworkPolicy = serde_yaml::from_str(policy_content)?;
   policy.current = Some(serde_yaml::from_str(current_state_content)?);
   let state = NetworkState::try_from(policy)?
   ```

 * Store captured data:

   ```rust
   let policy: NetworkPolicy = serde_yaml::from_str(policy_content)?;
   let current_state = serde_yaml::from_str(current_state_content)?;
   let captured_states = policy.capture.execute(&current_state)?;
   // Use your own way to store the captured data
   // You may also use `NetworkCaptureRules::execute()` directly.
   ```

 * Load captured data:

   ```rust
   // Use your own way to load the data. We just need
   // HashMap<String, NetworkState> for captured_states
   let current_state = serde_yaml::from_str(current_state_content)?;
   let policy: NetworkPolicy = serde_yaml::from_str(policy_content)?;
   let state = policy.desired.fill_with_captured_data(&captured_states)?;
   // You may also use `NetworkStateTemplate::fill_with_captured_data()`
   // directly.
   ```

Both unit test cases and integration test case are included.
