### PR TITLE
WIP: sriov: Fix SR-IOV enabling and use in single desire state

### DIFF
--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     ErrorKind, EthernetConfig, EthernetInterface, Interface, InterfaceType,
-    Interfaces, MergedInterface, MergedNetworkState, NmstateError, SrIovConfig,
-    VethConfig,
+    Interfaces, NetworkState, NmstateError, SrIovConfig, VethConfig,
 };
 
 impl EthernetInterface {
@@ -101,36 +100,80 @@ impl Interfaces {
     }
 }
 
-impl MergedNetworkState {
-    // Return newly create MergedNetworkState containing only ethernet section
-    // of interface with SR-IOV PF changes.
-    // The self will have SR-IOV PF change removed.
-    pub(crate) fn isolate_sriov_conf_out(&mut self) -> Option<Self> {
-        let mut pf_ifaces: Vec<MergedInterface> = Vec::new();
+impl NetworkState {
+    pub(crate) fn has_vf_count_change_and_missing_eth(
+        &self,
+        current: &Self,
+    ) -> bool {
+        self.has_vf_count_change(current) && self.has_missing_eth(current)
+    }
 
-        for iface in self.interfaces.kernel_ifaces.values_mut().filter(|i| {
-            i.is_desired() && i.merged.iface_type() == InterfaceType::Ethernet
-        }) {
-            if let Some(Interface::Ethernet(apply_iface)) =
-                iface.for_apply.as_mut()
+    fn has_vf_count_change(&self, current: &Self) -> bool {
+        for iface in
+            self.interfaces.kernel_ifaces.values().filter(|i| {
+                i.is_up() && i.iface_type() == InterfaceType::Ethernet
+            })
+        {
+            if let (
+                Interface::Ethernet(iface),
+                Some(Interface::Ethernet(cur_iface)),
+            ) = (iface, current.interfaces.kernel_ifaces.get(iface.name()))
             {
-                if let Some(true) =
-                    apply_iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
-                {
-                    if let Some(eth_conf) = apply_iface.ethernet.as_ref() {
-                        let new_iface = EthernetInterface {
-                            base: apply_iface.base.clone_name_type_only(),
-                            ethernet: Some(eth_conf.clone()),
-                            ..Default::default()
-                        };
-                        if let Ok(new_merged_iface) = MergedInterface::new(
-                            Some(Interface::Ethernet(new_iface)),
-                            iface.current.clone(),
-                        ) {
-                            pf_ifaces.push(new_merged_iface);
-                            apply_iface.ethernet = None;
-                        }
-                    }
+                let pf_count = iface
+                    .ethernet
+                    .as_ref()
+                    .and_then(|e| e.sr_iov.as_ref())
+                    .and_then(|s| s.total_vfs);
+                let cur_pf_count = cur_iface
+                    .ethernet
+                    .as_ref()
+                    .and_then(|e| e.sr_iov.as_ref())
+                    .and_then(|s| s.total_vfs);
+                if pf_count.is_some() && pf_count != cur_pf_count {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn has_missing_eth(&self, current: &Self) -> bool {
+        self.interfaces
+            .kernel_ifaces
+            .values()
+            .filter(|i| {
+                i.is_up()
+                    && (i.iface_type() == InterfaceType::Ethernet
+                        || i.iface_type() == InterfaceType::Unknown)
+            })
+            .any(|i| !current.interfaces.kernel_ifaces.contains_key(i.name()))
+    }
+
+    // Return newly create NetworkState containing only ethernet section of
+    // interface with SR-IOV PF changes.
+    pub(crate) fn get_sriov_pf_conf_state(&self) -> Option<Self> {
+        let mut pf_ifaces: Vec<Interface> = Vec::new();
+
+        for iface in self.interfaces.kernel_ifaces.values().filter_map(|i| {
+            if i.is_up() {
+                if let Interface::Ethernet(iface) = i {
+                    Some(iface)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }) {
+            if let Some(true) =
+                iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
+            {
+                if let Some(eth_conf) = iface.ethernet.as_ref() {
+                    pf_ifaces.push(Interface::Ethernet(EthernetInterface {
+                        base: iface.base.clone_name_type_only(),
+                        ethernet: Some(eth_conf.clone()),
+                        ..Default::default()
+                    }));
                 }
             }
         }
@@ -138,16 +181,9 @@ impl MergedNetworkState {
         if pf_ifaces.is_empty() {
             None
         } else {
-            let mut pf_state = MergedNetworkState::default();
+            let mut pf_state = NetworkState::default();
             for pf_iface in pf_ifaces {
-                pf_state.interfaces.insert_order.push((
-                    pf_iface.merged.name().to_string(),
-                    pf_iface.merged.iface_type(),
-                ));
-                pf_state
-                    .interfaces
-                    .kernel_ifaces
-                    .insert(pf_iface.merged.name().to_string(), pf_iface);
+                pf_state.interfaces.push(pf_iface);
             }
             Some(pf_state)
         }

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -110,21 +110,6 @@ fn verify_desire_absent_but_found_in_current(
 }
 
 impl MergedInterfaces {
-    pub(crate) fn state_for_apply(&self) -> Interfaces {
-        let mut ifaces = Interfaces::new();
-        for merged_iface in self
-            .kernel_ifaces
-            .values()
-            .chain(self.user_ifaces.values())
-            .filter(|i| i.is_changed())
-        {
-            if let Some(iface) = merged_iface.for_apply.as_ref() {
-                ifaces.push(iface.clone());
-            }
-        }
-        ifaces
-    }
-
     pub(crate) fn verify(
         &self,
         current: &Interfaces,

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -438,6 +438,7 @@ class TestSrIov:
         iface_infos = [
             {
                 Interface.NAME: pf_name,
+                Interface.TYPE: InterfaceType.ETHERNET,
                 Interface.STATE: InterfaceState.UP,
                 Ethernet.CONFIG_SUBTREE: {
                     Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},


### PR DESCRIPTION
Currently, we isolate SR-IOV PF changes out for `enable-and-use` use
case, but the second desire state contains no SR-IOV PF changes which
cause the verification stage does not wait on VF shows up again.

Instead of isolating PF changes out to apply first, we only clone PF
changes to apply first when VF count changed and has missing ethernet in
desire state. This means we will apply twice SR-IOV PF changes to ensure
the final apply also wait on VF shows up.

Unit test cases included.

Current integration test case `test_wait_sriov_vf_been_created` has
covered the use case.