### PR TITLE
ifaces: Expose `iter()` and `iter_mut()`

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -567,7 +567,7 @@ impl Interface {
         }
     }
 
-    pub(crate) fn base_iface_mut(&mut self) -> &mut BaseInterface {
+    pub fn base_iface_mut(&mut self) -> &mut BaseInterface {
         match self {
             Self::LinuxBridge(iface) => &mut iface.base,
             Self::Bond(iface) => &mut iface.base,

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -328,6 +328,16 @@ impl Interfaces {
             iface.base_iface_mut().hide_secrets();
         }
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Interface> {
+        self.user_ifaces.values().chain(self.kernel_ifaces.values())
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Interface> {
+        self.user_ifaces
+            .values_mut()
+            .chain(self.kernel_ifaces.values_mut())
+    }
 }
 
 fn gen_ifaces_to_del(

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -241,3 +241,42 @@ fn test_ifaces_ignore_iface_in_current_but_desired() {
         vec![("br0".to_string(), InterfaceType::OvsBridge)]
     );
 }
+
+#[test]
+fn test_ifaces_iter() {
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: br0
+  type: ovs-bridge
+  state: up
+"#,
+    )
+    .unwrap();
+    let ifaces_vec: Vec<&Interface> = ifaces.iter().collect();
+    assert_eq!(ifaces_vec.len(), 2);
+}
+
+#[test]
+fn test_ifaces_iter_mut() {
+    let mut ifaces = serde_yaml::from_str::<Interfaces>(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: br0
+  type: ovs-bridge
+  state: up
+"#,
+    )
+    .unwrap();
+    for iface in ifaces.iter_mut() {
+        iface.base_iface_mut().mtu = Some(1280);
+    }
+    let ifaces_vec: Vec<&Interface> = ifaces.iter().collect();
+    assert_eq!(ifaces_vec.len(), 2);
+    assert_eq!(ifaces_vec[0].base_iface().mtu, Some(1280));
+    assert_eq!(ifaces_vec[1].base_iface().mtu, Some(1280));
+}


### PR DESCRIPTION
Adding `Interfaces.iter()` and `Interfaces.iter_mut()` for easy access
to internal interfaces.

Unit test case included.