### PR TITLE
ip: Add support of custom metric for auto routes

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -71,6 +71,13 @@ struct InterfaceIp {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub auto_table_id: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "auto-route-metric",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
+    pub auto_route_metric: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
     pub addr_gen_mode: Option<Ipv6AddrGenMode>,
     #[serde(
@@ -142,6 +149,10 @@ pub struct InterfaceIpv4 {
     /// Ignore when serializing.
     /// Deserialize from `allow-extra-address`
     pub allow_extra_address: bool,
+    /// Metric for routes retrieved from DHCP server.
+    /// Only available for DHCPv4 enabled interface.
+    /// Deserialize from `auto-route-metric`
+    pub auto_route_metric: Option<u32>,
 }
 
 impl Default for InterfaceIpv4 {
@@ -158,6 +169,7 @@ impl Default for InterfaceIpv4 {
             auto_routes: None,
             auto_table_id: None,
             allow_extra_address: default_allow_extra_address(),
+            auto_route_metric: None,
         }
     }
 }
@@ -191,6 +203,7 @@ impl InterfaceIpv4 {
             self.auto_gateway = None;
             self.auto_routes = None;
             self.auto_table_id = None;
+            self.auto_route_metric = None;
         }
     }
 
@@ -296,6 +309,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
             allow_extra_address: ip.allow_extra_address,
+            auto_route_metric: ip.auto_route_metric,
             ..Default::default()
         }
     }
@@ -318,6 +332,7 @@ impl From<InterfaceIpv4> for InterfaceIp {
             auto_gateway: ip.auto_gateway,
             auto_table_id: ip.auto_table_id,
             allow_extra_address: ip.allow_extra_address,
+            auto_route_metric: ip.auto_route_metric,
             ..Default::default()
         }
     }
@@ -393,6 +408,10 @@ pub struct InterfaceIpv6 {
     /// Ignored when serializing.
     /// Deserialize from `allow-extra-address`.
     pub allow_extra_address: bool,
+    /// Metric for routes retrieved from DHCP server.
+    /// Only available for autoconf enabled interface.
+    /// Deserialize from `auto-route-metric`.
+    pub auto_route_metric: Option<u32>,
 }
 
 impl Default for InterfaceIpv6 {
@@ -411,6 +430,7 @@ impl Default for InterfaceIpv6 {
             auto_routes: None,
             auto_table_id: None,
             allow_extra_address: default_allow_extra_address(),
+            auto_route_metric: None,
         }
     }
 }
@@ -445,6 +465,7 @@ impl InterfaceIpv6 {
             self.auto_gateway = None;
             self.auto_routes = None;
             self.auto_table_id = None;
+            self.auto_route_metric = None;
         }
     }
 
@@ -567,6 +588,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
             auto_table_id: ip.auto_table_id,
             addr_gen_mode: ip.addr_gen_mode,
             allow_extra_address: ip.allow_extra_address,
+            auto_route_metric: ip.auto_route_metric,
             ..Default::default()
         }
     }
@@ -591,6 +613,7 @@ impl From<InterfaceIpv6> for InterfaceIp {
             auto_table_id: ip.auto_table_id,
             addr_gen_mode: ip.addr_gen_mode,
             allow_extra_address: ip.allow_extra_address,
+            auto_route_metric: ip.auto_route_metric,
             ..Default::default()
         }
     }

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -98,6 +98,7 @@ pub struct NmSettingIp {
     pub dhcp_timeout: Option<i32>,
     pub gateway: Option<String>,
     pub may_fail: Option<bool>,
+    pub route_metric: Option<i64>,
     // IPv6 only
     pub ra_timeout: Option<i32>,
     // IPv6 only
@@ -138,6 +139,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             route_table: _from_map!(v, "route-table", u32::try_from)?,
             gateway: _from_map!(v, "gateway", String::try_from)?,
             may_fail: _from_map!(v, "may-fail", bool::try_from)?,
+            route_metric: _from_map!(v, "route-metric", i64::try_from)?,
             ..Default::default()
         };
 
