### PR TITLE
Fix CI on NM 1.41 where loopback interface is supported

### DIFF
--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     nispor::ethtool::np_ethtool_to_nmstate,
     nispor::ip::{np_ipv4_to_nmstate, np_ipv6_to_nmstate},
@@ -109,10 +111,10 @@ pub(crate) fn np_iface_to_base_iface(
         ],
         ..Default::default()
     };
-    if let InterfaceType::Other(t) = &base_iface.iface_type {
+    if !InterfaceType::SUPPORTED_LIST.contains(&base_iface.iface_type) {
         log::info!(
             "Got unsupported interface type {}: {}, ignoring",
-            t,
+            &base_iface.iface_type,
             &base_iface.name
         );
         base_iface.state = InterfaceState::Ignore;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -175,6 +175,20 @@ pub(crate) fn nm_retrieve(
             }
         }
     }
+    for iface in net_state
+        .interfaces
+        .kernel_ifaces
+        .values_mut()
+        .chain(net_state.interfaces.user_ifaces.values_mut())
+    {
+        // Do not touch interfaces nmstate does not support yet
+        if !InterfaceType::SUPPORTED_LIST.contains(&iface.iface_type()) {
+            if !iface.base_iface_mut().prop_list.contains(&"state") {
+                iface.base_iface_mut().prop_list.push("state");
+            }
+            iface.base_iface_mut().state = InterfaceState::Ignore;
+        }
+    }
 
     net_state.dns = retrieve_dns_info(&nm_api, &net_state.interfaces)?;
     if running_config_only {

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -255,3 +255,20 @@ impl Interface {
         }
     }
 }
+
+impl InterfaceType {
+    pub(crate) const SUPPORTED_LIST: [InterfaceType; 12] = [
+        InterfaceType::Bond,
+        InterfaceType::LinuxBridge,
+        InterfaceType::Dummy,
+        InterfaceType::Ethernet,
+        InterfaceType::Veth,
+        InterfaceType::MacVtap,
+        InterfaceType::MacVlan,
+        InterfaceType::OvsBridge,
+        InterfaceType::OvsInterface,
+        InterfaceType::Vlan,
+        InterfaceType::Vxlan,
+        InterfaceType::InfiniBand,
+    ];
+}


### PR DESCRIPTION
The test case `test_dynamic_ip_with_static_dns` will fail on NM 1.41+
where loopback interface is supported.

Marking unsupported interface as ignored in both nispor and nm plugin
will fix this problem.