### PR TITLE
nmstate.service: remain after exit

### DIFF
--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -7,6 +7,7 @@ Requires=NetworkManager.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/nmstatectl service
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -106,7 +106,7 @@ def nmstate_etc_config():
 
 
 def test_nmstate_service_apply(nmstate_etc_config):
-    exec_cmd("systemctl start nmstate".split(), check=True)
+    exec_cmd("systemctl restart nmstate".split(), check=True)
 
     desire_state = yaml.load(TEST_YAML2_CONTENT, Loader=yaml.SafeLoader)
     assert_state_match(desire_state)
@@ -151,7 +151,7 @@ def test_nmstate_service_apply_nmpolicy(dummy1_up):
     assert current_state[Interface.KEY][0][Interface.NAME] == DUMMY1
 
     try:
-        exec_cmd("systemctl start nmstate".split(), check=True)
+        exec_cmd("systemctl restart nmstate".split(), check=True)
         assert_absent(DUMMY1)
         assert os.path.isfile(TEST_CONFIG3_APPLIED_FILE_PATH)
     finally:


### PR DESCRIPTION
This is generally a good idea for oneshot units.  If we don't remain after exit, the unit will run and then immediately stop itself.  As a result, if a dependent unit is started in a subsequent transaction, `nmstate.service` will run again.  Furthermore, if the service is stopped, systemd will consider any dependent targets to no longer be running.