### PR TITLE
route and route rule: Treat empty IP string as None

### DIFF
--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -152,6 +152,7 @@ impl RouteEntry {
 
     pub(crate) fn is_match(&self, other: &Self) -> bool {
         if self.destination.as_ref().is_some()
+            && self.destination.as_deref() != Some("")
             && self.destination != other.destination
         {
             return false;
@@ -195,14 +196,18 @@ impl RouteEntry {
 
     pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
         if let Some(dst) = self.destination.as_ref() {
-            let new_dst = sanitize_ip_network(dst)?;
-            if dst != &new_dst {
-                log::warn!(
-                    "Route destination {} sanitized to {}",
-                    dst,
-                    new_dst
-                );
-                self.destination = Some(new_dst);
+            if dst.is_empty() {
+                self.destination = None;
+            } else {
+                let new_dst = sanitize_ip_network(dst)?;
+                if dst != &new_dst {
+                    log::warn!(
+                        "Route destination {} sanitized to {}",
+                        dst,
+                        new_dst
+                    );
+                    self.destination = Some(new_dst);
+                }
             }
         }
         if let Some(via) = self.next_hop_addr.as_ref() {

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -259,3 +259,24 @@ next-hop-address: "2001:db8:a:0000:000::1"
     assert_eq!(route.destination, Some("2001:db8:1::1/128".to_string()));
     assert_eq!(route.next_hop_addr, Some("2001:db8:a::1".to_string()));
 }
+
+#[test]
+fn test_route_treat_empty_dst_as_none_for_matching() {
+    let absent_route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: ""
+        state: absent
+        "#,
+    )
+    .unwrap();
+    let route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: ::/0
+        next-hop-address: 2001:db8:1::2
+        next-hop-interface: eth1
+        "#,
+    )
+    .unwrap();
+
+    assert!(absent_route.is_match(&route));
+}

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -135,3 +135,50 @@ family: ipv4
 
     rule.sanitize().unwrap();
 }
+
+#[test]
+fn test_route_rule_treat_empty_ip_from_as_none_for_matching() {
+    let absent_rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        ip-from: ""
+        state: absent
+        route-table: 200
+        "#,
+    )
+    .unwrap();
+
+    let rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        ip-from: 192.168.2.0/24
+        priority: 30000
+        route-table: 200
+        family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    assert!(absent_rule.is_match(&rule));
+}
+#[test]
+fn test_route_rule_treat_empty_ip_to_as_none_for_matching() {
+    let absent_rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        ip-to: ""
+        state: absent
+        route-table: 200
+        "#,
+    )
+    .unwrap();
+
+    let rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        ip-to: 192.168.2.0/24
+        priority: 30000
+        route-table: 200
+        family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    assert!(absent_rule.is_match(&rule));
+}


### PR DESCRIPTION
When deleting route or route rule with empty string like

```yml
- ip-to: 2001:db8:1::2/64
  ip-from: ''
  state: absent
```

Nmstate will fail with error on `Invalid IP network: invalid IP address
syntax`.

Fixed by treating empty IP string as None during `sanitize()` and
`is_match()`.

Unit test cases and integration test cases included.