### PR TITLE
ip: Ignore `dhcp-client-id` when DHCPv4 disabled

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -319,6 +319,13 @@ impl InterfaceIpv4 {
             self.auto_routes = None;
             self.auto_table_id = None;
             self.auto_route_metric = None;
+            if is_desired && self.dhcp_client_id.is_some() {
+                log::warn!(
+                    "Ignoring `dhcp-client-id` setting when DHCPv4 is \
+                    disabled"
+                );
+            }
+            self.dhcp_client_id = None;
         }
         if let Some(addrs) = self.addresses.as_mut() {
             for addr in addrs.iter_mut() {

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -56,7 +56,11 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             ],
             dns: Some(nm_dns_to_nmstate("", nm_ip_setting)),
             rules: nm_rules_to_nmstate(false, nm_ip_setting),
-            dhcp_client_id: nm_dhcp_client_id_to_nmstate(nm_ip_setting),
+            dhcp_client_id: if enabled && dhcp == Some(true) {
+                nm_dhcp_client_id_to_nmstate(nm_ip_setting)
+            } else {
+                None
+            },
             auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
             ..Default::default()
         }

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -884,3 +884,27 @@ def test_remove_all_ip_address(setup_eth1_static_ip):
     ] = False
 
     assertlib.assert_state_match(desired_state)
+
+
+def test_ignore_dhcp_client_id_if_static(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: False,
+                    InterfaceIPv4.DHCP_CLIENT_ID: "ll",
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)


### PR DESCRIPTION
When desire state has `dhcp-client-id` set with DHCPv4 disabled, nmstate
verification will complain about:

    NmstateVerificationError: Verification failure:
   eth1.interface.ipv4.dhcp-client-id desire '"ll"', current 'null

Fixed by ignore `dhcp-client-id` and log a warning when DHCPv4 disabled.

Integration test case included.