### PR TITLE
route: Treat empty string to match None

### DIFF
--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -66,8 +66,8 @@ impl Routes {
     pub fn validate(&self) -> Result<(), NmstateError> {
         // All desire non-absent route should have next hop interface
         if let Some(config_routes) = self.config.as_ref() {
-            for route in config_routes.iter().filter(|r| !r.is_absent()) {
-                if route.next_hop_iface.is_none() {
+            for route in config_routes.iter() {
+                if !route.is_absent() && route.next_hop_iface.is_none() {
                     return Err(NmstateError::new(
                         ErrorKind::NotImplementedError,
                         format!(
@@ -110,6 +110,7 @@ pub struct RouteEntry {
     pub state: Option<RouteState>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Route destination address or network
+    /// Mandatory for every non-absent routes.
     pub destination: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -117,6 +118,7 @@ pub struct RouteEntry {
     )]
     /// Route next hop interface name.
     /// Serialize and deserialize to/from `next-hop-interface`.
+    /// Mandatory for every non-absent routes.
     pub next_hop_iface: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -124,6 +126,8 @@ pub struct RouteEntry {
     )]
     /// Route next hop IP address.
     /// Serialize and deserialize to/from `next-hop-address`.
+    /// When setting this as empty string for absent route, it will only delete
+    /// routes __without__ `next-hop-address`.
     pub next_hop_addr: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -70,10 +70,14 @@ pub struct RouteRuleEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Source prefix to match.
     /// Serialize and deserialize to/from `ip-from`.
+    /// When setting to empty string in absent route rule, it will only delete
+    /// route rule __without__ `ip-from`.
     pub ip_from: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Destination prefix to match.
     /// Serialize and deserialize to/from `ip-to`.
+    /// When setting to empty string in absent route rule, it will only delete
+    /// route rule __without__ `ip-to`.
     pub ip_to: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -220,6 +224,12 @@ impl RouteRuleEntry {
                 if other.ip_from != Some(ip_from) {
                     return false;
                 }
+            } else if other.ip_from.as_deref().map(|s| s.is_empty())
+                == Some(false)
+            {
+                // Use desire 'ip_from: ""' means it should only match empty
+                // ip_from
+                return false;
             }
         }
         if let Some(ip_to) = self.ip_to.as_deref() {
@@ -238,6 +248,12 @@ impl RouteRuleEntry {
                 if other.ip_to != Some(ip_to) {
                     return false;
                 }
+            } else if other.ip_to.as_deref().map(|s| s.is_empty())
+                == Some(false)
+            {
+                // Use desire 'ip_to: ""' means it should only match empty
+                // ip_to
+                return false;
             }
         }
         if self.priority.is_some()

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -137,7 +137,7 @@ family: ipv4
 }
 
 #[test]
-fn test_route_rule_treat_empty_ip_from_as_none_for_matching() {
+fn test_route_rule_matching_empty_ip_from_with_none() {
     let absent_rule: RouteRuleEntry = serde_yaml::from_str(
         r#"
         ip-from: ""
@@ -147,7 +147,7 @@ fn test_route_rule_treat_empty_ip_from_as_none_for_matching() {
     )
     .unwrap();
 
-    let rule: RouteRuleEntry = serde_yaml::from_str(
+    let not_match_rule: RouteRuleEntry = serde_yaml::from_str(
         r#"
         ip-from: 192.168.2.0/24
         priority: 30000
@@ -157,10 +157,21 @@ fn test_route_rule_treat_empty_ip_from_as_none_for_matching() {
     )
     .unwrap();
 
-    assert!(absent_rule.is_match(&rule));
+    let match_rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        priority: 30000
+        route-table: 200
+        family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    assert!(!absent_rule.is_match(&not_match_rule));
+    assert!(absent_rule.is_match(&match_rule));
 }
+
 #[test]
-fn test_route_rule_treat_empty_ip_to_as_none_for_matching() {
+fn test_route_rule_matching_empty_ip_to_with_none() {
     let absent_rule: RouteRuleEntry = serde_yaml::from_str(
         r#"
         ip-to: ""
@@ -170,7 +181,7 @@ fn test_route_rule_treat_empty_ip_to_as_none_for_matching() {
     )
     .unwrap();
 
-    let rule: RouteRuleEntry = serde_yaml::from_str(
+    let not_match_rule: RouteRuleEntry = serde_yaml::from_str(
         r#"
         ip-to: 192.168.2.0/24
         priority: 30000
@@ -180,5 +191,15 @@ fn test_route_rule_treat_empty_ip_to_as_none_for_matching() {
     )
     .unwrap();
 
-    assert!(absent_rule.is_match(&rule));
+    let match_rule: RouteRuleEntry = serde_yaml::from_str(
+        r#"
+        priority: 30000
+        route-table: 200
+        family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    assert!(!absent_rule.is_match(&not_match_rule));
+    assert!(absent_rule.is_match(&match_rule));
 }


### PR DESCRIPTION
When user desiring absent route or route rule with empty string, it
should means this absent route only matches current route/route_rule
with this property been set to None.

For example on route rule:

```yml
- ip-to: 2001:db8:b::/64
  ip-from: ''
  state: absent
```

Should match

```yml
- ip-to: 2001:db8:b::/64
  priority: 1000
  route-table: 50
```

Should not match
```
- ip-from: 2001:db8:b::/64
  ip-to: 2001:db8:b::/64
  priority: 20000
  route-table: 50
```

This change applied to `ip-from` and `ip-to` in route rule.
This change applied to `next-hop-address` in route.

The empty string in route destination is invalid IP address string, user
should set it to null/None or use proper IP address.

Unit test cases and integration test cases included.

There is no integration test case as empty `next-hop-address` require
point to point interface which does not exist in CI. Unit test case is
enough for this use case.