### PR TITLE
test: Fix `test_ipv6_link_local_dns_srv` in NMCI

### DIFF
--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -90,8 +90,7 @@ where
             Ok(n) => Ok(n),
             Err(json_error) => Err(format!(
                 "Failed to load from file, \
-                     tried both YAML and JSON format. Errors: {}, {}",
-                yaml_error, json_error
+                     tried both YAML and JSON format. Errors: {yaml_error}, {json_error}"
             )
             .into()),
         },
@@ -142,8 +141,7 @@ fn store_capture_states_from_file(
         .open(file_path)
         .map_err(|e| {
             CliError::from(format!(
-                "Failed to store captured states to file {}: {}",
-                file_path, e
+                "Failed to store captured states to file {file_path}: {e}"
             ))
         })?;
     fd.write_all(states_string.as_bytes())?;

--- a/rust/src/clib/apply.rs
+++ b/rust/src/clib/apply.rs
@@ -58,8 +58,7 @@ pub extern "C" fn nmstate_net_state_apply(
         Err(e) => {
             unsafe {
                 *err_msg = CString::new(format!(
-                    "Error on converting C char to rust str: {}",
-                    e
+                    "Error on converting C char to rust str: {e}"
                 ))
                 .unwrap()
                 .into_raw();

--- a/rust/src/clib/checkpoint.rs
+++ b/rust/src/clib/checkpoint.rs
@@ -46,8 +46,7 @@ pub extern "C" fn nmstate_checkpoint_commit(
             Err(e) => {
                 unsafe {
                     *err_msg = CString::new(format!(
-                        "Error on converting C char to rust str: {}",
-                        e
+                        "Error on converting C char to rust str: {e}"
                     ))
                     .unwrap()
                     .into_raw();
@@ -119,8 +118,7 @@ pub extern "C" fn nmstate_checkpoint_rollback(
             Err(e) => {
                 unsafe {
                     *err_msg = CString::new(format!(
-                        "Error on converting C char to rust str: {}",
-                        e
+                        "Error on converting C char to rust str: {e}"
                     ))
                     .unwrap()
                     .into_raw();

--- a/rust/src/clib/gen_conf.rs
+++ b/rust/src/clib/gen_conf.rs
@@ -53,8 +53,7 @@ pub extern "C" fn nmstate_generate_configurations(
         Err(e) => {
             unsafe {
                 *err_msg = CString::new(format!(
-                    "Error on converting C char to rust str: {}",
-                    e
+                    "Error on converting C char to rust str: {e}"
                 ))
                 .unwrap()
                 .into_raw();
@@ -92,12 +91,10 @@ pub extern "C" fn nmstate_generate_configurations(
                 NMSTATE_PASS
             },
             Err(e) => unsafe {
-                *err_msg = CString::new(format!(
-                    "serde_json::to_string failure: {}",
-                    e
-                ))
-                .unwrap()
-                .into_raw();
+                *err_msg =
+                    CString::new(format!("serde_json::to_string failure: {e}"))
+                        .unwrap()
+                        .into_raw();
                 *err_kind =
                     CString::new(format!("{}", nmstate::ErrorKind::Bug))
                         .unwrap()

--- a/rust/src/clib/policy.rs
+++ b/rust/src/clib/policy.rs
@@ -40,10 +40,9 @@ pub extern "C" fn nmstate_net_state_from_policy(
         Ok(l) => l,
         Err(e) => {
             unsafe {
-                *err_msg =
-                    CString::new(format!("Failed to setup logger: {}", e))
-                        .unwrap()
-                        .into_raw();
+                *err_msg = CString::new(format!("Failed to setup logger: {e}"))
+                    .unwrap()
+                    .into_raw();
             }
             return NMSTATE_FAIL;
         }
@@ -93,12 +92,10 @@ pub extern "C" fn nmstate_net_state_from_policy(
                 NMSTATE_PASS
             },
             Err(e) => unsafe {
-                *err_msg = CString::new(format!(
-                    "serde_json::to_string failure: {}",
-                    e
-                ))
-                .unwrap()
-                .into_raw();
+                *err_msg =
+                    CString::new(format!("serde_json::to_string failure: {e}"))
+                        .unwrap()
+                        .into_raw();
                 *err_kind =
                     CString::new(format!("{}", nmstate::ErrorKind::Bug))
                         .unwrap()
@@ -132,8 +129,7 @@ where
         Err(e) => {
             unsafe {
                 *err_msg = CString::new(format!(
-                    "Error on converting C char to rust str: {}",
-                    e
+                    "Error on converting C char to rust str: {e}"
                 ))
                 .unwrap()
                 .into_raw();

--- a/rust/src/clib/query.rs
+++ b/rust/src/clib/query.rs
@@ -78,12 +78,10 @@ pub extern "C" fn nmstate_net_state_retrieve(
                 NMSTATE_PASS
             },
             Err(e) => unsafe {
-                *err_msg = CString::new(format!(
-                    "serde_json::to_string failure: {}",
-                    e
-                ))
-                .unwrap()
-                .into_raw();
+                *err_msg =
+                    CString::new(format!("serde_json::to_string failure: {e}"))
+                        .unwrap()
+                        .into_raw();
                 *err_kind =
                     CString::new(format!("{}", nmstate::ErrorKind::Bug))
                         .unwrap()

--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -285,9 +285,8 @@ impl std::convert::TryFrom<serde_json::Value> for NumberAsString {
             _ => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid data type: {}, should be \
-                     integer or string",
-                    s
+                    "Invalid data type: {s}, should be \
+                     integer or string"
                 ),
             )),
         }

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -479,8 +479,7 @@ fn _save_dns_to_iface(
             ErrorKind::InvalidArgument,
             format!(
                 "Failed to find suitable(IP enabled with DHCP off \
-                or auto-dns: false) interface for DNS server {:?}",
-                servers
+                or auto-dns: false) interface for DNS server {servers:?}"
             ),
         );
         log::error!("{}", e);
@@ -545,8 +544,7 @@ fn _save_dns_to_iface(
             let e = NmstateError::new(
                 ErrorKind::Bug,
                 format!(
-                    "Selected interface {} for dns, but not found it",
-                    iface_name
+                    "Selected interface {iface_name} for dns, but not found it"
                 ),
             );
             log::error!("{}", e);
@@ -578,9 +576,8 @@ pub(crate) fn validate_ipv6_link_local_address_dns_srv(
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Desired IPv6 link local DNS server {} is \
-                            pointing to interface {} which does not exist.",
-                            srv, iface_name
+                            "Desired IPv6 link local DNS server {srv} is \
+                            pointing to interface {iface_name} which does not exist."
                         ),
                     ));
                 };
@@ -590,10 +587,9 @@ pub(crate) fn validate_ipv6_link_local_address_dns_srv(
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Interface {} has IPv6 disabled, \
+                            "Interface {iface_name} has IPv6 disabled, \
                             hence cannot hold desired IPv6 link local \
-                            DNS server {}",
-                            iface_name, srv
+                            DNS server {srv}"
                         ),
                     ));
                 }
@@ -626,11 +622,10 @@ fn parse_dns_ipv6_link_local_srv(
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Invalid IPv6 address in {}, only IPv6 link local \
+                            "Invalid IPv6 address in {srv}, only IPv6 link local \
                             address is allowed to have '%' character in DNS \
                             name server, the correct format should be \
-                            'fe80::deef:1%eth1'",
-                            srv
+                            'fe80::deef:1%eth1'"
                         ),
                     ));
                 }
@@ -639,10 +634,9 @@ fn parse_dns_ipv6_link_local_srv(
             return Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid DNS server {}, the IPv6 \
+                    "Invalid DNS server {srv}, the IPv6 \
                         link local DNS server should be in the format like \
-                        'fe80::deef:1%eth1'",
-                    srv
+                        'fe80::deef:1%eth1'"
                 ),
             ));
         }

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -79,9 +79,8 @@ impl Interfaces {
                         return Err(NmstateError::new(
                             ErrorKind::Bug,
                             format!(
-                                "BUG: Failed to convert {:?} to serde_json \
-                                value: {}",
-                                iface, e
+                                "BUG: Failed to convert {iface:?} to serde_json \
+                                value: {e}"
                             ),
                         ));
                     }
@@ -92,8 +91,7 @@ impl Interfaces {
                         return Err(NmstateError::new(
                             ErrorKind::InvalidArgument,
                             format!(
-                                "Invalid property for ethernet interface: {}",
-                                e
+                                "Invalid property for ethernet interface: {e}"
                             ),
                         ));
                     }

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -345,9 +345,8 @@ impl TryFrom<NumberAsString> for BondAdSelect {
             s => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid bond ad_select value: {}, should be \
-                    0, stable, 1, bandwidth, 2, or count",
-                    s
+                    "Invalid bond ad_select value: {s}, should be \
+                    0, stable, 1, bandwidth, 2, or count"
                 ),
             )),
         }
@@ -403,9 +402,8 @@ impl TryFrom<NumberAsString> for BondLacpRate {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid bond lacp-rate {}, should be \
-                    0, slow, 1 or fast",
-                    v
+                    "Invalid bond lacp-rate {v}, should be \
+                    0, slow, 1 or fast"
                 ),
             )),
         }
