### PR TITLE
[nmstate-1.2] nm: Do not touch ovs-port unless required

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -17,6 +17,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import time
+
 import pytest
 
 import libnmstate
@@ -495,3 +497,78 @@ def test_remove_ovs_bridge_and_modify_ports(bridge_with_ports):
             ]
         }
         libnmstate.apply(absent_state)
+
+
+def get_nm_conn_timestamp(conn_name):
+    output = cmdlib.exec_cmd(
+        f"nmcli -g connection.timestamp c show {conn_name}".split(), check=True
+    )[1]
+    return int(output)
+
+
+def get_nm_conn_uuid(conn_name):
+    output = cmdlib.exec_cmd(
+        f"nmcli -g connection.uuid c show {conn_name}".split(), check=True
+    )[1]
+    return output
+
+
+def test_do_not_touch_ovs_port_when_not_desired_system_iface(
+    bridge_with_ports,
+):
+    """
+    The modification like MTU of ovs system interface should not reactivate its
+    OVS port
+    """
+    old_timestamp = get_nm_conn_timestamp("eth1-port")
+    old_uuid = get_nm_conn_uuid("eth1-port")
+    time.sleep(1)
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MTU: 2000,
+            },
+        ]
+    }
+
+    libnmstate.apply(desired_state)
+
+    new_timestamp = get_nm_conn_timestamp("eth1-port")
+    new_uuid = get_nm_conn_uuid("eth1-port")
+
+    assert old_timestamp == new_timestamp
+    assert old_uuid == new_uuid
+
+
+def test_do_not_touch_ovs_port_when_not_desired_internal_iface(
+    bridge_with_ports,
+):
+    """
+    The modification like MTU of ovs internal interface should not reactivate
+    its OVS port
+    """
+    old_timestamp = get_nm_conn_timestamp(f"{IFACE0}-port")
+    old_uuid = get_nm_conn_uuid(f"{IFACE0}-port")
+    time.sleep(1)
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: IFACE0,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MTU: 2000,
+            },
+        ]
+    }
+    libnmstate.apply(desired_state)
+
+    new_timestamp = get_nm_conn_timestamp(f"{IFACE0}-port")
+    new_uuid = get_nm_conn_uuid(f"{IFACE0}-port")
+
+    assert old_timestamp == new_timestamp
+    assert old_uuid == new_uuid


### PR DESCRIPTION
We always create/update ovs-port connection when there is a OVS
interface desire. To achieve that, we skip marking OVS port as changed
when a OVS (system or internal) interface all below matches:
    * Desired interface is up
    * Desire state did not mentioned its OVS bridge controller
    * Interface has no changed to controller property
    * Interface has no ovs-db setting change in desire state

The timestamp of NM connection will not update on Reapply call, hence
the included integration test case cannot reproduce the problem.

No other way except manual test can check whether ovs-port is impacted.
Mocked unit test case might able to reproduce this problem, but playing
with python mock is a pain.

Manual tested.