### PR TITLE
[nmstate-1.3] python: iface: Add support of controller property

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -124,7 +124,6 @@ class IPState:
 
 
 class BaseIface:
-    CONTROLLER_METADATA = "_controller"
     CONTROLLER_TYPE_METADATA = "_controller_type"
     DNS_METADATA = "_dns"
     ROUTES_METADATA = "_routes"
@@ -357,7 +356,7 @@ class BaseIface:
         return False
 
     def set_controller(self, controller_iface_name, controller_type):
-        self._info[BaseIface.CONTROLLER_METADATA] = controller_iface_name
+        self._info[Interface.CONTROLLER] = controller_iface_name
         self._info[BaseIface.CONTROLLER_TYPE_METADATA] = controller_type
         if (
             not self.can_have_ip_as_port
@@ -368,7 +367,7 @@ class BaseIface:
 
     @property
     def controller(self):
-        return self._info.get(BaseIface.CONTROLLER_METADATA)
+        return self._info.get(Interface.CONTROLLER)
 
     @property
     def controller_type(self):
@@ -379,7 +378,8 @@ class BaseIface:
             for port_name in self.port:
                 port_iface = ifaces.all_kernel_ifaces.get(port_name)
                 if port_iface:
-                    port_iface.set_controller(self.name, self.type)
+                    if port_iface.controller != "":
+                        port_iface.set_controller(self.name, self.type)
 
     def update(self, info):
         self._info.update(info)
@@ -445,6 +445,8 @@ class BaseIface:
             state[Interface.STATE] = InterfaceState.DOWN
         _convert_ovs_external_ids_values_to_string(state)
         state.pop(BaseIface.PERMANENT_MAC_ADDRESS_METADATA, None)
+        if self.controller == "":
+            state.pop(Interface.CONTROLLER, None)
 
         return state
 

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -119,7 +119,9 @@ def rollback(*, checkpoint=None):
 
 def _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk):
     for plugin in plugins:
-        plugin.apply_changes(net_state, save_to_disk)
+        # Do not allow plugin to modify the net_state for future verification
+        tmp_net_state = copy.deepcopy(net_state)
+        plugin.apply_changes(tmp_net_state, save_to_disk)
 
     verified = False
     if verify_change:

--- a/libnmstate/netinfo.py
+++ b/libnmstate/netinfo.py
@@ -39,6 +39,7 @@ def show(*, include_status_data=False, include_secrets=False):
                 plugins,
                 include_status_data=include_status_data,
                 include_secrets=include_secrets,
+                include_controller_prop=False,
             )
         )
 

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -115,6 +115,8 @@ class NisporPluginBaseIface:
             if ethtool_info_dict:
                 iface_info[Ethtool.CONFIG_SUBTREE] = ethtool_info_dict
 
+        if self.np_iface.controller:
+            iface_info[Interface.CONTROLLER] = self.np_iface.controller
         return iface_info
 
 

--- a/libnmstate/nm/connection.py
+++ b/libnmstate/nm/connection.py
@@ -94,7 +94,7 @@ class _ConnectionSetting:
         self._setting = new
 
     def set_controller(self, controller, port_type):
-        if controller is not None:
+        if controller:
             self._setting.props.master = controller
             self._setting.props.slave_type = port_type
 

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -49,6 +49,7 @@ from .ovs import get_interface_info as get_ovs_interface_info
 from .ovs import get_ovs_bridge_info
 from .ovs import get_ovsdb_external_ids
 from .ovs import has_ovs_capability
+from .ovs import set_ovs_iface_controller_info
 from .profiles import NmProfiles
 from .profiles import get_all_applied_configs
 from .team import get_info as get_team_info
@@ -191,6 +192,8 @@ class NetworkManagerPlugin(NmstatePlugin):
                 iface_info.update(get_ovsdb_external_ids(applied_config))
 
             info.append(iface_info)
+
+        set_ovs_iface_controller_info(info)
 
         info.sort(key=itemgetter("name"))
 

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -73,6 +73,7 @@ def show_with_plugins(
     include_status_data=None,
     info_type=_INFO_TYPE_RUNNING,
     include_secrets=False,
+    include_controller_prop=True,
 ):
     for plugin in plugins:
         plugin.refresh_content()
