### PR TITLE
nm: Retry when NetworkManager starting up

### DIFF
--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -24,6 +24,11 @@ pub(crate) fn ncl_service(
         );
     }
 
+    // Due to bug of NetworkManager, the `After=NetworkManager.service` in
+    // `nmstate.service` cannot guarantee the ready of NM dbus.
+    // We sleep for 2 seconds here to avoid meaningless retry.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
     for file_path in config_files {
         let mut fd = match std::fs::File::open(&file_path) {
             Ok(fd) => fd,


### PR DESCRIPTION
nm: Retry when NetworkManager starting up

When OS boot up with `nmstate.service` enabled, nmstate will fail as
NetworkManager daemon is not fully setup the DBUS interface yet.

The `nmstate.service` has `After=NetworkManager.service`. Considering
`NetworkManager.service` is dbus type systemd service, it is guaranteed
that when `nmstate.service` starts, the DBUS interface is acquired by
NetworkManager. The failure is
`org.freedesktop.DBus.Error.UnknownMethod` as NetworkManager has not
finished the DBUS interface setup yet.

The `org.freedesktop.DBus.Error.UnknownMethod` is too generic, we cannot
assume it as daemon not started with checking the error string.
Considering the DBUS error string is not an API, we will not parse that
error message. Instead, we change top level retry to cover on querying
failures in `apply()`. The retry has been expend to twice with 2 seconds
interval(was 1 second interval).

Do not want to create complex integration test case for this corner case.
Manually tested.