### PR TITLE
sriov: Support modify only defined VF

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -634,7 +634,13 @@ impl Interface {
             .pre_edit_cleanup(current.map(|i| i.base_iface()))?;
         match self {
             Interface::LinuxBridge(iface) => iface.pre_edit_cleanup(),
-            Interface::Ethernet(iface) => iface.pre_edit_cleanup(),
+            Interface::Ethernet(iface) => iface.pre_edit_cleanup(
+                if let Some(Interface::Ethernet(current)) = current {
+                    Some(current)
+                } else {
+                    None
+                },
+            ),
             Interface::OvsInterface(iface) => iface.pre_edit_cleanup(),
             Interface::Vrf(iface) => iface.pre_edit_cleanup(current),
             Interface::Bond(iface) => iface.pre_edit_cleanup(current),

--- a/rust/src/lib/nm/settings/sriov.rs
+++ b/rust/src/lib/nm/settings/sriov.rs
@@ -28,16 +28,27 @@ pub(crate) fn gen_nm_sriov_setting(
     }
 
     if let Some(vfs) = &sriov_conf.vfs {
-        nm_sriov_set.vfs = Some(gen_nm_vfs(vfs));
+        nm_sriov_set.vfs = Some(gen_nm_vfs(
+            vfs,
+            nm_sriov_set.vfs.as_ref().cloned().unwrap_or_default(),
+        ));
     }
 
     nm_conn.sriov = Some(nm_sriov_set);
 }
 
-fn gen_nm_vfs(vfs: &[SrIovVfConfig]) -> Vec<NmSettingSriovVf> {
-    let mut ret: Vec<NmSettingSriovVf> = Vec::new();
-    for vf in vfs {
-        let mut nm_vf = NmSettingSriovVf::default();
+fn gen_nm_vfs(
+    vfs: &[SrIovVfConfig],
+    exist_nm_sriov_sets: Vec<NmSettingSriovVf>,
+) -> Vec<NmSettingSriovVf> {
+    let mut ret = Vec::with_capacity(vfs.len());
+    for (i, vf) in vfs.iter().enumerate() {
+        let mut nm_vf =
+            if let Some(exist_nm_sriov_set) = exist_nm_sriov_sets.get(i) {
+                exist_nm_sriov_set.clone()
+            } else {
+                NmSettingSriovVf::default()
+            };
         nm_vf.index = Some(vf.id);
         if let Some(v) = &vf.mac_address {
             nm_vf.mac = Some(v.to_string());

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -22,9 +22,14 @@ impl EthernetInterface {
         }
     }
 
-    pub(crate) fn pre_verify_cleanup(&mut self) {
+    pub(crate) fn pre_verify_cleanup(
+        &mut self,
+        pre_apply_current: Option<&Self>,
+    ) {
         if let Some(eth_conf) = self.ethernet.as_mut() {
-            eth_conf.pre_verify_cleanup()
+            eth_conf.pre_verify_cleanup(
+                pre_apply_current.and_then(|c| c.ethernet.as_ref()),
+            )
         }
         if self.base.iface_type == InterfaceType::Ethernet {
             self.veth = None;
@@ -57,13 +62,18 @@ impl EthernetConfig {
         }
     }
 
-    pub(crate) fn pre_verify_cleanup(&mut self) {
+    pub(crate) fn pre_verify_cleanup(
+        &mut self,
+        pre_apply_current: Option<&Self>,
+    ) {
         if self.auto_neg == Some(true) {
             self.speed = None;
             self.duplex = None;
         }
         if let Some(sriov_conf) = self.sr_iov.as_mut() {
-            sriov_conf.pre_verify_cleanup()
+            sriov_conf.pre_verify_cleanup(
+                pre_apply_current.and_then(|c| c.sr_iov.as_ref()),
+            )
         }
     }
 }

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -32,9 +32,15 @@ impl Interface {
             Self::Bond(ref mut iface) => {
                 iface.pre_verify_cleanup();
             }
-            Self::Ethernet(ref mut iface) => {
-                iface.pre_verify_cleanup();
-            }
+            Self::Ethernet(ref mut iface) => iface.pre_verify_cleanup(
+                if let Some(Self::Ethernet(pre_apply_current)) =
+                    pre_apply_current
+                {
+                    Some(pre_apply_current)
+                } else {
+                    None
+                },
+            ),
             Self::OvsBridge(ref mut iface) => {
                 iface.pre_verify_cleanup();
             }

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -19,15 +19,14 @@ impl SrIovConfig {
         }
     }
 
-    // Convert VF MAC address to upper case
-    // Ignore 'vfs: []' which is just reverting all VF config to default.
-    pub(crate) fn pre_verify_cleanup(&mut self) {
+    // * Invoke `pre_edit_cleanup()`
+    // * Ignore 'vfs: []' which is just reverting all VF config to default.
+    pub(crate) fn pre_verify_cleanup(
+        &mut self,
+        pre_apply_current: Option<&Self>,
+    ) {
+        self.pre_edit_cleanup(pre_apply_current);
         if let Some(vfs) = self.vfs.as_mut() {
-            for vf in vfs.iter_mut() {
-                if let Some(address) = vf.mac_address.as_mut() {
-                    address.make_ascii_uppercase()
-                }
-            }
             if vfs.is_empty() {
                 self.vfs = None;
             }

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -402,3 +402,31 @@ class TestSrIov:
                 {OVSBridge.Port.NAME: TEST_OVS_IFACE},
             ]
             assertlib.assert_state_match(expected_state)
+
+    def test_sriov_partial_editing_vf(self, sriov_iface_vf):
+        expected_state = copy.deepcopy(sriov_iface_vf)
+        expected_state[Interface.KEY][0][Ethernet.CONFIG_SUBTREE][
+            Ethernet.SRIOV_SUBTREE
+        ][Ethernet.SRIOV.VFS_SUBTREE][1][Ethernet.SRIOV.VFS.TRUST] = True
+
+        iface_name = sriov_iface_vf[Interface.KEY][0][Interface.NAME]
+        eth_config = sriov_iface_vf[Interface.KEY][0][Ethernet.CONFIG_SUBTREE]
+        vf_conf = eth_config[Ethernet.SRIOV_SUBTREE][
+            Ethernet.SRIOV.VFS_SUBTREE
+        ][1]
+        vf_conf[Ethernet.SRIOV.VFS.TRUST] = True
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: iface_name,
+                    Ethernet.CONFIG_SUBTREE: {
+                        Ethernet.SRIOV_SUBTREE: {
+                            Ethernet.SRIOV.VFS_SUBTREE: [vf_conf]
+                        }
+                    },
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+
+        assertlib.assert_state_match(expected_state)


### PR DESCRIPTION
It is legal desire state to modify only defined VF via:

```yml
interfaces:
- name: eth1
  type: ethernet
  ethernet:
    sr-iov:
      total-vfs: 4
      vfs:
        - id: 2
          trust: true
```

Previously, we will fail as we do exact match on list. For this use case,
this patch will instruct nmstate to auto convert above state to:

```yml
interfaces:
- name: eth1
  type: ethernet
  ethernet:
    sr-iov:
      total-vfs: 4
      vfs:
        - id: 0
        - id: 1
        - id: 2
          trust: true
        - id: 3
```

Unit test case included for this use case.

Also patched nm code to preserver unmentioned VF.

Integration test case included.