### PR TITLE
state: Keep current interface state intact

### DIFF
--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+from copy import deepcopy
 import logging
 
 from libnmstate.error import NmstateKernelIntegerRoundedError
@@ -98,12 +99,14 @@ class Ifaces:
         self._cur_user_space_ifaces = _UserSpaceIfaces()
         if cur_iface_infos:
             for iface_info in cur_iface_infos:
-                cur_iface = _to_specific_iface_obj(iface_info, save_to_disk)
+                cur_iface = _to_specific_iface_obj(
+                    deepcopy(iface_info), save_to_disk
+                )
                 if cur_iface.is_user_space_only:
-                    self._user_space_ifaces.set(cur_iface)
+                    self._user_space_ifaces.set(deepcopy(cur_iface))
                     self._cur_user_space_ifaces.set(cur_iface)
                 else:
-                    self._kernel_ifaces[cur_iface.name] = cur_iface
+                    self._kernel_ifaces[cur_iface.name] = deepcopy(cur_iface)
                     self._cur_kernel_ifaces[cur_iface.name] = cur_iface
 
         if des_iface_infos:

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -32,6 +32,7 @@ from libnmstate.schema import Route
 from ..testlib import cmdlib
 from ..testlib.dummy import nm_unmanaged_dummy
 from ..testlib.assertlib import assert_state_match
+from ..testlib.assertlib import assert_absent
 
 BOND99 = "bond99"
 DUMMY1 = "dummy1"
@@ -162,3 +163,17 @@ interfaces:
             gw6_found = True
     assert gw4_found
     assert gw6_found
+
+
+def test_bring_unmanaged_iface_down(unmanged_dummy1_with_static_ip):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.DOWN,
+                }
+            ]
+        }
+    )
+    assert_absent(DUMMY1)

--- a/tests/lib/ifaces_test.py
+++ b/tests/lib/ifaces_test.py
@@ -499,6 +499,30 @@ class TestIfaces:
             == MAC_ADDRESS1
         )
 
+    def test_cur_iface_intact(self):
+        cur_iface_infos = [gen_foo_iface_info(), gen_foo_iface_info()]
+        cur_iface_infos[0][Interface.NAME] = PORT1_IFACE_NAME
+        cur_iface_infos[1][Interface.NAME] = PORT2_IFACE_NAME
+        des_bridge_info = gen_bridge_iface_info()
+        des_bridge_info[Interface.NAME] = LINUX_BRIDGE_IFACE_NAME
+        des_iface_infos = [des_bridge_info]
+
+        ifaces = Ifaces(des_iface_infos, cur_iface_infos)
+        ifaces.gen_metadata()
+        cur_port1 = ifaces.get_cur_iface(
+            PORT1_IFACE_NAME, InterfaceType.ETHERNET
+        )
+        cur_port2 = ifaces.get_cur_iface(
+            PORT2_IFACE_NAME, InterfaceType.ETHERNET
+        )
+        des_port1 = ifaces.get_iface(PORT1_IFACE_NAME, InterfaceType.ETHERNET)
+        des_port2 = ifaces.get_iface(PORT2_IFACE_NAME, InterfaceType.ETHERNET)
+
+        assert cur_port1.controller is None
+        assert cur_port2.controller is None
+        assert des_port1.controller == LINUX_BRIDGE_IFACE_NAME
+        assert des_port2.controller == LINUX_BRIDGE_IFACE_NAME
+
 
 class TestIfacesSriov:
     def test_ignore_vf_when_pf_is_down(self):


### PR DESCRIPTION
In the `Ifaces.__init__()`, the overlapping use of `cur_iface` and
`des_iface` is causing `cur_iface` been modified by `Ifaces.gen_metadata()`

Unit test case included.