### PR TITLE
[nmstate-1.3] nm: Fix activation retry

### DIFF
--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -405,3 +405,33 @@ def test_new_veth_with_ipv6_only():
             },
             verify_change=False,
         )
+
+
+@pytest.mark.slow
+def test_add_32_veth_in_single_transaction():
+    desired_state = {Interface.KEY: []}
+    for i in range(0, 33):
+        desired_state[Interface.KEY].append(
+            {
+                Interface.NAME: f"veth{i}",
+                Interface.TYPE: InterfaceType.VETH,
+                Interface.STATE: InterfaceState.UP,
+                Veth.CONFIG_SUBTREE: {
+                    Veth.PEER: f"veth{i}_peer",
+                },
+            }
+        )
+
+    try:
+        libnmstate.apply(desired_state)
+    finally:
+        desired_state = {Interface.KEY: []}
+        for i in range(0, 33):
+            desired_state[Interface.KEY].append(
+                {
+                    Interface.NAME: f"veth{i}",
+                    Interface.TYPE: InterfaceType.VETH,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            )
+        libnmstate.apply(desired_state, verify_change=False)


### PR DESCRIPTION
Using `time.sleep(5)` will not process the MainLoop of NM library which
will cause checkpoint expire during `time.sleep()`.

Use Glib timer will fix this problem.

Integration test case created to create 32 veth in single transaction, the
test case is marked as slow as it takes 10 seconds to finish.