@@ -451,9 +449,8 @@ impl TryFrom<NumberAsString> for BondAllPortsActive {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid all_slaves_active value: {}, should be \
-                    0, dropped, 1 or delivered",
-                    v
+                    "Invalid all_slaves_active value: {v}, should be \
+                    0, dropped, 1 or delivered"
                 ),
             )),
         }
@@ -506,9 +503,8 @@ impl TryFrom<NumberAsString> for BondArpAllTargets {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid arp_all_targets value {}, should be \
-                    0, any, 1 or all",
-                    v
+                    "Invalid arp_all_targets value {v}, should be \
+                    0, any, 1 or all"
                 ),
             )),
         }
@@ -582,10 +578,9 @@ impl TryFrom<NumberAsString> for BondArpValidate {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid arp_validate value {}, should be \
+                    "Invalid arp_validate value {v}, should be \
                     0, none, 1, active, 2, backup, 3, all, 4, filter, 5, \
-                    filter_active, 6 or filter_backup",
-                    v
+                    filter_active, 6 or filter_backup"
                 ),
             )),
         }
@@ -652,9 +647,8 @@ impl TryFrom<NumberAsString> for BondFailOverMac {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid fail_over_mac value: {}, should be \
-                    0, none, 1, active, 2 or follow",
-                    v
+                    "Invalid fail_over_mac value: {v}, should be \
+                    0, none, 1, active, 2 or follow"
                 ),
             )),
         }
