### PR TITLE
[nmstate-1.4] dns: Support static DNS search with auto DNS nameserver

### DIFF
--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -84,7 +84,7 @@ class NetState:
                         self._dns, self._route, ignored_dns_ifaces
                     )
                 except NmstateValueError as e:
-                    if gen_conf_mode:
+                    if gen_conf_mode or self._dns.is_search_only_config():
                         raise e
                     else:
                         logging.warning(


### PR DESCRIPTION
Introduce the support of static DNS search along with DNS nameserver
learn from DHCP/autoconf.

For implementation in NM, we choose interface with dynamic IP (prefer
desired interface) and fallback to any interface with IP stack enabled
(prefer desired interface). We will not use global DNS for this use case
as it will suppress DNS nameserver learn from DHCP.

Extra fixes:

 * Instruct `_find_ifaces_with_static_gateways()` to search desired
   interface first, then fallback to current interface.
 * Instruct `_find_ifaces_with_auto_dns_false()` to search desired
   interface first, then fallback to current interface.

Integration test case included.