### PR TITLE
ipv6: Support Tokenised IPv6 Identifiers

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 path = "lib.rs"
 
 [dependencies.nispor]
-version = "1.2.9"
+version = "1.2.10"
 optional = true
 
 [dependencies.ipnet]

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::str::FromStr;
 
 use crate::{
@@ -71,6 +73,11 @@ pub(crate) fn np_ipv6_to_nmstate(
             return Some(ip);
         }
         ip.enabled = true;
+        if let Some(token) = np_ip.token.as_ref() {
+            ip.prop_list.push("token");
+            ip.token = Some(token.to_string());
+        }
+
         let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -107,6 +107,8 @@ pub struct NmSettingIp {
     pub dhcp_duid: Option<String>,
     // IPv6 only
     pub dhcp_iaid: Option<String>,
+    // IPv6 only
+    pub token: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -140,6 +142,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             gateway: _from_map!(v, "gateway", String::try_from)?,
             may_fail: _from_map!(v, "may-fail", bool::try_from)?,
             route_metric: _from_map!(v, "route-metric", i64::try_from)?,
+            token: _from_map!(v, "token", String::try_from)?,
             ..Default::default()
         };
 
@@ -258,6 +261,9 @@ impl ToDbusValue for NmSettingIp {
         }
         if let Some(v) = &self.route_metric {
             ret.insert("route-metric", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.token {
+            ret.insert("token", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -164,6 +164,13 @@ fn gen_nm_ipv6_setting(
                 .to_string(),
         );
         nm_setting.dhcp_iaid = Some("mac".to_string());
+        if let Some(token) = iface_ip.token.as_ref() {
+            if token.is_empty() || token == "::" {
+                nm_setting.token = None;
+            } else {
+                nm_setting.token = Some(token.to_string());
+            }
+        }
         nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
         apply_dhcp_opts(
             &mut nm_setting,
@@ -180,6 +187,7 @@ fn gen_nm_ipv6_setting(
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, true)?;
         }
+        nm_setting.token = None;
     }
     if let Some(rules) = iface_ip.rules.as_ref() {
         nm_setting.route_rules = gen_nm_ip_rules(rules, true)?;

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -94,6 +94,9 @@ impl InterfaceIpv6 {
         if other.prop_list.contains(&"auto_route_metric") {
             self.auto_route_metric = other.auto_route_metric;
         }
+        if other.prop_list.contains(&"token") {
+            self.token = other.token.clone();
+        }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
                 self.prop_list.push(other_prop_name);

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -145,6 +145,7 @@ class InterfaceIPv6(InterfaceIP):
     ADDR_GEN_MODE = "addr-gen-mode"
     ADDR_GEN_MODE_EUI64 = "eui64"
     ADDR_GEN_MODE_STABLE_PRIVACY = "stable-privacy"
+    TOKEN = "token"
 
 
 class Bond:


### PR DESCRIPTION
Similar to `ip token set ::123/64 dev eth1` which setting the IPv6
address retried from IPv6 RA/autoconf to `<ra_prefix>::<token>`.

Example yaml:

```yml
---
interfaces:
- name: eth1
  state: up
  ipv6:
    token: ::fac1
    autoconf: true
    dhcp: true
    enabled: true
```

To remove the IPv6 token, you may set use:
 * Empty string: `token: ""`
 * Explicitly all zero: `token: "::"`

Due to kernel limitation, you cannot set IPv6 token to all zero.

You will get invalid argument error when:
 * Specified token not been started with 64 bits of 0.
 * Setting `autoconf: false` with non-empty token and non-all-zero token.

Integration test cases included.