### PR TITLE
vlan: Update protocol when `update_vlan()`

### DIFF
--- a/rust/src/lib/query_apply/vlan.rs
+++ b/rust/src/lib/query_apply/vlan.rs
@@ -18,6 +18,7 @@ impl VlanConfig {
         if let Some(other) = other {
             self.base_iface = other.base_iface.clone();
             self.id = other.id;
+            self.protocol = other.protocol;
         }
     }
 }

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     ErrorKind, InterfaceType, Interfaces, MergedInterfaces, VlanInterface,
+    VlanProtocol,
 };
 
 #[test]
@@ -180,4 +181,35 @@ fn test_vlan_orphan_has_now_parent() {
     .unwrap();
 
     MergedInterfaces::new(desired, current, false, false).unwrap();
+}
+
+#[test]
+fn test_vlan_update() {
+    let mut iface1: VlanInterface = serde_yaml::from_str(
+        r#"---
+        name: bond0.100
+        type: vlan
+        vlan:
+          base-iface: bond0
+          id: 100"#,
+    )
+    .unwrap();
+
+    let iface2: VlanInterface = serde_yaml::from_str(
+        r#"---
+        name: bond0.100
+        type: vlan
+        vlan:
+          base-iface: bond0
+          id: 100
+          protocol: 802.1q"#,
+    )
+    .unwrap();
+
+    iface1.update_vlan(&iface2);
+
+    assert_eq!(
+        iface1.vlan.as_ref().unwrap().protocol,
+        Some(VlanProtocol::Ieee8021Q)
+    );
 }


### PR DESCRIPTION
When merging VLAN information via `update_vlan()`, we should update
protocol also.

Unit test case included.