### PR TITLE
DO NOT MERGE: Show the race problem of NM dbus interface

### DIFF
--- a/rust/src/lib/nm/apply.rs
+++ b/rust/src/lib/nm/apply.rs
@@ -27,7 +27,7 @@ use super::{
 
 use crate::{Interface, InterfaceType, NetworkState, NmstateError, RouteEntry};
 
-const ACTIVATION_RETRY_COUNT: usize = 5;
+const ACTIVATION_RETRY_COUNT: usize = 1;
 const ACTIVATION_RETRY_INTERVAL: u64 = 1;
 
 pub(crate) fn nm_apply(

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -25,7 +25,7 @@ pub struct NmApi<'a> {
 }
 
 const RETRY_INTERVAL_MILLISECOND: u64 = 500;
-const RETRY_COUNT: usize = 60;
+const RETRY_COUNT: usize = 1;
 
 impl<'a> NmApi<'a> {
     pub fn new() -> Result<Self, NmError> {

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -16,7 +16,7 @@ const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
 const VERIFY_RETRY_COUNT: usize = 5;
 const VERIFY_RETRY_COUNT_SRIOV: usize = 60;
 const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
-const VERIFY_RETRY_NM: usize = 2;
+const VERIFY_RETRY_NM: usize = 1;
 const MAX_SUPPORTED_INTERFACES: usize = 1000;
 
 impl NetworkState {


### PR DESCRIPTION
Dedicate PR showing the failure we might get if we remove the retry code of NM dbus.

NetworkManager efforts is tracking at https://bugzilla.redhat.com/show_bug.cgi?id=2143587