### PR TITLE
bond: Fix the bond `ad_select` option

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -237,6 +237,7 @@ impl BondConfig {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
 #[serde(try_from = "NumberAsString")]
 pub enum BondAdSelect {
     Stable,


### PR DESCRIPTION
The `BondAdSelect` should be serialized into lower case.