### PR TITLE
Makefile: add `-Z namespaced-features` to fix compiler error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ PYTHON3_SITE_DIR ?=$(shell \
 		 print(get_python_lib())")
 
 $(CLI_EXEC_RELEASE) $(CLIB_SO_DEV_RELEASE):
-	cd rust; cargo build --all --release
+	cd rust; cargo build --all --release -Z namespaced-features
 
 $(CLIB_SO_DEV_DEBUG):
 	cd rust; cargo build --all


### PR DESCRIPTION
When compiling nmstatectl in Copr infraestructure, it is failing with an error related to the `Cargo.toml`. This option has been already stabilized but Copr is using an older version of rustc.

```
namespaced features with the `dep:` prefix are only allowed on the
nightly channel and requires the `-Z namespaced-features` flag on the
command-line
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>