### PR TITLE
deserialize: Deny unknown field in NetworkState

### DIFF
--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -27,6 +27,8 @@ mod mac_vtap;
 #[cfg(test)]
 mod mptcp;
 #[cfg(test)]
+mod net_state;
+#[cfg(test)]
 mod ovs;
 #[cfg(test)]
 mod ovsdb;

--- a/rust/src/lib/unit_tests/net_state.rs
+++ b/rust/src/lib/unit_tests/net_state.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NetworkState;
+
+#[test]
+fn test_invalid_top_key() {
+    let result = serde_yaml::from_str::<NetworkState>(
+        r#"---
+invalid_key: abc
+"#,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_invalid_top_type() {
+    let result = serde_yaml::from_str::<NetworkState>(
+        r#"---
+- invalid_key: abc
+"#,
+    );
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Since we implement Deserializer for NetworkState by ourselves, we lose
the ability of macro -- `serde(deny_unknown_fields)`. Hence we should do
it by ourselves.

Unit test case included to test both invalid key and invalid type.