### PR TITLE
[nmstate-1.2] ROUTE_RULE: Fixes apply route rule issue.

### DIFF
--- a/libnmstate/route_rule.py
+++ b/libnmstate/route_rule.py
@@ -196,11 +196,15 @@ class RouteRuleState:
             rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
             cur_rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
             for rule in self._cur_rules[route_table]:
-                cur_rules_ipfamily[Interface.IPV6].add(rule) if rule.is_ipv6 \
-                    else cur_rules_ipfamily[Interface.IPV4].add(rule)
+                cur_rules_ipfamily[Interface.IPV6].add(
+                    rule
+                ) if rule.is_ipv6 else cur_rules_ipfamily[Interface.IPV4].add(
+                    rule
+                )
             for rule in rules:
-                rules_ipfamily[Interface.IPV6].add(rule) if rule.is_ipv6 \
-                    else rules_ipfamily[Interface.IPV4].add(rule)
+                rules_ipfamily[Interface.IPV6].add(
+                    rule
+                ) if rule.is_ipv6 else rules_ipfamily[Interface.IPV4].add(rule)
             for ip_family in (Interface.IPV4, Interface.IPV6):
                 if len(rules_ipfamily[ip_family]) == 0:
                     continue
@@ -218,14 +222,15 @@ class RouteRuleState:
                     ] = True
                 for rule in rules_ipfamily[ip_family]:
                     route_rule_metadata[iface_name][ip_family].append(
-                        rule.to_dict())
+                        rule.to_dict()
+                    )
         return route_rule_metadata
 
     def _verify_ip4_ipv6_enabled(self, route, ifaces, ip_family):
         for iface in ifaces.values():
             iface_dict = iface.to_dict()
