### PR TITLE
[nmstate-1.3] ip route: Add support of changing metric of auto routes

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -61,6 +61,7 @@ class IPState:
                 InterfaceIP.AUTO_ROUTES,
                 InterfaceIP.AUTO_GATEWAY,
                 InterfaceIP.AUTO_DNS,
+                InterfaceIP.AUTO_ROUTE_METRIC,
             ):
                 self._info.pop(dhcp_option, None)
 

--- a/libnmstate/ifaces/linux_bridge.py
+++ b/libnmstate/ifaces/linux_bridge.py
@@ -192,9 +192,9 @@ class LinuxBridgeIface(BridgeIface):
                 # There is no good way to detect kernel HZ in user space. Hence
                 # we check whether certain value is rounded.
                 if cur_value != value:
-                    if value >= 8 * (10 ** 6):
+                    if value >= 8 * (10**6):
                         if abs(value - cur_value) <= int(
-                            value / 8 * (10 ** 6)
+                            value / 8 * (10**6)
                         ):
                             return key, value, cur_value
                     else:

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -77,6 +77,9 @@ def create_setting(config, base_con_profile):
             # when the DHCP timeout expired, set it to the maximum value to
             # make this unlikely.
             setting_ipv4.props.dhcp_timeout = INT32_MAX
+            route_metric = config.get(InterfaceIPv4.AUTO_ROUTE_METRIC)
+            if route_metric is not None:
+                setting_ipv4.props.route_metric = route_metric
         elif config.get(InterfaceIPv4.ADDRESS):
             setting_ipv4.props.method = NM.SETTING_IP4_CONFIG_METHOD_MANUAL
             _add_addresses(setting_ipv4, config[InterfaceIPv4.ADDRESS])
@@ -129,6 +132,8 @@ def get_info(active_connection, applied_config):
                 info[InterfaceIPv4.AUTO_GATEWAY] = not props.never_default
                 info[InterfaceIPv4.AUTO_DNS] = not props.ignore_auto_dns
                 info[InterfaceIPv4.AUTO_ROUTE_TABLE_ID] = props.route_table
+                if props.route_metric >= 0:
+                    info[InterfaceIPv4.AUTO_ROUTE_METRIC] = props.route_metric
                 if props.dhcp_client_id:
                     info[InterfaceIPv4.DHCP_CLIENT_ID] = props.dhcp_client_id
 

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -27,7 +27,7 @@ from libnmstate.schema import Route
 from ..ifaces import BaseIface
 from .common import NM
 
-INT32_MAX = 2 ** 31 - 1
+INT32_MAX = 2**31 - 1
 
 
 def create_setting(config, base_con_profile):

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -73,6 +73,8 @@ def get_info(active_connection, applied_config):
             info[InterfaceIPv6.AUTO_ROUTE_TABLE_ID] = props.route_table
             if props.dhcp_duid:
                 info[InterfaceIPv6.DHCP_DUID] = props.dhcp_duid
