### PR TITLE
[nmstate-1.2] nm: Support global DNS

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -42,7 +42,7 @@ fi
 
 if [ $NM_TYPE == "nm_main" ];then
     COPR_ARG="--copr networkmanager/NetworkManager-main"
-elif [ $NM_TYPE == "nm_main" ];then
+elif [ $NM_TYPE == "nm_1_36" ];then
     COPR_ARG="--copr networkmanager/NetworkManager-1.36"
 fi
 

--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -1,27 +1,9 @@
-#
-# Copyright (c) 2020-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from copy import deepcopy
 
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.iplib import canonicalize_ip_address
 from libnmstate.iplib import is_ipv6_address
 from libnmstate.prettystate import format_desired_current_state_diff
@@ -44,7 +26,6 @@ class DnsState:
         self._cur_dns_state = deepcopy(cur_dns_state) if cur_dns_state else {}
         self._dns_state = merge_dns(des_dns_state, cur_dns_state or {})
         if des_dns_state and des_dns_state.get(DNS.CONFIG):
-            self._validate()
             if cur_dns_state:
                 self._config_changed = _is_dns_config_changed(
                     des_dns_state, cur_dns_state
@@ -53,8 +34,7 @@ class DnsState:
 
     def _canonicalize_ip_address(self):
         canonicalized_addrs = [
-            canonicalize_ip_address(address)
-            for address in self._config_servers
+            canonicalize_ip_address(address) for address in self.config_servers
         ]
         self.config[DNS.SERVER] = canonicalized_addrs
 
@@ -67,14 +47,14 @@ class DnsState:
         return _get_config(self._dns_state)
 
     @property
-    def _config_servers(self):
+    def config_servers(self):
         return _get_config_servers(self._dns_state)
 
     @property
-    def _config_searches(self):
+    def config_searches(self):
         return _get_config_searches(self._dns_state)
 
-    def gen_metadata(self, ifaces, route_state):
+    def gen_metadata(self, ifaces, route_state, ignored_dns_ifaces):
         """
         Return DNS configure targeting to store as metadata of interface.
         Data structure returned is:
@@ -92,10 +72,11 @@ class DnsState:
             }
         """
         iface_metadata = {}
-        if not self._config_servers and not self._config_searches:
+        if not self.config_servers and not self.config_searches:
             return iface_metadata
+
         ipv4_iface, ipv6_iface = self._find_ifaces_for_name_servers(
-            ifaces, route_state
+            ifaces, route_state, ignored_dns_ifaces
         )
         if ipv4_iface == ipv6_iface and ipv4_iface:
             iface_metadata = {
@@ -115,7 +96,7 @@ class DnsState:
                 }
         index = 0
         searches_saved = False
-        for server in self._config_servers:
+        for server in self.config_servers:
             iface_name = None
             if is_ipv6_address(server):
                 iface_name = ipv6_iface
@@ -134,12 +115,15 @@ class DnsState:
             iface_dns_metada[DNS.SERVER].append(server)
             iface_dns_metada.setdefault(DnsState.PRIORITY_METADATA, index)
             if not searches_saved:
-                iface_dns_metada[DNS.SEARCH] = self._config_searches
+                iface_dns_metada[DNS.SEARCH] = self.config_searches
             searches_saved = True
             index += 1
+
         return iface_metadata
 
-    def _find_ifaces_for_name_servers(self, ifaces, route_state):
+    def _find_ifaces_for_name_servers(
+        self, ifaces, route_state, ignored_dns_ifaces
+    ):
         """
         Find interface to store the DNS configurations in the order of:
             * Any interface with static gateway
@@ -147,13 +131,17 @@ class DnsState:
         Return tuple: (ipv4_iface, ipv6_iface)
         """
         ipv4_iface, ipv6_iface = self._find_ifaces_with_static_gateways(
-            ifaces, route_state
+            ifaces,
+            route_state,
+            ignored_dns_ifaces,
         )
         if not (ipv4_iface and ipv6_iface):
             (
                 auto_ipv4_iface,
                 auto_ipv6_iface,
-            ) = self._find_ifaces_with_auto_dns_false(ifaces)
+            ) = self._find_ifaces_with_auto_dns_false(
+                ifaces, ignored_dns_ifaces
+            )
             if not ipv4_iface and auto_ipv4_iface:
                 ipv4_iface = auto_ipv4_iface
             if not ipv6_iface and auto_ipv6_iface:
