### PR TITLE
sriov: Fix error when reverting VFS conf to default

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -206,7 +206,10 @@ impl BaseInterface {
         self.ipv6.as_ref().map(|i| i.enabled) == Some(true)
     }
 
-    pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
+    pub(crate) fn sanitize(
+        &mut self,
+        is_desired: bool,
+    ) -> Result<(), NmstateError> {
         if let Some(mac) = self.mac_address.as_mut() {
             mac.make_ascii_uppercase();
         }
@@ -217,10 +220,10 @@ impl BaseInterface {
         self.copy_mac_from = None;
 
         if let Some(ipv4_conf) = self.ipv4.as_mut() {
-            ipv4_conf.sanitize()?;
+            ipv4_conf.sanitize(is_desired)?;
         }
         if let Some(ipv6_conf) = self.ipv6.as_mut() {
-            ipv6_conf.sanitize()?;
+            ipv6_conf.sanitize(is_desired)?;
             if ipv6_conf.enabled {
                 if let Some(mtu) = self.mtu {
                     if mtu < MINIMUM_IPV6_MTU {
@@ -245,25 +248,6 @@ impl BaseInterface {
             self.wait_ip = None;
         }
         Ok(())
-    }
-
-    pub(crate) fn sanitize_for_verify(&mut self) {
-        if self.controller.as_deref() == Some("") {
-            self.controller = None;
-        }
-        if let Some(mptcp_conf) = self.mptcp.as_mut() {
-            mptcp_conf.sanitize_for_verify();
-        }
-        if let Some(ipv4_conf) = self.ipv4.as_mut() {
-            ipv4_conf.sanitize_for_verify();
-        }
-        if let Some(ipv6_conf) = self.ipv6.as_mut() {
-            ipv6_conf.sanitize_for_verify();
-        }
-        // ovsdb None equal to empty
-        if self.ovsdb.is_none() {
-            self.ovsdb = Some(OvsDbIfaceConfig::empty());
-        }
     }
 }
 

--- a/rust/src/lib/ifaces/loopback.rs
+++ b/rust/src/lib/ifaces/loopback.rs
@@ -52,33 +52,40 @@ impl LoopbackInterface {
         Self::default()
     }
 
-    pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
-        if self.base.ipv4.as_ref().map(|i| i.enabled) == Some(false) {
-            return Err(NmstateError::new(
-                ErrorKind::InvalidArgument,
-                "Loopback interface cannot be have IPv4 disabled".to_string(),
-            ));
-        }
-        if self.base.ipv6.as_ref().map(|i| i.enabled) == Some(false) {
-            return Err(NmstateError::new(
-                ErrorKind::InvalidArgument,
-                "Loopback interface cannot be have IPv6 disabled".to_string(),
-            ));
-        }
-        if self.base.ipv4.as_ref().map(|i| i.is_auto()) == Some(true) {
-            return Err(NmstateError::new(
-                ErrorKind::InvalidArgument,
-                "Loopback interface cannot be have IPv4 DHCP enabled"
-                    .to_string(),
-            ));
-        }
-        if self.base.ipv6.as_ref().map(|i| i.is_auto()) == Some(true) {
-            return Err(NmstateError::new(
-                ErrorKind::InvalidArgument,
-                "Loopback interface cannot be have IPv6 \
+    pub(crate) fn sanitize(
+        &self,
+        is_desired: bool,
+    ) -> Result<(), NmstateError> {
+        if is_desired {
+            if self.base.ipv4.as_ref().map(|i| i.enabled) == Some(false) {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Loopback interface cannot be have IPv4 disabled"
+                        .to_string(),
+                ));
+            }
+            if self.base.ipv6.as_ref().map(|i| i.enabled) == Some(false) {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Loopback interface cannot be have IPv6 disabled"
+                        .to_string(),
+                ));
+            }
+            if self.base.ipv4.as_ref().map(|i| i.is_auto()) == Some(true) {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Loopback interface cannot be have IPv4 DHCP enabled"
+                        .to_string(),
+                ));
+            }
+            if self.base.ipv6.as_ref().map(|i| i.is_auto()) == Some(true) {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Loopback interface cannot be have IPv6 \
                 autoconf/DHCPv6 enabled"
-                    .to_string(),
-            ));
+                        .to_string(),
+                ));
+            }
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -44,19 +44,24 @@ impl MacVlanInterface {
         Self::default()
     }
 
