### PR TITLE
[nmstate-2.1] nm: Fix moving bridge port to bond

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -102,9 +102,9 @@ impl Interfaces {
         ifaces
     }
 
-    pub fn get_iface<'a, 'b>(
+    pub fn get_iface<'a>(
         &'a self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a Interface> {
         if iface_type == InterfaceType::Unknown {
@@ -120,9 +120,9 @@ impl Interfaces {
         }
     }
 
-    fn get_iface_mut<'a, 'b>(
+    fn get_iface_mut<'a>(
         &'a mut self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a mut Interface> {
         if iface_type.is_userspace() {

--- a/rust/src/lib/nispor/hostname.rs
+++ b/rust/src/lib/nispor/hostname.rs
@@ -76,7 +76,7 @@ pub(crate) fn set_running_hostname(hostname: &str) -> Result<(), NmstateError> {
     }
 
     let os_str = std::ffi::OsStr::new(hostname);
-    if nix::unistd::sethostname(&os_str).is_err() {
+    if nix::unistd::sethostname(os_str).is_err() {
         let e = NmstateError::new(
             ErrorKind::InvalidArgument,
             format!(

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -107,7 +107,7 @@ pub(crate) fn nmstate_ipv4_to_np(
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf.prefix_len = nms_addr.prefix_length;
                 ip_conf
             });
         }
@@ -124,7 +124,7 @@ pub(crate) fn nmstate_ipv6_to_np(
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length as u8;
+                ip_conf.prefix_len = nms_addr.prefix_length;
                 ip_conf
             });
         }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -279,6 +279,14 @@ pub(crate) fn iface_to_nm_connections(
         _ => (),
     };
 
+    if nm_conn.controller_type() != Some(NM_SETTING_BRIDGE_SETTING_NAME) {
+        nm_conn.bridge_port = None;
+    }
+
+    if nm_conn.controller_type() != Some(NM_SETTING_OVS_PORT_SETTING_NAME) {
+        nm_conn.ovs_iface = None;
+    }
+
     if let Some(Interface::LinuxBridge(br_iface)) = ctrl_iface {
         gen_nm_br_port_setting(br_iface, &mut nm_conn);
     }

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -58,7 +58,8 @@ from .testlib.vlan import vlan_interface
 
 
 TEST_BRIDGE0 = "linux-br0"
-TEST_TAP0 = "tap0"
+TEST_TAP0 = "test-tap0"
+TEST_BOND0 = "test-bond0"
 ETH1 = "eth1"
 # RFC 7042 reserved EUI-48 MAC range for document
 TEST_MAC_ADDRESS = "00:00:5E:00:53:01"
@@ -607,6 +608,18 @@ class TestVlanFiltering:
         current_state = show_only((TEST_BRIDGE0,))
         pretty_state = PrettyState(current_state)
         assert VLAN_FILTER_PORT_YAML in pretty_state.yaml
+
+    def test_move_bridge_port_to_bond(self, bridge_with_access_port_config):
+        with bond_interface(
+            TEST_BOND0, ["eth1"], create=False
+        ) as desired_state:
+            desired_state[Interface.KEY].append(
+                {
+                    Interface.NAME: TEST_BRIDGE0,
+                    LinuxBridge.CONFIG_SUBTREE: {LinuxBridge.PORT_SUBTREE: []},
+                }
+            )
+            libnmstate.apply(desired_state)
 
 
 @pytest.fixture

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -46,11 +46,12 @@ from .testlib import assertlib
 from .testlib import cmdlib
 from .testlib import iprule
 from .testlib import statelib
+from .testlib.bondlib import bond_interface
 from .testlib.env import nm_major_minor_version
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.nmplugin import mount_devnull_to_path
-from .testlib.statelib import state_match
 from .testlib.ovslib import Bridge
+from .testlib.statelib import state_match
 from .testlib.vlan import vlan_interface
 
 
@@ -1143,3 +1144,20 @@ def test_add_new_sys_veth_interface_to_existing_ovs_bridge(
     )
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_move_ovs_system_interface_to_bond(bridge_with_ports):
+    with bond_interface(BOND1, ["eth1"], create=False) as desired_state:
+        desired_state[Interface.KEY].append(
+            {
+                Interface.NAME: BRIDGE1,
+                OVSBridge.CONFIG_SUBTREE: {
+                    OVSBridge.PORT_SUBTREE: [
+                        {
+                            OVSBridge.Port.NAME: PORT1,
+                        }
+                    ]
+                },
+            }
+        )
+        libnmstate.apply(desired_state)


### PR DESCRIPTION
When moving bridge port with VLAN filtering setting to bond, we got failure:
    A connection with a 'bridge-port' setting must have the slave-type
    set to 'bridge'. Instead it is 'bond'

The root cause is we forgot to remove `NmSettingBridgePort` when detaching port away from bridge.

The fix is remove `NmSettingBridgePort` and
`NmSettingOvsBridgeInterface` if not bridge port or OVS interface anymore.

Integration test cases for linux bridge and OVS bridge are included.

Signed-off-by: Gris Ge <fge@redhat.com>
(cherry picked from commit d2c40c3aade1d7764b84f0aafe8d3d907bb1c4a6)