### PR TITLE
nm dns: Fix error when new DNS interface hold IPv6 link local address only

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -5,10 +5,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    ip::is_ipv6_addr, ErrorKind, MergedInterface, MergedNetworkState,
-    NmstateError,
-};
+use crate::{ip::is_ipv6_addr, ErrorKind, MergedNetworkState, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -296,25 +293,4 @@ pub(crate) fn parse_dns_ipv6_link_local_srv(
         }
     }
     Ok(None)
-}
-
-impl MergedInterface {
-    // IP stack is merged with current at this point.
-    pub(crate) fn is_iface_valid_for_dns(&self, is_ipv6: bool) -> bool {
-        if is_ipv6 {
-            self.merged.base_iface().ipv6.as_ref().map(|ip_conf| {
-                ip_conf.enabled
-                    && (ip_conf.is_static()
-                        || (ip_conf.is_auto()
-                            && ip_conf.auto_dns == Some(false)))
-            }) == Some(true)
-        } else {
-            self.merged.base_iface().ipv4.as_ref().map(|ip_conf| {
-                ip_conf.enabled
-                    && (ip_conf.is_static()
-                        || (ip_conf.is_auto()
-                            && ip_conf.auto_dns == Some(false)))
-            }) == Some(true)
-        }
-    }
 }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -123,7 +123,6 @@ pub(crate) fn nispor_retrieve(
                 })
             }
         };
-        log::debug!("Got interface {:?}", iface);
         net_state.append_interface_data(iface);
     }
     set_controller_type(&mut net_state.interfaces);

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -137,7 +137,6 @@ impl<'a> NmApi<'a> {
                 &self.dbus.connection,
                 &nm_conn_obj_path,
             ) {
-                debug!("Got connection {:?}", c);
                 nm_conns.push(c);
             }
         }
@@ -164,9 +163,6 @@ impl<'a> NmApi<'a> {
                 }
             }
         }
