### PR TITLE
DEMO: Support invoking dispatch script

### DIFF
--- a/rust/src/lib/dispatch.rs
+++ b/rust/src/lib/dispatch.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct DispatchConfig {
+    /// Dispatch bash script content to be invoked after interface activation
+    /// finished by network backend. Nmstate will append additional lines
+    /// to make sure this script is only invoked for specified interface when
+    /// backend interface activation finished.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_activation: Option<String>,
+    /// Dispatch bash script content to be invoked after interface deactivation
+    /// finished by network backend. Nmstate will append additional lines
+    /// to make sure this script is only invoked for specified interface when
+    /// backend interface deactivation finished.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_deactivation: Option<String>,
+}

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -3,10 +3,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ErrorKind, EthtoolConfig, Ieee8021XConfig, InterfaceIdentifier,
-    InterfaceIpv4, InterfaceIpv6, InterfaceState, InterfaceType, LldpConfig,
-    MergedInterface, MptcpConfig, NmstateError, OvsDbIfaceConfig, RouteEntry,
-    WaitIp,
+    DispatchConfig, ErrorKind, EthtoolConfig, Ieee8021XConfig,
+    InterfaceIdentifier, InterfaceIpv4, InterfaceIpv6, InterfaceState,
+    InterfaceType, LldpConfig, MergedInterface, MptcpConfig, NmstateError,
+    OvsDbIfaceConfig, RouteEntry, WaitIp,
 };
 
 const MINIMUM_IPV6_MTU: u64 = 1280;
@@ -126,6 +126,9 @@ pub struct BaseInterface {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Ethtool configurations
     pub ethtool: Option<EthtoolConfig>,
+    /// Dispatch script configurations
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch: Option<DispatchConfig>,
     #[serde(skip)]
     /// TODO: internal use, hide it.
     pub controller_type: Option<InterfaceType>,
@@ -262,6 +265,19 @@ impl BaseInterface {
         if !self.can_have_ip() {
             self.wait_ip = None;
         }
+
+        if self.iface_type.is_userspace() && self.dispatch.is_some() {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "User space interface {}/{} is not allow to hold \
+                    dispatch configurations",
+                    self.name.as_str(),
+                    self.iface_type,
+                ),
+            ));
+        }
+
         Ok(())
     }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -84,6 +84,7 @@
 //! ```
 
 mod deserializer;
+mod dispatch;
 mod dns;
 mod error;
 #[cfg(feature = "gen_conf")]
@@ -113,6 +114,7 @@ mod serializer;
 mod state;
 mod unit_tests;
 
