### PR TITLE
New release 2.2.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,25 @@
 # Changelog
+## [2.2.3] - 2023-01-09
+### Breaking changes
+ - Minimum supported rust version changed from 1.60 to 1.58. (d2f669ed)
+
+### New features
+ - Support OVS VLAN filtering in trunk mode. (dce50734)
+ - Support parital modification of SR-IOV VF config. (92827cbb)
+ - Querying OVS database instead of NM daemon. (625fdb7a)
+
+### Bug fixes
+ - Fix regression on VRF interface. (3c88135d)
+ - Improve NM retry. (2a506379)
+ - Improve NM checkpoint refresh. (94c7341a)
+ - Fix LLDP error on `neighbors` property. (0a6fac0e)
+ - Improve state merging. (19133302)
+ - Fix error when moving dns from port to controller. (f619d8b4)
+ - Empty IPv4 address should be considered as disabled. (23535503)
+ - Auto manage ignored port in desired controller. (399c46b2)
+ - Fix error when searching default route table ID for route rule. (053db219)
+ - Raise proper error when desired IPv6 enabled with MTU < 1280. (76379ae9)
+
 ## [2.2.2] - 2022-12-13
 ### Breaking changes
  - N/A

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmstatectl"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 description = "Command line tool for networking management in a declarative manner"
 license = "Apache-2.0"

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nmstate-clib"
 description = "Nmstate C binding"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmstate"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 description = "Library for networking management in a declarative manner"
 license = "Apache-2.0"

--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -20,6 +20,6 @@ __all__ = [
     "show_running_config",
 ]
 
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 
 BASE_ON_RUST = True

--- a/rust/src/python/setup.py
+++ b/rust/src/python/setup.py
@@ -13,7 +13,7 @@ def requirements():
 
 setuptools.setup(
     name="nmstate",
-    version="2.2.2",
+    version="2.2.3",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of nmstate",


### PR DESCRIPTION
### Breaking changes
 - Minimum supported rust version changed from 1.60 to 1.58. (d2f669ed)

### New features
 - Support OVS VLAN filtering in trunk mode. (dce50734)
 - Support parital modification of SR-IOV VF config. (92827cbb)
 - Querying OVS database instead of NM daemon. (625fdb7a)

### Bug fixes
 - Fix regression on VRF interface. (3c88135d)
 - Improve NM retry. (2a506379)
 - Improve NM checkpoint refresh. (94c7341a)
 - Fix LLDP error on `neighbors` property. (0a6fac0e)
 - Improve state merging. (19133302)
 - Fix error when moving dns from port to controller. (f619d8b4)
 - Empty IPv4 address should be considered as disabled. (23535503)
 - Auto manage ignored port in desired controller. (399c46b2)
 - Fix error when searching default route table ID for route rule. (053db219)
 - Raise proper error when desired IPv6 enabled with MTU < 1280. (76379ae9)