### PR TITLE
[nmstate-1.2] nm: Fix activation retry

### DIFF
--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -502,6 +502,7 @@ class NmProfile:
                 break
             else:
                 time.sleep(IMPORT_NM_DEV_RETRY_INTERNAL)
+                self._ctx.refresh()
 
     def import_current(self):
         self._nm_dev = get_nm_dev(

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -357,3 +357,33 @@ def veth_interface(ifname, peer):
             }
         )
         libnmstate.apply(d_state)
+
+
+@pytest.mark.slow
+def test_add_32_veth_in_single_transaction():
+    desired_state = {Interface.KEY: []}
+    for i in range(0, 33):
+        desired_state[Interface.KEY].append(
+            {
+                Interface.NAME: f"veth{i}",
+                Interface.TYPE: InterfaceType.VETH,
+                Interface.STATE: InterfaceState.UP,
+                Veth.CONFIG_SUBTREE: {
+                    Veth.PEER: f"veth{i}_peer",
+                },
+            }
+        )
+
+    try:
+        libnmstate.apply(desired_state)
+    finally:
+        desired_state = {Interface.KEY: []}
+        for i in range(0, 33):
+            desired_state[Interface.KEY].append(
+                {
+                    Interface.NAME: f"veth{i}",
+                    Interface.TYPE: InterfaceType.VETH,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            )
+        libnmstate.apply(desired_state, verify_change=False)


### PR DESCRIPTION
Using `time.sleep(5)` will not process the MainLoop of NM library which
will cause checkpoint expire during `time.sleep()`.

Use Glib timer will fix this problem.

Integration test case created to create 32 veth in single transaction,
the test case is marked as slow as it takes 10 seconds to finish.

Cherry-pick from 2a98b06c70c93c63298ac0cc5402a74d8015f40b

Also added extra fixed for `time.sleep()` in `_import_current_device()`
with `self._ctx.refresh()` after each small sleep to make sure
checkpoint refresher does not expires.