### PR TITLE
nm ovs: Do not touch ovs-port when not required

### DIFF
--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -166,6 +166,17 @@ pub struct VethConfig {
 }
 
 impl MergedInterfaces {
+    pub(crate) fn has_sriov_vf_changes(&self) -> bool {
+        self.kernel_ifaces.values().any(|i| {
+            if let Some(Interface::Ethernet(eth_iface)) = i.for_apply.as_ref() {
+                eth_iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
+                    == Some(true)
+            } else {
+                false
+            }
+        })
+    }
+
     // Raise error if new veth interface has no peer defined.
     // Mark old veth peer as absent when veth changed its peer.
     // Mark veth peer as absent also when veth is marked as absent.
@@ -194,6 +205,7 @@ impl MergedInterfaces {
                 if eth_iface.veth.is_none()
                     && !self.gen_conf_mode
                     && !veth_peers.contains(&eth_iface.base.name.as_str())
+                    && !self.has_sriov_vf_changes()
                 {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -57,16 +57,6 @@ impl Interfaces {
         }
     }
 
-    pub(crate) fn has_sriov_enabled(&self) -> bool {
-        self.kernel_ifaces.values().any(|i| {
-            if let Interface::Ethernet(eth_iface) = i {
-                eth_iface.sriov_is_enabled()
-            } else {
-                false
-            }
-        })
-    }
-
     pub(crate) fn hide_controller_prop(&mut self) {
         for iface in self.kernel_ifaces.values_mut() {
             iface.base_iface_mut().controller = None;

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -463,3 +463,75 @@ def test_purge_unmanged_ovs_bridge_in_show(ovs_unmanaged_bridge):
     assert (
         state[Interface.KEY][0][Interface.TYPE] == InterfaceType.OVS_INTERFACE
     )
+
+
+def get_nm_conn_timestamp(conn_name):
+    output = cmdlib.exec_cmd(
+        f"nmcli -g connection.timestamp c show {conn_name}".split(), check=True
+    )[1]
+    return int(output)
+
+
+def get_nm_conn_uuid(conn_name):
+    output = cmdlib.exec_cmd(
+        f"nmcli -g connection.uuid c show {conn_name}".split(), check=True
+    )[1]
+    return output
+
+
+def test_do_not_touch_ovs_port_when_not_desired_system_iface(
+    bridge_with_ports,
+):
+    """
+    The modification like MTU of ovs system interface should not reactivate its
+    OVS port
+    """
+    old_timestamp = get_nm_conn_timestamp("eth1-port")
+    old_uuid = get_nm_conn_uuid("eth1-port")
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MTU: 2000,
+            },
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    new_uuid = get_nm_conn_uuid("eth1-port")
+    new_timestamp = get_nm_conn_timestamp("eth1-port")
+
+    assert old_timestamp == new_timestamp
+    assert old_uuid == new_uuid
+
+
+def test_do_not_touch_ovs_port_when_not_desired_internal_iface(
+    bridge_with_ports,
+):
+    """
+    The modification like MTU of ovs internal interface should not reactivate
+    its OVS port
+    """
+    old_timestamp = get_nm_conn_timestamp(f"{IFACE0}-port")
+    old_uuid = get_nm_conn_uuid(f"{IFACE0}-port")
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: IFACE0,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MTU: 2000,
+            },
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    new_timestamp = get_nm_conn_timestamp(f"{IFACE0}-port")
+    new_uuid = get_nm_conn_uuid(f"{IFACE0}-port")
+
+    assert old_timestamp == new_timestamp
+    assert old_uuid == new_uuid

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -9,6 +9,8 @@ import libnmstate
 from libnmstate.schema import Bond
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import LinuxBridge
@@ -430,3 +432,37 @@ class TestSrIov:
         libnmstate.apply(desired_state)
 
         assertlib.assert_state_match(expected_state)
+
+    def test_enable_sriov_and_use_future_vf(self, disable_sriov):
+        pf_name = _test_nic_name()
+        iface_infos = [
+            {
+                Interface.NAME: pf_name,
+                Interface.STATE: InterfaceState.UP,
+                Ethernet.CONFIG_SUBTREE: {
+                    Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+                },
+            },
+            {
+                Interface.NAME: f"sriov:{pf_name}:0",
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: False,
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: False,
+                },
+            },
+            {
+                Interface.NAME: f"sriov:{pf_name}:1",
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: False,
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: False,
+                },
+            },
+        ]
+        desired_state = {Interface.KEY: iface_infos}
+        libnmstate.apply(desired_state)


### PR DESCRIPTION
Current code will always create ovs-port when desire state just modify MTU
of OVS system interface.

The fix is `iface_to_nm_connections()` only modify or create OVS port when
controller is changed.

Integration test case included.