### PR TITLE
controller: Auto manage ignored port in desired controller

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -184,6 +184,14 @@ pub enum InterfaceState {
     /// Interface is not managed by backend. For apply action, interface marked
     /// as ignore will not be changed and will not cause verification failure
     /// neither.
+    /// When desired controller listed currently ignored interfaces as its
+    /// port, nmstate will automatically convert these ignored interfaces from
+    /// 'state: ignore' to 'state: up' only when:
+    ///  1. This ignored port is not mentioned in desire state.
+    ///  2. This ignored port is listed as port of a desired controller.
+    ///  3. Controller interface is new or does not contain ignored interfaces
+    ///     currently.
+    ///
     /// Deserialize and serialize from/to 'ignore'.
     Ignore,
 }

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -585,3 +585,114 @@ fn test_iface_detach_controller_been_list_in_other_port_list() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_auto_manage_ports() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+  state: ignore
+"#,
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+
+    let br_iface = merged_ifaces
+        .get_iface("br0", InterfaceType::LinuxBridge)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    let eth1_iface = merged_ifaces
+        .get_iface("eth1", InterfaceType::Ethernet)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    let eth2_iface = merged_ifaces
+        .get_iface("eth1", InterfaceType::Ethernet)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    assert_eq!(br_iface.ports(), Some(vec!["eth1", "eth2"]));
+    assert!(eth1_iface.is_up());
+    assert_eq!(eth1_iface.base_iface().controller.as_deref(), Some("br0"));
+    assert_eq!(eth2_iface.base_iface().controller.as_deref(), Some("br0"));
+}
+
+#[test]
+fn test_do_not_auto_manage_ports_if_current_has_ignore() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth1
+    - name: eth2
+"#,
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: eth1
+  type: ethernet
+  state: ignore
+- name: eth2
+  type: ethernet
+  state: ignore
+- name: eth3
+  type: ethernet
+  state: ignore
+- name: br0
+  type: linux-bridge
+  state: up
+  bridge:
+    port:
+    - name: eth3
+"#,
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+
+    let br_iface = merged_ifaces
+        .get_iface("br0", InterfaceType::LinuxBridge)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    assert!(merged_ifaces
+        .get_iface("eth1", InterfaceType::Ethernet)
+        .is_none());
+    assert!(merged_ifaces
+        .get_iface("eth2", InterfaceType::Ethernet)
+        .is_none());
+
+    assert_eq!(br_iface.ports(), Some(vec![]));
+}


### PR DESCRIPTION
When desired controller listed currently ignored interfaces as its port,
nmstate will automatically convert these ignored interfaces from
'state: ignore' to 'state: up' only when:
 1. This ignored port is not mentioned in desire state.
 2. This ignored port is listed as port of a desired controller.
 3. Controller interface is new or does not contain ignored interfaces
    currently.

Unit test case and integration test case included.