### PR TITLE
[nmstate-1.4] Support enable SRIOV and use VF in single desire state

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,6 +2,7 @@
 specfile_path: nmstate.spec
 upstream_package_name: nmstate
 upstream_project_url: http://nmstate.io
+enable_net: true
 srpm_build_deps:
   - python3-pip
   - python3-setuptools_scm

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -24,7 +24,7 @@ import time
 
 from libnmstate import validator
 from libnmstate.error import NmstateVerificationError
-from libnmstate.schema import InterfaceType
+from libnmstate.schema import Interface
 
 from .net_state import NetState
 from .nmstate import create_checkpoints
@@ -73,20 +73,56 @@ def apply(
 
     desired_state = copy.deepcopy(desired_state)
     remove_the_reserved_secrets(desired_state)
+
     with plugin_context() as plugins:
         validator.schema_validate(desired_state)
         current_state = show_with_plugins(
             plugins, include_status_data=True, include_secrets=True
         )
         validator.validate_capabilities(
-            desired_state, plugins_capabilities(plugins)
+            copy.deepcopy(desired_state), plugins_capabilities(plugins)
         )
         ignored_ifnames = _get_ignored_interface_names(plugins)
         net_state = NetState(
             desired_state, ignored_ifnames, current_state, save_to_disk
         )
         checkpoints = create_checkpoints(plugins, rollback_timeout)
-        _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk)
+        # When we have VF count changes and missing eth, it might be user
+        # referring future VF in the same desire state, we just apply
+        # VF changes state only first.
+        if net_state.ifaces.has_vf_count_change_and_missing_eth():
+            sriov_ifaces = net_state.ifaces.get_sriov_pf_ifaces()
+            if sriov_ifaces:
+                pf_net_state = NetState(
+                    {Interface.KEY: sriov_ifaces},
+                    ignored_ifnames,
+                    current_state,
+                    save_to_disk,
+                )
+                _apply_ifaces_state(
+                    plugins,
+                    pf_net_state,
+                    verify_change,
+                    save_to_disk,
+                    has_sriov_pf=True,
+                )
+                # Refresh the current state
+                current_state = show_with_plugins(
+                    plugins, include_status_data=True, include_secrets=True
+                )
+                validator.validate_capabilities(
+                    desired_state, plugins_capabilities(plugins)
+                )
+                ignored_ifnames = _get_ignored_interface_names(plugins)
+                net_state = NetState(
+                    copy.deepcopy(desired_state),
+                    ignored_ifnames,
+                    current_state,
+                    save_to_disk,
+                )
+        _apply_ifaces_state(
+            plugins, net_state, verify_change, save_to_disk, has_sriov_pf=False
+        )
         if commit:
             destroy_checkpoints(plugins, checkpoints)
         else:
@@ -117,7 +153,9 @@ def rollback(*, checkpoint=None):
         rollback_checkpoints(plugins, checkpoint)
 
 
-def _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk):
+def _apply_ifaces_state(
+    plugins, net_state, verify_change, save_to_disk, has_sriov_pf=False
+):
     for plugin in plugins:
         # Do not allow plugin to modify the net_state for future verification
         tmp_net_state = copy.deepcopy(net_state)
@@ -125,7 +163,7 @@ def _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk):
 
     verified = False
     if verify_change:
-        if _net_state_contains_sriov_interface(net_state):
+        if has_sriov_pf:
             # If SR-IOV is present, the verification timeout is being increased
             # to avoid timeouts due to slow drivers like i40e.
             verify_retry = VERIFY_RETRY_COUNT_SRIOV
@@ -140,14 +178,6 @@ def _apply_ifaces_state(plugins, net_state, verify_change, save_to_disk):
                 time.sleep(VERIFY_RETRY_INTERNAL)
         if not verified:
             _verify_change(plugins, net_state)
-
-
-def _net_state_contains_sriov_interface(net_state):
-    for iface in net_state.ifaces.all_kernel_ifaces.values():
-        if iface.type == InterfaceType.ETHERNET and iface.is_sriov:
-            return True
-
-    return False
 
 
 def _verify_change(plugins, net_state):

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -30,7 +30,7 @@ impl MergedOvsDbGlobalConfig {
             other_config: Some(other_config),
             prop_list: vec!["external_ids", "other_config"],
         };
-        let desired_value = serde_json::to_value(&desired)?;
+        let desired_value = serde_json::to_value(desired)?;
         let current_value = serde_json::to_value(current)?;
 
         if let Some((reference, desire, current)) = get_json_value_difference(

--- a/tests/lib/netapplier_test.py
+++ b/tests/lib/netapplier_test.py
@@ -80,7 +80,7 @@ def test_iface_admin_state_change(
     plugin_context_mock.return_value.__enter__.return_value = [plugin]
     netapplier.apply(desired_config, verify_change=False)
 
-    plugin.apply_changes.assert_called_once_with(
+    plugin.apply_changes.assert_called_with(
         net_state_mock(desired_config, current_config), True
     )
 
@@ -113,7 +113,7 @@ def test_add_new_bond(
     plugin_context_mock.return_value.__enter__.return_value = [plugin]
     netapplier.apply(desired_config, verify_change=False)
 
-    plugin.apply_changes.assert_called_once_with(
+    plugin.apply_changes.assert_called_with(
         net_state_mock(desired_config, {}), True
     )
 
@@ -151,7 +151,7 @@ def test_edit_existing_bond(
     plugin_context_mock.return_value.__enter__.return_value = [plugin]
     netapplier.apply(desired_config, verify_change=False)
 
-    plugin.apply_changes.assert_called_once_with(
+    plugin.apply_changes.assert_called_with(
         net_state_mock(desired_config, current_config), True
     )
 


### PR DESCRIPTION
Support enabling SR-IOV and using future VF at the same time:

```yml
--- interfaces:
- name: eth1v1
  type: ethernet
  state: up
  ipv4:
    enabled: false
  ipv6:
    enabled: false
- name: eth1
  type: ethernet
  state: up
  ethernet:
    sr-iov:
      total-vfs: 2
```

Since nmstate-1.x does not support referring SR-IOV VF via
`sriov:<pf_name>:<vf_id>`, we cannot create realizable way to test this.

Hence no test case attached.

Manually test in openshift SR-IOV setup.