### PR TITLE
route: Add support of local(255) route table support

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -18,7 +18,6 @@ const SUPPORTED_ROUTE_PROTOCOL: [nispor::RouteProtocol; 7] = [
 const SUPPORTED_STATIC_ROUTE_PROTOCOL: [nispor::RouteProtocol; 2] =
     [nispor::RouteProtocol::Boot, nispor::RouteProtocol::Static];
 
-const LOCAL_ROUTE_TABLE: u32 = 255;
 const IPV4_DEFAULT_GATEWAY: &str = "0.0.0.0/0";
 const IPV6_DEFAULT_GATEWAY: &str = "::/0";
 const IPV4_EMPTY_NEXT_HOP_ADDRESS: &str = "0.0.0.0";
@@ -59,7 +58,6 @@ pub(crate) fn get_routes(running_config_only: bool) -> Routes {
         let mut running_routes = Vec::new();
         for np_route in np_routes.iter().filter(|np_route| {
             SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope)
-                && np_route.table != LOCAL_ROUTE_TABLE
                 && np_route.oif.as_ref() != Some(&"lo".to_string())
         }) {
             if is_multipath(np_route) {
@@ -77,7 +75,6 @@ pub(crate) fn get_routes(running_config_only: bool) -> Routes {
     for np_route in np_routes.iter().filter(|np_route| {
         SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope)
             && SUPPORTED_STATIC_ROUTE_PROTOCOL.contains(&np_route.protocol)
-            && np_route.table != LOCAL_ROUTE_TABLE
             && np_route.oif.as_ref() != Some(&"lo".to_string())
     }) {
         if is_multipath(np_route) {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1554,3 +1554,26 @@ def test_auto_choose_route_rule_priority(
     original_rules[0][RouteRule.PRIORITY] = 30000
     original_rules[1][RouteRule.PRIORITY] = 30001
     _check_ip_rules(original_rules)
+
+
+def test_add_routes_to_local_route_table_255(static_eth1_with_routes):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.TABLE_ID: 255,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.TABLE_ID: 255,
+        },
+    ]
+
+    state = {Route.KEY: {Route.CONFIG: routes}}
+    libnmstate.apply(state)
+
+    cur_state = libnmstate.show()
+    _assert_routes(routes, cur_state)


### PR DESCRIPTION
Previously, we are filtering out all routes from 255(local) route table
which cause verification failure when user desired so.

Removed the restriction in nispor plugin.

Integration test case included.