### PR TITLE
nm dns: Support arbitrary DNS config

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -138,22 +138,10 @@ impl DnsClientState {
                     ));
                 }
             }
-            validate_dns_srvs(sanitized_srvs.as_slice())?;
             self.server = Some(sanitized_srvs);
         }
         Ok(())
     }
-}
-
-fn is_mixed_dns_servers(srvs: &[String]) -> bool {
-    let mut pattern = String::new();
-    for srv in srvs {
-        let cur_char = if is_ipv6_addr(srv) { '6' } else { '4' };
-        if !pattern.ends_with(cur_char) {
-            pattern.push(cur_char);
-        }
-    }
-    pattern.contains("464") || pattern.contains("646")
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -222,20 +210,6 @@ impl MergedDnsState {
 
         self.servers != cur_servers || self.searches != cur_searches
     }
-}
-
-fn validate_dns_srvs(srvs: &[String]) -> Result<(), NmstateError> {
-    if srvs.len() > 2 && is_mixed_dns_servers(srvs) {
-        let e = NmstateError::new(
-            ErrorKind::NotImplementedError,
-            "Placing IPv4/IPv6 nameserver in the middle of IPv6/IPv4 \
-            nameservers is not supported yet"
-                .to_string(),
-        );
-        log::error!("{}", e);
-        return Err(e);
-    }
-    Ok(())
 }
 
 impl MergedNetworkState {

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -3,7 +3,7 @@
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
 use super::{
-    dns::store_dns_config, profile::perpare_nm_conns,
+    dns::store_dns_config_to_iface, profile::perpare_nm_conns,
     route::store_route_config, route_rule::store_route_rule_config,
 };
 
@@ -26,7 +26,7 @@ pub(crate) fn nm_gen_conf(
     let mut merged_state = merged_state.clone();
     store_route_config(&mut merged_state)?;
     store_route_rule_config(&mut merged_state)?;
-    store_dns_config(&mut merged_state)?;
+    store_dns_config_to_iface(&mut merged_state)?;
 
     let nm_conns = perpare_nm_conns(
         &merged_state,

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -1,16 +1,4 @@
-// Copyright 2021 Red Hat, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -368,6 +356,19 @@ impl<'a> NmDbus<'a> {
 
     pub(crate) fn hostname_set(&self, hostname: &str) -> Result<(), NmError> {
         Ok(self.setting_proxy.save_hostname(hostname)?)
+    }
+
+    pub(crate) fn global_dns_configuration(
+        &self,
+    ) -> Result<HashMap<String, zvariant::OwnedValue>, NmError> {
+        Ok(self.proxy.global_dns_configuration()?)
+    }
+
+    pub(crate) fn set_global_dns_configuration(
+        &self,
+        value: zvariant::Value,
+    ) -> Result<(), NmError> {
+        Ok(self.proxy.set_property("GlobalDnsConfiguration", value)?)
     }
 }
 

--- a/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
@@ -1,16 +1,4 @@
-// Copyright 2021 Red Hat, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 
@@ -32,6 +20,11 @@ trait NetworkManager {
 
     #[dbus_proxy(property)]
     fn checkpoints(&self) -> zbus::Result<Vec<zvariant::OwnedObjectPath>>;
+
+    #[dbus_proxy(property)]
+    fn global_dns_configuration(
+        &self,
+    ) -> zbus::Result<HashMap<String, zvariant::OwnedValue>>;
 
     /// CheckpointCreate method
     fn checkpoint_create(

--- a/rust/src/lib/nm/nm_dbus/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/dns.rs
@@ -1,16 +1,4 @@
-// Copyright 2021 Red Hat, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -49,4 +37,161 @@ impl TryFrom<HashMap<String, zvariant::OwnedValue>> for NmDnsEntry {
             _other: v,
         })
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct NmGlobalDnsConfig {
+    pub searches: Vec<String>,
+    pub options: Vec<String>,
+    pub domains: HashMap<String, NmGlobalDnsDomainConfig>,
+}
+
+impl NmGlobalDnsConfig {
+    pub fn is_empty(&self) -> bool {
+        self.searches.is_empty()
+            && self.options.is_empty()
+            && self.domains.is_empty()
+    }
+
+    pub fn new_wildcard(searches: Vec<String>, servers: Vec<String>) -> Self {
+        let mut domains = HashMap::new();
+        domains.insert(
+            "*".to_string(),
+            NmGlobalDnsDomainConfig {
+                servers,
+                options: Vec::new(),
+            },
+        );
+        Self {
+            searches,
+            domains,
+            options: Vec::new(),
+        }
+    }
+
+    pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+        if !self.searches.is_empty() {
+            ret.append(
+                zvariant::Value::new("searches"),
+                zvariant::Value::new(zvariant::Value::new(
+                    self.searches.clone(),
+                )),
+            )?;
+        }
+        if !self.options.is_empty() {
+            ret.append(
+                zvariant::Value::new("options"),
+                zvariant::Value::new(zvariant::Value::new(
+                    self.options.clone(),
+                )),
+            )?;
+        }
+        if !self.domains.is_empty() {
+            ret.append(
+                zvariant::Value::new("domains"),
+                zvariant::Value::new(global_dns_domain_configs_to_value(
+                    &self.domains,
+                )?),
+            )?;
+        }
+        Ok(zvariant::Value::Dict(ret))
+    }
+}
+
+impl TryFrom<HashMap<String, zvariant::OwnedValue>> for NmGlobalDnsConfig {
+    type Error = NmError;
+    fn try_from(
+        mut v: HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            searches: _from_map!(v, "searches", Vec::<String>::try_from)?
+                .unwrap_or_default(),
+            options: _from_map!(v, "options", Vec::<String>::try_from)?
+                .unwrap_or_default(),
+            domains: _from_map!(v, "domains", parse_global_dns_domain_configs)?
+                .unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct NmGlobalDnsDomainConfig {
+    pub servers: Vec<String>,
+    pub options: Vec<String>,
+}
+
+impl NmGlobalDnsDomainConfig {
+    pub(crate) fn to_value(&self) -> Result<zvariant::Value, NmError> {
+        let mut ret = zvariant::Dict::new(
+            zvariant::Signature::from_str_unchecked("s"),
+            zvariant::Signature::from_str_unchecked("v"),
+        );
+        if !self.servers.is_empty() {
+            ret.append(
+                zvariant::Value::new("servers"),
+                zvariant::Value::new(zvariant::Value::new(
+                    self.servers.clone(),
+                )),
+            )?;
+        }
+        if !self.options.is_empty() {
+            ret.append(
+                zvariant::Value::new("options"),
+                zvariant::Value::new(zvariant::Value::new(
+                    self.options.clone(),
+                )),
+            )?;
+        }
+        Ok(zvariant::Value::Dict(ret))
+    }
+}
+
+impl TryFrom<HashMap<String, zvariant::OwnedValue>>
+    for NmGlobalDnsDomainConfig
+{
+    type Error = NmError;
+    fn try_from(
+        mut v: HashMap<String, zvariant::OwnedValue>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            servers: _from_map!(v, "servers", Vec::<String>::try_from)?
+                .unwrap_or_default(),
+            options: _from_map!(v, "options", Vec::<String>::try_from)?
+                .unwrap_or_default(),
+        })
+    }
+}
+
+fn parse_global_dns_domain_configs(
+    v: zvariant::OwnedValue,
+) -> Result<HashMap<String, NmGlobalDnsDomainConfig>, NmError> {
+    let mut ret = HashMap::new();
+    let mut raw_confs =
+        HashMap::<String, HashMap<String, zvariant::OwnedValue>>::try_from(v)?;
+    for (domain, raw_conf) in raw_confs.drain() {
+        ret.insert(domain, NmGlobalDnsDomainConfig::try_from(raw_conf)?);
+    }
+    Ok(ret)
+}
+
+fn global_dns_domain_configs_to_value(
+    configs: &HashMap<String, NmGlobalDnsDomainConfig>,
+) -> Result<zvariant::Value, NmError> {
+    let mut ret = zvariant::Dict::new(
+        zvariant::Signature::from_str_unchecked("s"),
+        zvariant::Signature::from_str_unchecked("v"),
+    );
+    for (domain, config) in configs.iter() {
+        ret.append(
+            zvariant::Value::new(domain.as_str()),
+            zvariant::Value::new(config.to_value()?),
+        )?;
+    }
+    Ok(zvariant::Value::Dict(ret))
 }

--- a/rust/src/lib/nm/nm_dbus/error.rs
+++ b/rust/src/lib/nm/nm_dbus/error.rs
@@ -289,6 +289,16 @@ impl From<zbus::Error> for NmError {
     }
 }
 
