### PR TITLE
test: Fix `test_wait_sriov_vf_been_created` on mlx5 NIC

### DIFF
--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -27,6 +27,7 @@ RUN dnf update -y && \
                    python3-devel \
                    python3-pyyaml \
                    python3-setuptools \
+                   python3-gobject-base \
                    python36 \
                    dnsmasq \
                    git \

--- a/tests/integration/testlib/sriov.py
+++ b/tests/integration/testlib/sriov.py
@@ -1,22 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import json
-
-import libnmstate
-from libnmstate.schema import Interface
-
-from .cmdlib import exec_cmd
+import glob
+import os
 
 
 def get_sriov_vf_names(pf_name):
-    output = exec_cmd(f"ip -j -d link show {pf_name}".split())[1]
-    link_info = json.loads(output)[0]
-    macs = [
-        vf_info["address"].upper()
-        for vf_info in link_info.get("vfinfo_list", [])
-    ]
-    return [
-        iface[Interface.NAME]
-        for iface in libnmstate.show()[Interface.KEY]
-        if iface[Interface.MAC] in macs
-    ]
+    ret = []
+    for folder in glob.glob(f"/sys/class/net/{pf_name}/device/virtfn*/net/"):
+        ret.extend(os.listdir(folder))
+    return ret


### PR DESCRIPTION
On some `mlx5_core` NIC, the `ip -d link show <pf_name>` does not have
VF interface name, which will fail the `test_wait_sriov_vf_been_created`
for VF name not found.

The fix would be changed the test code to use this folder for VF
interface name as the production code:

    /sys/class/net/{pf_name}/device/virtfn{sriov_id}/net/

Manually test on mlx5 MT27710 NIC.