### PR TITLE
route rule: automatically set route rule priority

### DIFF
--- a/rust/src/lib/nm/settings/route_rule.rs
+++ b/rust/src/lib/nm/settings/route_rule.rs
@@ -5,13 +5,9 @@ use std::convert::TryFrom;
 use super::super::nm_dbus::NmIpRouteRule;
 
 use crate::{
-    ip::is_ipv6_addr, ip::AddressFamily, InterfaceIpAddr, NmstateError,
-    RouteRuleEntry,
+    ip::is_ipv6_addr, ip::AddressFamily, ErrorKind, InterfaceIpAddr,
+    NmstateError, RouteRuleEntry,
 };
-
-// NM require route rule priority been set explicitly, use 30,000 when
-// desire state instruct to use USE_DEFAULT_PRIORITY
-const ROUTE_RULE_DEFAULT_PRIORIRY: u32 = 30000;
 
 const AF_INET6: i32 = 10;
 const AF_INET: i32 = 2;
@@ -51,7 +47,13 @@ pub(crate) fn gen_nm_ip_rules(
         }
         nm_rule.priority = match rule.priority {
             Some(RouteRuleEntry::USE_DEFAULT_PRIORITY) | None => {
-                Some(ROUTE_RULE_DEFAULT_PRIORIRY)
+                return Err(NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "NM route rule got None \
+                        or USE_DEFAULT_PRIORITY priority: {nm_rule:?}"
+                    ),
+                ));
             }
             Some(i) => Some(i as u32),
         };

--- a/rust/src/lib/query_apply/route_rule.rs
+++ b/rust/src/lib/query_apply/route_rule.rs
@@ -21,11 +21,11 @@ impl MergedRouteRules {
                 cur_rules.push(cur_rule);
             }
         }
-        for rule in self.for_apply.as_slice() {
+        for rule in self.for_verify.as_slice() {
             if rule.is_absent() {
                 // Ignore absent rule when desired matches
                 if self
-                    .for_apply
+                    .for_verify
                     .as_slice()
                     .iter()
                     .any(|r| !r.is_absent() && rule.is_match(r))

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{unit_tests::testlib::gen_test_rule_entries, RouteRuleEntry};
+use crate::{
+    unit_tests::testlib::gen_test_rule_entries, MergedRouteRules,
+    RouteRuleEntry, RouteRules,
+};
 
 #[test]
 fn test_sort_uniqe_route_rules() {
@@ -202,4 +205,118 @@ fn test_route_rule_matching_empty_ip_to_with_none() {
 
     assert!(!absent_rule.is_match(&not_match_rule));
     assert!(absent_rule.is_match(&match_rule));
+}
+
+#[test]
+fn test_route_rule_auto_priority_increasing_from_desire() {
+    let des_rules: RouteRules = serde_yaml::from_str(
+        r#"
+        config:
+        - state: absent
+          priority: 30001
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.31
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.32
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.33
+          route-table: 200
+          priority: 30001
+          family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    let cur_rules: RouteRules = serde_yaml::from_str(
+        r#"
+        config:
+        - ip-to: 192.168.2.100
+          priority: 100
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.30
+          priority: 30001
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.101
+          priority: 101
+          route-table: 200
+          family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    let merged = MergedRouteRules::new(des_rules, cur_rules).unwrap();
+
+    let mut rules = merged.for_apply;
+    rules.sort_unstable();
+
+    assert_eq!(rules.len(), 4);
+    assert!(rules[0].is_absent());
+    assert_eq!(
+        rules[0].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.30/32".to_string())
+    );
+    assert_eq!(rules[0].priority, Some(30001));
+    assert_eq!(
+        rules[1].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.31/32".to_string())
+    );
+    assert_eq!(rules[1].priority, Some(30002));
+    assert_eq!(
+        rules[2].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.32/32".to_string())
+    );
+    assert_eq!(rules[2].priority, Some(30003));
+    assert_eq!(
+        rules[3].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.33/32".to_string())
+    );
+    assert_eq!(rules[3].priority, Some(30001));
+}
+
+#[test]
+fn test_route_rule_auto_priority_increasing_from_empty() {
+    let des_rules: RouteRules = serde_yaml::from_str(
+        r#"
+        config:
+        - ip-to: 192.168.2.30
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.31
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.32
+          route-table: 200
+          family: ipv4
+        "#,
+    )
+    .unwrap();
+
+    let cur_rules = RouteRules::new();
+
+    let merged = MergedRouteRules::new(des_rules, cur_rules).unwrap();
+
+    let mut rules = merged.for_apply;
+    rules.sort_unstable();
+
+    assert_eq!(rules.len(), 3);
+    assert_eq!(
+        rules[0].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.30/32".to_string())
+    );
+    assert_eq!(rules[0].priority, Some(30000));
+    assert_eq!(
+        rules[1].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.31/32".to_string())
+    );
+    assert_eq!(rules[1].priority, Some(30001));
+    assert_eq!(
+        rules[2].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.32/32".to_string())
+    );
+    assert_eq!(rules[2].priority, Some(30002));
 }


### PR DESCRIPTION
When user appending route rule without priority to existing ones, current
nmstate code will have multiple 30000 priority. For example:

    30000:  from 203.0.113.0/24 to 192.0.2.0/24 lookup 50 proto static
    30000:  from 203.0.113.2 to 192.0.2.2 lookup 50 proto static

Fixed by always set auto increasing priority before sending to NM backend.

Integration and unit test case included.