### PR TITLE
cli: Change install section of nmstate.service

### DIFF
--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -10,4 +10,4 @@ ExecStart=/usr/bin/nmstatectl service
 RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=NetworkManager.service


### PR DESCRIPTION
Instead of `WantedBy=multi-user.target` which install nmstate.service to
`multi-user.target`, we should use `WantedBy=NetworkManager.service` to
make sure we only run nmstate.service when NetworkManager been enabled.

Manually tested in VM. Since this require OS reboot, no auto test case
yet.