### PR TITLE
ip: Validate IP address type matching with ip stack type

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -300,6 +300,17 @@ impl InterfaceIpv4 {
                 for addr in addrs.as_slice().iter().filter(|a| a.is_auto()) {
                     log::info!("Ignoring Auto IP address {}", addr);
                 }
+                if let Some(addr) =
+                    addrs.as_slice().iter().find(|a| a.ip.is_ipv6())
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Got IPv6 address {} in ipv4 config section",
+                            addr
+                        ),
+                    ));
+                }
             }
             addrs.retain(|a| !a.is_auto());
             addrs.iter_mut().for_each(|a| {
@@ -546,6 +557,13 @@ impl InterfaceIpv6 {
                 for addr in addrs.as_slice().iter().filter(|a| a.is_auto()) {
                     log::info!("Ignoring Auto IP address {}", addr);
                 }
+            }
+            if let Some(addr) = addrs.as_slice().iter().find(|a| a.ip.is_ipv4())
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Got IPv4 address {} in ipv6 config section", addr),
+                ));
             }
             addrs.retain(|a| !a.is_auto());
             addrs.iter_mut().for_each(|a| {

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -280,3 +280,53 @@ fn test_ipv6_verify_emtpy() {
 
     merged_ifaces.verify(&cur_ifaces).unwrap();
 }
+
+#[test]
+fn test_should_not_have_ipv6_in_ipv4_section() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: "true"
+                dhcp: "false"
+                address:
+                  - ip: "2001:db8:2::1"
+                    prefix-length: 64"#,
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_should_not_have_ipv4_in_ipv6_section() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv6:
+                enabled: true
+                dhcp: false
+                address:
+                  - ip: 192.0.2.1
+                    prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}


### PR DESCRIPTION
We should raise `InvalidArgument` error when user define IPv6 address in
ipv4 section or vise versa.

Unit test case included.