### PR TITLE
test: Add test for vlan with both parent and controller

### DIFF
--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -1,4 +1,6 @@
-use crate::{Interfaces, VrfInterface};
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{InterfaceType, Interfaces, MergedInterfaces, VrfInterface};
 
 #[test]
 fn test_vrf_stringlized_attributes() {
@@ -33,4 +35,53 @@ fn test_vrf_ports() {
     .unwrap();
 
     assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
+}
+
+#[test]
+fn test_vrf_on_bond_vlan_got_auto_remove() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+        - name: test-bond0.100
+          type: vlan
+          vlan:
+            base-iface: test-bond0
+            id: 100
+        - name: test-bond0
+          type: bond
+          link-aggregation:
+            mode: balance-rr
+        - name: test-vrf0
+          type: vrf
+          state: up
+          vrf:
+            port:
+            - test-bond0
+            - test-bond0.100
+            route-table-id: 100
+        "#,
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+        - name: test-bond0
+          type: bond
+          state: absent
+        - name: test-vrf0
+          type: vrf
+          state: absent
+        "#,
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+
+    let iface = merged_ifaces
+        .get_iface("test-bond0.100", InterfaceType::Vlan)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+    assert!(iface.is_absent());
 }


### PR DESCRIPTION
With a VLAN attached to a controller, it holds both parent and
controller information, when its controller been marked as absent,
the VLAN should be marked as absent automatically without causing any
failures.

Unit test case and integration test case included.