### PR TITLE
nm: Refresh active connection after deletion

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -141,11 +141,7 @@ pub(crate) fn nm_apply(
         )?;
     }
 
-    activate_nm_profiles(
-        &mut nm_api,
-        nm_conns_to_activate.as_slice(),
-        &nm_acs,
-    )?;
+    activate_nm_profiles(&mut nm_api, nm_conns_to_activate.as_slice())?;
 
     deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
 

--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -3,7 +3,7 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use super::super::nm_dbus::{
-    self, NmActiveConnection, NmApi, NmConnection, NmSettingsConnectionFlag,
+    self, NmApi, NmConnection, NmSettingsConnectionFlag,
 };
 use super::super::{
     error::nm_error_to_nmstate,
@@ -122,9 +122,11 @@ pub(crate) fn save_nm_profiles(
 pub(crate) fn activate_nm_profiles(
     nm_api: &mut NmApi,
     nm_conns: &[NmConnection],
-    nm_acs: &[NmActiveConnection],
 ) -> Result<(), NmstateError> {
     let mut nm_conns = nm_conns.to_vec();
+    let nm_acs = nm_api
+        .active_connections_get()
+        .map_err(nm_error_to_nmstate)?;
     let nm_ac_uuids: Vec<&str> =
         nm_acs.iter().map(|nm_ac| &nm_ac.uuid as &str).collect();
 


### PR DESCRIPTION
Problem:

When changing veth peer, we noticed nmstate try to run `reapply()` on
veth which its connection been deactivated before activation, this is
incorrect.

Root cause:

Before `activate_nm_profiles()`, we have `deactivate_nm_profiles()`,
`delete_exist_profiles()` and `delete_orphan_ovs_ports()` which could
impact on active connections.

Fix:

Refresh the active connection list during `activate_nm_profiles()`.

Test:

This is very hard to test automatically, manually confirmed veth peer
change will not trigger NM reapply action.