### PR TITLE
[nmstate-1.3] python: gen_conf: Treating state:down as autoconnect false

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -108,7 +108,7 @@ class Ifaces:
         if des_iface_infos:
             for iface_info in des_iface_infos:
                 iface = BaseIface(iface_info, save_to_disk)
-                if not iface.is_up and self._gen_conf_mode:
+                if not (iface.is_up or iface.is_down) and self._gen_conf_mode:
                     continue
                 if iface.type == InterfaceType.UNKNOWN:
                     cur_ifaces = self._get_cur_ifaces(iface.name)

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -139,6 +139,11 @@ class NmProfile:
         else:
             return ""
 
+    def disable_autoconnect(self):
+        if self._nm_simple_conn:
+            nm_conn_setting = self._nm_simple_conn.get_setting_connection()
+            nm_conn_setting.props.autoconnect = False
+
     def update_controller(self, controller):
         nm_simple_conn_update_controller(self._nm_simple_conn, controller)
 
@@ -276,7 +281,9 @@ class NmProfile:
         )
 
     def prepare_config(self, save_to_disk, gen_conf_mode=False):
-        if self._iface.is_absent or self._iface.is_down:
+        if self._iface.is_absent or (
+            self._iface.is_down and not gen_conf_mode
+        ):
             return
 
         # Don't create new profile if original desire does not ask

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -51,9 +51,11 @@ class NmProfiles:
         _append_nm_ovs_port_iface(net_state)
         all_profiles = []
         for iface in net_state.ifaces.all_ifaces():
-            if iface.is_up:
+            if iface.is_up or iface.is_down:
                 profile = NmProfile(self._ctx, iface)
                 profile.prepare_config(save_to_disk=False, gen_conf_mode=True)
+                if iface.is_down:
+                    profile.disable_autoconnect()
                 all_profiles.append(profile)
 
         _use_uuid_as_controller_and_parent(all_profiles)

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -107,7 +107,7 @@ pub(crate) fn nmstate_ipv4_to_np(
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf.prefix_len = nms_addr.prefix_length;
                 ip_conf
             });
         }
@@ -124,7 +124,7 @@ pub(crate) fn nmstate_ipv6_to_np(
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf.prefix_len = nms_addr.prefix_length;
                 ip_conf
             });
         }

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -33,6 +33,7 @@ from libnmstate.schema import Route
 from ..testlib import assertlib
 from ..testlib import cmdlib
 from ..testlib import statelib
+from ..testlib.genconf import gen_conf_apply
 from ..testlib.ovslib import Bridge as OvsBridge
 
 
@@ -581,3 +582,24 @@ def test_ovs_dup_name_different_conn_name(ovs_bridge_internal_dup_name):
 
     assert "br0-br" in out
     assert "br0-if" in out
+
+
+@pytest.mark.tier1
+def test_gen_conf_with_iface_state_down():
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "dummy1",
+                Interface.TYPE: InterfaceType.DUMMY,
+                Interface.STATE: InterfaceState.DOWN,
+            },
+        ]
+    }
+    with gen_conf_apply(desired_state):
+        assert (
+            cmdlib.exec_cmd(
+                "nmcli -g connection.autoconnect c show dummy1".split(),
+                check=True,
+            )[1].strip()
+            == "no"
+        )


### PR DESCRIPTION
According to openshift team, they would like to see a profile been
created with `autoconnect: false` for `state:down` interface in
`gen_conf` mode. So that they could have a interface been disabled on
boot.

NetworkManager is treating interface with `autoconnect: false` profile
as `disconnected` state which means both IPv4 and IPv6 are disabled.

Integration test case included.