### PR TITLE
test: Add test case for preserving IP order of external managed interface

### DIFF
--- a/tests/integration/testlib/iproutelib.py
+++ b/tests/integration/testlib/iproutelib.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 from functools import wraps


### PR DESCRIPTION
Add test case ensuring we preserve the IP address order when consuming a
external managed interface.