### PR TITLE
test: Add test case for IP address order

### DIFF
--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -1,25 +1,10 @@
-#
-# Copyright (c) 2019-2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
 
 import gi
+
+from .cmdlib import exec_cmd
 
 gi.require_version("NM", "1.0")
 # It is required to state the NM version before importing it
@@ -49,3 +34,7 @@ def nm_minor_version():
 
 def is_k8s():
     return os.getenv("RUN_K8S") == "true"
+
+
+def is_el8():
+    return exec_cmd("rpm -E %{?rhel}".split())[1].strip() == "8"

--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -19,9 +19,12 @@
 
 from contextlib import contextmanager
 from functools import wraps
+import json
 import subprocess
 import threading
 import time
+
+from .cmdlib import exec_cmd
 
 
 TIMEOUT = 10
@@ -102,3 +105,14 @@ def _thread(func, name, teardown_cb=lambda: None):
     finally:
         teardown_cb()
         t.join()
+
+
+def iproute_get_ip_addrs_with_order(iface, is_ipv6):
+    """
+    Return a list of ip address with the order reported by ip route
+    """
+    family = 6 if is_ipv6 else 4
+    output = json.loads(
+        exec_cmd(f"ip -d -j -{family} addr show dev {iface}".split())[1]
+    )
+    return [addr_info["local"] for addr_info in output[0]["addr_info"]]


### PR DESCRIPTION
Add test case to test the order of IP addresses is preserved.

It is known issue in RHEL 8 with reverted IPv6 address order. Downstream
nmstate package will have their own patch to revert the address list
before sent to NM.