### PR TITLE
route: Validate the route destination address

### DIFF
--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -99,11 +99,11 @@ impl SrIovConfig {
             vfs.sort_unstable_by(|a, b| a.id.cmp(&b.id));
 
             if !vfs.is_empty() {
-                let total_vfs = self.total_vfs.unwrap_or(
+                let total_vfs = self.total_vfs.unwrap_or_else(|| {
                     current.and_then(|c| c.total_vfs).unwrap_or(
                         vfs.iter().map(|v| v.id).max().unwrap_or_default() + 1,
-                    ),
-                );
+                    )
+                });
                 self.total_vfs = Some(total_vfs);
                 // Auto fill the missing
                 if total_vfs as usize != vfs.len() {

--- a/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
@@ -166,7 +166,7 @@ const RTN_BLACKHOLE: u8 = 6;
 const RTN_UNREACHABLE: u8 = 7;
 const RTN_PROHIBIT: u8 = 8;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum NmIpRouteRuleAction {
     Blackhole,

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -330,6 +330,7 @@ impl MergedRoutes {
         current: Routes,
         merged_ifaces: &MergedInterfaces,
     ) -> Result<Self, NmstateError> {
+        desired.validate()?;
         let mut desired_routes = Vec::new();
         if let Some(rts) = desired.config.as_ref() {
             for rt in rts {

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -326,3 +326,85 @@ fn test_route_ipv4_ecmp_is_match() {
     .unwrap();
     assert!(absent_route.is_match(&route));
 }
+
+#[test]
+fn test_route_valid_default_gateway() {
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0/0
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    routes.validate().unwrap();
+}
+
+#[test]
+fn test_route_invalid_destination() {
+    let routes1: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0/8
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    let result = routes1.validate();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+
+    let routes2: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0/f
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    let result = routes2.validate();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+
+    let routes3: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    let result = routes3.validate();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+
+    let routes4: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0.0/0
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    let result = routes4.validate();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+
+    let routes5: Routes = serde_yaml::from_str(
+        r#"
+config:
+- destination: 0.0.0.0.0/7
+  next-hop-address: 192.0.2.1
+  next-hop-interface: eth1
+"#,
+    )
+    .unwrap();
+    let result = routes5.validate();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+}


### PR DESCRIPTION
'0.0.0.0/8' and its subnet should never be used as the destination address for the route, thus raise the invalid argument error during the route validation.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>