### PR TITLE
[nmstate-1.3] Fix infiniband

### DIFF
--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -186,7 +186,7 @@ def create_new_nm_simple_conn(iface, nm_profile):
         settings.extend(create_ovs_interface_setting(patch_state, dpdk_state))
     elif iface.type == InterfaceType.INFINIBAND:
         ib_setting = create_infiniband_setting(
-            iface_info,
+            iface,
             nm_profile,
             iface.original_desire_dict,
         )

--- a/libnmstate/nm/infiniband.py
+++ b/libnmstate/nm/infiniband.py
@@ -71,7 +71,9 @@ def _nm_ib_mode_to_nmstate(nm_ib_mode):
         return None
 
 
-def create_setting(iface_info, base_con_profile, original_iface_info):
+def create_setting(iface, base_con_profile, original_iface_info):
+    iface.pre_edit_validation_and_cleanup()
+    iface_info = iface.to_dict()
     ib_config = iface_info.get(InfiniBand.CONFIG_SUBTREE)
     if not ib_config:
         return None

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -392,6 +392,10 @@ def _use_uuid_as_controller_and_parent(nm_profiles):
         iface = nm_profile.iface
         if not iface.is_up:
             continue
+        # InfiniBand setting does not support UUID as parent
+        if iface.type == InterfaceType.INFINIBAND:
+            continue
+
         if (
             iface.controller
             and (iface.is_changed or iface.is_desired)


### PR DESCRIPTION
* Do not used UUID for `infiniband.parent` in NM.
 * Fix error when applying with pre-exist IB profile.