@@ -711,9 +705,8 @@ impl TryFrom<NumberAsString> for BondPrimaryReselect {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid primary_reselect vlaue {}, should be \
-                    0, always, 1, better, 2 or failure",
-                    v
+                    "Invalid primary_reselect vlaue {v}, should be \
+                    0, always, 1, better, 2 or failure"
                 ),
             )),
         }
@@ -779,10 +772,9 @@ impl TryFrom<NumberAsString> for BondXmitHashPolicy {
             v => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid xmit_hash_policy value {}, should be \
+                    "Invalid xmit_hash_policy value {v}, should be \
                     0, layer2, 1, layer34, 2, layer23, 3, encap2+3, 4, \
-                    encap3+4, 5, vlan+srcmac",
-                    v
+                    encap3+4, 5, vlan+srcmac"
                 ),
             )),
         }

--- a/rust/src/lib/ifaces/bridge_vlan.rs
+++ b/rust/src/lib/ifaces/bridge_vlan.rs
@@ -106,23 +106,20 @@ impl<'de> Deserialize<'de> for BridgePortTunkTag {
                 Ok(Self::Id(id.parse::<u16>().map_err(|e| {
                     serde::de::Error::custom(format!(
                         "Failed to parse BridgePortTunkTag id \
-                        {} as u16: {}",
-                        id, e
+                        {id} as u16: {e}"
                     ))
                 })?))
             } else if let Some(id) = id.as_u64() {
                 Ok(Self::Id(u16::try_from(id).map_err(|e| {
                     serde::de::Error::custom(format!(
                         "Failed to parse BridgePortTunkTag id \
-                        {} as u16: {}",
-                        id, e
+                        {id} as u16: {e}"
                     ))
                 })?))
             } else {
                 Err(serde::de::Error::custom(format!(
                     "The id of BridgePortTunkTag should be \
-                    unsigned 16 bits integer, but got {}",
-                    v
+                    unsigned 16 bits integer, but got {v}"
                 )))
             }
         } else if let Some(id_range) = v.get("id-range") {
@@ -133,8 +130,7 @@ impl<'de> Deserialize<'de> for BridgePortTunkTag {
         } else {
             Err(serde::de::Error::custom(format!(
                 "BridgePortTunkTag only support 'id' or 'id-range', \
-                but got {}",
-                v
+                but got {v}"
             )))
         }
     }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -298,9 +298,8 @@ impl Interfaces {
                         let e = NmstateError::new(
                             ErrorKind::InvalidArgument,
                             format!(
-                                "Failed to find mac address of interface {} \
-                                for copy-mac-from of iface {}",
-                                src_iface_name, iface_name
+                                "Failed to find mac address of interface {src_iface_name} \
+                                for copy-mac-from of iface {iface_name}"
                             ),
                         );
                         log::error!("{}", e);
@@ -310,9 +309,8 @@ impl Interfaces {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Failed to find interface {} for \
-                            copy-mac-from of iface {}",
-                            src_iface_name, iface_name
+                            "Failed to find interface {src_iface_name} for \
+                            copy-mac-from of iface {iface_name}"
                         ),
                     );
                     log::error!("{}", e);

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -131,9 +131,8 @@ pub(crate) fn handle_changed_ports(
                                 return Err(NmstateError::new(
                                     ErrorKind::InvalidArgument,
                                     format!(
-                                        "Interface {} is holding unknown \
-                                        port {}",
-                                        ctrl_name, iface_name
+                                        "Interface {ctrl_name} is holding unknown \
+                                        port {iface_name}"
                                     ),
                                 ));
                             }
@@ -401,8 +400,7 @@ fn is_port_overbook(
         let e = NmstateError::new(
             ErrorKind::InvalidArgument,
             format!(
-                "Port {} is overbooked by two controller: {}, {}",
-                port, ctrl, cur_ctrl
+                "Port {port} is overbooked by two controller: {ctrl}, {cur_ctrl}"
             ),
         );
         log::error!("{}", e);

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -529,9 +529,8 @@ impl FromStr for LinuxBridgeMulticastRouterType {
             _ => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid linux bridge multicast_router type {}, \
-                    expecting 0|1|2 or auto|disabled|enabled",
-                    s
+                    "Invalid linux bridge multicast_router type {s}, \
+                    expecting 0|1|2 or auto|disabled|enabled"
                 ),
             )),
         }
@@ -548,9 +547,8 @@ impl TryFrom<u64> for LinuxBridgeMulticastRouterType {
             _ => Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid linux bridge multicast_router type {}, \
-                    expecting 0|1|2 or auto|disabled|enabled",
-                    value
+                    "Invalid linux bridge multicast_router type {value}, \
+                    expecting 0|1|2 or auto|disabled|enabled"
                 ),
             )),
         }

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -136,8 +136,7 @@ impl<'de> Deserialize<'de> for NetworkState {
             Some(v) => v,
             None => {
                 return Err(serde::de::Error::custom(format!(
-                    "Expecting a HashMap/Object/Dictionary, but got {}",
-                    v
+                    "Expecting a HashMap/Object/Dictionary, but got {v}"
                 )));
             }
         };
