### PR TITLE
dns: Fix error when desired no DNS changes

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -288,7 +288,9 @@ fn current_dns_ifaces_are_still_valid(
                 if let Some(des_iface) =
                     desired.interfaces.kernel_ifaces.get(iface_name)
                 {
-                    if !is_iface_valid_for_dns(false, des_iface) {
+                    if des_iface.base_iface().ipv4.is_some()
+                        && !is_iface_valid_for_dns(false, des_iface)
+                    {
                         return false;
                     }
                 }
@@ -299,7 +301,9 @@ fn current_dns_ifaces_are_still_valid(
                 if let Some(des_iface) =
                     desired.interfaces.kernel_ifaces.get(iface_name)
                 {
-                    if !is_iface_valid_for_dns(true, des_iface) {
+                    if des_iface.base_iface().ipv6.is_some()
+                        && !is_iface_valid_for_dns(true, des_iface)
+                    {
                         return false;
                     }
                 }


### PR DESCRIPTION
When a interface holding DNS information, applying simple state like
below will cause failure on DNS interface not found.

```yml
interfaces:
  - name: eth1
```

This is caused by `current_dns_ifaces_are_still_valid()` does not have
IP stack info merged from current which lead to thinking IP stack
disabled.

The fix is skip the test if desired interface has unmentioned IP
stack(set to None). This is a workaround, not final fix. The ideal fix
should given `desire_state` and `current_state`, get merged state for
validation, state for verifying, state for applying. But that require
massive code changes.

Unit test case included.