### PR TITLE
[nmstate-1.2] DNS: fix error when server has static DNS search with auto DNS server

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -97,7 +97,7 @@ class DnsState:
         ipv4_iface, ipv6_iface = self._find_ifaces_for_name_servers(
             ifaces, route_state
         )
-        if ipv4_iface == ipv6_iface:
+        if ipv4_iface == ipv6_iface and ipv4_iface:
             iface_metadata = {
                 ipv4_iface: {
                     Interface.IPV4: {DNS.SERVER: [], DNS.SEARCH: []},

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1297,3 +1297,60 @@ def test_wait_ip(eth1_up, wait_ip):
             ],
         }
     )
+
+
+@pytest.fixture
+def static_dns_search_with_auto_dns_nameserver(dhcp_env):
+    libnmstate.apply(
+        {
+            DNS.KEY: {DNS.CONFIG: {DNS.SERVER: [], DNS.SEARCH: []}},
+            Interface.KEY: [
+                {
+                    Interface.NAME: DHCP_CLI_NIC,
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.IPV4: {
+                        InterfaceIPv4.DHCP: True,
+                        InterfaceIPv4.ENABLED: True,
+                    },
+                }
+            ],
+        }
+    )
+    cmdlib.exec_cmd(
+        f"nmcli c modify {DHCP_CLI_NIC} ipv4.dns-search example.com".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(f"nmcli c up {DHCP_CLI_NIC}".split(), check=True)
+    yield
+    cmdlib.exec_cmd(f"nmcli c del {DHCP_CLI_NIC}".split())
+
+
+# Even this test case is NM specific, but it require DHCP environment setup,
+# it is hard to place it in tests/integration/nm folder without dirty hacks,
+# hence place it here
+def test_prexist_static_dns_search_with_auto_dns_nameserver(
+    static_dns_search_with_auto_dns_nameserver,
+):
+    try:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "dummy0",
+                        Interface.TYPE: InterfaceType.DUMMY,
+                    }
+                ],
+            }
+        )
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: "dummy0",
+                        Interface.TYPE: InterfaceType.DUMMY,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ],
+            }
+        )


### PR DESCRIPTION
When a server is holding static DNS search domains along with automatic
DNS name servers, nmstate will fail with error:

    File "libnmstate/ifaces/ifaces.py", line 812, in gen_dns_metadata
        self._kernel_ifaces[iface_name].store_dns_metadata(dns_metadata)
    KeyError: None

This is caused `dns.gen_metadata()` use `None` as key for interface
name in returned data.

To fix the problem, we skip metadata generation when both IPv4 and IPv6
interface is None.

Integration test case included.