+            if props.route_metric > 0:
+                info[InterfaceIPv6.AUTO_ROUTE_METRIC] = props.route_metric
             info[InterfaceIPv6.ADDR_GEN_MODE] = (
                 InterfaceIPv6.ADDR_GEN_MODE_STABLE_PRIVACY
                 if props.addr_gen_mode
@@ -145,6 +147,10 @@ def create_setting(config, base_con_profile):
         route_table = config.get(InterfaceIPv6.AUTO_ROUTE_TABLE_ID)
         if route_table:
             setting_ip.props.route_table = route_table
+
+        route_metric = config.get(InterfaceIPv6.AUTO_ROUTE_METRIC)
+        if route_metric is not None:
+            setting_ip.props.route_metric = route_metric
 
     elif ip_addresses:
         _set_static(setting_ip, ip_addresses)

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -31,7 +31,7 @@ from ..ifaces import BaseIface
 from .common import NM
 
 IPV6_DEFAULT_ROUTE_METRIC = 1024
-INT32_MAX = 2 ** 31 - 1
+INT32_MAX = 2**31 - 1
 
 
 def get_info(active_connection, applied_config):

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -148,6 +148,7 @@ class InterfaceIP:
     AUTO_GATEWAY = "auto-gateway"
     AUTO_ROUTES = "auto-routes"
     AUTO_ROUTE_TABLE_ID = "auto-route-table-id"
+    AUTO_ROUTE_METRIC = "auto-route-metric"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/tests/integration/nm/checkpoint.py
+++ b/tests/integration/nm/checkpoint.py
@@ -51,14 +51,14 @@ def nm_context():
 
 
 def test_creating_one_checkpoint(nm_context):
-    """ I can create a checkpoint """
+    """I can create a checkpoint"""
     checkpoint = CheckPoint.create(nm_context)
     assert checkpoint is not None
     checkpoint.destroy()
 
 
 def test_creating_two_checkpoints(nm_context):
-    """ I cannot create a checkpoint when a checkpoint already exists. """
+    """I cannot create a checkpoint when a checkpoint already exists."""
     checkpoint = CheckPoint.create(nm_context)
     with pytest.raises(NmstateConflictError):
         CheckPoint.create(nm_context)
@@ -67,7 +67,7 @@ def test_creating_two_checkpoints(nm_context):
 
 
 def test_checkpoint_timeout(nm_context):
-    """ I can create a checkpoint that is removed after one second. """
+    """I can create a checkpoint that is removed after one second."""
     checkpoint_a = CheckPoint.create(nm_context, timeout=1)
     time.sleep(1)
     checkpoint_b = CheckPoint.create(nm_context)
@@ -78,7 +78,7 @@ def test_checkpoint_timeout(nm_context):
 
 
 def test_getting_a_checkpoint(nm_context):
-    """ I can get a list of all checkpoints. """
+    """I can get a list of all checkpoints."""
 
     checkpoints = get_checkpoints(nm_context.client)
 

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -215,7 +215,7 @@ def test_apply_command_with_two_states():
 
 
 def test_manual_confirmation(eth1_up):
-    """ I can manually confirm a state. """
+    """I can manually confirm a state."""
 
     with example_state(CONFIRMATION_CLEAN, CONFIRMATION_CLEAN):
 
@@ -226,7 +226,7 @@ def test_manual_confirmation(eth1_up):
 
 
 def test_manual_rollback(eth1_up):
-    """ I can manually roll back a state. """
+    """I can manually roll back a state."""
 
     with example_state(CONFIRMATION_CLEAN, CONFIRMATION_CLEAN) as clean_state:
 
@@ -256,7 +256,7 @@ def test_dual_change(eth1_up):
 
 
 def test_automatic_rollback(eth1_up):
-    """ If I do not confirm the state, it is automatically rolled back. """
+    """If I do not confirm the state, it is automatically rolled back."""
 
     with example_state(CONFIRMATION_CLEAN, CONFIRMATION_CLEAN) as clean_state:
 

--- a/tests/integration/testlib/ifacelib.py
+++ b/tests/integration/testlib/ifacelib.py
@@ -26,7 +26,7 @@ from . import statelib
 
 
 def ifaces_init(*ifnames):
-    """ Remove any existing definitions on the interfaces. """
+    """Remove any existing definitions on the interfaces."""
     for ifname in ifnames:
         _set_eth_admin_state(ifname, schema.InterfaceState.ABSENT)
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ skip_install = true
 basepython = python3.6
 changedir = {toxinidir}
 deps =
-    black==20.8b1
+    black==22.6.0
 # style configured via pyproject.toml
 commands =
     black \


### PR DESCRIPTION
Example:

```yml
---
interfaces:
  - name: eth1
    state: up
    ipv4:
      enabled: true
      dhcp: true
      auto-route-metric: 101
    ipv6:
      enabled: true
      dhcp: true
      autoconf: true
      auto-route-metric: 102
```