### PR TITLE
[nmstate-1.0] ip: Preserve the IP address order when applying

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -44,7 +44,6 @@ class IPState:
         self._family = family
         self._info = info
         self._remove_stack_if_disabled()
-        self._sort_addresses()
         self._canonicalize_ip_addr()
         self._canonicalize_dynamic()
 
@@ -68,7 +67,7 @@ class IPState:
                 addr[InterfaceIP.ADDRESS_IP]
             )
 
-    def _sort_addresses(self):
+    def sort_addresses(self):
         self.addresses.sort(key=itemgetter(InterfaceIP.ADDRESS_IP))
 
     def _remove_stack_if_disabled(self):
@@ -393,6 +392,7 @@ class BaseIface:
         self.sort_port()
         for family in (Interface.IPV4, Interface.IPV6):
             ip_state = self.ip_state(family)
+            ip_state.sort_addresses()
             ip_state.remove_link_local_address()
             self._info[family] = ip_state.to_dict()
         state = self.to_dict()

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2018-2022 Red Hat, Inc.
 #
 # This file is part of nmstate
 #
@@ -31,6 +31,8 @@ from .testlib import assertlib
 from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.dummy import nm_unmanaged_dummy
+from .testlib.env import is_el8
+from .testlib.iproutelib import iproute_get_ip_addrs_with_order
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 
 # TEST-NET addresses: https://tools.ietf.org/html/rfc5737#section-3
@@ -675,3 +677,66 @@ def test_ignore_invalid_ip_on_absent_interface(eth1_up):
             ]
         }
     )
+
+
+def test_preserve_ipv4_addresses_order(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS2,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        },
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    ip_addrs = iproute_get_ip_addrs_with_order(iface="eth1", is_ipv6=False)
+    assert ip_addrs[0] == IPV4_ADDRESS2
+    assert ip_addrs[1] == IPV4_ADDRESS1
+
+
+@pytest.mark.skipif(
+    is_el8(),
+    reason="RHEL 8 hold different IPv6 address order in rpm between "
+    "downstream shipped and copr main branch built",
+)
+def test_preserve_ipv6_addresses_order(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        },
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    ip_addrs = iproute_get_ip_addrs_with_order(iface="eth1", is_ipv6=True)
+    assert ip_addrs[0] == IPV6_ADDRESS2
+    assert ip_addrs[1] == IPV6_ADDRESS1

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -18,6 +18,7 @@
 #
 
 import os
+from .cmdlib import exec_cmd
 
 import gi
 
@@ -38,3 +39,11 @@ def is_ubuntu_kernel():
 
 def nm_major_minor_version():
     return float(f"{NM.MAJOR_VERSION}.{NM.MINOR_VERSION}")
+
+
+def is_k8s():
+    return os.getenv("RUN_K8S") == "true"
+
+
+def is_el8():
+    return exec_cmd("rpm -E %{?rhel}".split())[1].strip() == "8"

--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -19,9 +19,12 @@
 
 from contextlib import contextmanager
 from functools import wraps
+import json
 import subprocess
 import threading
 import time
+
+from .cmdlib import exec_cmd
 
 
 TIMEOUT = 10
@@ -102,3 +105,14 @@ def _thread(func, name, teardown_cb=lambda: None):
     finally:
         teardown_cb()
         t.join()
+
+
+def iproute_get_ip_addrs_with_order(iface, is_ipv6):
+    """
+    Return a list of ip address with the order reported by ip route
+    """
+    family = 6 if is_ipv6 else 4
+    output = json.loads(
+        exec_cmd(f"ip -d -j -{family} addr show dev {iface}".split())[1]
+    )
+    return [addr_info["local"] for addr_info in output[0]["addr_info"]]

--- a/tests/lib/ifaces/ip_state_test.py
+++ b/tests/lib/ifaces/ip_state_test.py
@@ -124,9 +124,11 @@ class TestIPState:
     def test_sort_address(self, ip_ver):
         family, ip_info = ip_ver
         ip_state1 = IPState(family, ip_info)
+        ip_state1.sort_addresses()
         ip_info2 = deepcopy(ip_info)
         ip_info2[InterfaceIP.ADDRESS].reverse()
         ip_state2 = IPState(family, ip_info2)
+        ip_state2.sort_addresses()
         assert ip_state1.to_dict() == ip_state2.to_dict()
 
     def test_ipv6_non_abbreviated_address(self):


### PR DESCRIPTION
When applying the IP address, we should preserve the order for use case whether user is expecting non-first ones been set with `secondary` flag.

In RHEL/CentOS 8, NetworkManager is using reverted IPv6 address according to
https://bugzilla.redhat.com/show_bug.cgi?id=2139443

Hence downstream nmstate will ship additional patch to fix it. The upstream nmstate will not revert the IPv6 address list before sending to NM.

The downstream build of RHEL 8 has different behaviour than copr build from git main branch. It is hard to tell whether we are using downstream build or git build at runtime, hence we ship the
`test_preserve_ipv6_addresses_order` test in RHEL 8.

Integration test case included.

Signed-off-by: Gris Ge <fge@redhat.com>
(cherry picked from commit 2d0cfd5ad8e049f30cad10d977a5fae8bc4e6b64) (cherry picked from commit 4dc5ac73522b6dd9d84bde1824aef73d838548ca)