### PR TITLE
bridge vlan: Add more sanity check

### DIFF
--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -107,6 +107,17 @@ impl LinuxBridgeInterface {
         self.flatten_port_vlan_ranges();
         self.sort_port_vlans();
         self.remove_runtime_only_timers();
+        if let Some(port_confs) = self
+            .bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.port.as_ref())
+        {
+            for port_conf in port_confs {
+                if let Some(vlan_conf) = port_conf.vlan.as_ref() {
+                    vlan_conf.sanitize()?;
+                }
+            }
+        }
         Ok(())
     }
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -123,6 +123,18 @@ impl OvsBridgeInterface {
         self.base.ipv4 = None;
         self.base.ipv6 = None;
         self.sort_ports();
+
+        if let Some(port_confs) = self
+            .bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.ports.as_ref())
+        {
+            for port_conf in port_confs {
+                if let Some(vlan_conf) = port_conf.vlan.as_ref() {
+                    vlan_conf.sanitize()?;
+                }
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Add checks for these invalid use cases for both linux bridge and ovs bridge
 * VLAN trunk mode with tag defined but without `enable-native: true`.
 * Overlap of VLAN trunk tags.
 * Access mode with `enable-native: true` defined.
 * Trunk mode without trunk-tags defined.
 * Access mode with trunk-tags defined.

Unit test cases included.