### PR TITLE
k8s: Bump kubevirtci to use 1.24

### DIFF
--- a/k8s/kubevirtci.sh
+++ b/k8s/kubevirtci.sh
@@ -1,5 +1,5 @@
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.22'}
-export KUBEVIRTCI_TAG='2205231118-f12b50e'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.24'}
+export KUBEVIRTCI_TAG='2301300835-9998ef3'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"


### PR DESCRIPTION
This should fix 
```
Error: Failed to download metadata for repo 'devel_kubic_libcontainers_stable_cri-o_1.22': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```