### PR TITLE
nm route rule: Use loopback interface as final fallback interface

### DIFF
--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
+const LOOPBACK_IFACE_NAME: &str = "lo";
 
 // General work flow:
 //  * The `current` NetworkState returned by NM plugin has route rules
@@ -203,6 +204,7 @@ fn append_route_rule(
 // * If rule has `iif`, we use that
 // * If rule has table id, we find a interface configured for that route table
 // * fallback to first desired interface with ip stack enabled.
+// * fallback to use loop interface.
 fn find_interface_for_rule<'a>(
     merged_state: &'a MergedNetworkState,
     rule: &RouteRuleEntry,
@@ -313,10 +315,8 @@ fn find_interface_for_rule<'a>(
         }
     }
 
-    Err(NmstateError::new(
-        ErrorKind::InvalidArgument,
-        format!("Failed to find interface to store route rule {rule}"),
-    ))
+    log::info!("Using loopback interface to store route rule {rule}");
+    Ok(LOOPBACK_IFACE_NAME)
 }
 
 fn iface_has_route_for_table_id(

--- a/tests/integration/nm/route_rule_test.py
+++ b/tests/integration/nm/route_rule_test.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import libnmstate
+import pytest
+import yaml
+
+from ..testlib.env import nm_minor_version
+from ..testlib.cmdlib import exec_cmd
+
+
+@pytest.fixture
+def cleanup_loopback():
+    yield
+    libnmstate.apply(
+        yaml.load(
+            """---
+            interfaces:
+            - name: lo
+              type: loopback
+              state: absent
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 41,
+    reason=("Loopback is only supported by NetworkManager 1.41+"),
+)
+def test_store_route_table_local_rule_to_loopback(cleanup_loopback):
+    libnmstate.apply(
+        yaml.load(
+            """---
+            route-rules:
+              config:
+                - route-table: 255
+                  priority: 12345
+                  family: ipv4
+                - route-table: 255
+                  priority: 12346
+                  family: ipv6
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+
+    assert (
+        exec_cmd("nmcli -g ipv4.routing-rules c show lo".split())[1].strip()
+        == "priority 12345 from 0.0.0.0/0 table 255"
+    )
+
+    assert (
+        exec_cmd("nmcli -g ipv6.routing-rules c show lo".split())[1].strip()
+        == r"priority 12346 from \:\:/0 table 255"
+    )


### PR DESCRIPTION
When we exhausted all the way to find a interface to store the routing
route, we use loopback interface. This is useful when user try to
modify route rule to 255(local) table, for example:

```yml
route-rules:
  config:
    - route-table: 255
      priority: 12345
      family: ipv4
    - route-table: 255
      priority: 12346
      family: ipv6
```

Unit and integration test cases included.