### PR TITLE
ipv6: Fix verification error on empty address list

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -566,6 +566,9 @@ impl InterfaceIpv6 {
         if let Some(addrs) = self.addresses.as_mut() {
             addrs.sort_unstable();
             addrs.dedup();
+            if addrs.is_empty() {
+                self.addresses = None;
+            }
         }
     }
 

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -248,3 +248,35 @@ ipv6:
         assert!(e.msg().contains("MTU should be >= 1280"));
     }
 }
+
+#[test]
+fn test_ipv6_verify_emtpy() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv6:
+                enabled: "true"
+                dhcp: "false"
+                address: []"#,
+    )
+    .unwrap();
+
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv6:
+                enabled: "true"
+                dhcp: "false""#,
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false)
+            .unwrap();
+
+    merged_ifaces.verify(&cur_ifaces).unwrap();
+}


### PR DESCRIPTION
When user desiring empty list of IPv6 address, they get verification
error.

To fix it, we just set empty list of IPv6 address as None in
`sanitize_for_verify()`.

Unit test case included.