### PR TITLE
ovs: Fix error when adding internal interface

### DIFF
--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -68,7 +68,7 @@ fn test_resolve_unknown_type_absent_multiple() {
 }
 
 #[test]
-fn test_mark_orphan_vlan_as_absent() {
+fn test_vlan_over_ethernet_can_exist_after_ethernet_absent() {
     let mut current = Interfaces::new();
     current.push(new_eth_iface("eth0"));
     current.push(new_vlan_iface("eth0.10", "eth0", 10));
@@ -88,13 +88,11 @@ fn test_mark_orphan_vlan_as_absent() {
         .as_ref()
         .unwrap();
     assert!(iface.is_absent());
-    let iface = merged_ifaces
+    assert!(merged_ifaces
         .get_iface("eth0.10", InterfaceType::Vlan)
         .unwrap()
         .for_apply
-        .as_ref()
-        .unwrap();
-    assert!(iface.is_absent());
+        .is_none());
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -576,3 +576,68 @@ fn test_validate_dpdk_n_txq_desc() {
         assert!(e.msg().contains("OVS DPDK n_txq_desc must power of 2"));
     }
 }
+
+#[test]
+fn test_ovs_orphan_check_on_bridge_with_same_name_iface() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+              - name: ovs0
+        "#,
+    )
+    .unwrap();
+
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"
+        - name: br0
+          type: ovs-interface
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+              - name: br0
+        "#,
+    )
+    .unwrap();
+
+    MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+}
+
+#[test]
+fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"
+        - name: br0
+          type: ovs-interface
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+              - name: ovs0
+        "#,
+    )
+    .unwrap();
+
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r#"
+        - name: br0
+          type: ovs-interface
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+              - name: br0
+        "#,
+    )
+    .unwrap();
+
+    MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+}

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1823,3 +1823,50 @@ def test_ovs_sys_iface_other_config_and_remove(
     )
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.fixture
+def ovs_bridge_with_auto_create_internal_iface():
+    with Bridge(BRIDGE1).create():
+        yield
+
+
+def test_ovs_new_internal_iface_to_bridge_with_auto_create_iface(
+    ovs_bridge_with_auto_create_internal_iface,
+):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: new_ovs0
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+
+def test_ovs_replace_internal_iface_to_bridge_with_auto_create_iface(
+    ovs_bridge_with_auto_create_internal_iface,
+):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: br1
+          type: ovs-interface
+          state: absent
+        - name: br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: ovs0
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
Current state:
    * br1 OVS bridge has br1 OVS internal interface.

Desire state:
    * Replace this `br1` ovs internal interface with `ovs0`.

Error message:
    Interface ovs0 cannot be in up state as its parent br1 has been
    marked as absent

Root cause:
 * The `handle_changed_ports()` marked the orphan `br1` ovs interface as
   absent.
 * The `ovs0` parent is now `br1`.
 * The `mark_orphan_interface_as_absent()` incorrectly think the `ovs0`
   is depending on removed `br1` OVS interface.

Fixes:
 * The `mark_orphan_interface_as_absent()` should not check
   `InterfaceType::OvsInterface` as it was be processed by
   `handle_changed_ports()`.

 * Add additional check to fail when user desire the orphan interface as
   `state: up`.

Integration test cases and unit test cases included.