### PR TITLE
nm dns: Fix error when moving dns from port to controller

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -973,8 +973,14 @@ impl MergedInterface {
                 verify_iface.base_iface_mut().state = InterfaceState::Absent;
             }
         } else {
-            apply_iface.base_iface_mut().controller = Some(ctrl_name);
-            apply_iface.base_iface_mut().controller_type = ctrl_type;
+            apply_iface.base_iface_mut().controller = Some(ctrl_name.clone());
+            apply_iface.base_iface_mut().controller_type = ctrl_type.clone();
+            self.merged.base_iface_mut().controller = Some(ctrl_name);
+            self.merged.base_iface_mut().controller_type = ctrl_type;
+            if !self.merged.base_iface().can_have_ip() {
+                self.merged.base_iface_mut().ipv4 = None;
+                self.merged.base_iface_mut().ipv6 = None;
+            }
         }
         Ok(())
     }

--- a/tests/integration/testlib/genconf.py
+++ b/tests/integration/testlib/genconf.py
@@ -4,6 +4,7 @@ import os
 from contextlib import contextmanager
 
 import libnmstate
+from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
 
@@ -28,7 +29,7 @@ def gen_conf_apply(desire_state):
         activate_all_nm_connections()
         yield
     finally:
-        absent_state = {Interface.KEY: []}
+        absent_state = {DNS.KEY: {DNS.CONFIG: {}}, Interface.KEY: []}
         for iface_name in iface_names:
             absent_state[Interface.KEY].append(
                 {


### PR DESCRIPTION
When moving IP and DNS config from port to controller, nmstate will fail
with verification error as nmstate failed to store DNS config to
controller.

Fixed by:
 * `apply_ctrller_change()` should purge IP stack if interface is not
   valid to IP any more in merge state.

 * `store_dns_config()` should reconfig the DNS if changed interface is
   DNS interface and not valid for current DNS anymore even DNS config
   not changed.

 * `purge_dns_config()` should do nothing for absent interface.

Integration test case crated for two use cases:
 * Move identical IP and DNS config from port to controller.
 * Move identical IP from port to controller but with DNS changed.