### PR TITLE
route_rule: support `from all to all` routing policy

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -73,8 +73,8 @@ pub struct BaseInterface {
     pub ipv6: Option<InterfaceIpv6>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Interface wide MPTCP flags.
-    /// Nmstate will apply these flags to all valid IP addresses(both static and
-    /// dynamic).
+    /// Nmstate will apply these flags to all valid IP addresses(both static
+    /// and dynamic).
     pub mptcp: Option<MptcpConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     // None here mean no change, empty string mean detach from controller.

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -964,7 +964,7 @@ fn default_allow_extra_address() -> bool {
     true
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum AddressFamily {

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -7,6 +7,8 @@ use crate::{
     BaseInterface, DnsClientState, ErrorKind, MptcpAddressFlag, NmstateError,
 };
 
+const AF_INET: u8 = 2;
+const AF_INET6: u8 = 10;
 const IPV4_ADDR_LEN: usize = 32;
 const IPV6_ADDR_LEN: usize = 128;
 
@@ -960,4 +962,29 @@ fn is_none_or_empty_mptcp_flags(v: &Option<Vec<MptcpAddressFlag>>) -> bool {
 // Allow extra IP by default
 fn default_allow_extra_address() -> bool {
     true
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AddressFamily {
+    IPv4,
+    IPv6,
+    Unknown,
+}
+
+impl From<u8> for AddressFamily {
+    fn from(d: u8) -> Self {
+        match d {
+            AF_INET => AddressFamily::IPv4,
+            AF_INET6 => AddressFamily::IPv6,
+            _ => AddressFamily::Unknown,
+        }
+    }
+}
+
+impl Default for AddressFamily {
+    fn default() -> Self {
+        Self::IPv4
+    }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -138,8 +138,8 @@ pub use crate::ifaces::{
     VxlanInterface,
 };
 pub use crate::ip::{
-    Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
-    Ipv6AddrGenMode, WaitIp,
+    AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,
+    InterfaceIpv6, Ipv6AddrGenMode, WaitIp,
 };
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,

--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -1,14 +1,51 @@
-use crate::{RouteRuleEntry, RouteRules};
+use log::warn;
 
-pub(crate) fn get_route_rules(np_rules: &[nispor::RouteRule]) -> RouteRules {
+use crate::{AddressFamily, RouteRuleEntry, RouteRules};
+
+// Due to a bug in NetworkManager all route rules added using NetworkManager are
+// using RTM_PROTOCOL UnSpec. Therefore, we need to support it until it is
+// fixed.
+const SUPPORTED_STATIC_ROUTE_PROTOCOL: [nispor::RouteProtocol; 3] = [
+    nispor::RouteProtocol::Boot,
+    nispor::RouteProtocol::Static,
+    nispor::RouteProtocol::UnSpec,
+];
+
+const SUPPORTED_ROUTE_PROTOCOL: [nispor::RouteProtocol; 8] = [
+    nispor::RouteProtocol::Boot,
+    nispor::RouteProtocol::Static,
+    nispor::RouteProtocol::Ra,
+    nispor::RouteProtocol::Dhcp,
+    nispor::RouteProtocol::Mrouted,
+    nispor::RouteProtocol::KeepAlived,
+    nispor::RouteProtocol::Babel,
+    nispor::RouteProtocol::UnSpec,
+];
+
+pub(crate) fn get_route_rules(
+    np_rules: &[nispor::RouteRule],
+    running_config_only: bool,
+) -> RouteRules {
     let mut ret = RouteRules::new();
 
     let mut rules = Vec::new();
+    let protocols = if running_config_only {
+        SUPPORTED_STATIC_ROUTE_PROTOCOL.as_slice()
+    } else {
+        SUPPORTED_ROUTE_PROTOCOL.as_slice()
+    };
+
     for np_rule in np_rules {
         let mut rule = RouteRuleEntry::new();
         // We only support route rules with 'table' action
         if np_rule.action != nispor::RuleAction::Table {
             continue;
+        }
+        // Filter out the routes with protocols that we do not support
+        if let Some(rule_protocol) = np_rule.protocol.as_ref() {
+            if !protocols.contains(rule_protocol) {
+                continue;
+            }
         }
         rule.ip_to = np_rule.dst.clone();
         rule.ip_from = np_rule.src.clone();
@@ -16,6 +53,17 @@ pub(crate) fn get_route_rules(np_rules: &[nispor::RouteRule]) -> RouteRules {
         rule.priority = np_rule.priority.map(i64::from);
         rule.fwmark = np_rule.fw_mark;
         rule.fwmask = np_rule.fw_mask;
+        rule.family = match np_rule.address_family {
+            nispor::AddressFamily::IPv4 => Some(AddressFamily::IPv4),
+            nispor::AddressFamily::IPv6 => Some(AddressFamily::IPv6),
+            _ => {
+                warn!(
+                    "Unsupported route rule family {:?}",
+                    np_rule.address_family
+                );
+                None
+            }
+        };
         rules.push(rule);
     }
     ret.config = Some(rules);

--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -10,15 +10,6 @@ pub(crate) fn get_route_rules(np_rules: &[nispor::RouteRule]) -> RouteRules {
         if np_rule.action != nispor::RuleAction::Table {
             continue;
         }
-        // Neither ip_from or ip_to should be defeind
-        if np_rule.dst.is_none() && np_rule.src.is_none() {
-            continue;
-        }
-        if np_rule.dst.as_deref() == Some("")
-            && np_rule.src.as_deref() == Some("")
-        {
-            continue;
-        }
         rule.ip_to = np_rule.dst.clone();
         rule.ip_from = np_rule.src.clone();
         rule.table_id = np_rule.table;

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -123,7 +123,7 @@ pub(crate) fn nispor_retrieve(
     }
     set_controller_type(&mut net_state.interfaces);
     net_state.routes = get_routes(running_config_only);
-    net_state.rules = get_route_rules(&np_state.rules);
+    net_state.rules = get_route_rules(&np_state.rules, running_config_only);
 
     Ok(net_state)
 }

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -159,6 +159,7 @@ fn gen_rule_entry(
     fwmask: u32,
 ) -> RouteRuleEntry {
     RouteRuleEntry {
+        family: None,
         state: None,
         ip_from: Some(ip_from.to_string()),
         ip_to: Some(ip_to.to_string()),
@@ -390,4 +391,34 @@ ip-from: 2001:db8:2:0000::ffff
 
     assert_eq!(rule.ip_to.unwrap(), "2001:db8:1::2/128");
     assert_eq!(rule.ip_from.unwrap(), "2001:db8:2::ffff/128");
+}
+
+#[test]
+fn test_route_rule_validate_ipv6_family_ip_from() {
+    let rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+ip-from: 2001:db8:b::/64
+priority: 30000
+route-table: 200
+family: ipv6
+"#,
+    )
+    .unwrap();
+
+    rule.validate().unwrap();
+}
+
+#[test]
+fn test_route_rule_validate_ipv4_family_ip_from() {
+    let rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+ip-from: 192.168.2.0/24
+priority: 30000
+route-table: 200
+family: ipv4
+"#,
+    )
+    .unwrap();
+
+    rule.validate().unwrap();
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -68,6 +68,9 @@ class RouteRule:
     STATE_ABSENT = "absent"
     FWMARK = "fwmark"
     FWMASK = "fwmask"
+    FAMILY = "family"
+    FAMILY_IPV4 = "ipv4"
+    FAMILY_IPV6 = "ipv6"
 
 
 class DNS:

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -160,6 +160,7 @@ def test_add_remove_route_rule(eth1_up):
             rule.get(RouteRule.ROUTE_TABLE),
             rule.get(RouteRule.FWMARK),
             rule.get(RouteRule.FWMASK),
+            rule.get(RouteRule.FAMILY),
         )
 
 

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -118,6 +118,7 @@ route-rules:
             rule.get(RouteRule.ROUTE_TABLE),
             rule.get(RouteRule.FWMARK),
             rule.get(RouteRule.FWMASK),
+            rule.get(RouteRule.FAMILY),
         )
 
 

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -310,9 +310,11 @@ def eth1_with_static_route_and_rule(eth1_up):
             - ip-from: 2001:db8:b::/64
               priority: 30000
               route-table: 200
+              family: ipv6
             - ip-from: 192.168.3.2/32
               priority: 30001
               route-table: 200
+              family: ipv4
         interfaces:
           - name: eth1
             type: ethernet

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -939,6 +939,7 @@ def test_add_route_rule_to_ovs_interface_dhcp_auto_route_table(
         route_rule.get(RouteRule.ROUTE_TABLE),
         route_rule.get(RouteRule.FWMARK),
         route_rule.get(RouteRule.FWMASK),
+        route_rule.get(RouteRule.FAMILY),
     )
 
 

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -24,12 +24,16 @@ from libnmstate import iplib
 from . import cmdlib
 
 
-def ip_rule_exist_in_os(ip_from, ip_to, priority, table, fwmark, fwmask):
+def ip_rule_exist_in_os(
+    ip_from, ip_to, priority, table, fwmark, fwmask, family
+):
     expected_rule = locals()
     logging.debug("Checking ip rule for {}".format(expected_rule))
     cmds = ["ip"]
-    if (ip_from and iplib.is_ipv6_address(ip_from)) or (
-        ip_to and iplib.is_ipv6_address(ip_to)
+    if (
+        (ip_from and iplib.is_ipv6_address(ip_from))
+        or (ip_to and iplib.is_ipv6_address(ip_to))
+        or (family and family == "ipv6")
     ):
         cmds.append("-6")
     if ip_from and "/" not in ip_from:


### PR DESCRIPTION
    Add support to `from all to all` routing policy. In static config
    generator it will add `from 0.0.0.0/0` or `from ::/0` to the keyfile.
    
    A new parameter `family` have been introduced to the route-rule config
    field. This parameter is used to specify the address family. If `family`
    is not specified it will fail on validation, if not specified from
    Nispor it will assume IPv4 as it was done in the past.
    
    Example:
    
    ```yaml
    route-rules:
      config:
        - route-table: 254
          priority: 100
          family: ipv4
    ```
    
    Integration test cases added.
    
    Fixes #1417
    
    Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>

Fixes https://github.com/nmstate/nmstate/issues/1417