@@ -506,8 +505,7 @@ impl NetworkState {
                 let e = NmstateError::new(
                     ErrorKind::InvalidArgument,
                     format!(
-                    "Failed to find a interface for desired routes rules {:?} ",
-                    rules
+                    "Failed to find a interface for desired routes rules {rules:?} "
                 ),
                 );
                 log::error!("{}", e);
@@ -636,9 +634,8 @@ impl NetworkState {
                 let e = NmstateError::new(
                     ErrorKind::InvalidArgument,
                     format!(
-                        "Route table {} for route rule is not defined by \
-                        any routes",
-                        table_id
+                        "Route table {table_id} for route rule is not defined by \
+                        any routes"
                     ),
                 );
                 log::error!("{}", e);

--- a/rust/src/lib/nispor/mptcp.rs
+++ b/rust/src/lib/nispor/mptcp.rs
@@ -106,8 +106,7 @@ impl std::convert::TryFrom<nispor::MptcpAddressFlag> for MptcpAddressFlag {
             _ => Err(NmstateError::new(
                 ErrorKind::NotSupportedError,
                 format!(
-                    "MPTCP address flag {:?} is not supported by nmstate yet",
-                    value
+                    "MPTCP address flag {value:?} is not supported by nmstate yet"
                 ),
             )),
         }

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -82,8 +82,7 @@ pub(crate) fn nm_gen_conf(
                 return Err(NmstateError::new(
                     ErrorKind::PluginFailure,
                     format!(
-                        "Bug in NM plugin, failed to generate configure: {}",
-                        e
+                        "Bug in NM plugin, failed to generate configure: {e}"
                     ),
                 ));
             }

--- a/rust/src/lib/nm/nm_dbus/active_connection.rs
+++ b/rust/src/lib/nm/nm_dbus/active_connection.rs
@@ -29,8 +29,7 @@ fn nm_ac_obj_path_state_flags_get(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve StateFlags of active connection {}: {}",
-                obj_path, e
+                "Failed to retrieve StateFlags of active connection {obj_path}: {e}"
             ),
         )),
     }
@@ -51,8 +50,7 @@ pub(crate) fn nm_ac_obj_path_uuid_get(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve UUID of active connection {}: {}",
-                obj_path, e
+                "Failed to retrieve UUID of active connection {obj_path}: {e}"
             ),
         )),
     }

--- a/rust/src/lib/nm/nm_dbus/connection/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/dns.rs
@@ -59,8 +59,7 @@ pub(crate) fn parse_nm_dns(
                     ErrorKind::InvalidArgument,
                     format!(
                         "Failed to convert to IP address: \
-                        invalid signature {:?}",
-                        s
+                        invalid signature {s:?}"
                     ),
                 );
                 log::error!("{}", e);

--- a/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
@@ -97,8 +97,7 @@ impl NmSetting8021X {
                     ErrorKind::InvalidArgument,
                     format!(
                         "Failed to parse glib bytes to UTF-8 string: \
-                        {:?}: {:?}",
-                        value, e
+                        {value:?}: {e:?}"
                     ),
                 );
                 log::error!("{}", e);
@@ -112,8 +111,7 @@ impl NmSetting8021X {
             let e = NmError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Specified glib bytes is started with {}: {:?}",
-                    GLIB_FILE_PATH_PREFIX, value
+                    "Specified glib bytes is started with {GLIB_FILE_PATH_PREFIX}: {value:?}"
                 ),
             );
             log::error!("{}", e);

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -70,10 +70,7 @@ impl TryFrom<String> for NmVlanProtocol {
                 let e = NmError::new(
                     ErrorKind::InvalidArgument,
                     format!(
-                        "Invalid VLAN protocol {}, only support: {} and {}",
-                        vlan_protocol,
-                        NM_VLAN_PROTOCOL_802_1Q,
-                        NM_VLAN_PROTOCOL_802_1AD
+                        "Invalid VLAN protocol {vlan_protocol}, only support: {NM_VLAN_PROTOCOL_802_1Q} and {NM_VLAN_PROTOCOL_802_1AD}"
                     ),
                 );
                 error!("{}", e);

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -146,8 +146,7 @@ impl<'a> NmDbus<'a> {
                 if let zbus::Error::MethodError(ref error_type, ..) = e {
                     if error_type
                         == &format!(
-                            "{}.Settings.InvalidConnection",
-                            NM_DBUS_INTERFACE_ROOT,
+                            "{NM_DBUS_INTERFACE_ROOT}.Settings.InvalidConnection",
                         )
                     {
                         Err(NmError::new(
@@ -324,8 +323,7 @@ impl<'a> NmDbus<'a> {
                 {
                     if error_type
                         == &format!(
-                            "{}.Device.IncompatibleConnection",
-                            NM_DBUS_INTERFACE_ROOT
+                            "{NM_DBUS_INTERFACE_ROOT}.Device.IncompatibleConnection"
                         )
                     {
                         Err(NmError::new(

--- a/rust/src/lib/nm/nm_dbus/device.rs
+++ b/rust/src/lib/nm/nm_dbus/device.rs
@@ -405,8 +405,7 @@ fn nm_dev_name_get(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve interface name of device {}: {}",
-                obj_path, e
+                "Failed to retrieve interface name of device {obj_path}: {e}"
             ),
         )),
     }
@@ -459,10 +458,7 @@ fn nm_dev_iface_type_get(
         }),
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
-            format!(
-                "Failed to retrieve device type of device {}: {}",
-                obj_path, e
-            ),
+            format!("Failed to retrieve device type of device {obj_path}: {e}"),
         )),
     }
 }
@@ -482,8 +478,7 @@ fn nm_dev_state_reason_get(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve state reason of device {}: {}",
-                obj_path, e
+                "Failed to retrieve state reason of device {obj_path}: {e}"
             ),
         )),
     }
