### PR TITLE
vxlan: Add VXLAN properties for EVPN use

### DIFF
--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -48,7 +48,13 @@ impl VxlanInterface {
     }
 
     pub(crate) fn parent(&self) -> Option<&str> {
-        self.vxlan.as_ref().map(|cfg| cfg.base_iface.as_str())
+        self.vxlan.as_ref().and_then(|cfg| {
+            if cfg.base_iface.is_empty() {
+                None
+            } else {
+                Some(cfg.base_iface.as_str())
+            }
+        })
     }
 }
 
@@ -56,9 +62,14 @@ impl VxlanInterface {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct VxlanConfig {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub base_iface: String,
     #[serde(deserialize_with = "crate::deserializer::u32_or_string")]
     pub id: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub learning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local: Option<std::net::IpAddr>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote: Option<std::net::IpAddr>,
     #[serde(

--- a/rust/src/lib/nispor/vxlan.rs
+++ b/rust/src/lib/nispor/vxlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::str::FromStr;
 
 use crate::{BaseInterface, VxlanConfig, VxlanInterface};
@@ -9,6 +11,8 @@ pub(crate) fn np_vxlan_to_nmstate(
     let vxlan_conf = np_iface.vxlan.as_ref().map(|np_vxlan_info| VxlanConfig {
         id: np_vxlan_info.vxlan_id,
         base_iface: np_vxlan_info.base_iface.clone(),
+        learning: Some(np_vxlan_info.learning),
+        local: std::net::IpAddr::from_str(np_vxlan_info.local.as_str()).ok(),
         remote: std::net::IpAddr::from_str(np_vxlan_info.remote.as_str()).ok(),
         dst_port: Some(np_vxlan_info.dst_port),
     });

--- a/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
@@ -11,6 +11,8 @@ use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
 pub struct NmSettingVxlan {
     pub parent: Option<String>,
     pub id: Option<u32>,
+    pub learning: Option<bool>,
+    pub local: Option<String>,
     pub remote: Option<String>,
     pub dst_port: Option<u32>,
     _other: HashMap<String, zvariant::OwnedValue>,
@@ -22,6 +24,8 @@ impl TryFrom<DbusDictionary> for NmSettingVxlan {
         Ok(Self {
             parent: _from_map!(v, "parent", String::try_from)?,
             id: _from_map!(v, "id", u32::try_from)?,
+            learning: _from_map!(v, "learning", bool::try_from)?,
+            local: _from_map!(v, "local", String::try_from)?,
             remote: _from_map!(v, "remote", String::try_from)?,
             dst_port: _from_map!(v, "destination-port", u32::try_from)?,
             _other: v,
@@ -32,11 +36,19 @@ impl TryFrom<DbusDictionary> for NmSettingVxlan {
 impl ToDbusValue for NmSettingVxlan {
     fn to_value(&self) -> Result<HashMap<&str, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
-        if let Some(v) = &self.parent {
-            ret.insert("parent", zvariant::Value::new(v.clone()));
+        if let Some(v) = self.parent.as_deref() {
+            if !v.is_empty() {
+                ret.insert("parent", zvariant::Value::new(v));
+            }
         }
         if let Some(id) = self.id {
             ret.insert("id", zvariant::Value::new(id));
+        }
+        if let Some(v) = self.learning {
+            ret.insert("learning", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.local {
+            ret.insert("local", zvariant::Value::new(v));
         }
         if let Some(v) = &self.remote {
             ret.insert("remote", zvariant::Value::new(v));

--- a/rust/src/lib/nm/settings/vxlan.rs
+++ b/rust/src/lib/nm/settings/vxlan.rs
@@ -8,7 +8,15 @@ impl From<&VxlanConfig> for NmSettingVxlan {
     fn from(config: &VxlanConfig) -> Self {
         let mut setting = NmSettingVxlan::default();
         setting.id = Some(config.id);
-        setting.parent = Some(config.base_iface.clone());
+        if !config.base_iface.is_empty() {
+            setting.parent = Some(config.base_iface.clone());
+        }
+        if let Some(v) = config.learning {
+            setting.learning = Some(v);
+        }
+        if let Some(v) = config.local.as_ref() {
+            setting.local = Some(v.to_string());
+        }
         if let Some(v) = config.remote.as_ref() {
             setting.remote = Some(v.to_string());
         }

--- a/rust/src/lib/query_apply/vxlan.rs
+++ b/rust/src/lib/query_apply/vxlan.rs
@@ -18,6 +18,8 @@ impl VxlanConfig {
         if let Some(other) = other {
             self.base_iface = other.base_iface.clone();
             self.id = other.id;
+            self.learning = other.learning;
+            self.local = other.local;
             self.remote = other.remote;
             self.dst_port = other.dst_port;
         }

--- a/rust/src/lib/unit_tests/vxlan.rs
+++ b/rust/src/lib/unit_tests/vxlan.rs
@@ -20,4 +20,30 @@ vxlan:
 
     assert_eq!(vxlan_conf.id, 101);
     assert_eq!(vxlan_conf.dst_port, Some(3389));
+    assert_eq!(vxlan_conf.learning, None);
+}
+
+#[test]
+fn test_vxlan_evpn_config_stringlized_attributes() {
+    let iface: VxlanInterface = serde_yaml::from_str(
+        r#"---
+name: vxlan1
+type: vxlan
+state: up
+vxlan:
+  id: "101"
+  learning: false
+  local: "1.2.3.4"
+  destination-port: "3389"
+"#,
+    )
+    .unwrap();
+    let vxlan_conf = iface.vxlan.unwrap();
+
+    assert!(vxlan_conf.base_iface.is_empty());
+    assert_eq!(vxlan_conf.learning, Some(false));
+    assert_eq!(
+        vxlan_conf.local,
+        Some(std::net::IpAddr::V4("1.2.3.4".parse().unwrap()))
+    );
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -292,6 +292,8 @@ class VXLAN:
 
     ID = "id"
     BASE_IFACE = "base-iface"
+    LEARNING = "learning"
+    LOCAL = "local"
     REMOTE = "remote"
     DESTINATION_PORT = "destination-port"
 

--- a/tests/integration/testlib/vxlan.py
+++ b/tests/integration/testlib/vxlan.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 
@@ -27,26 +10,45 @@ from libnmstate.schema import VXLAN
 
 
 class VxlanState:
-    def __init__(self, id, base_if, remote, destination_port=4789):
+    def __init__(
+        self,
+        id,
+        base_if=None,
+        local=None,
+        remote=None,
+        learning=True,
+        destination_port=4789,
+    ):
         self.name = f"{base_if}.{id}"
         self.id = id
         self.base_if = base_if
+        self.learning = learning
+        self.local = local
         self.remote = remote
         self.destination_port = destination_port
 
     @property
     def up(self):
-        return {
+        state = {
             Interface.NAME: self.name,
             Interface.TYPE: VXLAN.TYPE,
             Interface.STATE: InterfaceState.UP,
             VXLAN.CONFIG_SUBTREE: {
                 VXLAN.ID: self.id,
                 VXLAN.BASE_IFACE: self.base_if,
+                VXLAN.LEARNING: self.learning,
+                VXLAN.LOCAL: self.local,
                 VXLAN.REMOTE: self.remote,
                 VXLAN.DESTINATION_PORT: self.destination_port,
             },
         }
+        if state[VXLAN.CONFIG_SUBTREE][VXLAN.BASE_IFACE] is None:
+            del state[VXLAN.CONFIG_SUBTREE][VXLAN.BASE_IFACE]
+        if state[VXLAN.CONFIG_SUBTREE][VXLAN.LOCAL] is None:
+            del state[VXLAN.CONFIG_SUBTREE][VXLAN.LOCAL]
+        if state[VXLAN.CONFIG_SUBTREE][VXLAN.REMOTE] is None:
+            del state[VXLAN.CONFIG_SUBTREE][VXLAN.REMOTE]
+        return state
 
     @property
     def absent(self):

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -72,6 +72,28 @@ def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
 
 
 @pytest.mark.tier1
+def test_add_and_remove_vxlan_without_base_if():
+    with vxlan_interfaces(
+        VxlanState(id=VXLAN1_ID, remote="192.168.100.1"),
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    vxlan1_ifname = desired_state[Interface.KEY][0][Interface.NAME]
+    assertlib.assert_absent(vxlan1_ifname)
+
+
+@pytest.mark.tier1
+def test_add_and_remove_vxlan_nolearning():
+    with vxlan_interfaces(
+        VxlanState(id=VXLAN1_ID, remote="192.168.100.1", learning=False),
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    vxlan1_ifname = desired_state[Interface.KEY][0][Interface.NAME]
+    assertlib.assert_absent(vxlan1_ifname)
+
+
+@pytest.mark.tier1
 @pytest.mark.xfail(
     is_k8s(),
     reason=(
@@ -142,6 +164,17 @@ def test_show_vxlan_with_no_remote(eth1_up):
     finally:
         libnmstate.apply(vxlans_absent([vxlan]))
         assertlib.assert_absent(vxlan.name)
+
+
+@pytest.mark.tier1
+def test_add_and_remove_vxlan_with_no_remote():
+    with vxlan_interfaces(
+        VxlanState(id=VXLAN1_ID, local="192.168.100.1"),
+    ) as desired_state:
+        assertlib.assert_state(desired_state)
+
+    vxlan1_ifname = desired_state[Interface.KEY][0][Interface.NAME]
+    assertlib.assert_absent(vxlan1_ifname)
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
In order to be able to use VXLAN interfaces as part of an EVPN fabric (separate control plane for VTEP and MAC learning), some expansions are done to the configurable properties:

- Make `base-if` non-mandatory

  EVPN networks are often run on top of a L3 underlay, which means that there are several L3 links to the host where ECMP routing is desired. The VXLAN interface should not be tied to any physical interface (and it's not required since multicast is not used) and the egress interface is determinted through standard routing.

- Allow specifying `local` IP

  Since the VXLAN interface is not tied to any physical interface, it is often desired to source the tunnel from a loopback IP.

- Disable data plane MAC `learning`

  In EVPN MAC learning is handled through a separate control plane like MP-BGP (e.g. FRR as daemon) writing entries to the bridge FDB.