+#[cfg(feature = "query_apply")]
+impl From<zbus::fdo::Error> for NmError {
+    fn from(e: zbus::fdo::Error) -> Self {
+        Self {
+            kind: ErrorKind::Bug,
+            msg: format!("zbus fdo error {e}"),
+        }
+    }
+}
+
 impl From<zvariant::Error> for NmError {
     fn from(e: zvariant::Error) -> Self {
         Self {

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -37,7 +37,7 @@ pub use self::connection::{
 #[cfg(feature = "query_apply")]
 pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 #[cfg(feature = "query_apply")]
-pub use self::dns::NmDnsEntry;
+pub use self::dns::{NmDnsEntry, NmGlobalDnsConfig};
 pub use self::error::{
     ErrorKind, NmConnectionError, NmDeviceError, NmError, NmManagerError,
     NmSettingError,

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -15,7 +15,7 @@ use super::{
         nm_dev_delete, nm_dev_from_obj_path, nm_dev_get_llpd, NmDevice,
         NmDeviceState, NmDeviceStateReason,
     },
-    dns::NmDnsEntry,
+    dns::{NmDnsEntry, NmGlobalDnsConfig},
     error::{ErrorKind, NmError},
     lldp::NmLldpNeighbor,
 };
@@ -371,6 +371,20 @@ impl<'a> NmApi<'a> {
             }
         }
         Ok(())
+    }
+
+    pub fn get_global_dns_configuration(
+        &self,
+    ) -> Result<NmGlobalDnsConfig, NmError> {
+        NmGlobalDnsConfig::try_from(self.dbus.global_dns_configuration()?)
+    }
+
+    pub fn set_global_dns_configuration(
+        &mut self,
+        config: &NmGlobalDnsConfig,
+    ) -> Result<(), NmError> {
+        self.extend_timeout_if_required()?;
+        self.dbus.set_global_dns_configuration(config.to_value()?)
     }
 }
 

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod apply;
-mod dns;
+pub(crate) mod dns;
 mod ieee8021x;
 mod ip;
 mod lldp;

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::dns::store_dns_config, DnsClientState, ErrorKind, InterfaceType,
-    MergedNetworkState, NetworkState,
+    nm::dns::store_dns_config_to_iface, DnsClientState, ErrorKind,
+    InterfaceType, MergedNetworkState, NetworkState,
 };
 
 #[test]
