### PR TITLE
vlan: Add VLAN protocol support

### DIFF
--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -60,6 +60,9 @@ pub struct VlanConfig {
     pub base_iface: String,
     #[serde(deserialize_with = "crate::deserializer::u16_or_string")]
     pub id: u16,
+    /// Could be `802.1q` or `802.1ad`. Default to `802.1q` if not defined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<VlanProtocol>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -1,4 +1,6 @@
-use crate::{BaseInterface, VlanConfig, VlanInterface};
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{BaseInterface, VlanConfig, VlanInterface, VlanProtocol};
 
 pub(crate) fn np_vlan_to_nmstate(
     np_iface: &nispor::Iface,
@@ -7,6 +9,17 @@ pub(crate) fn np_vlan_to_nmstate(
     let vlan_conf = np_iface.vlan.as_ref().map(|np_vlan_info| VlanConfig {
         id: np_vlan_info.vlan_id,
         base_iface: np_vlan_info.base_iface.clone(),
+        protocol: match &np_vlan_info.protocol {
+            nispor::VlanProtocol::Ieee8021Q => Some(VlanProtocol::Ieee8021Q),
+            nispor::VlanProtocol::Ieee8021AD => Some(VlanProtocol::Ieee8021Ad),
+            p => {
+                log::warn!(
+                    "Got unknown VLAN protocol {p:?} on VLAN iface {}",
+                    np_iface.name.as_str()
+                );
+                None
+            }
+        },
     });
 
     VlanInterface {

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -14,6 +14,7 @@ use super::super::{
 pub struct NmSettingVlan {
     pub parent: Option<String>,
     pub id: Option<u32>,
+    pub protocol: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -23,6 +24,7 @@ impl TryFrom<DbusDictionary> for NmSettingVlan {
         Ok(Self {
             parent: _from_map!(v, "parent", String::try_from)?,
             id: _from_map!(v, "id", u32::try_from)?,
+            protocol: _from_map!(v, "protocol", String::try_from)?,
             _other: v,
         })
     }
@@ -36,6 +38,9 @@ impl ToDbusValue for NmSettingVlan {
         }
         if let Some(id) = self.id {
             ret.insert("id", zvariant::Value::new(id));
+        }
+        if let Some(protocol) = self.protocol.as_ref() {
+            ret.insert("protocol", zvariant::Value::new(protocol));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -13,8 +13,8 @@ use super::super::{
         deactivate_nm_profiles, delete_exist_profiles, delete_orphan_ovs_ports,
         dns::{purge_global_dns_config, store_dns_config_via_global_api},
         is_mptcp_flags_changed, is_mptcp_supported, is_route_removed,
-        is_veth_peer_changed, is_vlan_id_changed, is_vrf_table_id_changed,
-        is_vxlan_id_changed, save_nm_profiles,
+        is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
+        is_vxlan_changed, save_nm_profiles,
     },
     route::store_route_config,
     route_rule::store_route_rule_config,
@@ -304,7 +304,7 @@ fn delete_orphan_ports(
 // * NM has problem on remove routes, we need to deactivate it first
 //  https://bugzilla.redhat.com/1837254
 // * NM cannot change VRF table ID, so we deactivate first
-// * VLAN ID changed.
+// * VLAN config changed.
 // * Veth peer changed.
 // * NM cannot reapply changes to MPTCP flags.
 fn gen_nm_conn_need_to_deactivate_first(
@@ -325,8 +325,8 @@ fn gen_nm_conn_need_to_deactivate_first(
             {
                 if is_route_removed(nm_conn, activated_nm_con)
                     || is_vrf_table_id_changed(nm_conn, activated_nm_con)
-                    || is_vlan_id_changed(nm_conn, activated_nm_con)
-                    || is_vxlan_id_changed(nm_conn, activated_nm_con)
+                    || is_vlan_changed(nm_conn, activated_nm_con)
+                    || is_vxlan_changed(nm_conn, activated_nm_con)
                     || is_veth_peer_changed(nm_conn, activated_nm_con)
                     || is_mptcp_flags_changed(nm_conn, activated_nm_con)
                 {

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -31,6 +31,6 @@ pub(crate) use self::profile::{
 pub(crate) use self::route::is_route_removed;
 pub(crate) use self::user::get_description;
 pub(crate) use self::veth::is_veth_peer_changed;
-pub(crate) use self::vlan::is_vlan_id_changed;
+pub(crate) use self::vlan::is_vlan_changed;
 pub(crate) use self::vrf::is_vrf_table_id_changed;
-pub(crate) use self::vxlan::is_vxlan_id_changed;
+pub(crate) use self::vxlan::is_vxlan_changed;

--- a/rust/src/lib/nm/query_apply/vlan.rs
+++ b/rust/src/lib/nm/query_apply/vlan.rs
@@ -2,7 +2,7 @@
 
 use super::super::nm_dbus::NmConnection;
 
-pub(crate) fn is_vlan_id_changed(
+pub(crate) fn is_vlan_changed(
     new_nm_conn: &NmConnection,
     cur_nm_conn: &NmConnection,
 ) -> bool {
@@ -10,6 +10,7 @@ pub(crate) fn is_vlan_id_changed(
         (new_nm_conn.vlan.as_ref(), cur_nm_conn.vlan.as_ref())
     {
         new_vlan_conf.id != cur_vlan_conf.id
+            || new_vlan_conf.protocol != cur_vlan_conf.protocol
     } else {
         false
     }

--- a/rust/src/lib/nm/query_apply/vxlan.rs
+++ b/rust/src/lib/nm/query_apply/vxlan.rs
@@ -2,7 +2,7 @@
 
 use super::super::nm_dbus::NmConnection;
 
-pub(crate) fn is_vxlan_id_changed(
+pub(crate) fn is_vxlan_changed(
     new_nm_conn: &NmConnection,
     cur_nm_conn: &NmConnection,
 ) -> bool {

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -2,13 +2,18 @@
 
 use super::super::nm_dbus::NmSettingVlan;
 
-use crate::VlanConfig;
+use crate::{VlanConfig, VlanProtocol};
 
 impl From<&VlanConfig> for NmSettingVlan {
     fn from(config: &VlanConfig) -> Self {
         let mut settings = NmSettingVlan::default();
         settings.id = Some(config.id.into());
         settings.parent = Some(config.base_iface.clone());
+        // To support old NetworkManager 1.41- which VLAN protocol is not
+        // supported, we only set non-default protocol(802.1ad)
+        if Some(VlanProtocol::Ieee8021Ad) == config.protocol {
+            settings.protocol = Some("802.1ad".to_string());
+        }
         settings
     }
 }

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -65,6 +65,7 @@ pub(crate) fn new_vlan_iface(name: &str, parent: &str, id: u16) -> Interface {
     iface.vlan = Some(VlanConfig {
         base_iface: parent.to_string(),
         id,
+        ..Default::default()
     });
     Interface::Vlan(iface)
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -281,6 +281,7 @@ class VLAN:
 
     ID = "id"
     BASE_IFACE = "base-iface"
+    PROTOCOL = "protocol"
     PROTOCOL_802_1AD = "802.1ad"
     PROTOCOL_802_1Q = "802.1q"
 


### PR DESCRIPTION
Introduce `vlan.protocol` support with:
 * `802.1q`: Default VLAN protocol
 * `802.1ad`: IEEE 802.1ad also known as stacked VLANs or QinQ

Example YAML:

```yml
---
interfaces:
  - name: eth1.101
    type: vlan
    state: up
    vlan:
      base-iface: eth1
      id: 101
      protocol: 802.1ad
```

Integration test case included.