-            if iface_dict['name'] == route.next_hop_interface:
-                return iface_dict[ip_family]['enabled']
+            if iface_dict["name"] == route.next_hop_interface:
+                return iface_dict[ip_family]["enabled"]
 
     def _iface_for_route_table(
         self, route_state, route_table, ifaces, ip_family

--- a/libnmstate/route_rule.py
+++ b/libnmstate/route_rule.py
@@ -193,21 +193,21 @@ class RouteRuleState:
         """
         route_rule_metadata = {}
         for route_table, rules in self._rules.items():
-            rules_ipfamily = {Interface.IPV4:set(), Interface.IPV6:set()}
-            cur_rules_ipfamily = {Interface.IPV4:set(), Interface.IPV6:set()}
+            rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
+            cur_rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
             for rule in self._cur_rules[route_table]:
                 cur_rules_ipfamily[Interface.IPV6].add(rule) if rule.is_ipv6 \
-                else cur_rules_ipfamily[Interface.IPV4].add(rule)
+                    else cur_rules_ipfamily[Interface.IPV4].add(rule)
             for rule in rules:
                 rules_ipfamily[Interface.IPV6].add(rule) if rule.is_ipv6 \
-                else rules_ipfamily[Interface.IPV4].add(rule)
+                    else rules_ipfamily[Interface.IPV4].add(rule)
             for ip_family in (Interface.IPV4, Interface.IPV6):
                 if len(rules_ipfamily[ip_family]) == 0:
                     continue
                 iface_name = self._iface_for_route_table(
                     route_state, route_table, ifaces, ip_family
                 )
-                if route_rule_metadata.get(iface_name) == None:
+                if route_rule_metadata.get(iface_name) is None:
                     route_rule_metadata[iface_name] = {
                         Interface.IPV4: [],
                         Interface.IPV6: [],
@@ -217,14 +217,19 @@ class RouteRuleState:
                         BaseIface.RULE_CHANGED_METADATA
                     ] = True
                 for rule in rules_ipfamily[ip_family]:
-                    route_rule_metadata[iface_name][ip_family].append(rule.to_dict())
+                    route_rule_metadata[iface_name][ip_family].append(
+                        rule.to_dict())
         return route_rule_metadata
-    def _verify_ip4_ipv6_enabled(self,route, ifaces, ip_family):
+
+    def _verify_ip4_ipv6_enabled(self, route, ifaces, ip_family):
         for iface in ifaces.values():
             iface_dict = iface.to_dict()
             if iface_dict['name'] == route.next_hop_interface:
                 return iface_dict[ip_family]['enabled']
-    def _iface_for_route_table(self, route_state, route_table, ifaces, ip_family):
+
+    def _iface_for_route_table(
+        self, route_state, route_table, ifaces, ip_family
+    ):
         for routes in route_state.config_iface_routes.values():
             for route in routes:
                 if route.table_id == route_table:

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -53,6 +53,8 @@ IPV6_ROUTE_TABLE_ID1 = 50
 IPV6_ROUTE_TABLE_ID2 = 51
 IPV6_TEST_NET1 = "2001:db8:e::/64"
 
+TEST_ROUTE_TABLE_ID = 99
+
 IPV4_DNS_NAMESERVER = "8.8.8.8"
 IPV6_DNS_NAMESERVER = "2001:4860:4860::8888"
 DNS_SEARCHES = ["example.org", "example.com"]
@@ -266,20 +268,20 @@ def _assert_in_current_route(route, current_routes):
     assert route_in_current_routes
 
 
-def _get_ipv4_test_routes():
+def _get_ipv4_test_routes(nic="eth1"):
     return [
         {
             Route.DESTINATION: "198.51.100.0/24",
             Route.METRIC: 103,
             Route.NEXT_HOP_ADDRESS: "192.0.2.1",
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV4_ROUTE_TABLE_ID1,
         },
         {
             Route.DESTINATION: "203.0.113.0/24",
             Route.METRIC: 103,
             Route.NEXT_HOP_ADDRESS: "192.0.2.1",
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV4_ROUTE_TABLE_ID2,
         },
     ]
@@ -304,20 +306,20 @@ def _get_ipv4_gateways():
     ]
 
 
-def _get_ipv6_test_routes():
+def _get_ipv6_test_routes(nic="eth1"):
     return [
         {
             Route.DESTINATION: "2001:db8:a::/64",
             Route.METRIC: 103,
             Route.NEXT_HOP_ADDRESS: "2001:db8:1::a",
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV6_ROUTE_TABLE_ID1,
         },
         {
             Route.DESTINATION: "2001:db8:b::/64",
             Route.METRIC: 103,
             Route.NEXT_HOP_ADDRESS: "2001:db8:1::b",
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV6_ROUTE_TABLE_ID2,
         },
     ]
@@ -984,3 +986,41 @@ def test_support_query_multipath_route(eth1_with_multipath_route):
     ]
     cur_state = libnmstate.show()
     _assert_routes(expected_routes, cur_state)
+
+
+@pytest.fixture
+def static_eth1_eth2_with_routes_on_same_table_id(eth1_up, eth2_up):
+    routes = _get_ipv4_test_routes("eth1") + _get_ipv6_test_routes("eth2")
+    for route in routes:
+        route[Route.TABLE_ID] = TEST_ROUTE_TABLE_ID
+    eth1_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    eth1_state.pop(Interface.IPV6)
+    eth2_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    eth2_state[Interface.NAME] = "eth2"
+    eth2_state.pop(Interface.IPV4)
+    state = {
+        Interface.KEY: [eth1_state, eth2_state],
+        Route.KEY: {Route.CONFIG: routes},
+    }
+    libnmstate.apply(state)
+    yield
+
+
+def test_add_route_rules_with_the_same_route_table_id_on_diff_ip_stack(
+    static_eth1_eth2_with_routes_on_same_table_id
+):
+    desired_state = {
+        RouteRule.KEY: {
+            RouteRule.CONFIG: [
+                {
+                    RouteRule.IP_FROM: "2001:db8:f::/64",
+                    RouteRule.ROUTE_TABLE: TEST_ROUTE_TABLE_ID,
+                },
+                {
+                    RouteRule.IP_FROM: "192.0.2.0/24",
+                    RouteRule.ROUTE_TABLE: TEST_ROUTE_TABLE_ID,
+                },
+            ]
+        }
+    }
+    libnmstate.apply(desired_state)

--- a/tests/lib/testlib/ifacelib.py
+++ b/tests/lib/testlib/ifacelib.py
@@ -62,11 +62,36 @@ def gen_foo_iface_info_static_ip(iface_type=InterfaceType.ETHERNET):
     return iface_info
 
 
+def gen_foo_iface_info_static_ip_only_ipv4(iface_type=InterfaceType.ETHERNET):
+    iface_info = gen_foo_iface_info(iface_type)
+    iface_info.update(
+        {
+            Interface.IPV4: {
+                InterfaceIPv4.ENABLED: True,
+                InterfaceIPv4.DHCP: False,
+                InterfaceIPv4.ADDRESS: deepcopy(IPV4_ADDRESSES),
+            },
+        }
+    )
+    return iface_info
+
+
 def gen_two_static_ip_ifaces(iface1_name, iface2_name):
     iface1_info = gen_foo_iface_info_static_ip()
     iface1_info[Interface.NAME] = iface1_name
     iface1_info[Interface.IPV4][InterfaceIPv4.ADDRESS].pop(1)
     iface1_info[Interface.IPV6][InterfaceIPv6.ADDRESS].pop(1)
+    iface2_info = gen_foo_iface_info_static_ip()
+    iface2_info[Interface.NAME] = iface2_name
+    iface2_info[Interface.IPV4][InterfaceIPv4.ADDRESS].pop(0)
+    iface2_info[Interface.IPV6][InterfaceIPv6.ADDRESS].pop(0)
+    return Ifaces([], [iface1_info, iface2_info])
+
+
+def gen_two_static_ip_ifaces_different(iface1_name, iface2_name):
+    iface1_info = gen_foo_iface_info_static_ip_only_ipv4()
+    iface1_info[Interface.NAME] = iface1_name
+    iface1_info[Interface.IPV4][InterfaceIPv4.ADDRESS].pop(1)
     iface2_info = gen_foo_iface_info_static_ip()
     iface2_info[Interface.NAME] = iface2_name
     iface2_info[Interface.IPV4][InterfaceIPv4.ADDRESS].pop(0)


### PR DESCRIPTION
This PR fixes issue #2235 
Issue root cause: for applying route rules, nmstate creates interface profiles in the metadata. All route-rules with a particular table id are added to an interface profile. This interface is identified by matching route-table id in the route rules to the route-table id in the routes. When it finds a match in the list of routes, the corresponding next-hop-interface is selected. But it doesn't verify if ipv4/ipv6 is enabled on that interface and the list of rules may have both ipv6 and ipv4 rules. In case, ipv4/ipv6 is not enabled on the interface and the rules list has ipv4/ipv6 rules, it's not applied. And nmstate apply eventually fails with desired state not applied error.  
Proposed fix un this PR: When nmstate identifies an interface based on route-table id matching, add an additional check to verify if the corresponding IP family (ipv4 or ipv6) is enabled on the interface identified. To achieve this, input rules are segregated into 2 sets of ipv6 and ipv4 rules. Apply the same logic of identifying the interface for these 2 sets separately by passing the corresponding IP family. So, for ipv4 rules, an interface with ipv4 enabled is always returned. Same for ipv6 rules as well. 