### PR TITLE
[nmstate-1.0] ip: Preserver IP when converting unmanaged interface to managed

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -76,6 +76,11 @@ function container_pre_test_setup {
 
     create_container
 
+    # Workaround for github CI problem on
+    #   fatal: detected dubious ownership in repository at '/workspace/nmstate'
+    container_exec "git config --global --add safe.directory \
+        $CONTAINER_WORKSPACE"
+
     container_exec "echo '$CONT_EXPORT_DIR/core.%h.%e.%t' > \
         /proc/sys/kernel/core_pattern"
     container_exec "ulimit -c unlimited"

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -70,9 +70,9 @@ function container_pre_test_setup {
     set -x
     ${CONTAINER_CMD} --version && cat /etc/resolv.conf
 
-    if [[ "$CI" == "true" ]];then
-        rebuild_container_images
-    fi
+    #if [[ "$CI" == "true" ]];then
+    #    rebuild_container_images
+    #fi
 
     create_container
 

--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -1,24 +1,6 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import logging
-from operator import attrgetter
 
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
@@ -99,9 +81,7 @@ class NisporPlugintIpState:
         self._np_ip_state = np_ip_state
         self._addresses = []
         if np_ip_state:
-            self._addresses = sorted(
-                np_ip_state.addresses, key=attrgetter("address")
-            )
+            self._addresses = np_ip_state.addresses
 
     @property
     def _is_ipv6(self):

--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
 
@@ -25,13 +8,18 @@ import libnmstate
 from libnmstate.schema import Bond
 from libnmstate.schema import BondMode
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 
 from ..testlib import cmdlib
+from ..testlib.iproutelib import iproute_get_ip_addrs_with_order
 
 BOND99 = "bond99"
 DUMMY1 = "dummy1"
 DUMMY2 = "dummy2"
+
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV4_ADDRESS2 = "192.0.2.252"
 
 
 @pytest.fixture
@@ -74,3 +62,48 @@ def test_external_managed_subordnates(bond99_with_dummy_port_by_iproute):
             ]
         }
     )
+
+
+@pytest.fixture
+def external_managed_dummy1_with_ips():
+    cmdlib.exec_cmd(f"ip link add {DUMMY1} type dummy".split(), check=True)
+    cmdlib.exec_cmd(f"ip link set {DUMMY1} up".split(), check=True)
+    cmdlib.exec_cmd(
+        f"ip addr add {IPV4_ADDRESS2}/24 dev {DUMMY1}".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(
+        f"ip addr add {IPV4_ADDRESS1}/24 dev {DUMMY1}".split(),
+        check=True,
+    )
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    cmdlib.exec_cmd(f"ip link del {DUMMY1}".split(), check=False)
+
+
+def test_perserve_ip_order_of_external_managed_nic(
+    external_managed_dummy1_with_ips,
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.TYPE: InterfaceType.DUMMY,
+                    Interface.STATE: InterfaceState.UP,
+                }
+            ]
+        }
+    )
+    ip_addrs = iproute_get_ip_addrs_with_order(iface=DUMMY1, is_ipv6=False)
+    assert ip_addrs[0] == IPV4_ADDRESS2
+    assert ip_addrs[1] == IPV4_ADDRESS1


### PR DESCRIPTION
When converting unmanaged(or external managed) interface to managed,
nmstate will sort the IP address in alphabet order which is incorrect
and break user's environment.

The root cause of this is nispor plugin sort the IP address during querying,
which lead to the IP address sending to NM been sorted.

The fix is just remove the IP address sorting  in nispor plugin.

Integration test case been included.