@@ -161,21 +149,33 @@ class DnsState:
 
         return ipv4_iface, ipv6_iface
 
-    def _find_ifaces_with_static_gateways(self, ifaces, route_state):
+    def _find_ifaces_with_static_gateways(
+        self, ifaces, route_state, ignored_dns_ifaces
+    ):
         """
         Return tuple of interfaces with IPv4 and IPv6 static gateways.
         """
         ipv4_iface = None
         ipv6_iface = None
         for iface_name, route_set in route_state.config_iface_routes.items():
+            if iface_name == "lo":
+                continue
             for route in route_set:
                 if ipv4_iface and ipv6_iface:
                     return (ipv4_iface, ipv6_iface)
                 if route.is_gateway:
-                    # Only interfaces not ignored can be considered as valid
-                    # static gateway for nameservers.
                     iface = ifaces.all_kernel_ifaces.get(iface_name)
-                    if iface and iface.is_ignore:
+                    if not iface:
+                        continue
+                    # Skip ignored interface
+                    if iface.is_ignore:
+                        continue
+                    # Skip plugin blacklist of DNS interface
+                    if (
+                        not iface.is_changed
+                        and not iface.is_desired
+                        and iface_name in ignored_dns_ifaces
+                    ):
                         continue
                     if route.is_ipv6:
                         ipv6_iface = iface_name
@@ -183,11 +183,15 @@ class DnsState:
                         ipv4_iface = iface_name
         return (ipv4_iface, ipv6_iface)
 
-    def _find_ifaces_with_auto_dns_false(self, ifaces):
+    def _find_ifaces_with_auto_dns_false(self, ifaces, ignored_dns_ifaces):
         ipv4_iface = None
         ipv6_iface = None
         for iface in ifaces.all_kernel_ifaces.values():
-            if iface.is_ignore:
+            if iface.is_ignore or (
+                iface.name in ignored_dns_ifaces
+                and not iface.is_changed
+                and not iface.is_desired
+            ):
                 continue
             if ipv4_iface and ipv6_iface:
                 return (ipv4_iface, ipv6_iface)
@@ -218,17 +222,13 @@ class DnsState:
                 )
             )
 
-    def _validate(self):
-        if (
-            len(self._config_servers) > 2
-            and any(is_ipv6_address(n) for n in self._config_servers)
-            and any(not is_ipv6_address(n) for n in self._config_servers)
-            and _is_mixed_dns_servers(self._config_servers)
-        ):
-            raise NmstateNotImplementedError(
-                "Placing IPv4/IPv6 nameserver in the middle of IPv6/IPv4 "
-                "nameservers is not supported yet"
-            )
+    def is_46_mixed_dns_servers(self):
+        return (
+            len(self.config_servers) > 2
+            and any(is_ipv6_address(n) for n in self.config_servers)
+            and any(not is_ipv6_address(n) for n in self.config_servers)
+            and _is_mixed_dns_servers(self.config_servers)
+        )
 
     @property
     def config_changed(self):

--- a/libnmstate/ifaces/ifaces.py
+++ b/libnmstate/ifaces/ifaces.py
@@ -734,8 +734,14 @@ class Ifaces:
                             )
                         )
 
-    def gen_dns_metadata(self, dns_state, route_state):
-        iface_metadata = dns_state.gen_metadata(self, route_state)
+    def gen_dns_metadata(
+        self, dns_state, route_state, ignored_dns_ifaces=None
+    ):
+        if ignored_dns_ifaces is None:
+            ignored_dns_ifaces = []
+        iface_metadata = dns_state.gen_metadata(
+            self, route_state, ignored_dns_ifaces
+        )
         for iface_name, dns_metadata in iface_metadata.items():
             self._kernel_ifaces[iface_name].store_dns_metadata(dns_metadata)
             if dns_state.config_changed:

--- a/libnmstate/netapplier.py
+++ b/libnmstate/netapplier.py
@@ -83,8 +83,14 @@ def apply(
             copy.deepcopy(desired_state), plugins_capabilities(plugins)
         )
         ignored_ifnames = _get_ignored_interface_names(plugins)
