### PR TITLE
rust/lib: Replace the unsafe 'libc::sysconf' to 'nix::unistd::sysconf'

### DIFF
--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -45,7 +45,7 @@ pub(crate) fn nispor_retrieve(
 
         let iface = match &base_iface.iface_type {
             InterfaceType::LinuxBridge => {
-                let mut br_iface = np_bridge_to_nmstate(np_iface, base_iface);
+                let mut br_iface = np_bridge_to_nmstate(np_iface, base_iface)?;
                 let mut port_np_ifaces = Vec::new();
                 for port_name in br_iface.ports().unwrap_or_default() {
                     if let Some(p) = np_state.ifaces.get(port_name) {


### PR DESCRIPTION
The `libc::sysconf` is unsafe function of rust, use its safe replacement `nix::unistd::sysconf` with proper error handling instead.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>