### PR TITLE
controller: Fix detaching port from controller

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -435,10 +435,11 @@ pub(crate) fn preserve_ctrl_cfg_if_unchanged(
     }
 
     for (iface_name, iface) in ifaces.kernel_ifaces.iter_mut() {
-        if iface.base_iface().controller.is_some()
-            && iface.base_iface().controller_type.is_some()
+        if (iface.base_iface().controller.is_some()
+            && iface.base_iface().controller_type.is_some())
+            || iface.base_iface().controller.as_ref() == Some(&String::new())
         {
-            // Iface already has controller information
+            // Iface already has controller information or detaching
             continue;
         }
         let cur_iface = match cur_ifaces.kernel_ifaces.get(iface_name) {

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -129,5 +129,11 @@ impl BaseInterface {
             ethtool_conf.pre_verify_cleanup();
         }
         mptcp_pre_verify_cleanup(self);
+
+        // If desired controller is Some("") for detaching, we should remove
+        // it for verification
+        if self.controller.as_ref() == Some(&"".to_string()) {
+            self.controller = None;
+        }
     }
 }


### PR DESCRIPTION
When detaching port from controller via:

```yml
---
interfaces:
- name: eth1
  state: up
  controller: ""
```

Nmstate will fail with verification error.

It is caused by two problem:
 * Verification thinks `Some("")` is different from `None`. Fixed by set
   controller as `None` before verification.
 * The function `preserve_ctrl_cfg_if_unchanged()` copied current
   controller information when got controller set as `Some("")`. Fixed
   by skipping the preserving.

Integration test cases included.