### PR TITLE
bond: Add support of balance-slb option

### DIFF
--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -38,4 +38,6 @@ pub(crate) use self::inter_connections::{
 };
 
 #[cfg(feature = "query_apply")]
+pub(crate) use self::bond::get_bond_balance_slb;
+#[cfg(feature = "query_apply")]
 pub(crate) use self::user::NMSTATE_DESCRIPTION;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -22,20 +22,22 @@ use super::{
         nm_ovs_bridge_conf_get, query_nmstate_wait_ip, retrieve_dns_info,
     },
     settings::{
-        NM_SETTING_BOND_SETTING_NAME, NM_SETTING_BRIDGE_SETTING_NAME,
-        NM_SETTING_DUMMY_SETTING_NAME, NM_SETTING_INFINIBAND_SETTING_NAME,
-        NM_SETTING_MACVLAN_SETTING_NAME, NM_SETTING_OVS_BRIDGE_SETTING_NAME,
-        NM_SETTING_OVS_IFACE_SETTING_NAME, NM_SETTING_VETH_SETTING_NAME,
-        NM_SETTING_VLAN_SETTING_NAME, NM_SETTING_VRF_SETTING_NAME,
-        NM_SETTING_VXLAN_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
+        get_bond_balance_slb, NM_SETTING_BOND_SETTING_NAME,
+        NM_SETTING_BRIDGE_SETTING_NAME, NM_SETTING_DUMMY_SETTING_NAME,
+        NM_SETTING_INFINIBAND_SETTING_NAME, NM_SETTING_MACVLAN_SETTING_NAME,
+        NM_SETTING_OVS_BRIDGE_SETTING_NAME, NM_SETTING_OVS_IFACE_SETTING_NAME,
+        NM_SETTING_VETH_SETTING_NAME, NM_SETTING_VLAN_SETTING_NAME,
+        NM_SETTING_VRF_SETTING_NAME, NM_SETTING_VXLAN_SETTING_NAME,
+        NM_SETTING_WIRED_SETTING_NAME,
     },
 };
 use crate::{
-    BaseInterface, BondInterface, DummyInterface, EthernetInterface,
-    InfiniBandInterface, Interface, InterfaceState, InterfaceType, Interfaces,
-    LinuxBridgeInterface, MacVlanInterface, MacVtapInterface, NetworkState,
-    NmstateError, OvsBridgeInterface, OvsInterface, UnknownInterface,
-    VlanInterface, VrfInterface, VxlanInterface,
+    BaseInterface, BondConfig, BondInterface, BondOptions, DummyInterface,
+    EthernetInterface, InfiniBandInterface, Interface, InterfaceState,
+    InterfaceType, Interfaces, LinuxBridgeInterface, MacVlanInterface,
+    MacVtapInterface, NetworkState, NmstateError, OvsBridgeInterface,
+    OvsInterface, UnknownInterface, VlanInterface, VrfInterface,
+    VxlanInterface,
 };
 
 pub(crate) fn nm_retrieve(
@@ -281,6 +283,14 @@ fn iface_get(
             InterfaceType::Bond => Interface::Bond({
                 let mut iface = BondInterface::new();
                 iface.base = base_iface;
+                let bond_config = BondConfig {
+                    options: Some(BondOptions {
+                        balance_slb: get_bond_balance_slb(nm_conn),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+                iface.bond = Some(bond_config);
                 iface
             }),
             InterfaceType::OvsInterface => Interface::OvsInterface({

--- a/rust/src/lib/query_apply/bond.rs
+++ b/rust/src/lib/query_apply/bond.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BondConfig, BondInterface};
+use crate::{BondConfig, BondInterface, BondOptions};
 
 impl BondInterface {
     pub(crate) fn update_bond(&mut self, other: &BondInterface) {
@@ -78,9 +78,29 @@ impl BondInterface {
 impl BondConfig {
     pub(crate) fn update(&mut self, other: Option<&BondConfig>) {
         if let Some(other) = other {
-            self.mode = other.mode;
-            self.options = other.options.clone();
-            self.port = other.port.clone();
+            if let Some(mode) = other.mode {
+                self.mode = Some(mode);
+            }
+            if let Some(self_opts) = self.options.as_mut() {
+                self_opts.update(other.options.as_ref());
+            } else {
+                self.options = other.options.clone();
+            }
+            if let Some(port) = other.port.as_ref() {
+                self.port = Some(port.clone());
+            }
+        }
+    }
+}
+
+impl BondOptions {
+    // Only allow update `balance_slb` as that is userspace value.
+    // Other options should be provided by nispor via kernel netlink.
+    pub(crate) fn update(&mut self, other: Option<&Self>) {
+        if let Some(other) = other {
+            if let Some(value) = other.balance_slb {
+                self.balance_slb = Some(value);
+            }
         }
     }
 }


### PR DESCRIPTION
The NetworkManager 1.41 introduced new bond option `balance-slb` to achieve
the same effect with ovs bond slb mode.

Example yaml:

```yml
---
interfaces:
- name: bond99
  type: bond
  state: up
  link-aggregation:
    mode: balance-xor
    options:
      xmit_hash_policy: "vlan+srcmac"
      balance-slb: 1
```

Unit and integration test cases included.