### PR TITLE
veth, tests: add veth peer renaming tests

### DIFF
--- a/tests/integration/nm/veth_test.py
+++ b/tests/integration/nm/veth_test.py
@@ -114,3 +114,23 @@ def test_veth_with_ignored_peer_changed_to_new_peer(veth1_with_ignored_peer):
     }
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+def test_veth_rename_peer():
+    with veth_interface(VETH1, VETH1PEER) as desired_state:
+        desired_state[Interface.KEY][0][Veth.CONFIG_SUBTREE][
+            Veth.PEER
+        ] = "anotherpeer"
+        libnmstate.apply(desired_state)
+        assert (
+            "connected"
+            in cmdlib.exec_cmd(
+                f"nmcli -g GENERAL.STATE d show {VETH1}".split()
+            )[1]
+        )
+        assert (
+            "connected"
+            in cmdlib.exec_cmd(
+                "nmcli -g GENERAL.STATE d show anotherpeer".split()
+            )[1]
+        )


### PR DESCRIPTION
When renaming a veth peer the new peer must be managed by NetworkManager.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1966944

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>