### PR TITLE
cli: Ignore failure when reading /etc/nmstate folder

### DIFF
--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -15,13 +15,23 @@ pub(crate) fn ncl_service(
         .value_of(crate::CONFIG_FOLDER_KEY)
         .unwrap_or(crate::DEFAULT_SERVICE_FOLDER);
 
-    let config_files = get_config_files(folder)?;
+    let config_files = match get_config_files(folder) {
+        Ok(f) => f,
+        Err(e) => {
+            log::info!(
+                "Failed to read config folder {folder} due to \
+                error {e}, ignoring"
+            );
+            return Ok(String::new());
+        }
+    };
     if config_files.is_empty() {
         log::info!(
             "No nmstate config(end with .{}) found in config folder {}",
             CONFIG_FILE_EXTENTION,
             folder
         );
+        return Ok(String::new());
     }
 
     // Due to bug of NetworkManager, the `After=NetworkManager.service` in

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
+import shutil
 
 import yaml
 import pytest
@@ -155,3 +156,10 @@ def test_nmstate_service_apply_nmpolicy(dummy1_up):
         assert os.path.isfile(TEST_CONFIG3_APPLIED_FILE_PATH)
     finally:
         os.remove(TEST_CONFIG3_APPLIED_FILE_PATH)
+
+
+def test_nmstate_service_without_etc_folder():
+    if os.path.isdir(CONFIG_DIR):
+        shutil.rmtree(CONFIG_DIR, ignore_errors=True)
+
+    exec_cmd("nmstatectl service".split(), check=True)


### PR DESCRIPTION
When /etc/nmstate not exists or other failure when reading it, we should
ignore it and exist 0.

Integration test case included.