### PR TITLE
cargo: Minimum rust version 1.60

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "nmstatectl"
 version = "2.2.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
+rust-version = "1.60"
 
 [[bin]]
 name = "nmstatectl"

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -5,6 +5,7 @@ version = "2.2.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
+rust-version = "1.60"
 
 [lib]
 name = "nmstate"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux-apis"]
+rust-version = "1.60"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
Set minimum rust version 1.60 due to the need for feature dependency
`dep:foo`.