### PR TITLE
ovs vlan: Support access mode with tag 0

### DIFF
--- a/rust/src/lib/nm/query/ovs.rs
+++ b/rust/src/lib/nm/query/ovs.rs
@@ -181,9 +181,8 @@ fn get_nm_ovs_iface_conns<'a>(
 
 fn get_vlan_info(nm_conn: &NmConnection) -> Option<BridgePortVlanConfig> {
     if let Some(port_conf) = nm_conn.ovs_port.as_ref() {
-        if let (Some(tag), Some(mode)) =
-            (port_conf.tag, port_conf.vlan_mode.as_deref())
-        {
+        if let Some(mode) = port_conf.vlan_mode.as_deref() {
+            let tag = port_conf.tag.unwrap_or_default();
             return Some(BridgePortVlanConfig {
                 mode: Some(match mode {
                     "access" => BridgePortVlanMode::Access,

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1383,3 +1383,23 @@ def test_move_ovs_sys_iface_to_linux_bridge(bridge_with_ports):
     }
     with linux_bridge("test-linux-br0", bridge_config) as state:
         assertlib.assert_state_match(state)
+
+
+def test_ovs_vlan_access_mode_with_tag_0():
+    bridge = Bridge(BRIDGE1)
+    bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
+    bridge.set_port_option(
+        PORT1,
+        {
+            OVSBridge.Port.NAME: PORT1,
+            OVSBridge.Port.VLAN_SUBTREE: {
+                OVSBridge.Port.Vlan.MODE: OVSBridge.Port.Vlan.Mode.ACCESS,
+                OVSBridge.Port.Vlan.TAG: 0,
+            },
+        },
+    )
+    with bridge.create() as state:
+        assertlib.assert_state_match(state)
+
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent(PORT1)


### PR DESCRIPTION
The default tag of VLAN access mode is 0, hence we should allow user to
define it explicitly.

Integration test case included.