### PR TITLE
nm: Fix error when bring down unmanaged interface

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -122,7 +122,6 @@ pub(crate) fn nm_apply(
         &mut nm_api,
         nm_conns_to_deactivate_first.as_slice(),
     )?;
-    deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
 
     save_nm_profiles(
         &mut nm_api,
@@ -148,6 +147,8 @@ pub(crate) fn nm_apply(
         nm_conns_to_activate.as_slice(),
         &nm_acs,
     )?;
+
+    deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
 
     Ok(())
 }
@@ -240,7 +241,9 @@ fn delete_remain_virtual_interface_as_desired(
         .interfaces
         .kernel_ifaces
         .values()
-        .filter(|i| i.is_changed() && i.merged.is_absent())
+        .filter(|i| {
+            i.is_changed() && (i.merged.is_absent() || i.merged.is_down())
+        })
         .map(|i| &i.merged)
     {
         if iface.is_virtual() {

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -31,9 +31,9 @@ impl MergedOvsDbGlobalConfig {
             prop_list: vec!["external_ids", "other_config"],
         };
 
-        let desired_value = serde_json::to_value(&desired)?;
+        let desired_value = serde_json::to_value(desired)?;
         let current_value = if current.is_none() {
-            serde_json::to_value(&OvsDbGlobalConfig {
+            serde_json::to_value(OvsDbGlobalConfig {
                 external_ids: Some(HashMap::new()),
                 other_config: Some(HashMap::new()),
                 prop_list: Vec::new(),

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -33,6 +33,7 @@ from libnmstate.schema import Route
 
 from ..testlib import cmdlib
 from ..testlib.dummy import nm_unmanaged_dummy
+from ..testlib.assertlib import assert_absent
 from ..testlib.assertlib import assert_state_match
 from ..testlib.statelib import show_only
 
@@ -206,3 +207,31 @@ def test_external_managed_veth_with_static_ip(
         InterfaceIPv6.ADDRESS_IP: "2001:db8:f::1",
         InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
     } in ipv6_info[InterfaceIPv6.ADDRESS]
+
+
+def test_bring_unmanaged_iface_down(unmanged_dummy1_with_static_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.DOWN,
+                }
+            ]
+        }
+    )
+    assert_absent(DUMMY1)
+
+
+def test_mark_unmanaged_iface_absent(unmanged_dummy1_with_static_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    assert_absent(DUMMY1)


### PR DESCRIPTION
When set `state: down` for unmanaged interface, nmstate will fail on
verification. This is because nmstate did not convert the interface to
managed before deactivate the profile.

The fix is create profile for unmanaged down interface, activate it then
deactivate it, for virtual interface, delete the link also.

Integration test cases included.