### PR TITLE
test: Wait till container is up before `container_exec`

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -100,5 +100,8 @@ function create_container {
       -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
       -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
   [ -n "$debug_exit_shell" ] && trap open_shell EXIT || trap run_exit EXIT
-  sleep 1
+  until [ "`$CONTAINER_CMD inspect -f {{.State.Running}} $CONTAINER_ID`" \
+      == "true" ]; do
+      sleep 0.1;
+  done;
 }


### PR DESCRIPTION
In github CI, the `sleep 1` is not enough for container to be up after
`podman run` which lead to failure on `container_exec`:

    + podman exec -i
      23c108712c04cec9e1ca87e95159025385804d51027175cd797d588dffe6ae8d
      /bin/bash -c 'cd /workspace/nmstate && ulimit -c unlimited'
      Error: timed out waiting for file

Fix it by use `podman inspect` to check whether container is up with
retry.