### PR TITLE
bridge: Fix serialization of VLAN trunk tags

### DIFF
--- a/rust/src/lib/ifaces/bridge_vlan.rs
+++ b/rust/src/lib/ifaces/bridge_vlan.rs
@@ -112,23 +112,20 @@ impl<'de> Deserialize<'de> for BridgePortTunkTag {
                 Ok(Self::Id(id.parse::<u16>().map_err(|e| {
                     serde::de::Error::custom(format!(
                         "Failed to parse BridgePortTunkTag id \
-                        {} as u16: {}",
-                        id, e
+                        {id} as u16: {e}"
                     ))
                 })?))
             } else if let Some(id) = id.as_u64() {
                 Ok(Self::Id(u16::try_from(id).map_err(|e| {
                     serde::de::Error::custom(format!(
                         "Failed to parse BridgePortTunkTag id \
-                        {} as u16: {}",
-                        id, e
+                        {id} as u16: {e}"
                     ))
                 })?))
             } else {
                 Err(serde::de::Error::custom(format!(
                     "The id of BridgePortTunkTag should be \
-                    unsigned 16 bits integer, but got {}",
-                    v
+                    unsigned 16 bits integer, but got {v}"
                 )))
             }
         } else if let Some(id_range) = v.get("id-range") {
@@ -139,8 +136,7 @@ impl<'de> Deserialize<'de> for BridgePortTunkTag {
         } else {
             Err(serde::de::Error::custom(format!(
                 "BridgePortTunkTag only support 'id' or 'id-range', \
-                but got {}",
-                v
+                but got {v}"
             )))
         }
     }

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -334,3 +334,31 @@ bridge:
 
     assert_eq!(desired.get_config_changed_ports(&current), vec!["eth1"])
 }
+
+#[test]
+fn test_linux_bridge_vlan_trunk_tags_yaml_serilize() {
+    let yml_content = r#"name: br0
+type: linux-bridge
+state: up
+bridge:
+  port:
+  - name: eth1
+    vlan:
+      mode: access
+      tag: 305
+      trunk-tags:
+      - id: 101
+      - id-range:
+          min: 500
+          max: 599
+  - name: eth2
+    vlan:
+      mode: trunk
+      trunk-tags:
+      - id: 500
+"#;
+    let iface: LinuxBridgeInterface =
+        serde_yaml::from_str(yml_content).unwrap();
+
+    assert_eq!(serde_yaml::to_string(&iface).unwrap(), yml_content);
+}


### PR DESCRIPTION
Previously, the yaml serialization of VLAN trunk tags looks like:

```yml
trunk-tags:
- !id 101
- !id-range
 max: 599
 min: 500
```

Fixed by using custom serializer for `BridgePortTunkTag`.

Unit test case included.