### PR TITLE
CI: Drop actions-rs actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: ${{ matrix.rust_version }}
-          override: true
-          components: rustfmt, clippy
+      run: |
+        rustup override set ${{ matrix.rust_version }}
+        rustup update ${{ matrix.rust_version }}
+        rustup component add rustfmt clippy
 
     - name: Check fmt
       if: matrix.rust_version == 'stable'
@@ -62,10 +61,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: ${{ matrix.rust_version }}
-          override: true
+      run: |
+        rustup override set ${{ matrix.rust_version }}
+        rustup update ${{ matrix.rust_version }}
 
     - name: Unit test
       run: cd rust && cargo test -- --show-output
@@ -173,11 +171,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Rust ${{ matrix.rust_version }}
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: ${{ matrix.rust_version }}
-          override: true
-          components: rustfmt, clippy
+      run: |
+        rustup override set ${{ matrix.rust_version }}
+        rustup update ${{ matrix.rust_version }}
+        rustup component add rustfmt clippy
 
     - name: Build gen_conf
       run: |


### PR DESCRIPTION
The actions-rs is unmaintained and causing deprecate warning on Node.js
12 of github.

Replacing it with rustup command.