### PR TITLE
ip: Support static route with auto ip

### DIFF
--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -54,7 +54,6 @@ fn gen_nm_ipv4_setting(
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
     if iface_ip.is_auto() {
-        nm_setting.gateway = None;
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
         nm_setting.dhcp_client_id = Some(nmstate_dhcp_client_id_to_nm(
@@ -75,15 +74,12 @@ fn gen_nm_ipv4_setting(
         // enabled.
         nm_setting.routes = Vec::new();
     }
-    if !iface_ip.is_auto() {
+    nm_setting.gateway = None;
+    if iface_ip.enabled {
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, false)?;
-            // We use above routes property for gateway also, in order
-            // to support multiple gateways.
-            nm_setting.gateway = None;
         }
-    }
-    if !iface_ip.enabled {
+    } else {
         // Clean up static routes if ip is disabled
         nm_setting.routes = Vec::new();
     }
@@ -153,7 +149,6 @@ fn gen_nm_ipv6_setting(
     nm_setting.addr_gen_mode =
         Some(nmstate_addr_gen_mode_to_nm(iface_ip.addr_gen_mode.as_ref()));
     if iface_ip.is_auto() {
-        nm_setting.gateway = None;
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.ra_timeout = Some(i32::MAX);
         nm_setting.dhcp_duid = Some(
@@ -182,12 +177,17 @@ fn gen_nm_ipv6_setting(
         // No use case indicate we should support static routes with DHCP
         // enabled.
         nm_setting.routes = Vec::new();
+    } else {
+        nm_setting.token = None;
     }
-    if !iface_ip.is_auto() {
+    nm_setting.gateway = None;
+    if iface_ip.enabled {
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, true)?;
         }
-        nm_setting.token = None;
+    } else {
+        // Clean up static routes if ip is disabled
+        nm_setting.routes = Vec::new();
     }
     if let Some(rules) = iface_ip.rules.as_ref() {
         nm_setting.route_rules = gen_nm_ip_rules(rules, true)?;

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -19,7 +19,7 @@ from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
-from libnmstate.schema import Route as RT
+from libnmstate.schema import Route
 
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
@@ -698,7 +698,7 @@ def _get_running_routes():
     return a list of running routes
     """
     running_routes = (
-        libnmstate.show().get(Constants.ROUTES, {}).get(RT.RUNNING, [])
+        libnmstate.show().get(Constants.ROUTES, {}).get(Route.RUNNING, [])
     )
     logging.debug("Current running routes: {}".format(running_routes))
     return running_routes
@@ -716,8 +716,8 @@ def _has_ipv6_auto_gateway(nic=DHCP_CLI_NIC):
     routes = _get_running_routes()
     for route in routes:
         if (
-            route[RT.DESTINATION] == IPV6_DEFAULT_GATEWAY
-            and route[RT.NEXT_HOP_INTERFACE] == nic
+            route[Route.DESTINATION] == IPV6_DEFAULT_GATEWAY
+            and route[Route.NEXT_HOP_INTERFACE] == nic
         ):
             return True
     return False
@@ -727,8 +727,8 @@ def _has_ipv6_auto_extra_route():
     routes = _get_running_routes()
     for route in routes:
         if (
-            route[RT.DESTINATION] == IPV6_CLASSLESS_ROUTE_DST_NET1
-            and route[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+            route[Route.DESTINATION] == IPV6_CLASSLESS_ROUTE_DST_NET1
+            and route[Route.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
         ):
             return True
     return False
@@ -746,8 +746,8 @@ def _has_ipv4_dhcp_gateway(nic=DHCP_CLI_NIC):
     routes = _get_running_routes()
     for route in routes:
         if (
-            route[RT.DESTINATION] == IPV4_DEFAULT_GATEWAY
-            and route[RT.NEXT_HOP_INTERFACE] == nic
+            route[Route.DESTINATION] == IPV4_DEFAULT_GATEWAY
+            and route[Route.NEXT_HOP_INTERFACE] == nic
         ):
             return True
     return False
@@ -757,9 +757,9 @@ def _has_ipv4_classless_route():
     routes = _get_running_routes()
     for route in routes:
         if (
-            route[RT.DESTINATION] == IPV4_CLASSLESS_ROUTE_DST_NET1
-            and route[RT.NEXT_HOP_ADDRESS] == IPV4_CLASSLESS_ROUTE_NEXT_HOP1
-            and route[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+            route[Route.DESTINATION] == IPV4_CLASSLESS_ROUTE_DST_NET1
+            and route[Route.NEXT_HOP_ADDRESS] == IPV4_CLASSLESS_ROUTE_NEXT_HOP1
+            and route[Route.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
         ):
             return True
     return False
@@ -1042,27 +1042,27 @@ def test_dummy_existance_after_ipv6_autoconf_timeout(dummy00):
 @pytest.fixture(scope="function")
 def dhcpcli_up_with_static_ip_and_route(dhcpcli_up_with_static_ip):
     desired_state = dhcpcli_up_with_static_ip
-    desired_state[RT.KEY] = {
-        RT.CONFIG: [
+    desired_state[Route.KEY] = {
+        Route.CONFIG: [
             {
-                RT.DESTINATION: IPV4_DEFAULT_GATEWAY,
-                RT.NEXT_HOP_ADDRESS: DHCP_SRV_IP4,
-                RT.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+                Route.DESTINATION: IPV4_DEFAULT_GATEWAY,
+                Route.NEXT_HOP_ADDRESS: DHCP_SRV_IP4,
+                Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
             },
             {
-                RT.DESTINATION: IPV4_NETWORK1,
-                RT.NEXT_HOP_ADDRESS: DHCP_SRV_IP4,
-                RT.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+                Route.DESTINATION: IPV4_NETWORK1,
+                Route.NEXT_HOP_ADDRESS: DHCP_SRV_IP4,
+                Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
             },
             {
-                RT.DESTINATION: IPV6_DEFAULT_GATEWAY,
-                RT.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
-                RT.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+                Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
+                Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
+                Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
             },
             {
-                RT.DESTINATION: IPV6_NETWORK1,
-                RT.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
-                RT.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+                Route.DESTINATION: IPV6_NETWORK1,
+                Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
+                Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
             },
         ]
     }
@@ -1076,7 +1076,7 @@ def test_static_ip_with_routes_switch_back_to_dynamic(
     dhcpcli_up_with_static_ip_and_route,
 ):
     desired_state = dhcpcli_up_with_static_ip_and_route
-    desired_state.pop(RT.KEY)
+    desired_state.pop(Route.KEY)
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
     dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
@@ -1100,8 +1100,8 @@ def test_static_ip_with_routes_switch_back_to_dynamic(
 
     current_config_routes = [
         route
-        for route in libnmstate.show()[RT.KEY][RT.CONFIG]
-        if route[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+        for route in libnmstate.show()[Route.KEY][Route.CONFIG]
+        if route[Route.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
     ]
     assert not current_config_routes
 
@@ -1258,8 +1258,8 @@ def test_show_running_config_does_not_include_auto_config(
     assert DHCP_SRV_IP6 not in running_config[DNS.KEY][DNS.CONFIG]
     assert not any(
         rt
-        for rt in running_config[RT.KEY][RT.CONFIG]
-        if rt[RT.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+        for rt in running_config[Route.KEY][Route.CONFIG]
+        if rt[Route.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
     )
 
 
@@ -1644,3 +1644,48 @@ def test_desired_ipv6_token_with_autoconf_off(dhcpcli_with_ipv6_token):
                 ],
             }
         )
+
+
+@pytest.mark.tier1
+def test_auto_iface_with_static_routes(dhcp_env):
+    static_routes = [
+        {
+            Route.DESTINATION: IPV4_NETWORK1,
+            Route.NEXT_HOP_ADDRESS: DHCP_SRV_IP4,
+            Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+        },
+        {
+            Route.DESTINATION: IPV6_NETWORK1,
+            Route.NEXT_HOP_ADDRESS: DHCP_SRV_IP6,
+            Route.NEXT_HOP_INTERFACE: DHCP_CLI_NIC,
+        },
+    ]
+    desired_state = {
+        Route.KEY: {
+            Route.CONFIG: static_routes,
+        },
+        Interface.KEY: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: _create_ipv4_state(enabled=True, dhcp=True),
+                Interface.IPV6: _create_ipv6_state(
+                    enabled=True, dhcp=True, autoconf=True
+                ),
+            }
+        ],
+    }
+    libnmstate.apply(desired_state)
+    current_config_routes = [
+        route
+        for route in libnmstate.show()[Route.KEY][Route.CONFIG]
+        if route[Route.NEXT_HOP_INTERFACE] == DHCP_CLI_NIC
+        and route[Route.DESTINATION] in (IPV4_NETWORK1, IPV6_NETWORK1)
+    ]
+    current_config_routes.sort(key=itemgetter(Route.DESTINATION))
+
+    assert len(current_config_routes) == 2
+    assert current_config_routes[0][Route.DESTINATION] == IPV6_NETWORK1
+    assert current_config_routes[0][Route.NEXT_HOP_ADDRESS] == DHCP_SRV_IP6
+    assert current_config_routes[1][Route.DESTINATION] == IPV4_NETWORK1
+    assert current_config_routes[1][Route.NEXT_HOP_ADDRESS] == DHCP_SRV_IP4


### PR DESCRIPTION
Supporting assigning static route to interface with auto ip. For
example:

```yml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      dhcp: true
      enabled: true
    ipv6:
      dhcp: true
      autoconf: true
      enabled: true
routes:
  config:
  - destination: 198.51.100.0/24
    metric: 150
    next-hop-address: 192.0.2.1
    next-hop-interface: eth1
    table-id: 254
  - destination: 2001:db8:2::/64
    metric: 151
    next-hop-address: 2001:db8:1::2
    next-hop-interface: eth1
```

Integration test case included and been marked as tier1.

Resovles: RHBZ#2169982