### PR TITLE
ipv6: raise proper error when MTU < 1280 and IPV6 enabled

### DIFF
--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -222,3 +222,29 @@ fn test_ipv6_not_allow_extra_address() {
         assert_eq!(e.kind(), ErrorKind::VerificationError);
     }
 }
+
+#[test]
+fn test_ipv6_mtu_lower_than_1280() {
+    let mut iface: BaseInterface = serde_yaml::from_str(
+        r#"---
+name: eth1
+type: ethernet
+state: up
+mtu: 1279
+ipv6:
+  enabled: "true"
+  dhcp: "false"
+  address:
+  - ip: "2001:0db8:85a3:0000:0000:8a2e:0370:7331"
+    prefix-length: "64"
+"#,
+    )
+    .unwrap();
+
+    let result = iface.sanitize();
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("MTU should be >= 1280"));
+    }
+}

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -1,30 +1,13 @@
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import copy
-import time
 
 import pytest
 
 import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv6
-from libnmstate.error import NmstateVerificationError
+from libnmstate.error import NmstateValueError
 
 from .testlib import assertlib
 from .testlib import statelib
@@ -103,11 +86,8 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu(eth1_with_ipv6):
     eth1_desired_state = desired_state[Interface.KEY][0]
     eth1_desired_state[Interface.MTU] = 1279
 
-    with pytest.raises(NmstateVerificationError) as err:
+    with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
-    assert "1279" in err.value.args[0]
-    # FIXME: Drop the sleep when the waiting logic is implemented.
-    time.sleep(2)
     assertlib.assert_state(original_state)
 
 


### PR DESCRIPTION
When IPv6 enabled, MTU should be bigger or equal to 1280.

Unit test case included.