### PR TITLE
test: Add test for assigning IP to detached port

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1230,3 +1230,34 @@ interfaces:
         Loader=yaml.SafeLoader,
     )
     assertlib.assert_state_match(expected_state)
+
+
+@pytest.mark.tier1
+def test_remove_bond_and_assign_ip_to_bond_port(bond99_with_2_port):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+          - name: bond99
+            state: absent
+          - name: eth1
+            type: ethernet
+            state: up
+            mtu: 1500
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.168.1.1
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
We should allow assigned IP to port where its controller is marked as
absent.

Integration test case included.