### PR TITLE
[nmstate-1.4] iface: Fix error when assigning IP to port of absent controller

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -253,7 +253,6 @@ class BaseIface:
                     self.ip_state(family).validate(
                         IPState(family, self._origin_info.get(family, {}))
                     )
-                self._validate_port_ip()
                 ip_state = self.ip_state(family)
                 ip_state.remove_link_local_address()
                 self._info[family] = ip_state.to_dict()
@@ -302,7 +301,7 @@ class BaseIface:
             if current_external_ids:
                 other._info[OvsDB.OVS_DB_SUBTREE].pop(OvsDB.EXTERNAL_IDS)
 
-    def _validate_port_ip(self):
+    def validate_port_ip(self):
         for family in (Interface.IPV4, Interface.IPV6):
             ip_state = IPState(family, self._origin_info.get(family, {}))
             if (
@@ -359,7 +358,8 @@ class BaseIface:
         self._info[Interface.CONTROLLER] = controller_iface_name
         self._info[BaseIface.CONTROLLER_TYPE_METADATA] = controller_type
         if (
-            not self.can_have_ip_as_port
+            controller_iface_name
+            and not self.can_have_ip_as_port
             and controller_type != InterfaceType.VRF
         ):
             for family in (Interface.IPV4, Interface.IPV6):

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -277,6 +277,12 @@ class Ifaces:
         self._remove_unknown_type_interfaces()
         self._validate_veth_peers()
         self._resolve_controller_type()
+        self._validate_port_ip()
+
+    def _validate_port_ip(self):
+        for iface in self.all_ifaces():
+            if iface.is_desired and iface.is_up:
+                iface.validate_port_ip()
 
     def _bring_port_up_if_not_in_desire(self):
         """

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1172,3 +1172,34 @@ def test_create_bond_with_copy_mac_from_bond_port_perm_hwaddr(
         ):
             current_state = statelib.show_only((BOND99,))
             assert_mac_address(current_state, eth1_mac)
+
+
+@pytest.mark.tier1
+def test_remove_bond_and_assign_ip_to_bond_port(bond99_with_2_port):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+          - name: bond99
+            state: absent
+          - name: eth1
+            type: ethernet
+            state: up
+            mtu: 1500
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.168.1.1
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
When applying this state with eth1 as bond99 port:

```yml
interfaces:
  - name: bond99
    state: absent
  - name: eth1
    state: up
    mtu: 1500
    ipv4:
      dhcp: true
      enabled: true
```

nmstate will fail with error:

     Interface eth0 is port of None interface bond99 which does not allow
     port to have ipv4 enabled

This is caused by `_validate_port_ip()` checking merged information
instead of desired one. And this function is called before
`_handle_controller_port_list_change()` which has the controller
information sanitized.

The fix is changed `_validate_port_ip()` use original desire state for
validation. Also changed instruct `BaseInterface.set_controller()` do
not  clear IP stack when detaching from controller.

Integration test case included.