@@ -81,7 +82,7 @@ def show_with_plugins(
         report["capabilities"] = plugins_capabilities(plugins)
 
     report[Interface.KEY] = _get_interface_info_from_plugins(
-        plugins, info_type
+        plugins, info_type, include_controller_prop=include_controller_prop
     )
 
     report[Route.KEY] = _get_routes_from_plugins(plugins, info_type)
@@ -103,6 +104,7 @@ def show_with_plugins(
 
     if not include_secrets:
         hide_the_secrets(report)
+
     return report
 
 
@@ -185,7 +187,9 @@ def _find_plugin_for_capability(plugins, capability):
     return chose_plugin
 
 
-def _get_interface_info_from_plugins(plugins, info_type):
+def _get_interface_info_from_plugins(
+    plugins, info_type, include_controller_prop=True
+):
     all_ifaces = {}
     IFACE_PRIORITY_METADATA = "_plugin_priority"
     IFACE_PLUGIN_SRC_METADATA = "_plugin_source"
@@ -287,6 +291,8 @@ def _get_interface_info_from_plugins(plugins, info_type):
     for iface in all_ifaces.values():
         iface.pop(IFACE_PRIORITY_METADATA)
         iface.pop(IFACE_PLUGIN_SRC_METADATA)
+        if not include_controller_prop:
+            iface.pop(Interface.CONTROLLER, None)
 
     return sorted(all_ifaces.values(), key=itemgetter(Interface.NAME))
 
@@ -404,6 +410,7 @@ def show_running_config_with_plugins(plugins, include_secrets):
         plugins,
         info_type=_INFO_TYPE_RUNNING_CONFIG,
         include_secrets=include_secrets,
+        include_controller_prop=False,
     )
 
 

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -48,6 +48,7 @@ class Interface:
     MTU = "mtu"
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
+    CONTROLLER = "controller"
 
 
 class Route:

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -77,8 +77,11 @@ pub struct BaseInterface {
     /// and dynamic).
     pub mptcp: Option<MptcpConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    // None here mean no change, empty string mean detach from controller.
-    /// TODO: Internal only. Hide it.
+    /// Controller of the specified interface.
+    /// Only valid for applying, `None` means no change, empty string means
+    /// detach from current controller, please be advise, an error will trigger
+    /// if this property conflict with ports list of bridge/bond/etc.
+    /// Been always set to `None` by [crate::NetworkState::retrieve()].
     pub controller: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -145,6 +145,7 @@ impl Interfaces {
         let mut new_ovs_ifaces = Vec::new();
 
         self.apply_copy_mac_from(current)?;
+        self.validate_controller_and_port_list_confliction()?;
         handle_changed_ports(self, current)?;
         preserve_ctrl_cfg_if_unchanged(self, current);
         self.set_up_priority()?;

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -435,10 +435,11 @@ pub(crate) fn preserve_ctrl_cfg_if_unchanged(
     }
 
     for (iface_name, iface) in ifaces.kernel_ifaces.iter_mut() {
-        if iface.base_iface().controller.is_some()
-            && iface.base_iface().controller_type.is_some()
+        if (iface.base_iface().controller.is_some()
+            && iface.base_iface().controller_type.is_some())
+            || iface.base_iface().controller.as_ref() == Some(&String::new())
         {
-            // Iface already has controller information
+            // Iface already has controller information or detaching
             continue;
         }
         let cur_iface = match cur_ifaces.kernel_ifaces.get(iface_name) {

--- a/rust/src/lib/nm/settings/inter_connections.rs
+++ b/rust/src/lib/nm/settings/inter_connections.rs
@@ -96,16 +96,10 @@ pub(crate) fn use_uuid_for_controller_reference(
                     ) {
                         ctrl_name = ovs_port_name.to_string();
                     } else {
-                        let e = NmstateError::new(
-                            ErrorKind::Bug,
-                            format!(
-                                "Failed to find OVS port name for \
-                                NmConnection {:?}",
-                                nm_conn
-                            ),
-                        );
-                        log::error!("{}", e);
-                        return Err(e);
+                        // User is attaching port to existing OVS bridge
+                        // using `controller` property without OVS bridge
+                        // interface mentioned in desire state
+                        ctrl_name = iface_name.to_string();
                     }
                 }
             } else {

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -129,5 +129,11 @@ impl BaseInterface {
             ethtool_conf.pre_verify_cleanup();
         }
         mptcp_pre_verify_cleanup(self);
+
+        // If desired controller is Some("") for detaching, we should remove
+        // it for verification
+        if self.controller.as_ref() == Some(&"".to_string()) {
+            self.controller = None;
+        }
     }
 }

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -335,6 +335,12 @@ impl Interfaces {
         }
         Ok(())
     }
+
+    pub(crate) fn hide_controller_prop(&mut self) {
+        for iface in self.kernel_ifaces.values_mut() {
+            iface.base_iface_mut().controller = None;
+        }
+    }
 }
 
 fn find_unknown_type_port<'a>(

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -37,6 +37,12 @@ impl NetworkState {
     /// Retrieve the `NetworkState`.
     /// Only available for feature `query_apply`.
     pub fn retrieve(&mut self) -> Result<&mut Self, NmstateError> {
+        self.retrieve_full()?;
+        self.interfaces.hide_controller_prop();
+        Ok(self)
+    }
+
+    pub(crate) fn retrieve_full(&mut self) -> Result<&mut Self, NmstateError> {
         let state = nispor_retrieve(self.running_config_only)?;
         if state.prop_list.contains(&"hostname") {
             self.hostname = state.hostname;
@@ -82,7 +88,7 @@ impl NetworkState {
         let mut cur_net_state = NetworkState::new();
         cur_net_state.set_kernel_only(self.kernel_only);
         cur_net_state.set_include_secrets(true);
-        cur_net_state.retrieve()?;
+        cur_net_state.retrieve_full()?;
 
         if desire_state_to_apply.interfaces.to_vec().len()
             >= MAX_SUPPORTED_INTERFACES
@@ -205,7 +211,7 @@ impl NetworkState {
                                     let mut new_cur_net_state =
                                         cur_net_state.clone();
                                     new_cur_net_state.set_include_secrets(true);
-                                    new_cur_net_state.retrieve()?;
+                                    new_cur_net_state.retrieve_full()?;
                                     desire_state_to_verify.verify(
                                         &cur_net_state,
                                         &new_cur_net_state,
@@ -237,7 +243,7 @@ impl NetworkState {
                     VERIFY_RETRY_COUNT_KERNEL_MODE,
                     || {
                         let mut new_cur_net_state = cur_net_state.clone();
-                        new_cur_net_state.retrieve()?;
+                        new_cur_net_state.retrieve_full()?;
                         desire_state_to_verify
                             .verify(&cur_net_state, &new_cur_net_state)
                     },

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -20,6 +20,7 @@ class Interface:
     COPY_MAC_FROM = "copy-mac-from"
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
     WAIT_IP = "wait-ip"
+    CONTROLLER = "controller"
 
 
 class Route:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019-2022 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 import os
@@ -1184,3 +1167,35 @@ def test_global_ovsdb_without_ovsdb_plugin():
         }
         with pytest.raises(NmstateDependencyError):
             libnmstate.apply({OvsDB.KEY: desired_ovs_config})
+
+
+def test_add_port_to_ovs_br_with_controller_property(
+    ovs_bridge1_with_internal_port_same_name, eth2_up
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth2",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.CONTROLLER: BRIDGE1,
+                }
+            ]
+        }
+    )
+    current_state = libnmstate.show()
+    br_iface = None
+    # The show_only() does not works well with ovs same name topology, hence
+    # we use our own code.
+    for iface in current_state[Interface.KEY]:
+        if (
+            iface[Interface.NAME] == BRIDGE1
+            and iface[Interface.TYPE] == InterfaceType.OVS_BRIDGE
+        ):
+            br_iface = iface
+            break
+    br_ports = br_iface[OVSBridge.CONFIG_SUBTREE][OVSBridge.PORT_SUBTREE]
+    assert br_iface[Interface.NAME] == BRIDGE1
+    assert len(br_ports) == 2
+    assert br_ports[0][OVSBridge.Port.NAME] == BRIDGE1
+    assert br_ports[1][OVSBridge.Port.NAME] == "eth2"


### PR DESCRIPTION
Introducing `Interface.CONTROLLER` property for attaching port to
existing controller without knowledge of current port list of that
controller.

Example on attach eth1 to br0:

```yaml
---
interfaces:
- name: eth1
  state: up
  controller: br0
```

Unit test cases and integration test case included.