### PR TITLE
nm: Fix deleting interface created by iproute

### DIFF
--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -331,7 +331,7 @@ fn delete_remain_virtual_interface_as_desired(
         if iface.is_virtual() {
             if let Some(nm_dev) = nm_devs_indexed.get(&(
                 iface.name().to_string(),
-                iface.iface_type().to_string(),
+                iface_type_to_nm(&iface.iface_type())?,
             )) {
                 log::info!(
                     "Deleting interface {}/{}: {}",

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1074,3 +1074,10 @@ def test_create_and_remove_linux_bridge_kernel_mode():
         assertlib.assert_state(desired_state)
 
     assertlib.assert_absent(bridge_name)
+
+
+def test_delete_bridge_created_by_iproute():
+    exec_cmd(f"ip link add {TEST_BRIDGE0} type bridge".split(), check=True)
+    with linux_bridge(TEST_BRIDGE0, bridge_subtree_state=None):
+        pass
+    assertlib.assert_absent(TEST_BRIDGE0)


### PR DESCRIPTION
When virtual interface(e.g. linux-bridge) was created by iproute
command, nmstate will fail when marking it as absent with error:

    Absent/Down interface br1/linux-bridge still found

This is caused by `delete_remain_virtual_interface_as_desired()` not
working as expected due to inconsistency between NM interface type and
nmstate interface type.

Integration test case included.