### PR TITLE
ip: Empty IPv4 address should be considered as disabled

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -246,6 +246,14 @@ impl InterfaceIpv4 {
     // * Set DHCP options to None if DHCP is false
     // * Remove mptcp_flags is they are for query only
     pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
+        // Empty address should equal to disabled IPv4 stack
+        if let Some(true) = self.addresses.as_ref().map(Vec::is_empty) {
+            if self.enabled {
+                log::info!("Empty IPv4 address is considered as IPv4 disabled");
+                self.enabled = false;
+            }
+        }
+
         if self.is_auto() {
             if self.auto_dns.is_none() {
                 self.auto_dns = Some(true);

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -857,3 +857,30 @@ def test_preserve_ipv6_addresses_order(eth1_up):
     ip_addrs = iproute_get_ip_addrs_with_order(iface="eth1", is_ipv6=True)
     assert ip_addrs[0] == IPV6_ADDRESS2
     assert ip_addrs[1] == IPV6_ADDRESS1
+
+
+def test_remove_all_ip_address(setup_eth1_static_ip):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [],
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.ADDRESS: [],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    # Nmstate should auto convert empty IPv4 address to disabled IPv4.
+    desired_state[Interface.KEY][0][Interface.IPV4][
+        InterfaceIPv4.ENABLED
+    ] = False
+
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
The empty IPv4 address is considered as IPv4 stack disabled.

Integration test case included.