-    pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
-        if let Some(conf) = &self.mac_vlan {
-            if conf.accept_all_mac == Some(false)
-                && conf.mode != MacVlanMode::Passthru
-            {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "Disable accept-all-mac-addresses(promiscuous) \
+    pub(crate) fn sanitize(
+        &self,
+        is_desired: bool,
+    ) -> Result<(), NmstateError> {
+        if is_desired {
+            if let Some(conf) = &self.mac_vlan {
+                if conf.accept_all_mac == Some(false)
+                    && conf.mode != MacVlanMode::Passthru
+                {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "Disable accept-all-mac-addresses(promiscuous) \
                     is only allowed on passthru mode"
-                        .to_string(),
-                );
-                log::error!("{}", e);
-                return Err(e);
+                            .to_string(),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -44,19 +44,24 @@ impl MacVtapInterface {
         Self::default()
     }
 
-    pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
-        if let Some(conf) = &self.mac_vtap {
-            if conf.accept_all_mac == Some(false)
-                && conf.mode != MacVtapMode::Passthru
-            {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "Disable accept-all-mac-addresses(promiscuous) \
-                    is only allowed on passthru mode"
-                        .to_string(),
-                );
-                log::error!("{}", e);
-                return Err(e);
+    pub(crate) fn sanitize(
+        &self,
+        is_desired: bool,
+    ) -> Result<(), NmstateError> {
+        if is_desired {
+            if let Some(conf) = &self.mac_vtap {
+                if conf.accept_all_mac == Some(false)
+                    && conf.mode != MacVtapMode::Passthru
+                {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "Disable accept-all-mac-addresses(promiscuous) \
+                        is only allowed on passthru mode"
+                            .to_string(),
+                    );
+                    log::error!("{}", e);
+                    return Err(e);
+                }
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -69,7 +69,6 @@ impl SrIovConfig {
 
     // * Convert VF MAC address to upper case
     // * Sort by VF ID
-    // * Ignore 'vfs: []' which is just reverting all VF config to default.
     pub(crate) fn sanitize(&mut self) {
         if let Some(vfs) = self.vfs.as_mut() {
             for vf in vfs.iter_mut() {
@@ -78,10 +77,6 @@ impl SrIovConfig {
                 }
             }
             vfs.sort_unstable_by(|a, b| a.id.cmp(&b.id));
-            // Ignore `vfs: []` which is just revert all VF config to default.
-            if vfs.is_empty() {
-                self.vfs = None;
-            }
         }
     }
 

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -63,9 +63,21 @@ impl VrfInterface {
             .map(|ports| ports.as_slice().iter().map(|p| p.as_str()).collect())
     }
 
-    pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
+    pub(crate) fn sanitize(
+        &mut self,
+        is_desired: bool,
+    ) -> Result<(), NmstateError> {
         // Ignoring the changes of MAC address of VRF as it is a layer 3
         // interface.
+        if is_desired {
+            if let Some(mac) = self.base.mac_address.as_ref() {
+                log::warn!(
+                    "Ignoring MAC address {mac} of VRF interface {} \
+                    as it is a layer 3(IP) interface",
+                    self.base.name.as_str()
+                );
+            }
+        }
         self.base.mac_address = None;
         if self.base.accept_all_mac_addresses == Some(false) {
             self.base.accept_all_mac_addresses = None;

--- a/rust/src/lib/mptcp.rs
+++ b/rust/src/lib/mptcp.rs
@@ -17,15 +17,6 @@ pub struct MptcpConfig {
     pub address_flags: Option<Vec<MptcpAddressFlag>>,
 }
 
-impl MptcpConfig {
-    pub(crate) fn sanitize_for_verify(&mut self) {
-        if let Some(flags) = self.address_flags.as_mut() {
-            flags.dedup();
-            flags.sort_unstable();
-        }
-    }
-}
-
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -65,12 +65,6 @@ pub struct OvsDbIfaceConfig {
 }
 
 impl OvsDbIfaceConfig {
-    pub(crate) fn empty() -> Self {
-        Self {
-            external_ids: Some(HashMap::new()),
-            other_config: Some(HashMap::new()),
-        }
-    }
     pub(crate) fn get_external_ids(&self) -> HashMap<&str, &str> {
         let mut ret = HashMap::new();
         if let Some(eids) = self.external_ids.as_ref() {

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -1,8 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, InterfaceType};
+use crate::{BaseInterface, InterfaceType, OvsDbIfaceConfig};
 
 impl BaseInterface {
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if self.controller.is_none() {
+            self.controller = Some(String::new());
+        }
+        if let Some(mptcp_conf) = self.mptcp.as_mut() {
+            mptcp_conf.sanitize_current_for_verify();
+        }
+        if let Some(ipv4_conf) = self.ipv4.as_mut() {
+            ipv4_conf.sanitize_current_for_verify();
+        }
+        if let Some(ipv6_conf) = self.ipv6.as_mut() {
+            ipv6_conf.sanitize_current_for_verify();
+        }
+        // ovsdb None equal to empty
+        if self.ovsdb.is_none() {
+            self.ovsdb = Some(OvsDbIfaceConfig::new_empty());
+        }
+    }
+
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(ipv4_conf) = self.ipv4.as_mut() {
+            ipv4_conf.sanitize_desired_for_verify();
+        }
+        if let Some(ipv6_conf) = self.ipv6.as_mut() {
+            ipv6_conf.sanitize_desired_for_verify();
+        }
+        if let Some(mptcp_conf) = self.mptcp.as_mut() {
+            mptcp_conf.sanitize_desired_for_verify();
+        }
+    }
+
     pub(crate) fn update(&mut self, other: &BaseInterface) {
         if other.prop_list.contains(&"name") {
             self.name = other.name.clone();

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -6,6 +6,14 @@ use crate::{
 };
 
 impl EthernetInterface {
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(sriov_conf) =
+            self.ethernet.as_mut().and_then(|e| e.sr_iov.as_mut())
+        {
+            sriov_conf.sanitize_desired_for_verify();
+        }
+    }
+
     pub(crate) fn sriov_is_enabled(&self) -> bool {
         self.ethernet
             .as_ref()

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -6,6 +6,25 @@ use crate::{
 };
 
 impl Interface {
+    // This function will clean up post-apply current state before verification
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        self.base_iface_mut().sanitize_current_for_verify();
+        if let Interface::LinuxBridge(iface) = self {
+            iface.sanitize_current_for_verify()
+        }
+        if let Interface::OvsBridge(iface) = self {
+            iface.sanitize_current_for_verify()
+        }
+    }
+
+    // This function will clean up desired state before verification
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        self.base_iface_mut().sanitize_desired_for_verify();
+        if let Interface::Ethernet(iface) = self {
+            iface.sanitize_desired_for_verify();
+        }
+    }
+
     pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {
         let mut current = current.clone();
         self.process_allow_extra_address(&mut current);

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -122,22 +122,24 @@ impl MergedInterfaces {
             .values_mut()
             .chain(current.user_ifaces.values_mut())
         {
-            iface.sanitize().ok();
-            iface.sanitize_for_verify();
+            iface.sanitize(false).ok();
+            iface.sanitize_current_for_verify();
         }
 
         for des_iface in self.iter().filter(|i| i.is_desired()) {
-            let iface = if let Some(i) = des_iface.for_verify.as_ref() {
-                i
+            let mut iface = if let Some(i) = des_iface.for_verify.as_ref() {
+                i.clone()
             } else {
                 continue;
             };
+            iface.sanitize(false).ok();
+            iface.sanitize_desired_for_verify();
             if iface.is_absent() || (iface.is_virtual() && iface.is_down()) {
                 if let Some(cur_iface) =
                     current.get_iface(iface.name(), iface.iface_type())
                 {
                     verify_desire_absent_but_found_in_current(
-                        iface, cur_iface,
+                        &iface, cur_iface,
                     )?;
                 }
             } else if let Some(cur_iface) =

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -3,6 +3,21 @@
 use crate::{Interface, InterfaceIpv4, InterfaceIpv6};
 
 impl InterfaceIpv4 {
+    // Sort addresses and dedup
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable();
+            addrs.dedup();
+        }
+    }
+
+    // Sort addresses and dedup
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable();
+            addrs.dedup();
+        }
+    }
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;
@@ -51,6 +66,29 @@ impl InterfaceIpv4 {
 }
 
 impl InterfaceIpv6 {
+    // Sort addresses and dedup
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable();
+            addrs.dedup();
+        }
+
+        // None IPv6 token should be treat as "::"
+        if self.token.is_none() {
+            self.token = Some("::".to_string());
+        }
+    }
+
+    // Sort addresses and dedup
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            addrs.sort_unstable();
+            addrs.dedup();
+            if addrs.is_empty() {
+                self.addresses = None;
+            }
+        }
+    }
     pub(crate) fn update(&mut self, other: &Self) {
         if other.prop_list.contains(&"enabled") {
             self.enabled = other.enabled;

--- a/rust/src/lib/query_apply/mod.rs
+++ b/rust/src/lib/query_apply/mod.rs
@@ -12,6 +12,7 @@ mod ip;
 mod linux_bridge;
 mod mac_vlan;
 mod mac_vtap;
+mod mptcp;
 mod net_state;
 mod ovs;
 mod route;

--- a/rust/src/lib/query_apply/mptcp.rs
+++ b/rust/src/lib/query_apply/mptcp.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MptcpConfig;
+
+impl MptcpConfig {
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(flags) = self.address_flags.as_mut() {
+            flags.dedup();
+            flags.sort_unstable();
+        }
+    }
+
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if let Some(flags) = self.address_flags.as_mut() {
+            flags.dedup();
+            flags.sort_unstable();
+        }
+    }
+}

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -129,7 +129,6 @@ impl NetworkState {
 
         with_nm_checkpoint(&checkpoint, self.no_commit, || {
             if let Some(pf_state) = pf_state {
-                pf_state.interfaces.check_sriov_capability()?;
                 let pf_merged_state = MergedNetworkState::new(
                     pf_state,
                     cur_net_state.clone(),
@@ -146,6 +145,7 @@ impl NetworkState {
                 cur_net_state.retrieve_full()?;
             }
 
+            self.interfaces.check_sriov_capability()?;
             let merged_state = MergedNetworkState::new(
                 self.clone(),
                 cur_net_state.clone(),

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 
 use crate::{
     state::get_json_value_difference, ErrorKind, MergedNetworkState,
-    MergedOvsDbGlobalConfig, NmstateError, OvsBridgeConfig, OvsBridgeInterface,
-    OvsDbGlobalConfig, OvsInterface,
+    MergedOvsDbGlobalConfig, NmstateError, OvsBridgeBondConfig,
+    OvsBridgeConfig, OvsBridgeInterface, OvsDbGlobalConfig, OvsDbIfaceConfig,
+    OvsInterface,
 };
 
 impl MergedOvsDbGlobalConfig {
@@ -69,6 +70,20 @@ impl OvsBridgeConfig {
 }
 
 impl OvsBridgeInterface {
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if let Some(port_confs) = self
+            .bridge
+            .as_mut()
+            .and_then(|br_conf| br_conf.ports.as_mut())
+        {
+            for port_conf in port_confs {
+                if let Some(bond_conf) = port_conf.bond.as_mut() {
+                    bond_conf.sanitize_current_for_verify();
+                }
+            }
+        }
+    }
+
     pub(crate) fn update_ovs_bridge(&mut self, other: &OvsBridgeInterface) {
         if let Some(br_conf) = &mut self.bridge {
             br_conf.update(other.bridge.as_ref());
@@ -118,6 +133,24 @@ impl MergedNetworkState {
             }
         } else {
             false
+        }
+    }
+}
+
+impl OvsDbIfaceConfig {
+    pub(crate) fn new_empty() -> Self {
+        Self {
+            external_ids: Some(HashMap::new()),
+            other_config: Some(HashMap::new()),
+        }
+    }
+}
+
+impl OvsBridgeBondConfig {
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        // None ovsbd equal to empty
+        if self.ovsdb.is_none() {
+            self.ovsdb = Some(OvsDbIfaceConfig::new_empty());
         }
     }
 }

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -5,6 +5,15 @@ use crate::{
 };
 
 impl SrIovConfig {
+    // * Set 'vfs: []' to None which is just reverting all VF config to default.
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if let Some(vfs) = self.vfs.as_mut() {
+            if vfs.is_empty() {
+                self.vfs = None;
+            }
+        }
+    }
+
     pub(crate) fn update(&mut self, other: Option<&SrIovConfig>) {
         if let Some(other) = other {
             if let Some(total_vfs) = other.total_vfs {

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -25,6 +25,6 @@ mac-address: "d4:ee:07:25:42:5a"
 "#,
     )
     .unwrap();
-    iface.sanitize().unwrap();
+    iface.sanitize(true).unwrap();
     assert_eq!(iface.mac_address, Some(String::from("D4:EE:07:25:42:5A")));
 }

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -448,7 +448,7 @@ fn test_bridge_vlan_filter_trunk_tag_without_enable_native() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -480,7 +480,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -514,7 +514,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -544,7 +544,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -572,7 +572,7 @@ fn test_bridge_vlan_filter_enable_native_with_access_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -601,7 +601,7 @@ fn test_bridge_vlan_filter_trunk_tags_with_access_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -628,7 +628,7 @@ fn test_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -650,7 +650,7 @@ fn test_bridge_validate_diff_group_forward_mask_and_group_fwd_mask() {
         "#,
     )
     .unwrap();
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -675,7 +675,7 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
         "#,
     )
     .unwrap();
-    desired_both.sanitize().unwrap();
+    desired_both.sanitize(true).unwrap();
 
     let mut desired_old: LinuxBridgeInterface = serde_yaml::from_str(
         r#"
@@ -688,7 +688,7 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
         "#,
     )
     .unwrap();
-    desired_old.sanitize().unwrap();
+    desired_old.sanitize(true).unwrap();
 
     let mut desired_new: LinuxBridgeInterface = serde_yaml::from_str(
         r#"
@@ -701,7 +701,7 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
         "#,
     )
     .unwrap();
-    desired_new.sanitize().unwrap();
+    desired_new.sanitize(true).unwrap();
 
     let expected: LinuxBridgeInterface = serde_yaml::from_str(
         r#"

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -241,7 +241,7 @@ ipv6:
     )
     .unwrap();
 
-    let result = iface.sanitize();
+    let result = iface.sanitize(true);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);

--- a/rust/src/lib/unit_tests/mptcp.rs
+++ b/rust/src/lib/unit_tests/mptcp.rs
@@ -84,7 +84,7 @@ ipv6:
     )
     .unwrap();
 
-    des_iface.sanitize().unwrap();
+    des_iface.sanitize(true).unwrap();
 
     assert_eq!(des_iface, expected_iface);
 }

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -361,7 +361,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_without_enable_native() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -390,7 +390,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -421,7 +421,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -448,7 +448,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -473,7 +473,7 @@ fn test_ovs_bridge_vlan_filter_enable_native_with_access_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -499,7 +499,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tags_with_access_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -523,7 +523,7 @@ fn test_ovs_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -545,7 +545,7 @@ fn test_validate_dpdk_n_rxq_desc() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -568,7 +568,7 @@ fn test_validate_dpdk_n_txq_desc() {
     )
     .unwrap();
 
-    let result = desired.sanitize();
+    let result = desired.sanitize(true);
 
     assert!(result.is_err());
     if let Err(e) = result {


### PR DESCRIPTION
Previous code does not revert VFS config to default when desiring
`vfs: []`.

This is caused by `sanitize()` convert `vfs: None` for verification
seek. To clarify the workflow, we have three type of sanitize now:
 * `sanitize()` for current and desire state pre-edit clean up and check.
 * `sanitize_current_for_verify()` clean up post-apply current state.
 * `sanitize_desired_for_verify()` clean up desired state before verify.

Unit test case included.