### PR TITLE
cli: New subcommand `format`

### DIFF
--- a/rust/src/cli/format.rs
+++ b/rust/src/cli/format.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nmstate::NetworkState;
+use std::io::Read;
+
+use crate::error::CliError;
+
+pub(crate) fn format(state_file: &str) -> Result<String, CliError> {
+    let mut content = String::new();
+    if state_file == "-" {
+        std::io::stdin().read_to_string(&mut content)?;
+    } else {
+        std::fs::File::open(state_file)?.read_to_string(&mut content)?;
+    };
+    // Replace non-breaking space '\u{A0}'  to normal space
+    let content = content.replace('\u{A0}', " ");
+
+    let state = NetworkState::new_from_yaml(&content)?;
+    Ok(serde_yaml::to_string(&state)?)
+}

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -5,6 +5,7 @@ mod apply;
 #[cfg(feature = "query_apply")]
 mod autoconf;
 mod error;
+mod format;
 #[cfg(feature = "gen_conf")]
 mod gen_conf;
 #[cfg(feature = "query_apply")]
@@ -49,6 +50,7 @@ const SUB_CMD_VERSION: &str = "version";
 const SUB_CMD_AUTOCONF: &str = "autoconf";
 const SUB_CMD_SERVICE: &str = "service";
 const SUB_CMD_POLICY: &str = "policy";
+const SUB_CMD_FORMAT: &str = "format";
 
 fn main() {
     let argv: Vec<String> = std::env::args().collect();
@@ -301,6 +303,18 @@ fn main() {
                 )
         )
         .subcommand(
+            clap::Command::new(SUB_CMD_FORMAT)
+                .about("Format specified state and print out")
+                .alias("f")
+                .alias("fmt")
+                .arg(
+                    clap::Arg::new("STATE_FILE")
+                        .index(1)
+                        .default_value("-")
+                        .help("Network state file"),
+                ),
+        )
+        .subcommand(
             clap::Command::new(SUB_CMD_VERSION)
             .about("Show version")
        ).get_matches();
@@ -362,6 +376,11 @@ fn main() {
         print_result_and_exit(ncl_service(matches));
     } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_POLICY) {
         print_result_and_exit(policy(matches));
+    } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_FORMAT) {
+        // The default_value() has ensured the unwrap() will never fail
+        print_result_and_exit(format::format(
+            matches.value_of("STATE_FILE").unwrap(),
+        ));
     } else if matches.subcommand_matches(SUB_CMD_VERSION).is_some() {
         print_result_and_exit(Ok(format!(
             "{} {}",


### PR DESCRIPTION
Introduce `format` subcommand, `nmstatectl` read state file and print out
the formated one.

The subcommand `format` has alias `f` and `fmt`.

This is developer use only tool, no test required.