### PR TITLE
mptcp: Fix mptcp error on older NetworkManager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,9 @@ jobs:
           - job_type: "c8s-nm_main-integ_tier2"
           - job_type: "c8s-nm_main-integ_slow"
           - job_type: "c8s-nm_main-rust_go"
-          - job_type: "ovs2_11-nm_stable-integ_tier1"
+          - job_type: "c9s-nm_1.36-integ_tier1"
+          - job_type: "c9s-nm_1.36-integ_tier2"
+          - job_type: "c9s-nm_1.36-integ_slow"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -45,6 +45,10 @@ if [ $NM_TYPE == "nm_main" ];then
     COPR_ARG="--copr networkmanager/NetworkManager-main"
 fi
 
+if [ $NM_TYPE == "nm_1.36" ];then
+    COPR_ARG="--copr networkmanager/NetworkManager-1.36"
+fi
+
 if [ $TEST_TYPE == "vdsm" ];then
     TEST_ARG="--test-vdsm"
 fi

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -231,14 +231,11 @@ function upgrade_nm_from_copr {
     clean_dnf_cache
     exec_cmd "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
     exec_cmd "yum copr enable --assumeyes ${copr_repo}"
-    if [ $CONTAINER_IMAGE == $CENTOS_8_STREAM_IMAGE_DEV ];then
-	# centos-stream NetworkManager package is providing the alpha builds.
-	# Sometimes it could be greater than the one packaged on Copr.
-        exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
-        exec_cmd "dnf install --assumeyes NetworkManager NetworkManager-team NetworkManager-ovs --disablerepo '*' --enablerepo '${copr_repo_id}'"
-    fi
-    # Update only from Copr to limit the changes in the environment
-    exec_cmd "yum update --assumeyes --disablerepo '*' --enablerepo '${copr_repo_id}'"
+    # centos-stream NetworkManager package is providing the alpha builds.
+    # Sometimes it could be greater than the one packaged on Copr.
+    exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
+    exec_cmd "dnf install --assumeyes NetworkManager NetworkManager-ovs  \
+        --disablerepo '*' --enablerepo '${copr_repo_id}'"
 }
 
 function upgrade_nm_from_rpm_dir {

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -60,14 +60,14 @@ pub(crate) fn perpare_nm_conns(
             &nm_ac_uuids,
             gen_conf_mode,
         )? {
-            if let Some(mptcp_conf) = iface.base_iface().mptcp.as_ref() {
-                if !mptcp_supported {
+            if !mptcp_supported {
+                remove_nm_mptcp_set(&mut nm_conn);
+                if let Some(mptcp_conf) = iface.base_iface().mptcp.as_ref() {
                     log::warn!(
                         "MPTCP not supported by NetworkManager, \
                         Ignoring MPTCP config {:?}",
                         mptcp_conf
                     );
-                    remove_nm_mptcp_set(&mut nm_conn);
                 }
             }
 

--- a/tests/integration/nm/ip_test.py
+++ b/tests/integration/nm/ip_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019-2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import pytest
 


### PR DESCRIPTION
With NM 1.36, this is the status nmstate shows:

```yml
interfaces:
- name: eth1
  type: ethernet
  ipv4:
    enabled: true
    address:
    - ip: 192.0.2.251
      prefix-length: 24
  ipv6:
    enabled: true
    address:
    - ip: 2001:db8:1::1
      prefix-length: 64
  mptcp:
    address-flags: []
```

But when applying the same state back, nmstate will fail with

    NmstateValueError:
   Connection(InvalidProperty):connection.mptcp-flags: unknown property

This is because NM 1.36 does not support MPTCP yet.

To fix this problem, when MPTCP is not supported, we remove mptcp settings
from NM connection before sending to NM daemon.

Removed `ovs2_11-nm_stable-integ_tier1` as we never see a problem caused by
different version of OVS.

Added `c9s-nm_1.36-integ_tier1`, `c9s-nm_1.36-integ_tier2` and
`c9s-nm_1.36-integ_slow` to make sure we works well on NM 1.36 branch.