### PR TITLE
[nmstate-1.3] Fix CI on NM 1.41 where loopback interface is supported

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -144,6 +144,7 @@ class DnsState:
         Find interface to store the DNS configurations in the order of:
             * Any interface with static gateway
             * Any interface configured as dynamic IP with 'auto-dns:False'
+        The loopback interface is ignored.
         Return tuple: (ipv4_iface, ipv6_iface)
         """
         ipv4_iface, ipv6_iface = self._find_ifaces_with_static_gateways(
@@ -168,6 +169,8 @@ class DnsState:
         ipv4_iface = None
         ipv6_iface = None
         for iface_name, route_set in route_state.config_iface_routes.items():
+            if iface_name == "lo":
+                continue
             for route in route_set:
                 if ipv4_iface and ipv6_iface:
                     return (ipv4_iface, ipv6_iface)

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -104,9 +104,9 @@ impl Interfaces {
     /// Search interface base on interface name and interface type.
     /// When using [InterfaceType::Unknown], we only search kernel
     /// interface(which has presentation in kernel space).
-    pub fn get_iface<'a, 'b>(
+    pub fn get_iface<'a>(
         &'a self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a Interface> {
         if iface_type == InterfaceType::Unknown {

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     nispor::ethtool::np_ethtool_to_nmstate,
     nispor::ip::{np_ipv4_to_nmstate, np_ipv6_to_nmstate},
@@ -109,10 +111,10 @@ pub(crate) fn np_iface_to_base_iface(
         ],
         ..Default::default()
     };
-    if let InterfaceType::Other(t) = &base_iface.iface_type {
+    if !InterfaceType::SUPPORTED_LIST.contains(&base_iface.iface_type) {
         log::info!(
             "Got unsupported interface type {}: {}, ignoring",
-            t,
+            &base_iface.iface_type,
             &base_iface.name
         );
         base_iface.state = InterfaceState::Ignore;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -175,6 +175,20 @@ pub(crate) fn nm_retrieve(
             }
         }
     }
+    for iface in net_state
+        .interfaces
+        .kernel_ifaces
+        .values_mut()
+        .chain(net_state.interfaces.user_ifaces.values_mut())
+    {
+        // Do not touch interfaces nmstate does not support yet
+        if !InterfaceType::SUPPORTED_LIST.contains(&iface.iface_type()) {
+            if !iface.base_iface_mut().prop_list.contains(&"state") {
+                iface.base_iface_mut().prop_list.push("state");
+            }
+            iface.base_iface_mut().state = InterfaceState::Ignore;
+        }
+    }
 
     net_state.dns = retrieve_dns_info(&nm_api, &net_state.interfaces)?;
     if running_config_only {

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -255,3 +255,20 @@ impl Interface {
         }
     }
 }
+
+impl InterfaceType {
+    pub(crate) const SUPPORTED_LIST: [InterfaceType; 12] = [
+        InterfaceType::Bond,
+        InterfaceType::LinuxBridge,
+        InterfaceType::Dummy,
+        InterfaceType::Ethernet,
+        InterfaceType::Veth,
+        InterfaceType::MacVtap,
+        InterfaceType::MacVlan,
+        InterfaceType::OvsBridge,
+        InterfaceType::OvsInterface,
+        InterfaceType::Vlan,
+        InterfaceType::Vxlan,
+        InterfaceType::InfiniBand,
+    ];
+}

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -238,9 +238,9 @@ impl Interfaces {
         }
     }
 
-    pub(crate) fn get_iface_mut<'a, 'b>(
+    pub(crate) fn get_iface_mut<'a>(
         &'a mut self,
-        iface_name: &'b str,
+        iface_name: &str,
         iface_type: InterfaceType,
     ) -> Option<&'a mut Interface> {
         if iface_type.is_userspace() {


### PR DESCRIPTION
The loopback interface is supported by NM 1.41+, we should not use it
for DNS storing yet.

Existing DNS integration test case have this covered.