### PR TITLE
dns: Support static DNS search with auto DNS nameserver

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -207,6 +207,10 @@ impl MergedDnsState {
 
         self.servers != cur_servers || self.searches != cur_searches
     }
+
+    pub(crate) fn is_search_only(&self) -> bool {
+        self.servers.is_empty() && !self.searches.is_empty()
+    }
 }
 
 impl MergedNetworkState {

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -564,3 +564,343 @@ fn is_unmanaged(iface_name: &str, nm_devs: &[NmDevice]) -> bool {
     }
     false
 }
+
+// Try to select a interface to store the DNS search only information in the
+// order of:
+// * Use current DNS interface if still desired and still valid
+// * Use auto interface from desired state
+// * Use auto interface from current state
+// * Use IP(prefer IPv6) enabled interface from desired state
+// * Use IP(prefer IPv6) enabled interface from current state
+// * Use current DNS interface if still valid
+pub(crate) fn store_dns_search_only_to_iface(
+    merged_state: &mut MergedNetworkState,
+    nm_acs: &[NmActiveConnection],
+    nm_devs: &[NmDevice],
+) -> Result<(), NmstateError> {
+    let (cur_v4_ifaces, cur_v6_ifaces) =
+        get_cur_dns_ifaces(&merged_state.interfaces);
+
+    // Use current DNS interface if they are desired
+    for iface_name in cur_v6_ifaces {
+        if let Some(iface) =
+            merged_state.interfaces.kernel_ifaces.get_mut(&iface_name)
+        {
+            if iface.is_iface_valid_for_dns(true) {
+                if let Some(apply_iface) = iface.for_apply.as_mut() {
+                    set_iface_dns_conf(
+                        true,
+                        apply_iface,
+                        Vec::new(),
+                        merged_state.dns.searches.clone(),
+                        Some(DEFAULT_DNS_PRIORITY),
+                    )?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    for iface_name in cur_v4_ifaces {
+        if let Some(iface) =
+            merged_state.interfaces.kernel_ifaces.get_mut(&iface_name)
+        {
+            if iface.is_iface_valid_for_dns(false) {
+                if let Some(apply_iface) = iface.for_apply.as_mut() {
+                    set_iface_dns_conf(
+                        false,
+                        apply_iface,
+                        Vec::new(),
+                        merged_state.dns.searches.clone(),
+                        Some(DEFAULT_DNS_PRIORITY),
+                    )?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    // Use auto interface
+    if store_dns_search_only_to_auto_iface(merged_state, nm_acs, nm_devs)
+        .is_ok()
+    {
+        return Ok(());
+    }
+
+    store_dns_search_only_to_ip_enabled_iface(merged_state, nm_acs, nm_devs)
+}
+
+fn set_iface_dns_search_only(
+    iface: &mut MergedInterface,
+    searches: Vec<String>,
+    is_ipv6: bool,
+) -> Result<(), NmstateError> {
+    if iface.for_apply.is_none() {
+        iface.mark_as_changed();
+    }
+    if let Some(apply_iface) = iface.for_apply.as_mut() {
+        if is_ipv6 {
+            if apply_iface.base_iface().ipv6.is_none() {
+                apply_iface.base_iface_mut().ipv6 =
+                    iface.merged.base_iface_mut().ipv6.clone();
+            }
+        } else if apply_iface.base_iface().ipv4.is_none() {
+            apply_iface.base_iface_mut().ipv4 =
+                iface.merged.base_iface_mut().ipv4.clone();
+        }
+        set_iface_dns_conf(
+            is_ipv6,
+            apply_iface,
+            Vec::new(),
+            searches,
+            Some(DEFAULT_DNS_PRIORITY),
+        )?;
+    }
+    Ok(())
+}
+
+fn store_dns_search_only_to_auto_iface(
+    merged_state: &mut MergedNetworkState,
+    nm_acs: &[NmActiveConnection],
+    nm_devs: &[NmDevice],
+) -> Result<(), NmstateError> {
+    // Use insert order to produce consistent DNS interface choice
+    for iface_name in merged_state
+        .interfaces
+        .insert_order
+        .as_slice()
+        .iter()
+        .filter_map(|(n, t)| {
+            if !t.is_userspace() && t != &InterfaceType::Loopback {
+                Some(n)
+            } else {
+                None
+            }
+        })
+    {
+        let iface =
+            match merged_state.interfaces.kernel_ifaces.get_mut(iface_name) {
+                Some(i) => i,
+                None => continue,
+            };
+        if iface
+            .merged
+            .base_iface()
+            .ipv6
+            .as_ref()
+            .map(|i| i.is_auto())
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                true,
+            );
+        }
+        if iface
+            .merged
+            .base_iface()
+            .ipv4
+            .as_ref()
+            .map(|i| i.is_auto())
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                false,
+            );
+        }
+    }
+
+    let mut cur_iface_names: Vec<String> = merged_state
+        .interfaces
+        .kernel_ifaces
+        .values()
+        .filter_map(|i| {
+            if !i.is_changed()
+                && i.merged.iface_type() != InterfaceType::Loopback
+            {
+                Some(i.merged.name().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    // Sort the interface names to produce consistent choice.
+    cur_iface_names.sort_unstable();
+
+    // * Use auto interface from current state
+    for iface_name in &cur_iface_names {
+        if is_external_managed(iface_name, nm_acs)
+            || is_unmanaged(iface_name, nm_devs)
+        {
+            continue;
+        }
+        let iface =
+            match merged_state.interfaces.kernel_ifaces.get_mut(iface_name) {
+                Some(i) => i,
+                None => continue,
+            };
+        if iface
+            .merged
+            .base_iface()
+            .ipv6
+            .as_ref()
+            .map(|i| i.is_auto())
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                true,
+            );
+        }
+        if iface
+            .merged
+            .base_iface()
+            .ipv4
+            .as_ref()
+            .map(|i| i.is_auto())
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                false,
+            );
+        }
+    }
+
+    Err(NmstateError::new(
+        ErrorKind::InvalidArgument,
+        format!(
+            "Failed to find suitable(Auto IP) interface for DNS searches \
+            '{}'",
+            merged_state.dns.searches.as_slice().join(" ")
+        ),
+    ))
+}
+
+fn store_dns_search_only_to_ip_enabled_iface(
+    merged_state: &mut MergedNetworkState,
+    nm_acs: &[NmActiveConnection],
+    nm_devs: &[NmDevice],
+) -> Result<(), NmstateError> {
+    // Use insert order to produce consistent DNS interface choice
+    for iface_name in merged_state
+        .interfaces
+        .insert_order
+        .as_slice()
+        .iter()
+        .filter_map(|(n, t)| {
+            if !t.is_userspace() && t != &InterfaceType::Loopback {
+                Some(n)
+            } else {
+                None
+            }
+        })
+    {
+        let iface =
+            match merged_state.interfaces.kernel_ifaces.get_mut(iface_name) {
+                Some(i) => i,
+                None => continue,
+            };
+        if iface
+            .merged
+            .base_iface()
+            .ipv6
+            .as_ref()
+            .map(|i| i.enabled)
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                true,
+            );
+        }
+        if iface
+            .merged
+            .base_iface()
+            .ipv4
+            .as_ref()
+            .map(|i| i.enabled)
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                false,
+            );
+        }
+    }
+
+    let mut cur_iface_names: Vec<String> = merged_state
+        .interfaces
+        .kernel_ifaces
+        .values()
+        .filter_map(|i| {
+            if !i.is_changed()
+                && i.merged.iface_type() != InterfaceType::Loopback
+            {
+                Some(i.merged.name().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    // Sort the interface names to produce consistent choice.
+    cur_iface_names.sort_unstable();
+
+    // * Use auto interface from current state
+    for iface_name in &cur_iface_names {
+        if is_external_managed(iface_name, nm_acs)
+            || is_unmanaged(iface_name, nm_devs)
+        {
+            continue;
+        }
+        let iface =
+            match merged_state.interfaces.kernel_ifaces.get_mut(iface_name) {
+                Some(i) => i,
+                None => continue,
+            };
+        if iface
+            .merged
+            .base_iface()
+            .ipv6
+            .as_ref()
+            .map(|i| i.enabled)
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                true,
+            );
+        }
+        if iface
+            .merged
+            .base_iface()
+            .ipv4
+            .as_ref()
+            .map(|i| i.enabled)
+            .unwrap_or_default()
+        {
+            return set_iface_dns_search_only(
+                iface,
+                merged_state.dns.searches.clone(),
+                false,
+            );
+        }
+    }
+
+    Err(NmstateError::new(
+        ErrorKind::InvalidArgument,
+        format!(
+            "Failed to find suitable(IP enabled) interface for DNS searches \
+            '{}'",
+            merged_state.dns.searches.as_slice().join(" ")
+        ),
+    ))
+}

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -3,8 +3,10 @@
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
 use super::{
-    dns::store_dns_config_to_iface, profile::perpare_nm_conns,
-    route::store_route_config, route_rule::store_route_rule_config,
+    dns::{store_dns_config_to_iface, store_dns_search_only_to_iface},
+    profile::perpare_nm_conns,
+    route::store_route_config,
+    route_rule::store_route_rule_config,
 };
 
 pub(crate) fn nm_gen_conf(
@@ -26,7 +28,11 @@ pub(crate) fn nm_gen_conf(
     let mut merged_state = merged_state.clone();
     store_route_config(&mut merged_state)?;
     store_route_rule_config(&mut merged_state)?;
-    store_dns_config_to_iface(&mut merged_state, &[], &[])?;
+    if merged_state.dns.is_search_only() {
+        store_dns_search_only_to_iface(&mut merged_state, &[], &[])?;
+    } else {
+        store_dns_config_to_iface(&mut merged_state, &[], &[])?;
+    }
 
     let nm_conns = perpare_nm_conns(
         &merged_state,

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -55,7 +55,7 @@ impl MergedDnsState {
             return Err(NmstateError::new(
                 ErrorKind::VerificationError,
                 format!(
-                    "Failed to apply DNS config: desire searches '{}',
+                    "Failed to apply DNS config: desire searches '{}', \
                     got '{}'",
                     self.searches.as_slice().join(" "),
                     cur_schs.as_slice().join(" "),


### PR DESCRIPTION
Introduce the support of static DNS search along with DNS nameserver
learn from DHCP/autoconf.

For implementation in NM, we try this order to find a interface to store
the DNS config:
 * Desired interface which currently hold DNS config and still valid for
   DNS.
 * Auto interface, prefer desired interface.
 * IP enabled interface, prefer desired interface.

We will not use global DNS for this use case
as it will suppress DNS nameserver learn from DHCP.

Integration test case included.