### PR TITLE
WIP: sriov: Support enabling SR-IOV and use future VF in single desire state

### DIFF
--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -166,6 +166,17 @@ pub struct VethConfig {
 }
 
 impl MergedInterfaces {
+    pub(crate) fn has_sriov_vf_changes(&self) -> bool {
+        self.kernel_ifaces.values().any(|i| {
+            if let Some(Interface::Ethernet(eth_iface)) = i.for_apply.as_ref() {
+                eth_iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
+                    == Some(true)
+            } else {
+                false
+            }
+        })
+    }
+
     // Raise error if new veth interface has no peer defined.
     // Mark old veth peer as absent when veth changed its peer.
     // Mark veth peer as absent also when veth is marked as absent.
@@ -194,6 +205,7 @@ impl MergedInterfaces {
                 if eth_iface.veth.is_none()
                     && !self.gen_conf_mode
                     && !veth_peers.contains(&eth_iface.base.name.as_str())
+                    && !self.has_sriov_vf_changes()
                 {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -57,16 +57,6 @@ impl Interfaces {
         }
     }
 
-    pub(crate) fn has_sriov_enabled(&self) -> bool {
-        self.kernel_ifaces.values().any(|i| {
-            if let Interface::Ethernet(eth_iface) = i {
-                eth_iface.sriov_is_enabled()
-            } else {
-                false
-            }
-        })
-    }
-
     pub(crate) fn hide_controller_prop(&mut self) {
         for iface in self.kernel_ifaces.values_mut() {
             iface.base_iface_mut().controller = None;
@@ -120,21 +110,6 @@ fn verify_desire_absent_but_found_in_current(
 }
 
 impl MergedInterfaces {
-    pub(crate) fn state_for_apply(&self) -> Interfaces {
-        let mut ifaces = Interfaces::new();
-        for merged_iface in self
-            .kernel_ifaces
-            .values()
-            .chain(self.user_ifaces.values())
-            .filter(|i| i.is_changed())
-        {
-            if let Some(iface) = merged_iface.for_apply.as_ref() {
-                ifaces.push(iface.clone());
-            }
-        }
-        ifaces
-    }
-
     pub(crate) fn verify(
         &self,
         current: &Interfaces,

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     unit_tests::testlib::new_eth_iface, BridgePortVlanMode, ErrorKind,
-    EthernetConfig, Interface, InterfaceType, Interfaces, MergedInterfaces,
-    SrIovConfig, SrIovVfConfig,
+    EthernetConfig, EthernetDuplex, Interface, InterfaceType, Interfaces,
+    MergedInterfaces, NetworkState, SrIovConfig, SrIovVfConfig,
 };
 
 #[test]
@@ -585,4 +585,51 @@ fn test_sriov_vf_auto_fill_vf_conf() {
         )
         .unwrap()
     );
+}
+
+#[test]
+fn test_sriov_enable_and_use_in_single_yaml() {
+    let mut desired = serde_yaml::from_str::<NetworkState>(
+        r#"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            speed: 10000
+            duplex: full
+            auto-negotiation: false
+            sr-iov:
+              total-vfs: 2
+        - name: eth1v0
+          type: ethernet
+          state: up
+        - name: eth1v1
+          type: ethernet
+          state: up
+        "#,
+    )
+    .unwrap();
+
+    let pf_state = desired.isolate_sriov_conf_out().unwrap();
+
+    if let Interface::Ethernet(pf_iface) =
+        pf_state.interfaces.kernel_ifaces.get("eth1").unwrap()
+    {
+        let eth_conf = pf_iface.ethernet.as_ref().unwrap();
+        assert_eq!(eth_conf.auto_neg, Some(false));
+        assert_eq!(eth_conf.speed, Some(10000));
+        assert_eq!(eth_conf.duplex, Some(EthernetDuplex::Full));
+        let sr_iov_conf = eth_conf.sr_iov.as_ref().unwrap();
+        assert_eq!(sr_iov_conf.total_vfs, Some(2));
+    } else {
+        panic!("Expecting Ethernet interface, got {:?}", pf_state);
+    }
+    if let Interface::Ethernet(second_pf_iface) =
+        desired.interfaces.kernel_ifaces.get("eth1").unwrap()
+    {
+        assert!(second_pf_iface.ethernet.is_none())
+    } else {
+        panic!("Expecting Ethernet interface, got {:?}", pf_state);
+    }
 }

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -9,6 +9,8 @@ import libnmstate
 from libnmstate.schema import Bond
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge
@@ -430,3 +432,37 @@ class TestSrIov:
         libnmstate.apply(desired_state)
 
         assertlib.assert_state_match(expected_state)
+
+    def test_enable_sriov_and_use_future_vf(self, disable_sriov):
+        pf_name = _test_nic_name()
+        iface_infos = [
+            {
+                Interface.NAME: pf_name,
+                Interface.STATE: InterfaceState.UP,
+                Ethernet.CONFIG_SUBTREE: {
+                    Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+                },
+            },
+            {
+                Interface.NAME: f"sriov:{pf_name}:0",
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: False,
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: False,
+                },
+            },
+            {
+                Interface.NAME: f"sriov:{pf_name}:1",
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: False,
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: False,
+                },
+            },
+        ]
+        desired_state = {Interface.KEY: iface_infos}
+        libnmstate.apply(desired_state)


### PR DESCRIPTION
When changing SR-IOV to add more VF interface, this patch allows user to
crate VF and use it in single desire state, for example with SR-IOV
disabled on eth1, you can apply this state:

```yml
---
interfaces:
  - name: sriov:eth1:1
    type: ethernet
    state: up
    ipv4:
      enabled: false
    ipv6:
      enabled: false
  - name: eth1
    type: ethernet
    state: up
    ethernet:
      sr-iov:
        total-vfs: 2
```

The implementation detail is introducing
`MergedNetworkState.isolate_sriov_conf_out()` to __move__ ethernet
section to new `MergedNetworkState` if SR-IOV config desired. This new
PF only state will be applied first and the follow-up verification
process will wait all VF shows up before proceed the original
MergedNetworkState.

Unit test case and integration test case included.