### PR TITLE
cli yaml: Replace non-breaking space with normal space

### DIFF
--- a/rust/src/cli/gen_conf.rs
+++ b/rust/src/cli/gen_conf.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::Read;
+
 use nmstate::NetworkState;
 
 use crate::error::CliError;
 
 pub(crate) fn gen_conf(file_path: &str) -> Result<String, CliError> {
-    let fd = std::fs::File::open(file_path)?;
-    let net_state: NetworkState = serde_yaml::from_reader(fd)?;
+    let mut fd = std::fs::File::open(file_path)?;
+    let mut content = String::new();
+    // Replace non-breaking space '\u{A0}'  to normal space
+    fd.read_to_string(&mut content)?;
+    let content = content.replace('\u{A0}', " ");
+    let net_state: NetworkState = serde_yaml::from_str(&content)?;
     let confs = net_state.gen_conf()?;
     let escaped_string = serde_yaml::to_string(&confs)?;
     Ok(escaped_string.replace("\\n", "\n\n"))


### PR DESCRIPTION
The unicode has U+00A0(UTF-8 is C2 A0) which should interpreted as
space. Since `serde_yaml` seems does not support so, let's replace it
before passing to deserialization.