+        ignored_dns_ifaces = _get_ignored_dns_ifaces(plugins)
         net_state = NetState(
-            desired_state, ignored_ifnames, current_state, save_to_disk
+            desired_state,
+            ignored_ifnames=ignored_ifnames,
+            current_state=current_state,
+            save_to_disk=save_to_disk,
+            gen_conf_mode=False,
+            ignored_dns_ifaces=ignored_dns_ifaces,
         )
         checkpoints = create_checkpoints(plugins, rollback_timeout)
         # When we have VF count changes and missing eth, it might be user
@@ -98,6 +104,7 @@ def apply(
                     ignored_ifnames,
                     current_state,
                     save_to_disk,
+                    ignored_dns_ifaces=ignored_dns_ifaces,
                 )
                 _apply_ifaces_state(
                     plugins,
@@ -119,6 +126,7 @@ def apply(
                     ignored_ifnames,
                     current_state,
                     save_to_disk,
+                    ignored_dns_ifaces=ignored_dns_ifaces,
                 )
         if net_state.ifaces.has_sriov_iface():
             # If SR-IOV is present, the verification timeout is being increased
@@ -189,6 +197,15 @@ def _get_ignored_interface_names(plugins):
     ifaces = set()
     for plugin in plugins:
         for iface_name in plugin.get_ignored_kernel_interface_names():
+            ifaces.add(iface_name)
+
+    return ifaces
+
+
+def _get_ignored_dns_ifaces(plugins):
+    ifaces = set()
+    for plugin in plugins:
+        for iface_name in plugin.get_ignored_iface_for_dns():
             ifaces.add(iface_name)
 
     return ifaces

--- a/libnmstate/nm/plugin.py
+++ b/libnmstate/nm/plugin.py
@@ -22,6 +22,7 @@ from .common import NM
 from .context import NmContext
 from .device import get_device_common_info
 from .device import get_iface_type
+from .device import is_externally_managed
 from .device import is_kernel_iface
 from .device import list_devices
 from .dns import get_running as get_dns_running
@@ -302,6 +303,19 @@ class NetworkManagerPlugin(NmstatePlugin):
                 and nm_dev.get_iface()
                 and not nm_dev.get_managed()
                 and is_kernel_iface(nm_dev)
+            ):
+                ignored_ifaces.add(nm_dev.get_iface())
+        return list(ignored_ifaces)
+
+    # Unmanaged and external managed interface are not suitable for storing DNS
+    def get_ignored_iface_for_dns(self):
+        ignored_ifaces = set()
+        for nm_dev in list_devices(self.client):
+            if (
+                nm_dev
+                and nm_dev.get_iface()
+                and is_kernel_iface(nm_dev)
+                and (not nm_dev.get_managed() or is_externally_managed(nm_dev))
             ):
                 ignored_ifaces.add(nm_dev.get_iface())
         return list(ignored_ifaces)

--- a/libnmstate/nm/profile.py
+++ b/libnmstate/nm/profile.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 # This file is targeting:
 #   * NM.RemoteConnection, NM.SimpleConnection releated

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -1,24 +1,7 @@
-#
-# Copyright (c) 2020-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 # This file is targeting:
-#   * Actions required the knownldege of multiple NmProfile
+#   * Actions required the knowledge of multiple NmProfile
 
 import logging
 from operator import attrgetter
@@ -35,6 +18,7 @@ from .device import get_iface_type
 from .device import get_nm_dev
 from .device import is_kernel_iface
 from .dns import get_dns_config_iface_names
+from .dns import apply_global_dns
 from .ipv4 import acs_and_ip_profiles as acs_and_ip4_profiles
 from .ipv6 import acs_and_ip_profiles as acs_and_ip6_profiles
 from .ovs import create_iface_for_nm_ovs_port
@@ -66,6 +50,14 @@ class NmProfiles:
         ]
 
     def apply_config(self, net_state, save_to_disk):
