### PR TITLE
sriov: Fix SR-IOV enabling and use in single desire state

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -238,13 +238,13 @@ impl<'de> Deserialize<'de> for UnknownInterface {
         D: Deserializer<'de>,
     {
         let mut ret = UnknownInterface::default();
-        let v = serde_json::Value::deserialize(deserializer)?;
+        let mut v = serde_json::Map::deserialize(deserializer)?;
         let mut base_value = serde_json::map::Map::new();
-        if let Some(n) = v.get("name") {
-            base_value.insert("name".to_string(), n.clone());
+        if let Some(n) = v.remove("name") {
+            base_value.insert("name".to_string(), n);
         }
-        if let Some(s) = v.get("state") {
-            base_value.insert("state".to_string(), s.clone());
+        if let Some(s) = v.remove("state") {
+            base_value.insert("state".to_string(), s);
         }
         // The BaseInterface will only have name and state
         // These two properties are also stored in `other` for serializing
@@ -252,7 +252,7 @@ impl<'de> Deserialize<'de> for UnknownInterface {
             serde_json::value::Value::Object(base_value),
         )
         .map_err(serde::de::Error::custom)?;
-        ret.other = v;
+        ret.other = serde_json::Value::Object(v);
         Ok(ret)
     }
 }

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -166,17 +166,6 @@ pub struct VethConfig {
 }
 
 impl MergedInterfaces {
-    pub(crate) fn has_sriov_vf_changes(&self) -> bool {
-        self.kernel_ifaces.values().any(|i| {
-            if let Some(Interface::Ethernet(eth_iface)) = i.for_apply.as_ref() {
-                eth_iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
-                    == Some(true)
-            } else {
-                false
-            }
-        })
-    }
-
     // Raise error if new veth interface has no peer defined.
     // Mark old veth peer as absent when veth changed its peer.
     // Mark veth peer as absent also when veth is marked as absent.
@@ -205,7 +194,6 @@ impl MergedInterfaces {
                 if eth_iface.veth.is_none()
                     && !self.gen_conf_mode
                     && !veth_peers.contains(&eth_iface.base.name.as_str())
-                    && !self.has_sriov_vf_changes()
                 {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -488,6 +488,7 @@ impl MergedInterfaces {
             desired.set_unknown_iface_to_eth()?;
             desired.set_missing_port_to_eth();
         } else {
+            desired.resolve_sriov_reference(&current)?;
             desired.resolve_unknown_ifaces(&current)?;
         }
 
@@ -509,8 +510,6 @@ impl MergedInterfaces {
 
         desired.unify_veth_and_eth();
         current.unify_veth_and_eth();
-
-        desired.resolve_sriov_reference(&current)?;
 
         for (iface_name, des_iface) in desired
             .kernel_ifaces

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -200,11 +200,7 @@ impl Interfaces {
         current: &Self,
     ) -> Result<(), NmstateError> {
         let mut changed_iface_names: Vec<String> = Vec::new();
-        for iface in self
-            .kernel_ifaces
-            .values_mut()
-            .filter(|i| i.iface_type() == InterfaceType::Ethernet)
-        {
+        for iface in self.kernel_ifaces.values_mut() {
             if let Some((pf_name, vf_id)) = parse_sriov_vf_naming(iface.name())?
             {
                 if let Some(vf_iface_name) =

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -110,21 +110,6 @@ fn verify_desire_absent_but_found_in_current(
 }
 
 impl MergedInterfaces {
-    pub(crate) fn state_for_apply(&self) -> Interfaces {
-        let mut ifaces = Interfaces::new();
-        for merged_iface in self
-            .kernel_ifaces
-            .values()
-            .chain(self.user_ifaces.values())
-            .filter(|i| i.is_changed())
-        {
-            if let Some(iface) = merged_iface.for_apply.as_ref() {
-                ifaces.push(iface.clone());
-            }
-        }
-        ifaces
-    }
-
     pub(crate) fn verify(
         &self,
         current: &Interfaces,

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -3,8 +3,7 @@
 use crate::{
     unit_tests::testlib::new_eth_iface, BridgePortVlanMode, ErrorKind,
     EthernetConfig, EthernetDuplex, Interface, InterfaceType, Interfaces,
-    MergedInterfaces, MergedNetworkState, NetworkState, SrIovConfig,
-    SrIovVfConfig,
+    MergedInterfaces, NetworkState, SrIovConfig, SrIovVfConfig,
 };
 
 #[test]
@@ -612,32 +611,10 @@ fn test_sriov_enable_and_use_in_single_yaml() {
     )
     .unwrap();
 
-    let current = serde_yaml::from_str::<NetworkState>(
-        r#"---
-        interfaces:
-        - name: eth1
-          type: ethernet
-          state: up
-          ethernet:
-            sr-iov:
-              total-vfs: 0
-        "#,
-    )
-    .unwrap();
+    let pf_state = desired.get_sriov_pf_conf_state().unwrap();
 
-    let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
-
-    let pf_state = merged_state.isolate_sriov_conf_out().unwrap();
-
-    if let Interface::Ethernet(pf_iface) = pf_state
-        .interfaces
-        .kernel_ifaces
-        .get("eth1")
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap()
+    if let Interface::Ethernet(pf_iface) =
+        pf_state.interfaces.kernel_ifaces.get("eth1").unwrap()
     {
         let eth_conf = pf_iface.ethernet.as_ref().unwrap();
         assert_eq!(eth_conf.auto_neg, Some(false));
@@ -648,17 +625,80 @@ fn test_sriov_enable_and_use_in_single_yaml() {
     } else {
         panic!("Expecting Ethernet interface, got {:?}", pf_state);
     }
-    if let Interface::Ethernet(second_pf_iface) = merged_state
-        .interfaces
-        .kernel_ifaces
-        .get("eth1")
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap()
-    {
-        assert!(second_pf_iface.ethernet.is_none())
-    } else {
-        panic!("Expecting Ethernet interface, got {:?}", pf_state);
-    }
+}
+
+#[test]
+fn test_sriov_has_vf_count_change_and_missing_eth() {
+    let desired = serde_yaml::from_str::<NetworkState>(
+        r#"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            speed: 10000
+            duplex: full
+            auto-negotiation: false
+            sr-iov:
+              total-vfs: 2
+        - name: eth1v0
+          type: ethernet
+          state: up
+        - name: eth1v1
+          type: ethernet
+          state: up
+        "#,
+    )
+    .unwrap();
+    let current = serde_yaml::from_str::<NetworkState>(
+        r#"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            speed: 10000
+            duplex: full
+            auto-negotiation: false
+            sr-iov:
+              total-vfs: 0
+        "#,
+    )
+    .unwrap();
+
+    assert!(desired.has_vf_count_change_and_missing_eth(&current));
+}
+
+#[test]
+fn test_sriov_has_vf_count_change_and_missing_eth_pf_none() {
+    let desired = serde_yaml::from_str::<NetworkState>(
+        r#"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            speed: 10000
+            duplex: full
+            auto-negotiation: false
+            sr-iov:
+              total-vfs: 2
+        - name: eth1v0
+          state: up
+        - name: eth1v1
+          state: up
+        "#,
+    )
+    .unwrap();
+    let current = serde_yaml::from_str::<NetworkState>(
+        r#"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+        "#,
+    )
+    .unwrap();
+
+    assert!(desired.has_vf_count_change_and_missing_eth(&current));
 }

--- a/tests/integration/testlib/sriov.py
+++ b/tests/integration/testlib/sriov.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import json
+
+import libnmstate
+from libnmstate.schema import Interface
+
+from .cmdlib import exec_cmd
+
+
+def get_sriov_vf_names(pf_name):
+    output = exec_cmd(f"ip -j -d link show {pf_name}".split())[1]
+    link_info = json.loads(output)[0]
+    macs = [
+        vf_info["address"].upper()
+        for vf_info in link_info.get("vfinfo_list", [])
+    ]
+    return [
+        iface[Interface.NAME]
+        for iface in libnmstate.show()[Interface.KEY]
+        if iface[Interface.MAC] in macs
+    ]


### PR DESCRIPTION
Currently, we isolate SR-IOV PF changes out for `enable-and-use` use
case, but the second desire state contains no SR-IOV PF changes which
cause the verification stage does not wait on VF shows up again.

Instead of isolating PF changes out to apply first, we only clone PF
changes to apply first when VF count changed and has missing ethernet in
desire state. This means we will apply twice SR-IOV PF changes to ensure
the final apply also wait on VF shows up.

Unit test cases included.

Current integration test case `test_wait_sriov_vf_been_created` and
`test_enable_sriov_and_use_future_vf` have covered the use case.