### PR TITLE
DEMO: service: Add support hard coding iface name to MAC

### DIFF
--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::ffi::OsStr;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+use nmstate::{InterfaceType, NetworkState};
 
 use crate::{apply::apply, error::CliError};
 
 const CONFIG_FILE_EXTENTION: &str = "yml";
 const RELOCATE_FILE_EXTENTION: &str = "applied";
+const PIN_IFACE_NAME_FOLDER: &str = "pin_iface_name";
+const PIN_STATE_FILENAME: &str = "pin.yml";
+const SYSTEMD_NETWORK_LINK_FOLDER: &str = "/etc/systemd/network";
 
 pub(crate) fn ncl_service(
     matches: &clap::ArgMatches,
@@ -14,6 +20,12 @@ pub(crate) fn ncl_service(
     let folder = matches
         .value_of(crate::CONFIG_FOLDER_KEY)
         .unwrap_or(crate::DEFAULT_SERVICE_FOLDER);
+
+    let pin_iface_name_dir = format!("{folder}/{PIN_IFACE_NAME_FOLDER}");
+    let pin_iface_path = Path::new(&pin_iface_name_dir);
+    if pin_iface_path.exists() {
+        pin_iface_name(&pin_iface_path)?;
+    }
 
     let config_files = match get_config_files(folder) {
         Ok(f) => f,
@@ -96,6 +108,89 @@ fn relocate_file(file_path: &Path) -> Result<(), CliError> {
         "Renamed applied config {} to {}",
         file_path.display(),
         new_path.display()
+    );
+    Ok(())
+}
+
+fn pin_iface_name(cfg_dir: &Path) -> Result<(), CliError> {
+    let file_path = cfg_dir.join(PIN_STATE_FILENAME);
+    let mut fd = std::fs::File::open(&file_path)?;
+    let mut content = String::new();
+    fd.read_to_string(&mut content)?;
+    let pin_state: NetworkState = serde_yaml::from_str(&content)?;
+    let mut cur_state = NetworkState::new();
+    cur_state.set_kernel_only(true);
+    cur_state.set_running_config_only(true);
+    cur_state.retrieve()?;
+
+    for cur_iface in cur_state
+        .interfaces
+        .iter()
+        .filter(|i| i.iface_type() == InterfaceType::Ethernet)
+    {
+        let cur_mac = match cur_iface.base_iface().mac_address.as_ref() {
+            Some(c) => c,
+            None => continue,
+        };
+        if pin_state
+            .interfaces
+            .get_iface(cur_iface.name(), cur_iface.iface_type())
+            .is_none()
+        {
+            for pin_iface in pin_state
+                .interfaces
+                .iter()
+                .filter(|i| i.iface_type() == InterfaceType::Ethernet)
+            {
+                if pin_iface.base_iface().mac_address.as_ref() == Some(cur_mac)
+                    && pin_iface.name() != cur_iface.name()
+                {
+                    log::info!(
+                        "Pining the interface with MAC {cur_mac} to \
+                        interface name {}",
+                        pin_iface.name()
+                    );
+                    pin_iface_name_via_systemd_link(cur_mac, pin_iface.name())?;
+                }
+            }
+        }
+    }
+
+    relocate_file(&file_path)?;
+    Ok(())
+}
+
+fn pin_iface_name_via_systemd_link(
+    mac: &str,
+    iface_name: &str,
+) -> Result<(), CliError> {
+    let link_dir = Path::new(SYSTEMD_NETWORK_LINK_FOLDER);
+    if !link_dir.exists() {
+        std::fs::create_dir(&link_dir)?;
+    }
+
+    let content =
+        format!("[Match]\nMACAddress={mac}\n\n[Link]\nName={iface_name}\n");
+
+    // 98 here is important as it should be invoked after others but before
+    // 99-default.link
+    let file_path = link_dir.join(format!("98-{iface_name}.link"));
+
+    let mut fd = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(&file_path)
+        .map_err(|e| {
+            CliError::from(format!(
+                "Failed to store captured states to file {}: {e}",
+                file_path.display()
+            ))
+        })?;
+    fd.write_all(content.as_bytes())?;
+    log::info!(
+        "Systemd network link file created at {}",
+        file_path.display()
     );
     Ok(())
 }


### PR DESCRIPTION
Some OS upgrade might cause interface name changes. To solve that:

 1. Before upgrade,
    * mkdir /etc/nmstate/pin_iface_name/
    * nmstatectl show -k | sudo tee /etc/nmstate/pin_iface_name/pin.yml
    * sudo systemctl enable nmstate

 2. Reboot to new version of OS and let nmstate.service run.
 3. Reboot again.

The `nmstate.service` will create file like if it found any interface
changed name according to stored state in /etc/nmstate/pin_iface_name/pin.yml

    /etc/systemd/network/98-ens9.link

With content:

```
[Match]
MACAddress=01:23:45:67:89:ab

[Link]
Name=ens9
```

After the second reboot, the systemd-udevd will use the old name ens9.

You may refer to the screen recording for detail: https://people.redhat.com/fge/demo/nmstate_pin_iface_name.ogv 