+        if net_state.dns.config_changed:
+            if net_state.use_global_dns:
+                apply_global_dns(
+                    net_state.dns.config_servers, net_state.dns.config_searches
+                )
+            else:
+                apply_global_dns([], [])
+
         self._prepare_state_for_profiles(net_state)
         # The activation order on bridge/bond ports determins their controler's
         # MAC address. The default NetworkManager is using alphabet order on

--- a/libnmstate/nmstate.py
+++ b/libnmstate/nmstate.py
@@ -92,9 +92,12 @@ def show_with_plugins(
         plugins, NmstatePlugin.PLUGIN_CAPABILITY_DNS
     )
     if dns_plugin:
-        report[DNS.KEY] = dns_plugin.get_dns_client_config()
-        if info_type != _INFO_TYPE_RUNNING:
-            report[DNS.KEY].pop(DNS.RUNNING, None)
+        try:
+            report[DNS.KEY] = dns_plugin.get_dns_client_config()
+            if info_type != _INFO_TYPE_RUNNING:
+                report[DNS.KEY].pop(DNS.RUNNING, None)
+        except NmstateDependencyError:
+            pass
 
     for plugin in plugins:
         report.update(plugin.get_global_state())

--- a/libnmstate/plugin.py
+++ b/libnmstate/plugin.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from abc import ABCMeta
 from abc import abstractproperty
@@ -134,5 +117,12 @@ class NmstatePlugin(metaclass=ABCMeta):
         """
         Return a list of kernel interface names which should be ignored
         during verification stage.
+        """
+        return []
+
+    def get_ignored_iface_for_dns(self):
+        """
+        Return a list of kernel interface which not suitable for storing DNS
+        into.
         """
         return []

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -1,26 +1,8 @@
-#
-# Copyright (c) 2019-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import pytest
 
 import libnmstate
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -114,33 +96,19 @@ def test_dns_edit_ipv6_nameserver_before_ipv4():
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
         (IPV4_DNS_NAMESERVERS + [EXTRA_IPV6_DNS_NAMESERVER]),
         (IPV6_DNS_NAMESERVERS + [EXTRA_IPV4_DNS_NAMESERVER]),
-        pytest.param(
-            (
-                [
-                    IPV4_DNS_NAMESERVERS[0],
-                    EXTRA_IPV6_DNS_NAMESERVER,
-                    IPV4_DNS_NAMESERVERS[1],
-                ]
-            ),
-            marks=pytest.mark.xfail(
-                reason="Not supported",
-                raises=NmstateNotImplementedError,
-                strict=True,
-            ),
+        (
+            [
+                IPV4_DNS_NAMESERVERS[0],
+                EXTRA_IPV6_DNS_NAMESERVER,
+                IPV4_DNS_NAMESERVERS[1],
+            ]
         ),
-        pytest.param(
-            (
-                [
-                    IPV6_DNS_NAMESERVERS[0],
-                    EXTRA_IPV4_DNS_NAMESERVER,
-                    IPV6_DNS_NAMESERVERS[1],
-                ]
-            ),
-            marks=pytest.mark.xfail(
-                reason="Not supported",
-                raises=NmstateNotImplementedError,
-                strict=True,
-            ),
+        (
+            [
+                IPV6_DNS_NAMESERVERS[0],
+                EXTRA_IPV4_DNS_NAMESERVER,
+                IPV6_DNS_NAMESERVERS[1],
+            ]
         ),
         (IPV4_DNS_NAMESERVERS + IPV6_DNS_NAMESERVERS),
         (IPV6_DNS_NAMESERVERS + IPV4_DNS_NAMESERVERS),

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import pytest
 
@@ -32,6 +15,7 @@ from ..testlib import cmdlib
 
 DUMMY0 = "dummy0"
 ETH1 = "eth1"
+TEST_DNS_SRVS = ["192.0.2.2", "192.0.2.1"]
 
 
 @pytest.fixture
@@ -98,3 +82,59 @@ def test_set_auto_dns_with_unamanged_iface_with_static_gw(
             ],
         }
         libnmstate.apply(absent_state)
+
+
+@pytest.fixture
+def all_unmanaged_with_gw_on_eth1(unmanaged_eth1_with_static_gw):
+    changed_ifaces = []
+    output = cmdlib.exec_cmd("nmcli -t -f DEVICE,STATE d".split(), check=True)[
+        1
+    ]
+    for line in output.split("\n"):
+        splited = line.split(":")
+        if len(splited) == 2:
+            iface_name, state = splited
+            if state.startswith("connected"):
+                changed_ifaces.append(iface_name)
+                cmdlib.exec_cmd(
+                    f"nmcli d set {iface_name} managed false".split(),
+                    check=True,
+                )
+    yield
+    for iface_name in changed_ifaces:
+        cmdlib.exec_cmd(
+            f"nmcli d set {iface_name} managed true".split(), check=True
+        )
+
+
+def test_do_not_use_unmanaged_iface_for_dns(all_unmanaged_with_gw_on_eth1):
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {DNS.SERVER: TEST_DNS_SRVS}}})
+
+    assert_global_dns(TEST_DNS_SRVS)
+
+
+@pytest.fixture
+def all_unmanaged_with_gw_on_eth1_as_ext_mgt(all_unmanaged_with_gw_on_eth1):
+    cmdlib.exec_cmd(
+        "nmcli d set eth1 managed true".split(),
+        check=True,
+    )
+    yield
+
+
+def test_do_not_use_external_managed_iface_for_dns(
+    all_unmanaged_with_gw_on_eth1_as_ext_mgt,
+):
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {DNS.SERVER: TEST_DNS_SRVS}}})
+
+    assert_global_dns(TEST_DNS_SRVS)
+
+
+GLOBAL_DNS_CONF_FILE = "/var/lib/NetworkManager/NetworkManager-intern.conf"
+
+
+def assert_global_dns(servers):
+    with open(GLOBAL_DNS_CONF_FILE) as fd:
+        content = fd.read()
+        for server in servers:
+            assert server in content

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -1,27 +1,9 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from copy import deepcopy
 
 import pytest
 