@@ -505,8 +500,7 @@ fn nm_dev_is_mac_vtap_get(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve Macvlan.Tab(tap) of device {}: {}",
-                obj_path, e
+                "Failed to retrieve Macvlan.Tab(tap) of device {obj_path}: {e}"
             ),
         )),
     }
@@ -592,8 +586,7 @@ pub(crate) fn nm_dev_get_llpd(
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
             format!(
-                "Failed to retrieve LLDP neighbors of device {}: {}",
-                obj_path, e
+                "Failed to retrieve LLDP neighbors of device {obj_path}: {e}"
             ),
         )),
     }

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -188,8 +188,7 @@ impl<'a> NmApi<'a> {
             Err(NmError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Failed to extract interface name from connection {:?}",
-                    nm_conn
+                    "Failed to extract interface name from connection {nm_conn:?}"
                 ),
             ))
         }

--- a/rust/src/lib/nm/query/dns.rs
+++ b/rust/src/lib/nm/query/dns.rs
@@ -21,7 +21,7 @@ pub(crate) fn nm_dns_to_nmstate(
         for srv in srvs {
             if let Ok(ip) = std::net::Ipv6Addr::from_str(srv.as_str()) {
                 if is_ipv6_unicast_link_local(&ip) {
-                    servers.push(format!("{}%{}", srv, iface_name));
+                    servers.push(format!("{srv}%{iface_name}"));
                 } else {
                     servers.push(srv.to_string());
                 }

--- a/rust/src/lib/nm/settings/inter_connections.rs
+++ b/rust/src/lib/nm/settings/inter_connections.rs
@@ -107,8 +107,7 @@ pub(crate) fn use_uuid_for_controller_reference(
                     ErrorKind::Bug,
                     format!(
                         "Failed to find OVS Bridge interface for \
-                        NmConnection {:?}",
-                        nm_conn
+                        NmConnection {nm_conn:?}"
                     ),
                 );
                 log::error!("{}", e);
@@ -125,8 +124,7 @@ pub(crate) fn use_uuid_for_controller_reference(
                 ErrorKind::Bug,
                 format!(
                     "BUG: Failed to find UUID of controller connection: \
-                {}, {}",
-                    ctrl_name, ctrl_type
+                {ctrl_name}, {ctrl_type}"
                 ),
             );
             log::error!("{}", e);

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -43,8 +43,7 @@ impl<'de> Deserialize<'de> for OvsDbGlobalConfig {
             }
         } else {
             return Err(serde::de::Error::custom(format!(
-                "Expecting dict/HashMap, but got {:?}",
-                v
+                "Expecting dict/HashMap, but got {v:?}"
             )));
         }
         Ok(ret)
@@ -85,8 +84,7 @@ impl<'de> Deserialize<'de> for OvsDbIfaceConfig {
             }
         } else {
             return Err(serde::de::Error::custom(format!(
-                "Expecting dict/HashMap, but got {:?}",
-                v
+                "Expecting dict/HashMap, but got {v:?}"
             )));
         }
         Ok(ret)

--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -119,9 +119,8 @@ impl OvsDbConnection {
                     let e = NmstateError::new(
                         ErrorKind::PluginFailure,
                         format!(
-                            "Invalid reply from OVSDB for querying {} \
-                            table: {:?}",
-                            table_name, reply
+                            "Invalid reply from OVSDB for querying {table_name} \
+                            table: {reply:?}"
                         ),
                     );
                     log::error!("{}", e);
@@ -132,8 +131,7 @@ impl OvsDbConnection {
                 let e = NmstateError::new(
                     ErrorKind::PluginFailure,
                     format!(
-                        "Invalid reply from OVSDB for querying {} table: {:?}",
-                        table_name, reply
+                        "Invalid reply from OVSDB for querying {table_name} table: {reply:?}"
                     ),
                 );
                 log::error!("{}", e);
@@ -183,8 +181,7 @@ impl OvsDbConnection {
                     let e = NmstateError::new(
                         ErrorKind::PluginFailure,
                         format!(
-                        "Invalid reply from OVSDB for querying {} table: {:?}",
-                        GLOBAL_CONFIG_TABLE, reply
+                        "Invalid reply from OVSDB for querying {GLOBAL_CONFIG_TABLE} table: {reply:?}"
                     ),
                     );
                     log::error!("{}", e);
@@ -195,8 +192,7 @@ impl OvsDbConnection {
                 let e = NmstateError::new(
                     ErrorKind::PluginFailure,
                     format!(
-                        "Invalid reply from OVSDB for querying {} table: {:?}",
-                        GLOBAL_CONFIG_TABLE, reply
+                        "Invalid reply from OVSDB for querying {GLOBAL_CONFIG_TABLE} table: {reply:?}"
                     ),
                 );
                 log::error!("{}", e);

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -92,8 +92,7 @@ impl OvsDbJsonRpc {
             let e = NmstateError::new(
                 ErrorKind::PluginFailure,
                 format!(
-                    "Transaction ID mismatch for OVS DB JSON RPC: {:?}",
-                    reply
+                    "Transaction ID mismatch for OVS DB JSON RPC: {reply:?}"
                 ),
             );
             log::error!("{}", e);
@@ -148,8 +147,7 @@ fn check_transact_error(reply: Value) -> Result<Value, NmstateError> {
                 let e = NmstateError::new(
                     ErrorKind::PluginFailure,
                     format!(
-                        "OVS DB JSON RPC error {}: {}",
-                        error_type, error_detail
+                        "OVS DB JSON RPC error {error_type}: {error_detail}"
                     ),
                 );
                 log::error!("{}", e);

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -43,8 +43,7 @@ impl<'de> Deserialize<'de> for NetworkCaptureRules {
                 ));
             } else {
                 return Err(serde::de::Error::custom(format!(
-                    "Expecting a string, but got {}",
-                    v
+                    "Expecting a string, but got {v}"
                 )));
             }
         }
@@ -159,7 +158,7 @@ impl NetworkCaptureCommand {
                 cap.clone()
             } else {
                 return Err(NmstateError::new_policy_error(
-                    format!("Capture {} not found", cap_name),
+                    format!("Capture {cap_name} not found"),
                     self.line.as_str(),
                     self.key_capture_pos,
                 ));
@@ -177,9 +176,8 @@ impl NetworkCaptureCommand {
                         NmstateError::new(
                             ErrorKind::Bug,
                             format!(
-                                "Failed to convert NetworkState {:?} \
-                                 to serde_json value: {}",
-                                input, e
+                                "Failed to convert NetworkState {input:?} \
+                                 to serde_json value: {e}"
                             ),
                         )
                     })?;
@@ -188,9 +186,8 @@ impl NetworkCaptureCommand {
                     NmstateError::new(
                         ErrorKind::Bug,
                         format!(
-                            "Failed to convert NetworkState {:?} \
-                             from serde_json value: {:?}",
-                            input_value, e
+                            "Failed to convert NetworkState {input_value:?} \
+                             from serde_json value: {e:?}"
                         ),
                     )
                 });
@@ -281,7 +278,7 @@ impl NetworkCaptureCommand {
             Some(v) => {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
-                    format!("Unsupported capture keyword '{}'", v),
+                    format!("Unsupported capture keyword '{v}'"),
                 ));
             }
             None => {
@@ -335,9 +332,8 @@ pub(crate) fn get_value(
                     NmstateError::new(
                         ErrorKind::Bug,
                         format!(
-                            "Failed to convert NetworkState {:?} \
-                            to serde_json value: {}",
-                            state, e
+                            "Failed to convert NetworkState {state:?} \
+                            to serde_json value: {e}"
                         ),
                     )
                 })?
@@ -349,8 +345,7 @@ pub(crate) fn get_value(
                 None => Err(NmstateError::new(
                     ErrorKind::Bug,
                     format!(
-                        "Failed to convert NetworkState {:?} to serde_json map",
-                        state,
+                        "Failed to convert NetworkState {state:?} to serde_json map",
                     ),
                 )),
             }
@@ -483,8 +478,7 @@ fn get_condition_value(
                             captured data, the correct format should be \
                             'interfaces.name == \
                             capture.default-gw.interfaces.0.name', \
-                            but got: {}",
-                            line
+                            but got: {line}"
                         ),
                     ));
                 }
