### PR TITLE
[nmstate-1.4] nm: Fix error when mark unmanaged interface as down

### DIFF
--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -32,6 +32,7 @@ from libnmstate.schema import Route
 from ..testlib import cmdlib
 from ..testlib.dummy import nm_unmanaged_dummy
 from ..testlib.assertlib import assert_state_match
+from ..testlib.assertlib import assert_absent
 
 BOND99 = "bond99"
 DUMMY1 = "dummy1"
@@ -162,3 +163,17 @@ interfaces:
             gw6_found = True
     assert gw4_found
     assert gw6_found
+
+
+def test_bring_unmanaged_iface_down(unmanged_dummy1_with_static_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.DOWN,
+                }
+            ]
+        }
+    )
+    assert_absent(DUMMY1)


### PR DESCRIPTION
When user would like to bring a unmanaged interface down, nmstate will
ignore that interface.

The root cause is `nm/profile.py` has many places ignoring `state: down`
interface.

The fix is to create a profile for `state: down` on unmanaged interface,
activate, then deactivate it, for virtual interface, delete the link
also.

Integration test case included.