-from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import DNS
@@ -219,22 +201,8 @@ class TestDnsState:
             ([IPV6_DNS_SERVER1, IPV6_DNS_SERVER2, IPV6_DNS_SERVER3]),
             ([IPV4_DNS_SERVER1, IPV4_DNS_SERVER2, IPV6_DNS_SERVER1]),
             ([IPV6_DNS_SERVER1, IPV6_DNS_SERVER2, IPV4_DNS_SERVER1]),
-            pytest.param(
-                ([IPV4_DNS_SERVER1, IPV6_DNS_SERVER1, IPV4_DNS_SERVER2]),
-                marks=pytest.mark.xfail(
-                    reason="Not supported",
-                    raises=NmstateNotImplementedError,
-                    strict=True,
-                ),
-            ),
-            pytest.param(
-                ([IPV6_DNS_SERVER1, IPV4_DNS_SERVER1, IPV6_DNS_SERVER2]),
-                marks=pytest.mark.xfail(
-                    reason="Not supported",
-                    raises=NmstateNotImplementedError,
-                    strict=True,
-                ),
-            ),
+            ([IPV4_DNS_SERVER1, IPV6_DNS_SERVER1, IPV4_DNS_SERVER2]),
+            ([IPV6_DNS_SERVER1, IPV4_DNS_SERVER1, IPV6_DNS_SERVER2]),
             (
                 [
                     IPV4_DNS_SERVER1,


### PR DESCRIPTION
By using the `org.freedesktop.NetworkManager.GlobalDnsConfiguration`
DBUS API, we can modify the `/etc/resolve.conf` directly overriding DNS
settings in NM profiles/connections.

We use this as fallback method when we failed to store DNS into
interface profile. And a warning message will be shown as:

WARNING  Cannot stored IPv4 IPv6 mixed DNS server into interface
         profile, using global DNS
WARNING  Storing DNS to NetworkManager via global dns API, this will
         cause __all__ interface level DNS settings been ignored

This will not be used for `gen_conf` mode. User still get error when not
able to store DNS into interface profile.

In order to not store DNS config to NM unmanaged or external managed
undesired interface, we introduced new plugin function
`get_ignored_iface_for_dns()` to prevent DNS metadata stored those
interfaces.

Removed the xfail of integration test case for `ipv6+ipv4+ipv6` and
`ipv4+ipv6+ipv4` name server format.

Added test cases to ensure nmstate will not use NM undesired unmanaged
interface or undesired external managed interface for DNS.