### PR TITLE
nm ovs: Do not delete OVS bond port still in use

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -119,6 +119,7 @@ pub(crate) fn nm_apply(
             &mut nm_api,
             &merged_state.interfaces,
             &exist_nm_conns,
+            &nm_conns_to_activate,
         )?;
     }
 


### PR DESCRIPTION
When detaching 2 ports from a existing OVS 4 ports bond, nmstate NM
plugin will remove the OVS bond port connection via
`delete_orphan_ovs_ports()` which cause failure in follow up activation.

The fix is instruct `delete_orphan_ovs_ports()` do not delete profiles
been marked in `nm_conns_to_activate`.

Integration test case included.