@@ -504,8 +498,7 @@ fn get_condition_value(
             ErrorKind::InvalidArgument,
             format!(
                 "The equal action should end with single value or \
-                property path but got: {}",
-                line
+                property path but got: {line}"
             ),
         )),
     }

--- a/rust/src/lib/policy/json.rs
+++ b/rust/src/lib/policy/json.rs
@@ -148,7 +148,7 @@ fn get_leaf_array_value(
         Some(l) => l,
         None => {
             return Err(NmstateError::new_policy_error(
-                format!("Failed to find index {} from {}", index, item_name),
+                format!("Failed to find index {index} from {item_name}"),
                 line,
                 pos,
             ));
@@ -161,14 +161,11 @@ fn get_leaf_array_value(
             prop_path,
             leaf,
             line,
-            pos + format!("{}.", index).chars().count(),
+            pos + format!("{index}.").chars().count(),
         )
     } else {
         Err(NmstateError::new_policy_error(
-            format!(
-                "The {} index {} leaf data is not a object",
-                item_name, index
-            ),
+            format!("The {item_name} index {index} leaf data is not a object"),
             line,
             pos,
         ))
@@ -287,8 +284,7 @@ where
         let mut item_value = serde_json::to_value(item).map_err(|e| {
             NmstateError::new_policy_error(
                 format!(
-                    "Failed to convert {:?} item into serde_json value: {}",
-                    item, e
+                    "Failed to convert {item:?} item into serde_json value: {e}"
                 ),
                 line,
                 pos,
@@ -304,8 +300,7 @@ where
                     NmstateError::new(
                         ErrorKind::Bug,
                         format!(
-                            "Failed to deserialize {:?} into {}: {}",
-                            item_value, item_name, e
+                            "Failed to deserialize {item_value:?} into {item_name}: {e}"
                         ),
                     )
                 })?,

--- a/rust/src/lib/policy/template.rs
+++ b/rust/src/lib/policy/template.rs
@@ -45,7 +45,7 @@ impl NetworkStateTemplate {
             desire_state_value.drain(),
         ))
         .map_err(|e| {
-            NmstateError::new(ErrorKind::InvalidArgument, format!("{}", e))
+            NmstateError::new(ErrorKind::InvalidArgument, format!("{e}"))
         })
     }
 }
