### PR TITLE
dns: Support IPv6 link local address as DNS nameserver

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     dns::{
         get_cur_dns_ifaces, is_dns_changed, purge_dns_config,
-        reselect_dns_ifaces,
+        reselect_dns_ifaces, validate_ipv6_link_local_address_dns_srv,
     },
     DnsState, ErrorKind, HostNameState, Interface, InterfaceType, Interfaces,
     NmstateError, OvsDbGlobalConfig, RouteRules, Routes,
@@ -530,6 +530,8 @@ impl NetworkState {
     ) -> Result<(), NmstateError> {
         let mut self_clone = self.clone();
         self_clone.dns.merge_current(&current.dns);
+
+        validate_ipv6_link_local_address_dns_srv(&self_clone, current)?;
 
         if is_dns_changed(&self_clone, current) {
             let (v4_iface_name, v6_iface_name) =

--- a/rust/src/lib/nm/query/ip.rs
+++ b/rust/src/lib/nm/query/ip.rs
@@ -51,7 +51,7 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
                 "auto_table_id",
                 "auto_route_metric",
             ],
-            dns: Some(nm_dns_to_nmstate(nm_ip_setting)),
+            dns: Some(nm_dns_to_nmstate("", nm_ip_setting)),
             dhcp_client_id: nm_dhcp_client_id_to_nmstate(nm_ip_setting),
             auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
             ..Default::default()
@@ -62,6 +62,7 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
 }
 
 pub(crate) fn nm_ip_setting_to_nmstate6(
+    iface_name: &str,
     nm_ip_setting: &NmSettingIp,
 ) -> InterfaceIpv6 {
     if let Some(nm_ip_method) = &nm_ip_setting.method {
@@ -97,7 +98,7 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
                 "addr_gen_mode",
                 "auto_route_metric",
             ],
-            dns: Some(nm_dns_to_nmstate(nm_ip_setting)),
+            dns: Some(nm_dns_to_nmstate(iface_name, nm_ip_setting)),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
             addr_gen_mode: {
                 if enabled {

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -218,7 +218,10 @@ fn nm_conn_to_base_iface(
 ) -> Option<BaseInterface> {
     if let Some(iface_name) = nm_conn.iface_name() {
         let ipv4 = nm_conn.ipv4.as_ref().map(nm_ip_setting_to_nmstate4);
-        let ipv6 = nm_conn.ipv6.as_ref().map(nm_ip_setting_to_nmstate6);
+        let ipv6 = nm_conn
+            .ipv6
+            .as_ref()
+            .map(|nm_ip_set| nm_ip_setting_to_nmstate6(iface_name, nm_ip_set));
 
         let mut base_iface = BaseInterface::new();
         base_iface.name = iface_name.to_string();

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -21,7 +21,13 @@ impl DnsState {
                 let mut canonicalized_srvs = Vec::new();
                 for srv in srvs {
                     if is_ipv6_addr(srv) {
-                        if let Ok(ip_addr) = srv.parse::<Ipv6Addr>() {
+                        let splits: Vec<&str> = srv.split('%').collect();
+                        if splits.len() == 2 {
+                            if let Ok(ip_addr) = splits[0].parse::<Ipv6Addr>() {
+                                canonicalized_srvs
+                                    .push(format!("{}%{}", ip_addr, splits[1]));
+                            }
+                        } else if let Ok(ip_addr) = srv.parse::<Ipv6Addr>() {
                             canonicalized_srvs.push(ip_addr.to_string());
                         }
                     } else if let Ok(ip_addr) = srv.parse::<Ipv4Addr>() {


### PR DESCRIPTION
When using IPv6 link local address as DNS nameserver, interface name is
required, for example: `fe80::deef:1%eth1`

Example yaml:

```yml
---
dns-resolver:
  config:
    search:
    - example.com
    - example.org
    server:
    - fe80::deef:1%eth1
    - 2001:4860:4860::8844
    - 8.8.4.4
    - 8.8.8.8
```

Restrictions:
 * You cannot have 2+ interface names in DNS server names. Massive work
   required to handle the DNS ordering between interfaces with the
   design of NetworkManager.

 * All other normal IPv6 nameserver will also stored in link local
   interface if exists.

Unit test cases and integration test case included.