-        nm_conns
-            .iter()
-            .for_each(|conn| debug!("Get Applied connection {:?}", conn));
         Ok(nm_conns)
     }
 

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -73,8 +73,9 @@ pub(crate) fn nm_retrieve(
             NmDeviceState::Unmanaged | NmDeviceState::Disconnected => {
                 if let Some(iface) = nm_dev_to_nm_iface(nm_dev) {
                     log::debug!(
-                        "Found unmanaged or disconnected interface {:?}",
-                        iface
+                        "Found unmanaged or disconnected interface {}/{}",
+                        iface.name(),
+                        iface.iface_type()
                     );
                     net_state.append_interface_data(iface);
                 }
@@ -89,8 +90,9 @@ pub(crate) fn nm_retrieve(
                     if (state_flag & NM_ACTIVATION_STATE_FLAG_EXTERNAL) > 0 {
                         if let Some(iface) = nm_dev_to_nm_iface(nm_dev) {
                             log::debug!(
-                                "Found external managed interface {:?}",
-                                iface
+                                "Found external managed interface {}/{}",
+                                iface.name(),
+                                iface.iface_type()
                             );
                             net_state.append_interface_data(iface);
                         }
@@ -148,7 +150,11 @@ pub(crate) fn nm_retrieve(
                         iface.base_iface_mut().mptcp = None;
                     }
 
-                    log::debug!("Found interface {:?}", iface);
+                    log::debug!(
+                        "Found NM interface {}/{}",
+                        iface.name(),
+                        iface.iface_type()
+                    );
                     net_state.append_interface_data(iface);
                 }
             }
@@ -346,7 +352,6 @@ fn iface_get(
                 return None;
             }
         };
-        log::debug!("Found interface {:?}", iface);
         Some(iface)
     } else {
         // NmConnection has no interface name

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -14,15 +14,9 @@ impl Interfaces {
                 .get_iface_mut(other_iface.name(), other_iface.iface_type())
             {
                 Some(self_iface) => {
-                    log::debug!(
-                        "Merging interface {:?} into {:?}",
-                        other_iface,
-                        self_iface
-                    );
                     self_iface.update(other_iface);
                 }
                 None => {
-                    log::debug!("Appending new interface {:?}", other_iface);
                     new_ifaces.push(other_iface);
                 }
             }

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::dns::store_dns_config_to_iface, DnsClientState, ErrorKind,
-    InterfaceType, MergedNetworkState, NetworkState,
+    nm::dns::{reselect_dns_ifaces, store_dns_config_to_iface},
+    DnsClientState, ErrorKind, InterfaceType, MergedNetworkState, NetworkState,
 };
 
 #[test]
@@ -225,4 +225,161 @@ fn test_dns_iface_has_no_ip_stack_info() {
         MergedNetworkState::new(desired, current, false, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state).unwrap();
+}
+
+#[test]
+fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        dns-resolver:
+          config:
+            search:
+            - example.com
+            - example.org
+            server:
+            - 2001:4860:4860::8844
+            - 2001:4860:4860::8888"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: dummy0
+            state: up
+            ipv6:
+              enabled: true
+              autoconf: false
+              dhcp: false
+              address:
+              - ip: fe80::db:1
+                prefix-length: 64
+          - name: dummy1
+            type: dummy
+            state: up
+            ipv6:
+              enabled: true
+              dhcp: true
+              autoconf: true
+              auto-dns: false"#,
+    )
+    .unwrap();
+
+    let merged_state =
+        MergedNetworkState::new(desired, current, false, false).unwrap();
+
+    let (v4_iface, v6_iface) = reselect_dns_ifaces(&merged_state, &[], &[]);
+
+    assert!(v4_iface.is_empty());
+    assert_eq!(v6_iface, "dummy1");
+}
+
+#[test]
+fn test_dns_prefer_desired_over_current() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        dns-resolver:
+          config:
+            search:
+            - example.com
+            - example.org
+            server:
+            - 8.8.8.8
+            - 2001:4860:4860::8888
+        interfaces:
+          - name: dummy0
+            type: dummy
+            state: up
+            ipv4:
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+            ipv6:
+              enabled: true
+              autoconf: false
+              dhcp: false
+              address:
+              - ip: fe80::db:1
+                prefix-length: 64"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: dummy1
+            type: dummy
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-dns: false
+            ipv6:
+              enabled: true
+              dhcp: true
+              autoconf: true
+              auto-dns: false"#,
+    )
+    .unwrap();
+
+    let merged_state =
+        MergedNetworkState::new(desired, current, false, false).unwrap();
+
+    let (v4_iface, v6_iface) = reselect_dns_ifaces(&merged_state, &[], &[]);
+
+    assert_eq!(v4_iface, "dummy0");
+    assert_eq!(v6_iface, "dummy0");
+}
+
+#[test]
+fn test_copy_ip_stack_if_marked_for_dns() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        dns-resolver:
+          config:
+            search:
+            - example.com
+            - example.org
+            server:
+            - 8.8.8.8
+            - 2001:4860:4860::8888
+        interfaces:
+          - name: dummy0
+            type: dummy
+            state: up"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: dummy0
+            type: dummy
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-dns: false
+            ipv6:
+              enabled: true
+              dhcp: true
+              autoconf: true
+              auto-dns: false"#,
+    )
+    .unwrap();
+
+    let mut merged_state =
+        MergedNetworkState::new(desired, current, false, false).unwrap();
+
+    store_dns_config_to_iface(&mut merged_state).unwrap();
+
+    let iface = merged_state
+        .interfaces
+        .get_iface("dummy0", InterfaceType::Dummy)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    assert!(iface.base_iface().ipv6.is_some());
+    assert!(iface.base_iface().ipv4.is_some());
 }


### PR DESCRIPTION
When storing DNS to interface, the `reselect_dns_ifaces()` might use
a desired interface with current state holding IPv6 link local address only.
This will trigger a bug log(not error):

    BUG: The dns interface is hold None IP {iface:?}

Root cause:
 * The `is_iface_valid_for_dns()` is checking `merged` interface state.
 * The `set_iface_dns_conf()` is using `for_apply` interface state.

Fixes:
 * Before calling `set_iface_dns_conf()`, copy IP stack from current.

Improvement:
 * Move `is_iface_valid_for_dns()` to `nm/dns.rs` as it is NM specific
   code.
 * Add `is_iface_prefered_for_dns()`. So we prefer desired interface
   with desired IP stack info as DNS interface.
 * Interface with IPv6 link local address only is not preferred.
 * Raise error `set_iface_dns_conf()` if IP stack is None instead of log
   only.
 * Sort the interfaces to make sure we are consistent on DNS interface
   choice. Also make the problem be consistent instead of randomly
   depend on HashMap::iter() order.
 * Removed noisy debug log which is not useful for debugging this issue.

Since the original problem is random failure, it is hard to reproduce it
using integration test case. Added unit test cases instead.