@@ -103,7 +103,7 @@ fn resolve_capture_data(
                             }
                         }
                     }
-                    write!(new_value, "{}", resolved).ok();
+                    write!(new_value, "{resolved}").ok();
                     if token_end_pos < tokens.len() - 1 {
                         println!("HAHA {:?}", &tokens);
                         for token in &tokens[token_end_pos + 1..] {

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -13,8 +13,7 @@ impl DnsState {
                     NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Failed to apply DNS config: desire {:?} got {:?}",
-                            self, current
+                            "Failed to apply DNS config: desire {self:?} got {current:?}"
                         ),
                     )
                 })?;
@@ -54,8 +53,7 @@ impl DnsState {
                     NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Failed to apply DNS config: desire {:?} got {:?}",
-                            self, current
+                            "Failed to apply DNS config: desire {self:?} got {current:?}"
                         ),
                     )
                 })?;

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -111,8 +111,7 @@ impl Interface {
             Err(NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(
-                    "Verification failure: {} desire '{}', current '{}'",
-                    reference, desire, current
+                    "Verification failure: {reference} desire '{desire}', current '{current}'"
                 ),
             ))
         } else {

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -301,9 +301,8 @@ impl Interfaces {
                         let e = NmstateError::new(
                             ErrorKind::InvalidArgument,
                             format!(
-                                "Failed to find unknown type interface {} \
-                                in current state",
-                                iface_name
+                                "Failed to find unknown type interface {iface_name} \
+                                in current state"
                             ),
                         );
                         log::error!("{}", e);

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -21,8 +21,7 @@ impl OvsDbGlobalConfig {
             let e = NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(
-                    "Verification failure: {} desire '{}', current '{}'",
-                    reference, desire, current
+                    "Verification failure: {reference} desire '{desire}', current '{current}'"
                 ),
             );
             log::error!("{}", e);

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -35,8 +35,7 @@ impl Routes {
                     let e = NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Desired route {:?} not found after apply",
-                            desire_route
+                            "Desired route {desire_route:?} not found after apply"
                         ),
                     );
                     log::error!("{}", e);
@@ -67,9 +66,8 @@ impl Routes {
                     let e = NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Desired absent route {:?} still found \
-                            after apply: {:?}",
-                            absent_route, cur_route
+                            "Desired absent route {absent_route:?} still found \
+                            after apply: {cur_route:?}"
                         ),
                     );
                     log::error!("{}", e);

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -225,9 +225,8 @@ fn parse_sriov_vf_naming(
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Invalid SR-IOV VF ID in {}, correct format \
-                            is 'sriov:<pf_name>:<vf_id>', error: {}",
-                            iface_name, e
+                            "Invalid SR-IOV VF ID in {iface_name}, correct format \
+                            is 'sriov:<pf_name>:<vf_id>', error: {e}"
                         ),
                     );
                     log::error!("{}", e);
@@ -238,9 +237,8 @@ fn parse_sriov_vf_naming(
             let e = NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Invalid SR-IOV VF name {}, correct format is \
+                    "Invalid SR-IOV VF name {iface_name}, correct format is \
                     'sriov:<pf_name>:<vf_id>'",
-                    iface_name,
                 ),
             );
             log::error!("{}", e);

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -71,8 +71,7 @@ impl Routes {
                         ErrorKind::NotImplementedError,
                         format!(
                             "Route with empty next hop interface \
-                        is not supported: {:?}",
-                            route
+                        is not supported: {route:?}"
                         ),
                     );
                     error!("{}", e);

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -71,8 +71,7 @@ impl RouteRules {
                     let e = NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Desired route rule {:?} not found after apply",
-                            rule
+                            "Desired route rule {rule:?} not found after apply"
                         ),
                     );
                     log::error!("{}", e);
