### PR TITLE
test: Speed up the `test_ipv6_dhcp_switch_on_to_off`

### DIFF
--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -35,6 +35,7 @@ from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
 from .testlib.retry import retry_till_true_or_timeout
+from .testlib.retry import retry_till_false_or_timeout
 from .testlib.veth import create_veth_pair
 from .testlib.veth import remove_veth_pair
 
@@ -435,7 +436,7 @@ def test_ipv4_dhcp_off_and_option_on(dhcpcli_up):
     assert InterfaceIPv4.AUTO_ROUTES not in ipv4_current_state
     assert InterfaceIPv4.AUTO_DNS not in ipv4_current_state
     assert InterfaceIPv4.AUTO_GATEWAY not in ipv4_current_state
-    assert not _poll(_has_ipv4_dhcp_nameserver)
+    assert not _poll_till_not(_has_ipv4_dhcp_nameserver)
     assert not _has_ipv4_dhcp_gateway()
     assert not _has_ipv4_classless_route()
 
@@ -470,7 +471,7 @@ def test_ipv6_dhcp_off_and_option_on(dhcpcli_up):
     assert InterfaceIPv6.AUTO_ROUTES not in ipv6_current_state
     assert InterfaceIPv6.AUTO_DNS not in ipv6_current_state
     assert InterfaceIPv6.AUTO_GATEWAY not in ipv6_current_state
-    assert not _poll(_has_ipv6_auto_gateway)
+    assert not _poll_till_not(_has_ipv6_auto_gateway)
     assert not _has_ipv6_auto_extra_route()
     assert not _has_ipv6_auto_nameserver()
 
@@ -497,7 +498,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
 
     libnmstate.apply(desired_state)
     assertlib.assert_state(desired_state)
-    assert not _poll(_has_ipv4_dhcp_nameserver)
+    assert not _poll_till_not(_has_ipv4_dhcp_nameserver)
     assert not _has_ipv4_dhcp_gateway()
     assert not _has_ipv4_classless_route()
 
@@ -527,7 +528,7 @@ def test_ipv6_dhcp_switch_on_to_off(dhcpcli_up):
     libnmstate.apply(desired_state)
 
     assertlib.assert_state(desired_state)
-    assert not _poll(_has_ipv6_auto_gateway)
+    assert not _poll_till_not(_has_ipv6_auto_gateway)
     assert not _has_ipv6_auto_extra_route()
     assert not _has_ipv6_auto_nameserver()
 
@@ -700,6 +701,10 @@ def _get_running_routes():
 
 def _poll(func, *args, **kwargs):
     return retry_till_true_or_timeout(DEFAULT_TIMEOUT, func, *args, **kwargs)
+
+
+def _poll_till_not(func, *args, **kwargs):
+    return retry_till_false_or_timeout(DEFAULT_TIMEOUT, func, *args, **kwargs)
 
 
 def _has_ipv6_auto_gateway(nic=DHCP_CLI_NIC):

--- a/tests/integration/testlib/retry.py
+++ b/tests/integration/testlib/retry.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
 
@@ -24,6 +7,17 @@ def retry_till_true_or_timeout(timeout, func, *args, **kwargs):
     ret = func(*args, **kwargs)
     while timeout > 0:
         if ret:
+            break
+        time.sleep(1)
+        timeout -= 1
+        ret = func(*args, **kwargs)
+    return ret
+
+
+def retry_till_false_or_timeout(timeout, func, *args, **kwargs):
+    ret = func(*args, **kwargs)
+    while timeout > 0:
+        if not ret:
             break
         time.sleep(1)
         timeout -= 1


### PR DESCRIPTION
The `test_ipv6_dhcp_switch_on_to_off` and other similar test cases use
`assert not _poll()` which only returns after `DEFAULT_TIMEOUT`
(20 seconds) expires.

Fix it by introduce `_poll_till_not()` for waiting on false instead of
true.