### PR TITLE
nm vlan: Fix random failure on `test_change_vlan_protocl`

### DIFF
--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -2,7 +2,7 @@
 
 use super::super::nm_dbus::{
     NmConnection, NmSettingConnection, NmSettingMacVlan, NmSettingVeth,
-    NmSettingVlan, NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
+    NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
 };
 use super::{
     bond::gen_nm_bond_setting,
@@ -20,6 +20,7 @@ use super::{
     sriov::gen_nm_sriov_setting,
     user::gen_nm_user_setting,
     veth::create_veth_peer_profile_if_not_found,
+    vlan::gen_nm_vlan_setting,
     wired::gen_nm_wired_setting,
 };
 
@@ -158,9 +159,7 @@ pub(crate) fn iface_to_nm_connections(
             gen_nm_ovs_iface_setting(iface, &mut nm_conn);
         }
         Interface::Vlan(vlan_iface) => {
-            if let Some(conf) = vlan_iface.vlan.as_ref() {
-                nm_conn.vlan = Some(NmSettingVlan::from(conf))
-            }
+            gen_nm_vlan_setting(vlan_iface, &mut nm_conn);
         }
         Interface::Vxlan(vxlan_iface) => {
             if let Some(conf) = vxlan_iface.vxlan.as_ref() {

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -1,19 +1,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::NmSettingVlan;
+use super::super::nm_dbus::NmConnection;
 
-use crate::{VlanConfig, VlanProtocol};
+use crate::{VlanInterface, VlanProtocol};
 
-impl From<&VlanConfig> for NmSettingVlan {
-    fn from(config: &VlanConfig) -> Self {
-        let mut settings = NmSettingVlan::default();
-        settings.id = Some(config.id.into());
-        settings.parent = Some(config.base_iface.clone());
-        // To support old NetworkManager 1.41- which VLAN protocol is not
-        // supported, we only set non-default protocol(802.1ad)
-        if Some(VlanProtocol::Ieee8021Ad) == config.protocol {
-            settings.protocol = Some("802.1ad".to_string());
+const NM_802_1_AD: &str = "802.1ad";
+const NM_802_1_Q: &str = "802.1Q";
+
+pub(crate) fn gen_nm_vlan_setting(
+    iface: &VlanInterface,
+    nm_conn: &mut NmConnection,
+) {
+    if let Some(vlan_conf) = iface.vlan.as_ref() {
+        let mut nm_vlan = nm_conn.vlan.as_ref().cloned().unwrap_or_default();
+        nm_vlan.id = Some(vlan_conf.id.into());
+        nm_vlan.parent = Some(vlan_conf.base_iface.clone());
+        if let Some(protocol) = vlan_conf.protocol {
+            match protocol {
+                VlanProtocol::Ieee8021Ad => {
+                    nm_vlan.protocol = Some(NM_802_1_AD.to_string());
+                }
+                VlanProtocol::Ieee8021Q => {
+                    // To support old NetworkManager 1.41- which VLAN protocol
+                    // is not supported, we only set 802.1q protocol explicitly
+                    // when protocol is already defined in NM connection.
+                    if nm_vlan.protocol.is_some() {
+                        nm_vlan.protocol = Some(NM_802_1_Q.to_string());
+                    }
+                }
+            }
         }
-        settings
+        nm_conn.vlan = Some(nm_vlan);
     }
 }

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -293,7 +293,7 @@ def test_preserve_existing_vlan_conf(eth1_up):
     nm_minor_version() < 41,
     reason="Modifying VLAN protocol is not supported on NM 1.41-.",
 )
-def test_change_vlan_protocl(vlan_on_eth1):
+def test_change_vlan_protocol(vlan_on_eth1):
     dot1q_state = {
         Interface.KEY: [
             {


### PR DESCRIPTION
In Github CI, we noticed random failure on `test_change_vlan_protocl`
complaining failed to change VLAN protocol from 802.1ad to default
802.1q.

The root case of previous code does not set VLAN protocol 802.1q
explicitly in NM connection for backwards compatibility but depend on
pre-activation deactivation for VLAN changes. There is race that when
nmstate ask for reapply right after invoked NM connection deactivation.

To fix the problem, we set 802.1q explicitly when existing NM connection
contains protocol property.

Existing integration test case `test_change_vlan_protocol` can cover
this problem here, no extra test required.