### PR TITLE
iface: Add support of `controller` property

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -77,8 +77,11 @@ pub struct BaseInterface {
     /// and dynamic).
     pub mptcp: Option<MptcpConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    // None here mean no change, empty string mean detach from controller.
-    /// TODO: Internal only. Hide it.
+    /// Controller of the specified interface.
+    /// Only valid for applying, `None` means no change, empty string means
+    /// detach from current controller, please be advise, an error will trigger
+    /// if this property conflict with ports list of bridge/bond/etc.
+    /// Been always set to `None` by [crate::NetworkState::retrieve()].
     pub controller: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -145,6 +145,7 @@ impl Interfaces {
         let mut new_ovs_ifaces = Vec::new();
 
         self.apply_copy_mac_from(current)?;
+        self.validate_controller_and_port_list_confliction()?;
         handle_changed_ports(self, current)?;
         preserve_ctrl_cfg_if_unchanged(self, current);
         self.set_up_priority()?;

--- a/rust/src/lib/nm/settings/inter_connections.rs
+++ b/rust/src/lib/nm/settings/inter_connections.rs
@@ -96,16 +96,10 @@ pub(crate) fn use_uuid_for_controller_reference(
                     ) {
                         ctrl_name = ovs_port_name.to_string();
                     } else {
-                        let e = NmstateError::new(
-                            ErrorKind::Bug,
-                            format!(
-                                "Failed to find OVS port name for \
-                                NmConnection {:?}",
-                                nm_conn
-                            ),
-                        );
-                        log::error!("{}", e);
-                        return Err(e);
+                        // User is attaching port to existing OVS bridge
+                        // using `controller` property without OVS bridge
+                        // interface mentioned in desire state
+                        ctrl_name = iface_name.to_string();
                     }
                 }
             } else {

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -335,6 +335,12 @@ impl Interfaces {
         }
         Ok(())
     }
+
+    pub(crate) fn hide_controller_prop(&mut self) {
+        for iface in self.kernel_ifaces.values_mut() {
+            iface.base_iface_mut().controller = None;
+        }
+    }
 }
 
 fn find_unknown_type_port<'a>(

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -37,6 +37,12 @@ impl NetworkState {
     /// Retrieve the `NetworkState`.
     /// Only available for feature `query_apply`.
     pub fn retrieve(&mut self) -> Result<&mut Self, NmstateError> {
+        self.retrieve_full()?;
+        self.interfaces.hide_controller_prop();
+        Ok(self)
+    }
+
+    pub(crate) fn retrieve_full(&mut self) -> Result<&mut Self, NmstateError> {
         let state = nispor_retrieve(self.running_config_only)?;
         if state.prop_list.contains(&"hostname") {
             self.hostname = state.hostname;
@@ -82,7 +88,7 @@ impl NetworkState {
         let mut cur_net_state = NetworkState::new();
         cur_net_state.set_kernel_only(self.kernel_only);
         cur_net_state.set_include_secrets(true);
-        cur_net_state.retrieve()?;
+        cur_net_state.retrieve_full()?;
 
         if desire_state_to_apply.interfaces.to_vec().len()
             >= MAX_SUPPORTED_INTERFACES
@@ -205,7 +211,7 @@ impl NetworkState {
                                     let mut new_cur_net_state =
                                         cur_net_state.clone();
                                     new_cur_net_state.set_include_secrets(true);
-                                    new_cur_net_state.retrieve()?;
+                                    new_cur_net_state.retrieve_full()?;
                                     desire_state_to_verify.verify(
                                         &cur_net_state,
                                         &new_cur_net_state,
@@ -237,7 +243,7 @@ impl NetworkState {
                     VERIFY_RETRY_COUNT_KERNEL_MODE,
                     || {
                         let mut new_cur_net_state = cur_net_state.clone();
-                        new_cur_net_state.retrieve()?;
+                        new_cur_net_state.retrieve_full()?;
                         desire_state_to_verify
                             .verify(&cur_net_state, &new_cur_net_state)
                     },

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -20,6 +20,7 @@ class Interface:
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
     WAIT_IP = "wait-ip"
+    CONTROLLER = "controller"
 
 
 class Route:

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1,21 +1,5 @@
-#
-# Copyright (c) 2019-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from contextlib import contextmanager
 from copy import deepcopy
 import os
@@ -1158,3 +1142,24 @@ def test_policy_create_bridge_by_description_of_port(
             ),
             verify_change=False,
         )
+
+
+def test_add_port_to_br_with_controller_property(bridge0_with_port0, eth2_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth2",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.CONTROLLER: TEST_BRIDGE0,
+                }
+            ]
+        }
+    )
+    current_state = show_only([TEST_BRIDGE0])
+    br_iface = current_state[Interface.KEY][0]
+    br_ports = br_iface[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE]
+    assert br_iface[Interface.NAME] == TEST_BRIDGE0
+    assert len(br_ports) == 2
+    assert br_ports[0][LinuxBridge.Port.NAME] == "eth1"
+    assert br_ports[1][LinuxBridge.Port.NAME] == "eth2"


### PR DESCRIPTION
Introducing `BaseInterface.controller` property for attaching port to
existing controller without knowledge of current port list of that
controller.

Example on attach eth1 to br0:

```yaml
---
interfaces:
- name: eth1
  state: up
  controller: br0
```

Unit test cases and integration test case included.