### PR TITLE
state: Set interface as up when `mark_as_changed()`

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -163,7 +163,7 @@ impl InterfaceType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 /// The state of interface
@@ -936,6 +936,7 @@ impl MergedInterface {
         &mut self,
         ctrl_name: String,
         ctrl_type: Option<InterfaceType>,
+        ctrl_state: InterfaceState,
     ) -> Result<(), NmstateError> {
         if self.merged.need_controller() && ctrl_name.is_empty() {
             if let Some(org_ctrl) = self
@@ -959,6 +960,12 @@ impl MergedInterface {
 
         if !self.is_desired() {
             self.mark_as_changed();
+            if ctrl_state == InterfaceState::Up {
+                self.merged.base_iface_mut().state = InterfaceState::Up;
+                if let Some(apply_iface) = self.for_apply.as_mut() {
+                    apply_iface.base_iface_mut().state = InterfaceState::Up;
+                }
+            }
             log::info!(
                 "Include interface {} to edit as its controller required so",
                 self.merged.name()

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -47,7 +47,7 @@ impl BaseInterface {
             self.iface_type = other.iface_type.clone();
         }
         if other.prop_list.contains(&"state") {
-            self.state = other.state.clone();
+            self.state = other.state;
         }
         if other.prop_list.contains(&"mtu") {
             self.mtu = other.mtu;


### PR DESCRIPTION
== Problem

When user create a linux bridge using eth1 in down state without
having eth1 desired, Nmstate will fail at verification stage complaining
port list not match with desired.

== Root cause

The `apply_ctrller_change()` invoke `mark_as_changed()` copied the
current interface state(down) which instructed backend to deactivate the
interface.

== Fix

 * Changed `apply_ctrller_change()` to mark port interface as up if
   its controller is up.
 * Ignore deactivation failure on `ConnectionNotActive`. (Required for
   testing creating a `down` linux bridge.

== Tests

Integration test cases included for original problem.
Additional test case included for creating a `down` linux bridge with
ports meaning nmstate just create config instead of activate them.