### PR TITLE
Misc fixes for publishing nmstatectl in crates.io

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -2,6 +2,13 @@
 name = "nmstatectl"
 version = "2.2.2"
 authors = ["Gris Ge <fge@redhat.com>"]
+description = "Command line tool for networking management in a declarative manner"
+license = "Apache-2.0"
+homepage = "https://nmstate.io"
+documentation = "https://nmstate.io"
+repository = "https://github.com/nmstate/nmstate"
+keywords = ["network", "linux"]
+categories = ["network-programming", "os::linux"]
 edition = "2018"
 rust-version = "1.60"
 

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -10,7 +10,7 @@ name = "nmstatectl"
 path = "ncl.rs"
 
 [dependencies]
-nmstate = {path = "../lib", default-features = false}
+nmstate = {path = "../lib", version = "2.2", default-features = false}
 serde_yaml = "0.9"
 clap = { version = "3.1", features = ["cargo"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Just some trivial `Cargo.toml` modification of nmstatectl.