### PR TITLE
cli: Support policy file in service mode

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -158,7 +158,6 @@ fn main() {
                     clap::Arg::new("TIMEOUT")
                       .long("timeout")
                       .takes_value(true)
-                      .default_value("60")
                       .help(
                         "Timeout in seconds before reverting uncommited changes."
                       ),


### PR DESCRIPTION
This patch enable the support of policy file format in service mode
(`systemctl start nmstate`).

Integration test case included.