### PR TITLE
show: Don't hide controller property

### DIFF
--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -56,12 +56,6 @@ impl Interfaces {
             }
         }
     }
-
-    pub(crate) fn hide_controller_prop(&mut self) {
-        for iface in self.kernel_ifaces.values_mut() {
-            iface.base_iface_mut().controller = None;
-        }
-    }
 }
 
 fn find_unknown_type_port<'a>(

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1166,10 +1166,10 @@ def test_add_port_to_br_with_controller_property(bridge0_with_port0, eth2_up):
     assert br_ports[1][LinuxBridge.Port.NAME] == "eth2"
 
 
-def test_hide_controller_in_show(bridge0_with_port0):
+def test_controller_in_show(bridge0_with_port0):
     current_state = show_only(["eth1"])
     assert current_state[Interface.KEY][0][Interface.NAME] == "eth1"
-    assert Interface.CONTROLLER not in current_state[Interface.KEY][0]
+    assert Interface.CONTROLLER in current_state[Interface.KEY][0]
 
 
 def test_has_controller_prop_but_not_in_port_list():


### PR DESCRIPTION
For use cases where we want to filter by interfaces not owned by a bridge showing the controller is quite helpful.