### PR TITLE
nm: Support `dns-data` in NetworkManager 1.41

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/dns.rs
@@ -1,17 +1,4 @@
-// Copyright 2021 Red Hat, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+// SPDX-License-Identifier: Apache-2.0
 
 use std::convert::TryFrom;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -82,6 +69,12 @@ pub(crate) fn parse_nm_dns(
         }
     }
     Ok(dns_srvs)
+}
+
+pub(crate) fn parse_nm_dns_data(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<String>, NmError> {
+    Ok(Vec::<String>::try_from(value)?)
 }
 
 pub(crate) fn parse_nm_dns_search(


### PR DESCRIPTION
The NetworkManager 1.41 introduced `dns-data` and deprecating `dns` DBUS
propriety.

Without this patch, we will not able to purge DNS on NM 1.41
as we always merge unknown DNS propriety which in this case `dns-data`.
The `dns-data` is effective if `dns` is not mentioned, hence we cannot
purge DNS in NM 1.41+.

We cannot simply set empty array in `dns` which take priority over
`dns-data` when applying because IPv4 and IPv6 dns setting has different
dbus signature which require at lease one dns server to determine.

This patch only enable the querying support on `dns-data`, but still use
old `dns` property when applying to achieve backwards compatibility,
and drop `dns-data` when applying also.

The integration test case `test_dns_edit_nameserver_with_static_gateway`
reproduced the problem and could confirm the fix.