### PR TITLE
cli: Place nmstate.service before network-online.target

### DIFF
--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -2,6 +2,7 @@
 Description=Apply nmstate on-disk state
 Documentation=man:nmstate.service(8) https://www.nmstate.io
 After=NetworkManager.service
+Before=network-online.target
 Requires=NetworkManager.service
 
 [Service]


### PR DESCRIPTION
By placing `nmstate.service` before `network-online.target`, we make
sure other network required service only been started after
nmstate.service finished its work on changing network.

Manually test in VM, the log indicate the `network-online.target` is
reached after `nmstate.service` finished.