### PR TITLE
test: nmci should have CI=true set

### DIFF
--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -52,4 +52,4 @@ if [[ -v debug_exit_shell ]];then
 fi
 
 cd $PROJECT_DIR
-env CONTAINER_CMD="podman" $TEST_CMD $ARGS
+env CONTAINER_CMD="podman" CI="true" $TEST_CMD $ARGS


### PR DESCRIPTION
Like github CI, NMCI container also has limitation on hostname dns and
etc, hence set `CI=true` environment.