### PR TITLE
Enable VRF test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,11 @@ jobs:
           name: rpms_el9
           path: rpms/el9
 
+      - name: Install extra kernel modules(e.g. vrf)
+        run: |
+          sudo apt-get update;
+          sudo apt-get -y install "linux-modules-extra-$(uname -r)"
+
       - name: Run tests
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -196,10 +196,6 @@ def test_add_ovs_patch_and_remove():
     assertlib.assert_absent("patch0")
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason=("CI does not have vrf enabled"),
-)
 def test_add_remove_vrf(eth1_up):
     with example_state(
         "vrf0_with_eth1.yml", cleanup="vrf0_absent.yml"

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -1,23 +1,4 @@
-#
-# Copyright (c) 2020-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
-
-import os
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import pytest
 import yaml
@@ -170,10 +151,6 @@ def vrf1_with_unmanaged_port(unmanaged_port_up):
         )
 
 
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason=("CI does not have vrf enabled"),
-)
 class TestVrf:
     def test_create_and_remove(self, vrf0_with_port0):
         pass


### PR DESCRIPTION
By installing `linux-modules-extra-azure` package, github CI could
support VRF tests now.

All VRF test cases are enabled in CI.