### PR TITLE
dns: Support uncompressed IPv6 server

### DIFF
--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -170,6 +170,7 @@ pub(crate) fn nm_retrieve(
     }
 
     net_state.dns = retrieve_dns_info(&mut nm_api, &net_state.interfaces)?;
+    net_state.dns.sanitize().ok();
     if running_config_only {
         net_state.dns.running = None;
     }

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -10,6 +10,9 @@ impl MergedDnsState {
         if !self.is_changed() {
             return Ok(());
         }
+        let mut current = current.clone();
+        current.sanitize().ok();
+
         let cur_srvs: Vec<String> = current
             .config
             .as_ref()

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DnsState, MergedDnsState};
+
+#[test]
+fn test_dns_verify_uncompressed_srvs() {
+    let current: DnsState = serde_yaml::from_str(
+        r#"---
+        config:
+          server:
+          - '3000::'
+          - ::100
+          - 0:0:f::100
+          - 3001:db8:0:1:1:1:1:1
+          - 3001:db8::2:1
+          - 3001:db8::1
+          - 3002:0:0:1::1
+          - 3003:db8::1:0:0:1
+          - 3004:db8::1:0:0:1
+          - 3005:db8::1:0:0:1
+          - ::ffff:192.0.2.1
+          - ::ffff:192.0.2.2
+          - 3::4
+        "#,
+    )
+    .unwrap();
+
+    let desired: DnsState = serde_yaml::from_str(
+        r#"---
+        config:
+          server:
+          - 3000:0000:0000:0000:0000:0000:0000:0000
+          - 0000:0000:0000:0000:0000:0000:0000:0100
+          - 0000:0000:000F:0000:0000:0000:0000:0100
+          - 3001:db8::1:1:1:1:1
+          - 3001:db8:0:0:0:0:2:1
+          - 3001:db8::0:1
+          - '3002:0:0:1:0:0:0:1'
+          - 3003:dB8:0:0:1:0:0:1
+          - 3004:db8::1:0:0:1
+          - 3005:DB8:0:0:1::1
+          - 0:0:0:0:0:FFFF:192.0.2.1
+          - ::FFFF:192.0.2.2
+          - 03:0000:000:00:0::4
+        "#,
+    )
+    .unwrap();
+
+    let merged = MergedDnsState::new(desired, DnsState::new()).unwrap();
+
+    merged.verify(&current).unwrap();
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -5,6 +5,8 @@ mod bond;
 #[cfg(test)]
 mod bridge;
 #[cfg(test)]
+mod dns;
+#[cfg(test)]
 mod ethernet;
 #[cfg(test)]
 mod ethtool;


### PR DESCRIPTION
When user desiring DNS nameserver as uncompress IPv6
format or other legal format like `2001:Db8:0:0:0:0:0:1`, nmstate is
complaining with VerificationError.

Fixed by sanitize DNS server before apply and verify.

Unit test case and integration test case included.