### PR TITLE
Revert "packit: Remove the PR copr build for EPEL8 and EPEL9"

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -20,3 +20,5 @@ jobs:
       targets:
         - centos-stream-8-x86_64
         - centos-stream-9-x86_64
+        - epel-8-x86_64
+        - epel-9-x86_64


### PR DESCRIPTION
The EPEL8 and EPEL9 has rust 1.62+ now, are ready for build this project.

This reverts commit 0bc69bc9484c672b29e7db7258b2e520eb75081a.