+pub use crate::dispatch::DispatchConfig;
 pub(crate) use crate::dns::MergedDnsState;
 pub use crate::dns::{DnsClientState, DnsState};
 pub use crate::error::{ErrorKind, NmstateError};

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -14,6 +14,7 @@ use super::super::{
     query_apply::{
         activate_nm_profiles, create_index_for_nm_conns_by_name_type,
         deactivate_nm_profiles, delete_exist_profiles, delete_orphan_ovs_ports,
+        dispatch::apply_dispatch_script,
         dns::{purge_global_dns_config, store_dns_config_via_global_api},
         is_mptcp_flags_changed, is_mptcp_supported, is_route_removed,
         is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
@@ -154,6 +155,8 @@ pub(crate) fn nm_apply(
     activate_nm_profiles(&mut nm_api, nm_conns_to_activate.as_slice())?;
 
     deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
+
+    apply_dispatch_script(&merged_state.interfaces)?;
 
     Ok(())
 }

--- a/rust/src/lib/nm/query_apply/dispatch.rs
+++ b/rust/src/lib/nm/query_apply/dispatch.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
+
+use crate::{DispatchConfig, ErrorKind, MergedInterfaces, NmstateError};
+
+const DEFAULT_DISPATCH_DIR: &str = "/etc/NetworkManager/dispatcher.d";
+
+const SCRIPT_START_COMMENT: &str = "## NMSTATE DISPATCH SCRIPT START";
+const SCRIPT_END_COMMENT: &str = "## NMSTATE DISPATCH SCRIPT END";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NmAction {
+    Up,
+    Down,
+}
+
+impl std::fmt::Display for NmAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Up => "up",
+                Self::Down => "down",
+            }
+        )
+    }
+}
+
+pub(crate) fn apply_dispatch_script(
+    merged_ifaces: &MergedInterfaces,
+) -> Result<(), NmstateError> {
+    for iface in merged_ifaces.kernel_ifaces.values().filter_map(|i| {
+        if i.is_desired() {
+            i.for_apply.as_ref()
+        } else {
+            None
+        }
+    }) {
+        if let Some(dispatch_conf) = iface.base_iface().dispatch.as_ref() {
+            let iface_name = iface.name();
+            if let Some(post_up) = dispatch_conf.post_activation.as_deref() {
+                create_dispatch_script(iface_name, post_up, NmAction::Up)?
+            }
+            if let Some(post_down) = dispatch_conf.post_deactivation.as_deref()
+            {
+                create_dispatch_script(iface_name, post_down, NmAction::Down)?
+            }
+        }
+    }
+    Ok(())
+}
+
+// Create dispatch script with file path as:
+//      /etc/NetworkManager/dispatcher.d/nmstate-eth1-up.sh
+//      /etc/networkmanager/dispatcher.d/nmstate-ovs1-down.sh
+fn create_dispatch_script(
+    iface_name: &str,
+    content: &str,
+    nm_action: NmAction,
+) -> Result<(), NmstateError> {
+    let dir = std::env::var("NMSTATE_NM_DISPATCH_DIR")
+        .unwrap_or(DEFAULT_DISPATCH_DIR.to_string());
+
+    let file_path = format!("{dir}/nmstate-{iface_name}-{nm_action}.sh");
+    let action_condition_line = match nm_action {
+        NmAction::Up => r#"{ [ "$2" == "up" ] || [ "$2" == "reapply" ]; }"#,
+        NmAction::Down => r#"[ "$2" == "down" ]"#,
+    };
+
+    let script_content = format!(
+        r#"#!/usr/bin/bash
+if [ "$1" == "{iface_name}" ] && {action_condition_line}; then
+{SCRIPT_START_COMMENT}
+{content}
+{SCRIPT_END_COMMENT}
+fi
+"#
+    );
+
+    if let Err(e) =
+        write_execute_file(file_path.as_str(), script_content.as_str())
+    {
+        return Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Failed to create NetworkManager dispatch script \
+                {file_path}: {e}"
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn write_execute_file(file_path: &str, content: &str) -> std::io::Result<()> {
+    let mut fd = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o744)
+        .open(file_path)?;
+    fd.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+pub(crate) fn get_dispatches() -> HashMap<String, DispatchConfig> {
+    let mut ret: HashMap<String, DispatchConfig> = HashMap::new();
+    let dir = std::env::var("NMSTATE_NM_DISPATCH_DIR")
+        .unwrap_or(DEFAULT_DISPATCH_DIR.to_string());
+
+    if let Ok(fd) = std::fs::read_dir(&dir) {
+        for entry in fd.filter_map(Result::ok) {
+            let file_name = if let Ok(s) = entry.file_name().into_string() {
+                if s.starts_with("nmstate-") {
+                    s
+                } else {
+                    continue;
+                }
+            } else {
+                continue;
+            };
+            let file_path = format!("{dir}/{file_name}");
+            let parts: Vec<&str> = file_name.split('-').collect();
+            if parts.len() == 3 {
+                let iface_name = parts[1];
+                if !["up.sh", "down.sh"].contains(&parts[2]) {
+                    log::debug!("Got unknown dispatch action for {file_name}");
+                    continue;
+                }
+                let script_content =
+                    if let Some(s) = read_dispatch_script(&file_path) {
+                        s
+                    } else {
+                        continue;
+                    };
+                let conf = match ret.entry(iface_name.to_string()) {
+                    Entry::Occupied(o) => o.into_mut(),
+                    Entry::Vacant(v) => v.insert(DispatchConfig::default()),
+                };
+                match parts[2] {
+                    "up.sh" => conf.post_activation = Some(script_content),
+                    "down.sh" => conf.post_deactivation = Some(script_content),
+                    _ => (),
+                }
+            }
+        }
+    }
+    ret
+}
+
+fn read_dispatch_script(file_path: &str) -> Option<String> {
+    if let Ok(mut fd) = std::fs::File::open(file_path) {
+        let mut script_content: Vec<&str> = Vec::new();
+        let mut content = String::new();
+        fd.read_to_string(&mut content).ok();
+        let mut begin = false;
+        for line in content.split('\n') {
+            if begin {
+                if line == SCRIPT_END_COMMENT {
+                    break;
+                } else {
+                    script_content.push(line);
+                }
+            } else if line == SCRIPT_START_COMMENT {
+                begin = true;
+                continue;
+            }
+        }
+        if !script_content.is_empty() {
+            return Some(script_content.join("\n"));
+        }
+    }
+    None
+}

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -2,6 +2,7 @@
 
 mod apply;
 pub(crate) mod device;
+pub(crate) mod dispatch;
 pub(crate) mod dns;
 mod ieee8021x;
 mod ip;

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -130,5 +130,8 @@ impl BaseInterface {
                 self.prop_list.push(other_prop_name)
             }
         }
+        if other.prop_list.contains(&"dispatch") {
+            self.dispatch = other.dispatch.clone();
+        }
     }
 }


### PR DESCRIPTION
Example yaml:

```yaml
---
interfaces:
- name: eth1
  type: ethernet
  state: up
  dispatch:
    post-activation: |
      echo post-up-eth1 | systemd-cat
    post-deactivation: |
      echo post-down-eth1 | systemd-cat
```

The `post-up` holds the content of script to be invoked after activation.

The `post-down` holds the content of script to be invoked after
deactivation.

Nmstate might append additional lines to make sure this script is only
invoked for specified interface.

TODO:
* Checkpoint support
* Support remove dispatch script
* Remove dispatch script for `state: absent`
* Integration test cases