### PR TITLE
WIP: CI: Fix k8s CI

### DIFF
--- a/automation/tests-k8s-utils.sh
+++ b/automation/tests-k8s-utils.sh
@@ -117,6 +117,7 @@ function k8s::pre_test_setup {
 
     ${KUBECTL_CMD} exec -n nmstate conformance -- rm -rf /workspace/
     ${KUBECTL_CMD} exec -n nmstate conformance -- mkdir -p /workspace/
+    ${KUBECTL_CMD} exec -n nmstate conformance -- mkdir -p /exported-artifacts/
     ${KUBECTL_CMD} cp -n nmstate $(pwd) conformance:/workspace/nmstate/
 
     k8s::kubectl_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \


### PR DESCRIPTION
The k8s CI is complaining about:

    [Errno 2] No such file or directory: '/exported-artifacts/pytest-run.log'

So let's create the /exported-artifacts folder before test run.