### PR TITLE
ovs: Fix incorrect ovs bond mode

### DIFF
--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -161,9 +161,11 @@ fn parse_ovs_bond_conf(
         }
     }
 
-    if let Some(Value::String(lacp)) = ovsdb_port.options.get("lacp") {
-        if lacp.as_str() == "active" {
-            bond_conf.mode = Some(OvsBridgeBondMode::Lacp);
+    if bond_conf.mode.is_none() {
+        if let Some(Value::String(lacp)) = ovsdb_port.options.get("lacp") {
+            if lacp.as_str() == "active" {
+                bond_conf.mode = Some(OvsBridgeBondMode::Lacp);
+            }
         }
     }
 


### PR DESCRIPTION
The `balance-tcp` mode also have `lacp: active` in database, we should
only set `lacp` mode when not `balance-tcp` mode.

Integration test case created to cover all four ovs bond mode.