### PR TITLE
ovs: Fix error when moving OVS system interface to linux bridge

### DIFF
--- a/rust/src/lib/nm/query/mod.rs
+++ b/rust/src/lib/nm/query/mod.rs
@@ -23,7 +23,8 @@ pub(crate) use self::mptcp::{
     is_mptcp_flags_changed, is_mptcp_supported, remove_nm_mptcp_set,
 };
 pub(crate) use self::ovs::{
-    get_ovs_dpdk_config, get_ovs_patch_config, nm_ovs_bridge_conf_get,
+    get_orphan_ovs_port_uuids, get_ovs_dpdk_config, get_ovs_patch_config,
+    nm_ovs_bridge_conf_get,
 };
 pub(crate) use self::route::is_route_removed;
 pub(crate) use self::user::get_description;

--- a/rust/src/lib/nm/query/ovs.rs
+++ b/rust/src/lib/nm/query/ovs.rs
@@ -2,13 +2,16 @@
 
 use std::convert::TryFrom;
 
-use super::super::nm_dbus::NmConnection;
+use super::super::{
+    nm_dbus::NmConnection,
+    settings::{get_exist_profile, NM_SETTING_OVS_PORT_SETTING_NAME},
+};
 
 use crate::{
-    BridgePortVlanConfig, BridgePortVlanMode, NmstateError,
-    OvsBridgeBondConfig, OvsBridgeBondMode, OvsBridgeBondPortConfig,
-    OvsBridgeConfig, OvsBridgeOptions, OvsBridgePortConfig, OvsDpdkConfig,
-    OvsPatchConfig,
+    BridgePortVlanConfig, BridgePortVlanMode, Interface, InterfaceType,
+    Interfaces, NmstateError, OvsBridgeBondConfig, OvsBridgeBondMode,
+    OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeOptions,
+    OvsBridgePortConfig, OvsDpdkConfig, OvsPatchConfig,
 };
 
 pub(crate) fn nm_ovs_bridge_conf_get(
@@ -232,4 +235,60 @@ pub(crate) fn get_ovs_dpdk_config(
         }
     }
     None
+}
+
+// When OVS system interface got detached from OVS bridge, we should remove its
+// ovs port also.
+pub(crate) fn get_orphan_ovs_port_uuids<'a>(
+    ifaces: &Interfaces,
+    cur_ifaces: &Interfaces,
+    exist_nm_conns: &'a [NmConnection],
+) -> Vec<&'a str> {
+    let mut ret = Vec::new();
+    for iface in ifaces.kernel_ifaces.values().filter(|i| {
+        i.base_iface().controller_type.is_some()
+            && i.base_iface().controller_type.as_ref()
+                != Some(&InterfaceType::OvsBridge)
+            && iface_was_ovs_sys_iface(i, cur_ifaces)
+    }) {
+        if let Some(exist_profile) = get_exist_profile(
+            exist_nm_conns,
+            iface.name(),
+            &iface.iface_type(),
+            &Vec::new(),
+        ) {
+            if exist_profile
+                .connection
+                .as_ref()
+                .and_then(|c| c.controller_type.as_ref())
+                == Some(&NM_SETTING_OVS_PORT_SETTING_NAME.to_string())
+            {
+                if let Some(parent) = exist_profile
+                    .connection
+                    .as_ref()
+                    .and_then(|c| c.controller.as_ref())
+                {
+                    // We only touch port profiles created by nmstate which is
+                    // using UUID for parent reference.
+                    if uuid::Uuid::parse_str(parent).is_ok() {
+                        log::info!(
+                            "Deleting orphan OVS port connection {} \
+                            as interface {}({}) detached from OVS bridge",
+                            parent,
+                            iface.name(),
+                            iface.iface_type()
+                        );
+                        ret.push(parent.as_str())
+                    }
+                }
+            }
+        }
+    }
+    ret
+}
+
+fn iface_was_ovs_sys_iface(iface: &Interface, cur_ifaces: &Interfaces) -> bool {
+    cur_ifaces.kernel_ifaces.get(iface.name()).map(|i| {
+        i.base_iface().controller_type == Some(InterfaceType::OvsBridge)
+    }) == Some(true)
 }

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -303,9 +303,7 @@ fn test_overbook_port_used_in_current_bridge() {
     let mut desired = Interfaces::new();
     desired.push(bridge_with_ports("br1", &["eth0"]));
 
-    let result = check_overbook_ports(&desired, &current);
-    assert!(result.is_err());
-    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+    check_overbook_ports(&desired, &current).unwrap();
 }
 
 #[test]
@@ -320,9 +318,7 @@ fn test_overbook_port_used_in_current_bond() {
     let mut desired = Interfaces::new();
     desired.push(bond_with_ports("bond1", &["eth0"]));
 
-    let result = check_overbook_ports(&desired, &current);
-    assert!(result.is_err());
-    assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
+    check_overbook_ports(&desired, &current).unwrap();
 }
 
 #[test]

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -12,6 +12,7 @@ from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
+from libnmstate.schema import LinuxBridge
 from libnmstate.schema import MacVlan
 from libnmstate.schema import MacVtap
 from libnmstate.schema import OVSBridge
@@ -30,6 +31,7 @@ from .testlib import cmdlib
 from .testlib import iprule
 from .testlib import statelib
 from .testlib.bondlib import bond_interface
+from .testlib.bridgelib import linux_bridge
 from .testlib.env import is_k8s
 from .testlib.env import nm_major_minor_version
 from .testlib.genconf import gen_conf_apply
@@ -1364,3 +1366,20 @@ def test_add_port_to_ovs_br_with_controller_property(
     assert len(br_ports) == 2
     assert br_ports[0][OVSBridge.Port.NAME] == BRIDGE1
     assert br_ports[1][OVSBridge.Port.NAME] == "eth2"
+
+
+def test_move_ovs_sys_iface_to_linux_bridge(bridge_with_ports):
+    bridge_config = {
+        LinuxBridge.OPTIONS_SUBTREE: {
+            LinuxBridge.STP_SUBTREE: {
+                LinuxBridge.STP.ENABLED: False,
+            },
+        },
+        LinuxBridge.PORT_SUBTREE: [
+            {
+                LinuxBridge.Port.NAME: "eth1",
+            }
+        ],
+    }
+    with linux_bridge("test-linux-br0", bridge_config) as state:
+        assertlib.assert_state_match(state)


### PR DESCRIPTION
When assigning current OVS system interface to linux bridge, nmstate
will complain about overbook with OVS bridge. This is incorrect as we
allows port been moving around without referring its old controller.

Fixed by remove the unnecessary overbook pre-edit check.

Changed NM code to remove the leftover OVS port connection.

Integration test case include.