### PR TITLE
iface: Include VRF as support type

### DIFF
--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -259,7 +259,7 @@ impl Interface {
 }
 
 impl InterfaceType {
-    pub(crate) const SUPPORTED_LIST: [InterfaceType; 13] = [
+    pub(crate) const SUPPORTED_LIST: [InterfaceType; 14] = [
         InterfaceType::Bond,
         InterfaceType::LinuxBridge,
         InterfaceType::Dummy,
@@ -273,5 +273,6 @@ impl InterfaceType {
         InterfaceType::Vxlan,
         InterfaceType::InfiniBand,
         InterfaceType::Loopback,
+        InterfaceType::Vrf,
     ];
 }


### PR DESCRIPTION
We accidentally forgot VRF as supported type.
The existing VRF test was skipped by CI hence not been found initially.

Manually run the test in RHEL host works well.