### PR TITLE
cargo: Support rust 1.58

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux"]
 edition = "2018"
-rust-version = "1.60"
+rust-version = "1.58"
 
 [[bin]]
 name = "nmstatectl"
@@ -30,5 +30,5 @@ chrono = "0.4"
 
 [features]
 default = ["query_apply", "gen_conf"]
-query_apply = ["nmstate/query_apply", "dep:ctrlc"]
+query_apply = ["nmstate/query_apply", "ctrlc"]
 gen_conf = ["nmstate/gen_conf"]

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -5,7 +5,7 @@ version = "2.2.2"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
-rust-version = "1.60"
+rust-version = "1.58"
 
 [lib]
 name = "nmstate"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux-apis"]
-rust-version = "1.60"
+rust-version = "1.58"
 edition = "2018"
 
 [lib]
@@ -62,5 +62,5 @@ serde_yaml = "0.9"
 
 [features]
 default = ["query_apply", "gen_conf"]
-query_apply = ["dep:nispor", "dep:nix", "dep:zbus"]
+query_apply = ["nispor", "nix", "zbus"]
 gen_conf = []

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -126,10 +126,13 @@ impl Interfaces {
             self.kernel_ifaces
                 .remove(&iface_name.to_string())
                 .or_else(|| {
-                    if let Some((n, t)) =
-                        self.user_ifaces.keys().find(|(i, _)| i == iface_name)
+                    if let Some((n, t)) = self
+                        .user_ifaces
+                        .keys()
+                        .cloned()
+                        .find(|(i, _)| i == iface_name)
                     {
-                        self.user_ifaces.remove(&(n.to_string(), t.clone()))
+                        self.user_ifaces.remove(&(n, t))
                     } else {
                         None
                     }


### PR DESCRIPTION
Add support of rust 1.58 which is shipped by RHEL 8.6 and 9.0 by:
 * Remove the use of named dependency which is for rust 1.60+.
 * Fixed a compile warning as rust 1.58 is not smart enough:

    cannot borrow `self.user_ifaces` as mutable because it is also
    borrowed as immutable