### PR TITLE
route rule: Add support of `iif` and `action`.

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 path = "lib.rs"
 
 [dependencies.nispor]
-version = "1.2.8"
+version = "1.2.9"
 optional = true
 
 [dependencies.ipnet]

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -158,4 +158,6 @@ pub use crate::policy::{
     NetworkCaptureRules, NetworkPolicy, NetworkStateTemplate,
 };
 pub use crate::route::{RouteEntry, RouteState, Routes};
-pub use crate::route_rule::{RouteRuleEntry, RouteRuleState, RouteRules};
+pub use crate::route_rule::{
+    RouteRuleAction, RouteRuleEntry, RouteRuleState, RouteRules,
+};

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -55,7 +55,7 @@ pub use self::ovs::{
     NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort,
 };
 pub use self::route::NmIpRoute;
-pub use self::route_rule::NmIpRouteRule;
+pub use self::route_rule::{NmIpRouteRule, NmIpRouteRuleAction};
 pub use self::sriov::{NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan};
 pub use self::user::NmSettingUser;
 pub use self::veth::NmSettingVeth;

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -26,14 +26,15 @@ pub use self::active_connection::{
     NmActiveConnection, NM_ACTIVATION_STATE_FLAG_EXTERNAL,
 };
 pub use self::connection::{
-    NmConnection, NmIpRoute, NmIpRouteRule, NmSetting8021X, NmSettingBond,
-    NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
-    NmSettingConnection, NmSettingEthtool, NmSettingInfiniBand, NmSettingIp,
-    NmSettingIpMethod, NmSettingLoopback, NmSettingMacVlan, NmSettingOvsBridge,
-    NmSettingOvsDpdk, NmSettingOvsExtIds, NmSettingOvsIface, NmSettingOvsPatch,
-    NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingUser, NmSettingVeth, NmSettingVlan, NmSettingVrf, NmSettingVxlan,
-    NmSettingWired, NmSettingsConnectionFlag, NmVlanProtocol,
+    NmConnection, NmIpRoute, NmIpRouteRule, NmIpRouteRuleAction,
+    NmSetting8021X, NmSettingBond, NmSettingBridge, NmSettingBridgePort,
+    NmSettingBridgeVlanRange, NmSettingConnection, NmSettingEthtool,
+    NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod, NmSettingLoopback,
+    NmSettingMacVlan, NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
+    NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort, NmSettingSriov,
+    NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingUser, NmSettingVeth,
+    NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingWired,
+    NmSettingsConnectionFlag, NmVlanProtocol,
 };
 #[cfg(feature = "query_apply")]
 pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};

--- a/rust/src/lib/nm/settings/route_rule.rs
+++ b/rust/src/lib/nm/settings/route_rule.rs
@@ -64,6 +64,12 @@ pub(crate) fn gen_nm_ip_rules<'a>(
 
         nm_rule.fw_mark = rule.fwmark;
         nm_rule.fw_mask = rule.fwmask;
+        if let Some(iif) = rule.iif.as_ref() {
+            nm_rule.iifname = Some(iif.to_string());
+        }
+        if let Some(action) = rule.action.as_ref() {
+            nm_rule.action = Some(u8::from(*action).into());
+        }
 
         ret.push(nm_rule);
     }

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -167,6 +167,7 @@ fn gen_rule_entry(
         priority: Some(priority),
         fwmark: Some(fwmark),
         fwmask: Some(fwmask),
+        ..Default::default()
     }
 }
 

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -55,6 +55,11 @@ class RouteRule:
     FAMILY = "family"
     FAMILY_IPV4 = "ipv4"
     FAMILY_IPV6 = "ipv6"
+    IIF = "iif"
+    ACTION = "action"
+    ACTION_BLACKHOLE = "blackhole"
+    ACTION_UNREACHABLE = "unreachable"
+    ACTION_PROHIBIT = "prohibit"
 
 
 class DNS:

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019-2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import json
 import logging
@@ -25,7 +8,15 @@ from . import cmdlib
 
 
 def ip_rule_exist_in_os(
-    ip_from, ip_to, priority, table, fwmark, fwmask, family
+    ip_from,
+    ip_to,
+    priority,
+    table,
+    fwmark,
+    fwmask,
+    family,
+    iif=None,
+    action=None,
 ):
     expected_rule = locals()
     logging.debug("Checking ip rule for {}".format(expected_rule))
@@ -74,6 +65,12 @@ def ip_rule_exist_in_os(
             found = False
             continue
         if fwmask is not None and rule["fwmask"] != hex(fwmask):
+            found = False
+            continue
+        if iif is not None and rule["iif"] != iif:
+            found = False
+            continue
+        if action is not None and rule["action"] != action:
             found = False
             continue
         if found:


### PR DESCRIPTION
* Added `RouteRule.iif` for matching on incoming interface name.
* Added `RouteRule.action` for these actions:
  * `RouteRuleAction::Blackhole`
  * `RouteRuleAction::Unreachable`
  * `RouteRuleAction::Prohibit`

Bumped required of nispor to 1.2.9 for the fix of route rule actions.

Integration test cases included.