### PR TITLE
[nmstate-1.4] DNS: fix error when server has static DNS search with auto DNS server

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -97,7 +97,7 @@ class DnsState:
         ipv4_iface, ipv6_iface = self._find_ifaces_for_name_servers(
             ifaces, route_state
         )
-        if ipv4_iface == ipv6_iface:
+        if ipv4_iface == ipv6_iface and ipv4_iface:
             iface_metadata = {
                 ipv4_iface: {
                     Interface.IPV4: {DNS.SERVER: [], DNS.SEARCH: []},


### PR DESCRIPTION
When a server is holding static DNS search domains along with automatic
DNS name servers, nmstate will fail with error:

    File "libnmstate/ifaces/ifaces.py", line 812, in gen_dns_metadata
        self._kernel_ifaces[iface_name].store_dns_metadata(dns_metadata)
    KeyError: None

This is caused `dns.gen_metadata()` use `None` as key for interface
name in returned data.

To fix the problem, we skip metadata generation when both IPv4 and IPv6
interface is None.

Integration test case included.