### PR TITLE
ip: Fix error when removing port with IP enabled in current

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -320,7 +320,7 @@ impl MergedInterface {
     }
 
     fn validate_can_have_ip(&mut self) -> Result<(), NmstateError> {
-        if self.is_desired() {
+        if self.is_desired() && self.merged.is_up() {
             if let Some(apply_iface) = self.for_apply.as_ref() {
                 let base_iface = apply_iface.base_iface();
                 if !base_iface.can_have_ip()

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -285,7 +285,7 @@ impl Interfaces {
             if iface.is_absent() {
                 for cur_iface in cur_ifaces.to_vec() {
                     if cur_iface.name() == iface_name {
-                        let mut new_iface = cur_iface.clone();
+                        let mut new_iface = cur_iface.clone_name_type_only();
                         new_iface.base_iface_mut().state =
                             InterfaceState::Absent;
                         resolved_ifaces.push(new_iface);


### PR DESCRIPTION
The kernel allows IP been assigned to ports even it is not correct.
In this mis-configured environment, marking that port as absent will
fail with:

    Interface eth1 cannot have IP enabled as it is attached to a
    controller where IP is not allowed

Please check unit test case `test_absent_iface_holding_controller_and_ip` for
detail reproducer.

This is caused by two problems:

    * The `resolve_unknown_ifaces()` is cloning the whole current
      interface which contains both controller information and IP stack
      interface.

    * The `validate_can_have_ip()` is checking on absent interface.

The fixes are:
    * The `resolve_unknown_ifaces()` will only clone type and name for
      unknown interface.
    * The `validate_can_have_ip()` do not check on absent interface.

Unit test case included. Since this is not a valid use case, no
integration test case required.