### PR TITLE
ovsdb: Fix verification error when ovs daemon off

### DIFF
--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -30,8 +30,17 @@ impl MergedOvsDbGlobalConfig {
             other_config: Some(other_config),
             prop_list: vec!["external_ids", "other_config"],
         };
+
         let desired_value = serde_json::to_value(&desired)?;
-        let current_value = serde_json::to_value(current)?;
+        let current_value = if current.is_none() {
+            serde_json::to_value(&OvsDbGlobalConfig {
+                external_ids: Some(HashMap::new()),
+                other_config: Some(HashMap::new()),
+                prop_list: Vec::new(),
+            })?
+        } else {
+            serde_json::to_value(current)?
+        };
 
         if let Some((reference, desire, current)) = get_json_value_difference(
             "ovsdb".to_string(),

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -156,3 +156,14 @@ other_config: {}
         expect.other_config.as_ref().unwrap()
     );
 }
+
+#[test]
+fn test_ovsdb_verify_null_current() {
+    let desired: OvsDbGlobalConfig = serde_yaml::from_str("{}").unwrap();
+    let pre_apply_current = desired.clone();
+    let current = desired.clone();
+
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, pre_apply_current);
+
+    merged_ovsdb.verify(&current).unwrap();
+}

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -39,6 +39,7 @@ from .testlib.genconf import gen_conf_apply
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.ovslib import Bridge
 from .testlib.retry import retry_till_true_or_timeout
+from .testlib.servicelib import disable_service
 from .testlib.statelib import state_match
 from .testlib.vlan import vlan_interface
 
@@ -1551,3 +1552,13 @@ def test_crate_ovs_bond(cleanup_ovs_bridge, eth1_up, eth2_up, bond_mode):
     )
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.fixture
+def ovs_service_off():
+    with disable_service("openvswitch"):
+        yield
+
+
+def test_global_ovsdb_with_ovs_service_off(ovs_service_off):
+    libnmstate.apply({OvsDB.KEY: {}})

--- a/tests/integration/testlib/servicelib.py
+++ b/tests/integration/testlib/servicelib.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 import time
@@ -26,6 +9,17 @@ from . import cmdlib
 @contextmanager
 def disable_service(service):
     cmdlib.exec_cmd(("systemctl", "stop", service), check=True)
+    # Wait service actually stopped
+    ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service), check=False)
+    timeout = 5
+    while timeout > 0:
+        if ret != 0:
+            break
+        time.sleep(1)
+        timeout -= 1
+        ret, _, _ = cmdlib.exec_cmd(
+            ("systemctl", "status", service), check=False
+        )
     try:
         yield
     finally:


### PR DESCRIPTION
When applying `ovs-db: {}` with ovs daemon stopped, nmstate will fail
with:

    NmstateError: VerificationError: Verification failure:
    ovsdb.external_ids desire '{}', current 'null'

Fixed by treating `ovs-db: {}` as

```yml
ovs-db:
  external_ids: {}
  other_config: {}
```

Unit test case and integration test case included.