### PR TITLE
CI: Remove VDSM CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
       uses: actions-rs/toolchain@v1
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
       uses: actions-rs/toolchain@v1
@@ -170,7 +170,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,6 @@ jobs:
           - job_type: "c8s-nm_main-integ_slow"
           - job_type: "c8s-nm_main-rust_go"
           - job_type: "ovs2_11-nm_stable-integ_tier1"
-          - job_type: "vdsm_el8-nm_main-vdsm"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The error in
https://github.com/nmstate/nmstate/actions/runs/3243416907/jobs/5318284486#step:6:853

indicate VDSM CI is still using old python code of nmstate for testing.
The correct CI setup should using __current__ PR code for testing.

Remove VDSM CI and add it back if we have maintainer.