### PR TITLE
[nmstate-1.4] nm: Ignore error when creating profile if not desired

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,5 +19,4 @@ jobs:
     metadata:
       targets:
         - centos-stream-8-x86_64
-        - centos-stream-9-x86_64
         - epel-8-x86_64

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -177,3 +177,43 @@ def test_bring_unmanaged_iface_down(unmanged_dummy1_with_static_ip):
         }
     )
     assert_absent(DUMMY1)
+
+
+@pytest.fixture
+def external_managed_dummy1_with_autoconf():
+    cmdlib.exec_cmd(f"ip link add {DUMMY1} type dummy".split(), check=True)
+    cmdlib.exec_cmd(f"ip link set {DUMMY1} up".split(), check=True)
+    cmdlib.exec_cmd(
+        f"ip addr add {IPV6_ADDRESS1}/64 dev {DUMMY1} "
+        "valid_lft 2000 preferred_lft 1000".split(),
+        check=True,
+    )
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    cmdlib.exec_cmd(f"ip link del {DUMMY1}".split(), check=False)
+
+
+# Make sure we are not impacted by undesired iface which is holding invalid
+# setting(here is DHCPv6 off with autoconf on)
+def test_external_managed_iface_with_autoconf_enabled(
+    eth1_up,
+    external_managed_dummy1_with_autoconf,
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
When a undesired interface holding `autoconf: true` and `dhcp: false`
for IPv6, nmstate will fail with error:

    Autoconf without DHCP is not supported yet

This is caused by `nm/connection.py` try to create `NM.SimpleConnection`
for every interface even not desired.

This patch changed to:
 * Only create new `NM.SimpleConnection` when desired or changed.
 * Use current profile if exists when not desired or changed.
 * Use `None` if not desired/changed and no current profile.

Integration test case included.