@@ -49,7 +49,7 @@ interfaces:
     let mut merged_state =
         MergedNetworkState::new(desired, current, false, false).unwrap();
 
-    store_dns_config(&mut merged_state).unwrap();
+    store_dns_config_to_iface(&mut merged_state).unwrap();
 
     let iface = merged_state
         .interfaces
@@ -224,5 +224,5 @@ fn test_dns_iface_has_no_ip_stack_info() {
     let mut merged_state =
         MergedNetworkState::new(desired, current, false, false).unwrap();
 
-    store_dns_config(&mut merged_state).unwrap();
+    store_dns_config_to_iface(&mut merged_state).unwrap();
 }

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -6,7 +6,6 @@ import pytest
 import yaml
 
 import libnmstate
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -105,34 +104,16 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
         (IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
-        pytest.param(
-            (
-                [
-                    IPV4_DNS_NAMESERVERS[0],
-                    EXTRA_IPV6_DNS_NAMESERVER,
-                    IPV4_DNS_NAMESERVERS[1],
-                ]
-            ),
-            marks=pytest.mark.xfail(
-                reason="Not supported",
-                raises=NmstateNotImplementedError,
-                strict=True,
-            ),
-        ),
-        pytest.param(
-            (
-                [
-                    IPV6_DNS_NAMESERVERS[0],
-                    EXTRA_IPV4_DNS_NAMESERVER,
-                    IPV6_DNS_NAMESERVERS[1],
-                ]
-            ),
-            marks=pytest.mark.xfail(
-                reason="Not supported",
-                raises=NmstateNotImplementedError,
-                strict=True,
-            ),
-        ),
+        [
+            IPV4_DNS_NAMESERVERS[0],
+            EXTRA_IPV6_DNS_NAMESERVER,
+            IPV4_DNS_NAMESERVERS[1],
+        ],
+        [
+            IPV6_DNS_NAMESERVERS[0],
+            EXTRA_IPV4_DNS_NAMESERVER,
+            IPV6_DNS_NAMESERVERS[1],
+        ],
         (IPV4_DNS_NAMESERVERS + IPV6_DNS_NAMESERVERS),
         (IPV6_DNS_NAMESERVERS + IPV4_DNS_NAMESERVERS),
     ],


### PR DESCRIPTION
By using the `org.freedesktop.NetworkManager.GlobalDnsConfiguration`
DBUS API, we can modify the `/etc/resolve.conf` directly overriding DNS
settings in NM profiles/connections.

We use this as fallback method when we failed to store DNS into
interface profile. And a warning message will be shown as:

    Cannot store DNS to NetworkManager interface connection:
    NotImplementedError: Placing IPv4/IPv6 nameserver in the middle of
    IPv6/IPv4 nameservers is not supported yet

    Storing DNS to NetworkManager via global dns API, this will cause
    _all__ interface level DNS settings been ignored

This will not be used for `gen_conf` mode. User still get error when not
able to store DNS into interface profile.

Removed the xfail of integration test case for `ipv6+ipv4+ipv6` and
`ipv4+ipv6+ipv4` name server format.