### PR TITLE
Packit: Enable network access for cargo

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,7 @@
 specfile_path: nmstate.spec
 upstream_package_name: nmstate
 upstream_project_url: http://nmstate.io
+enable_net: true
 srpm_build_deps:
   - make
   - git


### PR DESCRIPTION
The packit build need network access for cargo to fetch crates.