### PR TITLE
k8s ci: Fix `test_ipv6_link_local_dns_srv`

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1446,11 +1446,25 @@ def test_ipv6_link_local_dns_srv(dhcpcli_up_with_dynamic_ip):
     assert _poll(_has_dhcpv4_addr)
     assert _poll(_has_dhcpv6_addr)
     new_state = libnmstate.show()
-    assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER] == [
-        IPV6_DNS_NAMESERVER,
-        IPV6_DNS_NAMESERVER_LOCAL,
-    ]
-    assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER] == [
-        IPV6_DNS_NAMESERVER,
-        IPV6_DNS_NAMESERVER_LOCAL,
-    ]
+    if is_k8s():
+        # K8S CI has an TUN interface configured as auto_dns: true,
+        # which is not configurable by nmstate, hence we only make sure
+        # the first two DNS server is what we desired
+        assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER][:2] == [
+            IPV6_DNS_NAMESERVER,
+            IPV6_DNS_NAMESERVER_LOCAL,
+        ]
+        assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER][:2] == [
+            IPV6_DNS_NAMESERVER,
+            IPV6_DNS_NAMESERVER_LOCAL,
+        ]
+
+    else:
+        assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER] == [
+            IPV6_DNS_NAMESERVER,
+            IPV6_DNS_NAMESERVER_LOCAL,
+        ]
+        assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER] == [
+            IPV6_DNS_NAMESERVER,
+            IPV6_DNS_NAMESERVER_LOCAL,
+        ]


### PR DESCRIPTION
In K8S CI, `test_ipv6_link_local_dns_srv` test will fail with:

```
E       AssertionError: assert ['2001:4860:4...8c:f616%eth0'] == ['2001:4860:48...ef:1%dhcpcli']
E         Left contains more items, first extra item: '192.168.66.2'
E         Full diff:
E         + ['2001:4860:4860::8888', 'fe80::deef:1%dhcpcli']
E         - ['2001:4860:4860::8888',
E         -  'fe80::deef:1%dhcpcli',
E         -  '192.168.66.2',
E         -  'fd00::1',
E         -  'fe80::5cb5:33ff:fe8c:f616%eth0']
```

This is caused by extra interface tunl0 (TUN interface type) is
configured with `auto_dns: true`, it is not configurable via nmstata
which result extra DNS server appended after our desired ones.

Fixed by only checking first 2 DNS name servers in K8S CI.