### PR TITLE
test: Include test script for NMCI to run tier1 test

### DIFF
--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -ex
+
+EXEC_DIR=$(dirname "$(realpath "$0")")
+PROJECT_DIR="$(dirname $EXEC_DIR)"
+TEST_CMD="${EXEC_DIR}/run-tests.sh"
+
+options=$(getopt --options "" \
+    --long "copr:,rpm-dir:,help,debug-shell" \
+    -- "${@}")
+eval set -- "$options"
+while true; do
+    case "$1" in
+    --copr)
+        shift
+        NM_COPR="$1"
+        ;;
+    --rpm-dir)
+        shift
+        NM_RPM_DIR="$1"
+        ;;
+    --debug-shell)
+        debug_exit_shell="1"
+        ;;
+    --help)
+        set +x
+        echo -n "$0 [--copr=...] [--rpm-dir=...] [--debug-shell]"
+        echo
+        exit
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+echo $NM_COPR
+echo $NM_RPM_DIR
+
+ARGS="--test-type integ_tier1 --el9"
+if [[ -v NM_COPR ]];then
+    ARGS="$ARGS --copr $NM_COPR"
+fi
+
+if [[ -v NM_RPM_DIR ]];then
+    ARGS="$ARGS --nm-rpm-dir $NM_RPM_DIR"
+fi
+
+if [[ -v debug_exit_shell ]];then
+    ARGS="$ARGS --debug-shell"
+fi
+
+cd $PROJECT_DIR
+env CONTAINER_CMD="podman" $TEST_CMD $ARGS


### PR DESCRIPTION
The `automation/run-tests-in-nmci.sh` will be used for NMCI allowing two
arguments:
 * `--copr <copr_repo_name>`: Install NM rpm via copr
 * `--rpm-dir <rpm_dir>`: Install NM rpm from folder
 * `--debug-shell`: Provide a shell for debugging after tests

Will only run tier 1 tests using CentOS stream 9 container.