@@ -96,9 +95,8 @@ impl RouteRules {
                     let e = NmstateError::new(
                         ErrorKind::VerificationError,
                         format!(
-                            "Desired absent route rule {:?} still found \
-                            after apply: {:?}",
-                            absent_rule, cur_rule
+                            "Desired absent route rule {absent_rule:?} still found \
+                            after apply: {cur_rule:?}"
                         ),
                     );
                     log::error!("{}", e);
@@ -295,8 +293,7 @@ impl RouteRuleEntry {
             let e = NmstateError::new(
                 ErrorKind::InvalidArgument,
                 format!(
-                    "Neither ip-from, ip-to nor family is defined {:?}",
-                    self
+                    "Neither ip-from, ip-to nor family is defined {self:?}"
                 ),
             );
             log::error!("{}", e);
@@ -308,8 +305,7 @@ impl RouteRuleEntry {
                 {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
-                        format!("The ip-from format mismatches with the family set {:?}",
-                                self
+                        format!("The ip-from format mismatches with the family set {self:?}"
                         ),
                     );
                     log::error!("{}", e);
@@ -322,8 +318,7 @@ impl RouteRuleEntry {
                 {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
-                        format!("The ip-to format mismatches with the family set {:?}",
-                                self
+                        format!("The ip-to format mismatches with the family set {self:?}"
                         ),
                     );
                     log::error!("{}", e);
@@ -334,8 +329,7 @@ impl RouteRuleEntry {
         if self.fwmark.is_none() && self.fwmask.is_some() {
             let e = NmstateError::new(
                 ErrorKind::InvalidArgument,
-                format!("fwmask is present but fwmark is not defined or is zero {:?}",
-                        self
+                format!("fwmask is present but fwmark is not defined or is zero {self:?}"
                 ),
             );
             log::error!("{}", e);

--- a/rust/src/lib/unit_tests/policy/error.rs
+++ b/rust/src/lib/unit_tests/policy/error.rs
@@ -180,7 +180,7 @@ fn test_policy_equal_got_2_values() {
     let result = NetworkCaptureCommand::parse(line);
     assert!(result.is_err());
     if let Err(e) = result {
-        println!("HAHA {}", e);
+        println!("HAHA {e}");
         assert_eq!(e.kind(), ErrorKind::PolicyError);
         assert_eq!(e.line(), line);
         assert_eq!(e.position(), "interface.name == \"e".len() - 1);
@@ -447,7 +447,7 @@ fn test_policy_ilegal_char() {
     let result = NetworkCaptureCommand::parse(line);
     assert!(result.is_err());
     if let Err(e) = result {
-        println!("HAHA {}", e);
+        println!("HAHA {e}");
         assert_eq!(e.kind(), ErrorKind::PolicyError);
         assert_eq!(e.line(), line);
         assert_eq!(e.position(), "capture.abc | interface.name==-".len() - 1);

--- a/rust/src/lib/unit_tests/policy/example.rs
+++ b/rust/src/lib/unit_tests/policy/example.rs
@@ -20,7 +20,7 @@ fn test_policy_examples() {
     for entry in std::fs::read_dir(folded_path).unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();
-        println!("Testing {:?}", path);
+        println!("Testing {path:?}");
         let current_state = load_state(&path.join(CURRENT_YAML_FILENAME));
         let mut policy = load_policy(&path.join(POLICY_YAML_FILENAME));
         let expected_state = load_state(&path.join(EXPECTED_YAML_FILENAME));
@@ -28,18 +28,18 @@ fn test_policy_examples() {
         policy.current = Some(current_state);
         let state = NetworkState::try_from(policy).unwrap();
         assert_eq!(state, expected_state);
-        println!("Pass    {:?}", path);
+        println!("Pass    {path:?}");
     }
 }
 
 fn load_policy(file_path: &Path) -> NetworkPolicy {
-    println!("Loading NetworkPolicy from {:?}", file_path);
+    println!("Loading NetworkPolicy from {file_path:?}");
     let fd = std::fs::File::open(file_path).unwrap();
     serde_yaml::from_reader(fd).unwrap()
 }
 
 fn load_state(file_path: &Path) -> NetworkState {
-    println!("Loading NetworkState from {:?}", file_path);
+    println!("Loading NetworkState from {file_path:?}");
     let fd = std::fs::File::open(file_path).unwrap();
     serde_yaml::from_reader(fd).unwrap()
 }

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1446,25 +1446,13 @@ def test_ipv6_link_local_dns_srv(dhcpcli_up_with_dynamic_ip):
     assert _poll(_has_dhcpv4_addr)
     assert _poll(_has_dhcpv6_addr)
     new_state = libnmstate.show()
-    if is_k8s():
-        # K8S CI has an TUN interface configured as auto_dns: true,
-        # which is not configurable by nmstate, hence we only make sure
-        # the first two DNS server is what we desired
-        assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER][:2] == [
-            IPV6_DNS_NAMESERVER,
-            IPV6_DNS_NAMESERVER_LOCAL,
-        ]
-        assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER][:2] == [
-            IPV6_DNS_NAMESERVER,
-            IPV6_DNS_NAMESERVER_LOCAL,
-        ]
-
-    else:
-        assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER] == [
-            IPV6_DNS_NAMESERVER,
-            IPV6_DNS_NAMESERVER_LOCAL,
-        ]
-        assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER] == [
-            IPV6_DNS_NAMESERVER,
-            IPV6_DNS_NAMESERVER_LOCAL,
-        ]
+    # K8S and NM CI has an extra interface configured as auto_dns: true,
+    # which will append extra DNS entries to what we desired
+    assert new_state[DNS.KEY][DNS.CONFIG][DNS.SERVER][:2] == [
+        IPV6_DNS_NAMESERVER,
+        IPV6_DNS_NAMESERVER_LOCAL,
+    ]
+    assert new_state[DNS.KEY][DNS.RUNNING][DNS.SERVER][:2] == [
+        IPV6_DNS_NAMESERVER,
+        IPV6_DNS_NAMESERVER_LOCAL,
+    ]


### PR DESCRIPTION
NMCI also has extra interface configured as auto dns which fails the
`test_ipv6_link_local_dns_srv`.

Fixed by only check first two dns servers for desired.