### PR TITLE
clippy: drop needless lifetimes

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -104,9 +104,9 @@ impl Interfaces {
     /// Search interface base on interface name and interface type.
     /// When using [InterfaceType::Unknown], we only search kernel
     /// interface(which has presentation in kernel space).
-    pub fn get_iface<'a, 'b>(
+    pub fn get_iface<'a>(
         &'a self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a Interface> {
         if iface_type == InterfaceType::Unknown {

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -238,9 +238,9 @@ impl Interfaces {
         }
     }
 
-    pub(crate) fn get_iface_mut<'a, 'b>(
+    pub(crate) fn get_iface_mut<'a>(
         &'a mut self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a mut Interface> {
         if iface_type.is_userspace() {


### PR DESCRIPTION
According to
https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes these lifetimes can be dropped.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>