### PR TITLE
Make nmstate go module reflect v2

### DIFF
--- a/rust/src/go/nmstate/go.mod
+++ b/rust/src/go/nmstate/go.mod
@@ -1,4 +1,4 @@
-module github.com/nmstate/nmstate/rust/src/go/nmstate
+module github.com/nmstate/nmstate/rust/src/go/nmstate/v2
 
 go 1.16
 


### PR DESCRIPTION
When v2 was released and the tags started being v2.y.z, we introduced a mismatch between the go module definition (when it has no vX it is equivalent to v0/v1) and the repository (and release tags). This makes it hard to vendor the package referring to tags in other golang contexts.

You can read more about it in:
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>