### PR TITLE
ovs: Support interface level `other_config` (api break)

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -661,6 +661,9 @@ impl Interface {
         if let Interface::LinuxBridge(iface) = self {
             iface.sanitize_for_verify()
         }
+        if let Interface::OvsBridge(iface) = self {
+            iface.sanitize_for_verify()
+        }
     }
 
     pub(crate) fn parent(&self) -> Option<&str> {

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -260,6 +260,10 @@ impl BaseInterface {
         if let Some(ipv6_conf) = self.ipv6.as_mut() {
             ipv6_conf.sanitize_for_verify();
         }
+        // ovsdb None equal to empty
+        if self.ovsdb.is_none() {
+            self.ovsdb = Some(OvsDbIfaceConfig::empty());
+        }
     }
 }
 

--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -19,7 +19,8 @@ use super::super::{
     connection::mac_vlan::NmSettingMacVlan,
     connection::ovs::{
         NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-        NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort,
+        NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+        NmSettingOvsPort,
     },
     connection::sriov::NmSettingSriov,
     connection::user::NmSettingUser,
@@ -86,6 +87,7 @@ pub struct NmConnection {
     pub ovs_port: Option<NmSettingOvsPort>,
     pub ovs_iface: Option<NmSettingOvsIface>,
     pub ovs_ext_ids: Option<NmSettingOvsExtIds>,
+    pub ovs_other_config: Option<NmSettingOvsOtherConfig>,
     pub ovs_patch: Option<NmSettingOvsPatch>,
     pub ovs_dpdk: Option<NmSettingOvsDpdk>,
     pub wired: Option<NmSettingWired>,
@@ -150,6 +152,11 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
                 v,
                 "ovs-external-ids",
                 NmSettingOvsExtIds::try_from
+            )?,
+            ovs_other_config: _from_map!(
+                v,
+                "ovs-other-config",
+                NmSettingOvsOtherConfig::try_from
             )?,
             ovs_patch: _from_map!(v, "ovs-patch", NmSettingOvsPatch::try_from)?,
             ovs_dpdk: _from_map!(v, "ovs-dpdk", NmSettingOvsDpdk::try_from)?,
@@ -228,6 +235,9 @@ impl NmConnection {
         }
         if let Some(ovs_ext_ids) = &self.ovs_ext_ids {
             ret.insert("ovs-external-ids", ovs_ext_ids.to_value()?);
+        }
+        if let Some(ovs_other_config) = &self.ovs_other_config {
+            ret.insert("ovs-other-config", ovs_other_config.to_value()?);
         }
         if let Some(ovs_patch_set) = &self.ovs_patch {
             ret.insert("ovs-patch", ovs_patch_set.to_value()?);

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -52,7 +52,8 @@ pub use self::loopback::NmSettingLoopback;
 pub use self::mac_vlan::NmSettingMacVlan;
 pub use self::ovs::{
     NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort,
+    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+    NmSettingOvsPort,
 };
 pub use self::route::NmIpRoute;
 pub use self::route_rule::{NmIpRouteRule, NmIpRouteRuleAction};

--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -213,6 +213,45 @@ impl ToDbusValue for NmSettingOvsExtIds {
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]
 #[serde(try_from = "DbusDictionary")]
 #[non_exhaustive]
+pub struct NmSettingOvsOtherConfig {
+    pub data: Option<HashMap<String, String>>,
+    _other: HashMap<String, zvariant::OwnedValue>,
+}
+
+impl TryFrom<DbusDictionary> for NmSettingOvsOtherConfig {
+    type Error = NmError;
+    fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            data: _from_map!(v, "data", <HashMap<String, String>>::try_from)?,
+            _other: v,
+        })
+    }
+}
+
+impl ToDbusValue for NmSettingOvsOtherConfig {
+    fn to_value(&self) -> Result<HashMap<&str, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(v) = &self.data {
+            let mut dict_value = zvariant::Dict::new(
+                zvariant::Signature::from_str_unchecked("s"),
+                zvariant::Signature::from_str_unchecked("s"),
+            );
+            for (k, v) in v.iter() {
+                dict_value
+                    .append(zvariant::Value::new(k), zvariant::Value::new(v))?;
+            }
+            ret.insert("data", zvariant::Value::Dict(dict_value));
+        }
+        ret.extend(self._other.iter().map(|(key, value)| {
+            (key.as_str(), zvariant::Value::from(value.clone()))
+        }));
+        Ok(ret)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default, Deserialize)]
+#[serde(try_from = "DbusDictionary")]
+#[non_exhaustive]
 pub struct NmSettingOvsPatch {
     pub peer: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,

--- a/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
@@ -82,6 +82,9 @@ impl NmConnection {
         if let Some(ovs_eids) = &self.ovs_ext_ids {
             sections.push(("ovs-external-ids", ovs_eids.to_keyfile()?));
         }
+        if let Some(ovs_other_cfgs) = &self.ovs_other_config {
+            sections.push(("ovs-other-config", ovs_other_cfgs.to_keyfile()?));
+        }
 
         keyfile_sections_to_string(&sections)
     }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use super::super::{
     NmError, NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort, ToKeyfile,
+    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+    NmSettingOvsPort, ToKeyfile,
 };
 
 impl ToKeyfile for NmSettingOvsBridge {}
@@ -14,6 +15,18 @@ impl ToKeyfile for NmSettingOvsPatch {}
 impl ToKeyfile for NmSettingOvsDpdk {}
 
 impl ToKeyfile for NmSettingOvsExtIds {
+    fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+        if let Some(data) = self.data.as_ref() {
+            for (k, v) in data {
+                ret.insert(format!("data.{k}"), zvariant::Value::new(v));
+            }
+        }
+        Ok(ret)
+    }
+}
+
+impl ToKeyfile for NmSettingOvsOtherConfig {
     fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
         if let Some(data) = self.data.as_ref() {

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -29,10 +29,10 @@ pub use self::connection::{
     NmSettingBridgeVlanRange, NmSettingConnection, NmSettingEthtool,
     NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod, NmSettingLoopback,
     NmSettingMacVlan, NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsPatch, NmSettingOvsPort, NmSettingSriov,
-    NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingUser, NmSettingVeth,
-    NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingWired,
-    NmSettingsConnectionFlag, NmVlanProtocol,
+    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+    NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
+    NmSettingUser, NmSettingVeth, NmSettingVlan, NmSettingVrf, NmSettingVxlan,
+    NmSettingWired, NmSettingsConnectionFlag, NmVlanProtocol,
 };
 #[cfg(feature = "query_apply")]
 pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -14,8 +14,8 @@ use super::{
     loopback::gen_nm_loopback_setting,
     mptcp::apply_mptcp_conf,
     ovs::{
-        create_ovs_port_nm_conn, gen_nm_ovs_br_setting,
-        gen_nm_ovs_ext_ids_setting, gen_nm_ovs_iface_setting,
+        create_ovs_port_nm_conn, gen_nm_iface_ovs_db_setting,
+        gen_nm_ovs_br_setting, gen_nm_ovs_iface_setting,
     },
     sriov::gen_nm_sriov_setting,
     user::gen_nm_user_setting,
@@ -124,7 +124,7 @@ pub(crate) fn iface_to_nm_connections(
     {
         gen_nm_wired_setting(iface, &mut nm_conn);
     }
-    gen_nm_ovs_ext_ids_setting(iface, &mut nm_conn);
+    gen_nm_iface_ovs_db_setting(iface, &mut nm_conn);
     gen_nm_802_1x_setting(iface, &mut nm_conn);
     gen_nm_user_setting(iface, &mut nm_conn);
     gen_ethtool_setting(iface, &mut nm_conn)?;

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -56,14 +56,37 @@ pub struct OvsDbIfaceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_ids: Option<HashMap<String, Option<String>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// OpenvSwitch specific `other_config`. Please refer to
+    /// manpage `ovs-vswitchd.conf.db(5)` for more detail.
+    /// When setting to None, nmstate will try to preserve current
+    /// `other_config`, otherwise, nmstate will override all `other_config`
+    /// for specified interface.
     pub other_config: Option<HashMap<String, Option<String>>>,
 }
 
 impl OvsDbIfaceConfig {
+    pub(crate) fn empty() -> Self {
+        Self {
+            external_ids: Some(HashMap::new()),
+            other_config: Some(HashMap::new()),
+        }
+    }
     pub(crate) fn get_external_ids(&self) -> HashMap<&str, &str> {
         let mut ret = HashMap::new();
         if let Some(eids) = self.external_ids.as_ref() {
             for (k, v) in eids {
+                if let Some(v) = v {
+                    ret.insert(k.as_str(), v.as_str());
+                }
+            }
+        }
+        ret
+    }
+
+    pub(crate) fn get_other_config(&self) -> HashMap<&str, &str> {
+        let mut ret = HashMap::new();
+        if let Some(cfgs) = self.other_config.as_ref() {
+            for (k, v) in cfgs {
                 if let Some(v) = v {
                     ret.insert(k.as_str(), v.as_str());
                 }

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -180,6 +180,13 @@ fn parse_ovs_bond_conf(
                 if v == 0 { None } else { Some(v as u32) };
         }
     }
+    let external_ids = HashMap::from_iter(
+        ovsdb_port
+            .external_ids
+            .clone()
+            .drain()
+            .map(|(k, v)| (k, Some(v))),
+    );
 
     let other_config = HashMap::from_iter(
         ovsdb_port
@@ -188,7 +195,12 @@ fn parse_ovs_bond_conf(
             .drain()
             .map(|(k, v)| (k, Some(v))),
     );
-    bond_conf.other_config = Some(other_config);
+    if !external_ids.is_empty() || !other_config.is_empty() {
+        bond_conf.ovsdb = Some(OvsDbIfaceConfig {
+            external_ids: Some(external_ids),
+            other_config: Some(other_config),
+        });
+    }
 
     bond_conf.ports = Some(bond_port_confs);
     bond_conf
@@ -381,10 +393,12 @@ fn ovsdb_iface_to_nmstate(
             .drain()
             .map(|(k, v)| (k, Some(v))),
     );
-    iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
-        external_ids: Some(external_ids),
-        other_config: Some(other_config),
-    });
+    if !external_ids.is_empty() || !other_config.is_empty() {
+        iface.base_iface_mut().ovsdb = Some(OvsDbIfaceConfig {
+            external_ids: Some(external_ids),
+            other_config: Some(other_config),
+        });
+    }
     Some(iface)
 }
 

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -330,6 +330,7 @@ class OVSBridge(Bridge, OvsDB):
         class LinkAggregation:
             MODE = "mode"
             PORT_SUBTREE = "port"
+            OVS_DB_SUBTREE = "ovs-db"
 
             class Port:
                 NAME = "name"


### PR DESCRIPTION
The Rust API changed:

    The `OvsBridgeBondConfig.other_config: Option<HashMap>` changed to
    `OvsBridgeBondConfig.ovs_db:  Option<OvsDbIfaceConfig>`

The YAML API changed:

    The `other_config` under ovs bond should be stored under `ovs-db`
    section, please check follow up example for detail.

Considering the interface level `other_config` never works in previous
release, this is API change is acceptable.

Example on `other_config` of OVS bridge:

```yml
interfaces:
- name: br0
  type: ovs-bridge
  state: up
  ovs-db:
    other_config:
      in-band-queue: '12'
  bridge:
    port:
    - name: eth1
    - name: ovs0
```

Example on `other_config` of OVS Bond:

```yml
- name: br0
  type: ovs-bridge
  state: up
  bridge:
    port:
    - name: bond1
      link-aggregation:
        mode: balance-slb
        ovs-db:
          other_config:
            bond-miimon-interval: "100"
        port:
          - name: eth2
          - name: eth1
```

Example on `other_config` of OVS interface:

```yml
- name: eth1
  type: ethernet
  state: up
  ovs-db:
    other_config:
      emc-insert-inv-prob: 90
```

We hide interface level `ovs-db` section if it is empty. This help us
supporting older NetworkManager where `other_config` is not supported
yet. User will get error when they apply above yaml on old
NetworkManager:

    NmstateError: DependencyError: Please upgrade NetworkManager for
    specified interface type: Connection(InvalidSetting):ovs-other-config:
    unknown setting name

Integration test case included.