### PR TITLE
ovs dpdk: Add support of `n_rxq_desc` and `n_txq_desc`

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -286,6 +286,8 @@ impl ToDbusValue for NmSettingOvsPatch {
 pub struct NmSettingOvsDpdk {
     pub devargs: Option<String>,
     pub n_rxq: Option<u32>,
+    pub n_rxq_desc: Option<u32>,
+    pub n_txq_desc: Option<u32>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -295,6 +297,8 @@ impl TryFrom<DbusDictionary> for NmSettingOvsDpdk {
         Ok(Self {
             devargs: _from_map!(v, "devargs", String::try_from)?,
             n_rxq: _from_map!(v, "n-rxq", u32::try_from)?,
+            n_rxq_desc: _from_map!(v, "n-rxq-desc", u32::try_from)?,
+            n_txq_desc: _from_map!(v, "n-txq-desc", u32::try_from)?,
             _other: v,
         })
     }
@@ -308,6 +312,12 @@ impl ToDbusValue for NmSettingOvsDpdk {
         }
         if let Some(v) = &self.n_rxq {
             ret.insert("n-rxq", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.n_rxq_desc {
+            ret.insert("n-rxq-desc", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.n_txq_desc {
+            ret.insert("n-txq-desc", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -318,6 +318,16 @@ fn parse_ovs_iface_dpdk_conf(
                     conf.rx_queue = Some(i)
                 }
             }
+            if let Some(n_rxq_desc) = options.get("n_rxq_desc") {
+                if let Ok(i) = n_rxq_desc.parse::<u32>() {
+                    conf.n_rxq_desc = Some(i)
+                }
+            }
+            if let Some(n_txq_desc) = options.get("n_txq_desc") {
+                if let Ok(i) = n_txq_desc.parse::<u32>() {
+                    conf.n_txq_desc = Some(i)
+                }
+            }
             return Some(conf);
         }
     }

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ErrorKind, Interface, InterfaceType, Interfaces, MergedInterface,
-    MergedInterfaces, OvsBridgeInterface,
+    MergedInterfaces, OvsBridgeInterface, OvsInterface,
 };
 
 #[test]
@@ -528,5 +528,51 @@ fn test_ovs_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_validate_dpdk_n_rxq_desc() {
+    let desired: OvsInterface = serde_yaml::from_str(
+        r#"
+        name: ovs0
+        type: ovs-interface
+        state: up
+        dpdk:
+          devargs: 0000:af:00.1
+          n_rxq_desc: 1025
+        "#,
+    )
+    .unwrap();
+
+    let result = desired.sanitize();
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("OVS DPDK n_rxq_desc must power of 2"));
+    }
+}
+
+#[test]
+fn test_validate_dpdk_n_txq_desc() {
+    let desired: OvsInterface = serde_yaml::from_str(
+        r#"
+        name: ovs0
+        type: ovs-interface
+        state: up
+        dpdk:
+          devargs: 0000:af:00.1
+          n_txq_desc: 1025
+        "#,
+    )
+    .unwrap();
+
+    let result = desired.sanitize();
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("OVS DPDK n_txq_desc must power of 2"));
     }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -313,6 +313,8 @@ class OVSInterface(OvsDB):
     class Dpdk:
         DEVARGS = "devargs"
         RX_QUEUE = "rx-queue"
+        N_RXQ_DESC = "n_rxq_desc"
+        N_TXQ_DESC = "n_txq_desc"
 
 
 class OVSBridge(Bridge, OvsDB):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1190,6 +1190,27 @@ class TestOvsDpdk:
         assertlib.assert_absent(BRIDGE0)
         assertlib.assert_absent(PORT1)
 
+    def test_create_ovs_dpdk_queue_descriptor(self, datapaths):
+        dpdk0_state = {
+            OVSInterface.Dpdk.DEVARGS: _test_pci_path(),
+            OVSInterface.Dpdk.N_RXQ_DESC: 1024,
+            OVSInterface.Dpdk.N_TXQ_DESC: 2048,
+        }
+        bridge = Bridge(BRIDGE0)
+        bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)
+        bridge.set_options({OVSBridge.Options.DATAPATH: "netdev"})
+        desired_state = bridge.state
+        try:
+            libnmstate.apply(desired_state)
+            assertlib.assert_state_match(desired_state)
+        finally:
+            for iface in desired_state[Interface.KEY]:
+                iface[Interface.STATE] = InterfaceState.ABSENT
+            libnmstate.apply(desired_state)
+
+        assertlib.assert_absent(BRIDGE0)
+        assertlib.assert_absent(PORT1)
+
 
 @pytest.fixture
 def unmanged_ovs_vxlan():


### PR DESCRIPTION
Add support of `n_rxq_desc` and `n_txq_desc` for OVS DPDK. Please refer
to manpage of `ovs-vswitchd.conf.db` for detail.

Example yaml:

```yaml
---
interfaces:
- name: ovs0
  type: ovs-interface
  state: up
  dpdk:
    devargs: "0000:af:00.1"
    rx-queue: 100
    n-rxq-desc: 1024
    n-txq-desc: 2048
- name: br0
  type: ovs-bridge
  state: up
  bridge:
    options:
      datapath: "netdev"
    port:
    - name: ovs0
ovs-db:
  other_config:
    dpdk-init: "true"
```

Unit test case and integration test case included.