@@ -253,6 +255,9 @@ impl ToDbusValue for NmSettingIp {
         }
         if let Some(v) = &self.may_fail {
             ret.insert("may-fail", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.route_metric {
+            ret.insert("route-metric", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/query/ip.rs
+++ b/rust/src/lib/nm/query/ip.rs
@@ -49,9 +49,11 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
                 "auto_routes",
                 "auto_gateway",
                 "auto_table_id",
+                "auto_route_metric",
             ],
             dns: Some(nm_dns_to_nmstate(nm_ip_setting)),
             dhcp_client_id: nm_dhcp_client_id_to_nmstate(nm_ip_setting),
+            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
             ..Default::default()
         }
     } else {
@@ -93,6 +95,7 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
                 "auto_table_id",
                 "dhcp_duid",
                 "addr_gen_mode",
+                "auto_route_metric",
             ],
             dns: Some(nm_dns_to_nmstate(nm_ip_setting)),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
@@ -103,6 +106,7 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
                     None
                 }
             },
+            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
             ..Default::default()
         }
     } else {

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::ops::BitXor;
 
 use super::{
@@ -55,6 +57,7 @@ fn gen_nm_ipv4_setting<'a>(
     if iface_ip.is_auto() {
         nm_setting.gateway = None;
         nm_setting.dhcp_timeout = Some(i32::MAX);
+        nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
         nm_setting.dhcp_client_id = Some(nmstate_dhcp_client_id_to_nm(
             iface_ip
                 .dhcp_client_id
@@ -161,6 +164,7 @@ fn gen_nm_ipv6_setting<'a>(
                 .to_string(),
         );
         nm_setting.dhcp_iaid = Some("mac".to_string());
+        nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
         apply_dhcp_opts(
             &mut nm_setting,
             iface_ip.auto_dns,

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -37,6 +37,9 @@ impl InterfaceIpv4 {
         if other.prop_list.contains(&"allow_extra_address") {
             self.allow_extra_address = other.allow_extra_address;
         }
+        if other.prop_list.contains(&"auto_route_metric") {
+            self.auto_route_metric = other.auto_route_metric;
+        }
 
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
@@ -128,6 +131,9 @@ impl InterfaceIpv6 {
         }
         if other.prop_list.contains(&"addr_gen_mode") {
             self.addr_gen_mode = other.addr_gen_mode.clone();
+        }
+        if other.prop_list.contains(&"auto_route_metric") {
+            self.auto_route_metric = other.auto_route_metric;
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2018-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 
 class Interface:
@@ -139,6 +122,7 @@ class InterfaceIP:
     AUTO_GATEWAY = "auto-gateway"
     AUTO_ROUTES = "auto-routes"
     AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
+    AUTO_ROUTE_METRIC = "auto-route-metric"
     MPTCP_FLAGS = "mptcp-flags"
     ALLOW_EXTRA_ADDRESS = "allow-extra-address"
 

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1,21 +1,5 @@
-#
-# Copyright (c) 2018-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from contextlib import contextmanager
 from copy import deepcopy
 import logging
@@ -1388,3 +1372,39 @@ def test_wait_ip(eth1_up, wait_ip):
             ],
         }
     )
+
+
+def test_auto_route_metric(dhcpcli_up_with_dynamic_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                        InterfaceIPv4.AUTO_ROUTE_METRIC: 901,
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                        InterfaceIPv6.AUTO_ROUTE_METRIC: 902,
+                    },
+                }
+            ],
+        }
+    )
+    _poll(_has_auto_route_with_desired_metric, family=4, metric=901)
+    _poll(_has_auto_route_with_desired_metric, family=6, metric=902)
+
+
+def _has_auto_route_with_desired_metric(family, metric):
+    output = cmdlib.exec_cmd(
+        f"ip -{family} -j route show proto dhcp".split(), check=True
+    )[1]
+    ip_routes = json.loads(output)
+    if ip_routes:
+        return ip_routes[0].get("metric") == 901
+    else:
+        return False


### PR DESCRIPTION
Example:

```yml
---
interfaces:
  - name: eth1
    state: up
    ipv4:
      enabled: true
      dhcp: true
      auto-route-metric: 101
    ipv6:
      enabled: true
      dhcp: true
      autoconf: true
      auto-route-metric: 102
```

TODO: test