### PR TITLE
nm route rule: Support searching default route table ID

### DIFF
--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -329,6 +329,14 @@ impl RouteRuleEntry {
         self.validate_ip_from_to()?;
         self.validate_fwmark_and_fwmask()?;
 
+        if self.action.is_none() && self.table_id.is_none() {
+            log::info!(
+                "Route rule {self} has no action or route-table \
+                defined, using default route table 254"
+            );
+            self.table_id = Some(RouteRuleEntry::DEFAULR_ROUTE_TABLE_ID);
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
When desiring a route rule to table 254(main), nmstate should try to search
interfaces hold 254 as auto route id or static route to 254.

During route rule sanitize, we should explicitly set `RouteRuleEntry` to
route table id 254 when both `action` and `table-id` is None.

Unit test case included.