### PR TITLE
Route: Support IPV4 ECMP routes

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -15,18 +15,26 @@ pub struct NmIpRoute {
     pub next_hop: Option<String>,
     pub table: Option<u32>,
     pub metric: Option<u32>,
+    pub weight: Option<u32>,
     _other: DbusDictionary,
 }
 
 impl TryFrom<DbusDictionary> for NmIpRoute {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        let mut weight = _from_map!(v, "weight", u32::try_from)?;
+        if let Some(weight_num) = weight {
+            if weight_num == 0 {
+                weight = None;
+            }
+        }
         Ok(Self {
             dest: _from_map!(v, "dest", String::try_from)?,
             prefix: _from_map!(v, "prefix", u32::try_from)?,
             next_hop: _from_map!(v, "next-hop", String::try_from)?,
             table: _from_map!(v, "table", u32::try_from)?,
             metric: _from_map!(v, "metric", u32::try_from)?,
+            weight,
             _other: v,
         })
     }
@@ -65,6 +73,12 @@ impl NmIpRoute {
         if let Some(v) = &self.metric {
             ret.append(
                 zvariant::Value::new("metric"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.weight {
+            ret.append(
+                zvariant::Value::new("weight"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -32,7 +32,11 @@ pub(crate) fn gen_nm_ip_routes(
             None => None,
         };
         nm_route.next_hop = route.next_hop_addr.as_ref().cloned();
-
+        if let Some(weight) = route.weight {
+            if let Ok(w) = u32::try_from(weight) {
+                nm_route.weight = Some(w);
+            }
+        }
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -280,3 +280,49 @@ fn test_route_treat_empty_dst_as_none_for_matching() {
 
     assert!(absent_route.is_match(&route));
 }
+
+#[test]
+fn test_route_sanitize_ipv6_ecmp() {
+    let mut route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: 2001:db:1::/64
+        metric: 150
+        next-hop-address: 2001:db8::2
+        next-hop-interface: eth1
+        weight: 2
+        table-id: 254
+        "#,
+    )
+    .unwrap();
+    let result = route.sanitize();
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::NotSupportedError);
+}
+
+#[test]
+fn test_route_ipv4_ecmp_is_match() {
+    let absent_route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: 192.0.2.1
+        metric: 150
+        next-hop-address: 2001:db8::2
+        next-hop-interface: eth1
+        weight: 2
+        table-id: 254
+        state: absent
+        "#,
+    )
+    .unwrap();
+    let route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: 192.0.2.1
+        metric: 150
+        next-hop-address: 2001:db8::2
+        next-hop-interface: eth1
+        weight: 2
+        table-id: 254
+        "#,
+    )
+    .unwrap();
+    assert!(absent_route.is_match(&route));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -35,6 +35,7 @@ class Route:
     NEXT_HOP_INTERFACE = "next-hop-interface"
     NEXT_HOP_ADDRESS = "next-hop-address"
     METRIC = "metric"
+    WEIGHT = "weight"
     USE_DEFAULT_METRIC = -1
     USE_DEFAULT_ROUTE_TABLE = 0
 


### PR DESCRIPTION
Add `weight` property to route for ECMP route. Example YAML:

```yml
--- interfaces:
 - name: eth1
   type: ethernet
   state: up
   ipv4:
     address:
     - ip: 192.0.2.251
       prefix-length: 24
     dhcp: false
     enabled: true

routes:
 config:
 - destination: 198.51.100.0/24
   metric: 150
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
   weight: 2
   table-id: 254
 - destination: 198.51.100.0/24
   metric: 150
   next-hop-address: 192.0.2.2
   next-hop-interface: eth1
   weight: 25
   table-id: 254
```

Currently, IPv6 ECMP is not supported, nmstate will raise
`NotSupportedError` when desired IPv6 route with `weight`.

Integration and unit test case included.