### PR TITLE
[nmstate-1.3] tests, ovs: add updelay and downdelay ovs-bond options test

### DIFF
--- a/libnmstate/ifaces/ovs.py
+++ b/libnmstate/ifaces/ovs.py
@@ -297,6 +297,15 @@ class OvsPortIface(BaseIface):
     def is_user_space_only(self):
         return True
 
+    @property
+    def is_lag_port(self):
+        return (
+            self._info.get(OVSBridge.OPTIONS_SUBTREE, {}).get(
+                OVSBridge.Port.LINK_AGGREGATION_SUBTREE
+            )
+            is not None
+        )
+
 
 def _rename_ovs_bond_ports_to_port(info):
     br_conf = info.get(Bridge.CONFIG_SUBTREE, {})

--- a/libnmstate/nm/ovs.py
+++ b/libnmstate/nm/ovs.py
@@ -107,10 +107,10 @@ def create_port_setting(port_state):
             port_setting.props.bond_mode = mode
 
         down_delay = lag_state.get(OB.Port.LinkAggregation.Options.DOWN_DELAY)
-        if down_delay:
+        if down_delay is not None:
             port_setting.props.bond_downdelay = down_delay
         up_delay = lag_state.get(OB.Port.LinkAggregation.Options.UP_DELAY)
-        if up_delay:
+        if up_delay is not None:
             port_setting.props.bond_updelay = up_delay
 
     vlan_state = port_state.get(OB.Port.VLAN_SUBTREE, {})
@@ -261,10 +261,29 @@ def _get_lag_nmstate_port_info(nm_dev_ovs_port):
     mode = _get_lag_mode(nm_dev_ovs_port)
     if mode:
         lag[OVS_LAG.MODE] = mode
+    up_delay, down_delay = _get_lag_options(nm_dev_ovs_port)
+    if up_delay is not None:
+        lag[OVS_LAG.Options.UP_DELAY] = up_delay
+    if down_delay is not None:
+        lag[OVS_LAG.Options.DOWN_DELAY] = down_delay
     return {
         OB.Port.NAME: nm_dev_ovs_port.get_iface(),
         OB.Port.LINK_AGGREGATION_SUBTREE: lag,
     }
+
+
+def _get_lag_options(nm_dev_ovs_port):
+    """
+    Use applied profile to get ovs bond options
+    """
+    up_delay = None
+    down_delay = None
+    nm_setting = _get_nm_setting_ovs_port(nm_dev_ovs_port)
+    if nm_setting:
+        up_delay = nm_setting.props.bond_updelay
+        down_delay = nm_setting.props.bond_downdelay
+
+    return up_delay, down_delay
 
 
 def _get_lag_mode(nm_dev_ovs_port):

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -134,7 +134,11 @@ def _append_nm_ovs_port_iface(net_state):
             iface.set_controller(
                 nm_ovs_port_iface.name, InterfaceType.OVS_PORT
             )
-            if iface.is_desired or iface.is_changed:
+            if (
+                iface.is_desired
+                or iface.is_changed
+                or nm_ovs_port_iface.is_lag_port
+            ):
                 nm_ovs_port_iface.mark_as_changed()
             nm_ovs_port_ifaces[nm_ovs_port_iface.name] = nm_ovs_port_iface
 

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -77,7 +77,7 @@ def test_add_remove_ovs_bridge_bond(eth1_up, eth2_up):
     with example_state(
         "ovsbridge_bond_create.yml", cleanup="ovsbridge_delete.yml"
     ) as desired_state:
-        assertlib.assert_state(desired_state)
+        assertlib.assert_state_match(desired_state)
 
     assertlib.assert_absent("ovs-br0")
     assertlib.assert_absent("ovs-bond1")

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -337,6 +337,60 @@ class TestOvsLinkAggregation:
             libnmstate.apply(bridge.state)
             assertlib.assert_state_match(bridge.state)
 
+    @pytest.mark.tier1
+    def test_add_ovs_lag_with_updelay_and_downdelay(self, port0_up, port1_up):
+        port0_name = port0_up[Interface.KEY][0][Interface.NAME]
+        port1_name = port1_up[Interface.KEY][0][Interface.NAME]
+
+        bridge = Bridge(BRIDGE1)
+        bridge.add_link_aggregation_port(
+            BOND1,
+            (port0_name, port1_name),
+            mode="active-backup",
+            updelay=1000,
+            downdelay=1000,
+        )
+
+        with bridge.create() as state:
+            assertlib.assert_state_match(state)
+
+        assertlib.assert_absent(BRIDGE1)
+        assertlib.assert_absent(BOND1)
+
+    @pytest.mark.tier1
+    def test_modify_ovs_lag_with_updelay_and_downdelay(
+        self, port0_up, port1_up
+    ):
+        port0_name = port0_up[Interface.KEY][0][Interface.NAME]
+        port1_name = port1_up[Interface.KEY][0][Interface.NAME]
+
+        bridge = Bridge(BRIDGE1)
+        bridge.add_link_aggregation_port(
+            BOND1,
+            (port0_name, port1_name),
+            mode="active-backup",
+            updelay=1000,
+            downdelay=1000,
+        )
+
+        with bridge.create() as state:
+            assertlib.assert_state_match(state)
+            state[Interface.KEY][0][OVSBridge.CONFIG_SUBTREE][
+                OVSBridge.PORT_SUBTREE
+            ][0][OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
+                OVSBridge.Port.LinkAggregation.Options.DOWN_DELAY
+            ] = 100
+            state[Interface.KEY][0][OVSBridge.CONFIG_SUBTREE][
+                OVSBridge.PORT_SUBTREE
+            ][0][OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
+                OVSBridge.Port.LinkAggregation.Options.UP_DELAY
+            ] = 100
+            libnmstate.apply(state)
+            assertlib.assert_state_match(state)
+
+        assertlib.assert_absent(BRIDGE1)
+        assertlib.assert_absent(BOND1)
+
 
 @pytest.mark.tier1
 def test_ovs_vlan_access_tag():

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -51,7 +51,9 @@ class Bridge:
     def add_system_port(self, name):
         self._add_port(name)
 
-    def add_link_aggregation_port(self, name, port, mode=None):
+    def add_link_aggregation_port(
+        self, name, port, mode=None, updelay=None, downdelay=None
+    ):
         self._add_port(name)
         port_cfg = self._get_port(name)
         port_cfg[OVSBridge.Port.LINK_AGGREGATION_SUBTREE] = {
@@ -61,9 +63,17 @@ class Bridge:
             ]
         }
         if mode:
-            port[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
+            port_cfg[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
                 OVSBridge.Port.LinkAggregation.MODE
             ] = mode
+        if updelay is not None:
+            port_cfg[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
+                OVSBridge.Port.LinkAggregation.Options.UP_DELAY
+            ] = updelay
+        if downdelay is not None:
+            port_cfg[OVSBridge.Port.LINK_AGGREGATION_SUBTREE][
+                OVSBridge.Port.LinkAggregation.Options.DOWN_DELAY
+            ] = downdelay
 
     def add_internal_port(
         self,


### PR DESCRIPTION
Add missing integration tests for OVS Link Aggregation support. We support downdelay and updelay so they need to be tested properly.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>
(cherry picked from commit 7ddd51853dfb7c34d2d173a068d39063d6bcb0c3)