### PR TITLE
Feature: Matching interface with name

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -169,7 +169,7 @@ impl InterfaceType {
 /// The state of interface
 pub enum InterfaceState {
     /// Interface is up and running.
-    /// Deserialize and serialize from/to 'down'.
+    /// Deserialize and serialize from/to 'up'.
     Up,
     /// For apply action, down means configuration still exist but
     /// deactivate. The virtual interface will be removed and other interface
@@ -1045,4 +1045,41 @@ fn merge_desire_with_current(
     let iface: Interface = serde_json::from_value(desired_value)?;
 
     Ok(iface)
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+/// Interface Identifier defines the method for network backend on matching
+/// network interface
+pub enum InterfaceIdentifier {
+    /// Use interface name to match the network interface, default value.
+    /// Deserialize and serialize from/to 'name'.
+    Name,
+    /// Use interface MAC address to match the network interface.
+    /// Deserialize and serialize from/to 'mac-address'.
+    MacAddress,
+}
+
+impl Default for InterfaceIdentifier {
+    fn default() -> Self {
+        Self::Name
+    }
+}
+
+impl InterfaceIdentifier {
+    pub fn is_default(&self) -> bool {
+        self == &InterfaceIdentifier::default()
+    }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -120,7 +120,8 @@ pub(crate) use crate::hostname::MergedHostNameState;
 pub use crate::ieee8021x::Ieee8021XConfig;
 pub(crate) use crate::iface::MergedInterface;
 pub use crate::iface::{
-    Interface, InterfaceState, InterfaceType, UnknownInterface,
+    Interface, InterfaceIdentifier, InterfaceState, InterfaceType,
+    UnknownInterface,
 };
 pub(crate) use crate::ifaces::MergedInterfaces;
 pub use crate::ifaces::{

--- a/rust/src/lib/nm/nm_dbus/connection/wired.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/wired.rs
@@ -17,6 +17,7 @@ use super::super::{
 #[non_exhaustive]
 pub struct NmSettingWired {
     pub cloned_mac_address: Option<String>,
+    pub mac_address: Option<String>,
     pub mtu: Option<u32>,
     pub accept_all_mac_addresses: Option<i32>,
     pub speed: Option<u32>,
@@ -32,6 +33,12 @@ impl TryFrom<DbusDictionary> for NmSettingWired {
             cloned_mac_address: _from_map!(
                 v,
                 "cloned-mac-address",
+                own_value_to_bytes_array
+            )?
+            .map(u8_array_to_mac_string),
+            mac_address: _from_map!(
+                v,
+                "mac-address",
                 own_value_to_bytes_array
             )?
             .map(u8_array_to_mac_string),
@@ -55,6 +62,12 @@ impl ToDbusValue for NmSettingWired {
         if let Some(v) = &self.cloned_mac_address {
             ret.insert(
                 "cloned-mac-address",
+                zvariant::Value::new(mac_str_to_u8_array(v)),
+            );
+        }
+        if let Some(v) = &self.mac_address {
+            ret.insert(
+                "mac-address",
                 zvariant::Value::new(mac_str_to_u8_array(v)),
             );
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/wired.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/wired.rs
@@ -9,12 +9,15 @@ impl ToKeyfile for NmSettingWired {
     fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
         for (k, v) in self.to_value()?.drain() {
-            if k != "cloned-mac-address" {
+            if k != "cloned-mac-address" && k != "mac-address" {
                 ret.insert(k.to_string(), v);
             }
         }
         if let Some(v) = &self.cloned_mac_address {
             ret.insert("cloned-mac-address".to_string(), Value::new(v));
+        }
+        if let Some(v) = &self.mac_address {
+            ret.insert("mac-address".to_string(), Value::new(v));
         }
         Ok(ret)
     }

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -24,7 +24,9 @@ use super::super::{
     settings::{iface_type_to_nm, NM_SETTING_OVS_PORT_SETTING_NAME},
 };
 
-use crate::{InterfaceType, MergedNetworkState, NmstateError};
+use crate::{
+    InterfaceIdentifier, InterfaceType, MergedNetworkState, NmstateError,
+};
 
 // There is plan to simply the `add_net_state`, `chg_net_state`, `del_net_state`
 // `cur_net_state`, `des_net_state` into single struct. Suppress the clippy
@@ -166,33 +168,67 @@ fn delete_ifaces(
         create_index_for_nm_conns_by_name_type(&all_nm_conns);
     let mut uuids_to_delete: HashSet<&str> = HashSet::new();
 
-    for iface in merged_state
+    for merged_iface in merged_state
         .interfaces
         .iter()
         .filter(|i| i.is_changed() && i.merged.is_absent())
-        .map(|i| &i.merged)
     {
+        let iface = &merged_iface.merged;
         // If interface type not mentioned, we delete all profile with interface
         // name
-        let nm_conns_to_delete: Option<Vec<&NmConnection>> =
+        let mut nm_conns_to_delete: Vec<&NmConnection> =
             if iface.iface_type() == InterfaceType::Unknown {
-                Some(
-                    all_nm_conns
-                        .as_slice()
-                        .iter()
-                        .filter(|c| c.iface_name() == Some(iface.name()))
-                        .collect(),
-                )
+                all_nm_conns
+                    .as_slice()
+                    .iter()
+                    .filter(|c| c.iface_name() == Some(iface.name()))
+                    .collect()
             } else {
                 let nm_iface_type = iface_type_to_nm(&iface.iface_type())?;
                 nm_conns_name_type_index
                     .get(&(iface.name(), &nm_iface_type))
                     .cloned()
+                    .unwrap_or_default()
             };
+        // User might want to delete mac based interface using profile name
+        if let Some(cur_iface) = &merged_iface.current {
+            if cur_iface.base_iface().identifier
+                == InterfaceIdentifier::MacAddress
+                && cur_iface.base_iface().profile_name.as_deref()
+                    == Some(iface.name())
+            {
+                for nm_conn in &all_nm_conns {
+                    if nm_conn.id() == Some(iface.name()) {
+                        nm_conns_to_delete.push(nm_conn);
+                    }
+                }
+            }
+        }
+        // User might want to delete mac based interface using interface name
+        if let Some(cur_iface) = &merged_iface.current {
+            if cur_iface.base_iface().identifier
+                == InterfaceIdentifier::MacAddress
+                && cur_iface.base_iface().name.as_str() == iface.name()
+            {
+                if let Some(mac) = cur_iface.base_iface().mac_address.as_ref() {
+                    for nm_conn in &all_nm_conns {
+                        if nm_conn
+                            .wired
+                            .as_ref()
+                            .and_then(|w| w.mac_address.as_ref())
+                            .map(|s| s.to_uppercase())
+                            == Some(mac.to_uppercase())
+                        {
+                            nm_conns_to_delete.push(nm_conn);
+                        }
+                    }
+                }
+            }
+        }
         // Delete all existing connections for this interface
-        if let Some(nm_conns) = nm_conns_to_delete {
-            for nm_conn in nm_conns {
-                if let Some(uuid) = nm_conn.uuid() {
+        for nm_conn in nm_conns_to_delete {
+            if let Some(uuid) = nm_conn.uuid() {
+                if !uuids_to_delete.contains(uuid) {
                     log::info!(
                         "Deleting NM connection for absent interface \
                         {}/{}: {}",
@@ -202,12 +238,14 @@ fn delete_ifaces(
                     );
                     uuids_to_delete.insert(uuid);
                 }
-                // Delete OVS port profile along with OVS system and internal
-                // Interface
-                if nm_conn.controller_type() == Some("ovs-port") {
-                    // TODO: handle pre-exist OVS config using name instead of
-                    // UUID for controller
-                    if let Some(uuid) = nm_conn.controller() {
+            }
+            // Delete OVS port profile along with OVS system and internal
+            // Interface
+            if nm_conn.controller_type() == Some("ovs-port") {
+                // TODO: handle pre-exist OVS config using name instead of
+                // UUID for controller
+                if let Some(uuid) = nm_conn.controller() {
+                    if !uuids_to_delete.contains(uuid) {
                         log::info!(
                             "Deleting NM OVS port connection {} \
                              for absent OVS interface {}",

--- a/rust/src/lib/nm/settings/wired.rs
+++ b/rust/src/lib/nm/settings/wired.rs
@@ -1,7 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::NmConnection;
 
 use crate::{
     nm::version::nm_supports_accept_all_mac_addresses_mode, Interface,
+    InterfaceIdentifier,
 };
 
 pub(crate) fn gen_nm_wired_setting(
@@ -15,7 +18,11 @@ pub(crate) fn gen_nm_wired_setting(
     let base_iface = iface.base_iface();
 
     if let Some(mac) = &base_iface.mac_address {
-        nm_wired_set.cloned_mac_address = Some(mac.to_string());
+        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+            nm_wired_set.mac_address = Some(mac.to_string());
+        } else {
+            nm_wired_set.cloned_mac_address = Some(mac.to_string());
+        }
         flag_need_wired = true;
     }
     if let Some(mtu) = &base_iface.mtu {

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -32,6 +32,11 @@ impl BaseInterface {
         if let Some(mptcp_conf) = self.mptcp.as_mut() {
             mptcp_conf.sanitize_desired_for_verify();
         }
+        // When `profile_name` is the same with iface name, it was hidden during
+        // query, we should ignore it during verify
+        if self.profile_name.as_deref() == Some(self.name.as_str()) {
+            self.profile_name = None;
+        }
     }
 
     pub(crate) fn update(&mut self, other: &BaseInterface) {
@@ -113,6 +118,12 @@ impl BaseInterface {
         }
         if other.prop_list.contains(&"mptcp") {
             self.mptcp = other.mptcp.clone();
+        }
+        if other.prop_list.contains(&"identifier") {
+            self.identifier = other.identifier;
+        }
+        if other.prop_list.contains(&"profile_name") {
+            self.profile_name = other.profile_name.clone();
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -21,6 +21,10 @@ class Interface:
     ACCEPT_ALL_MAC_ADDRESSES = "accept-all-mac-addresses"
     WAIT_IP = "wait-ip"
     CONTROLLER = "controller"
+    PROFILE_NAME = "profile-name"
+    IDENTIFIER = "identifier"
+    IDENTIFIER_NAME = "name"
+    IDENTIFIER_MAC = "mac-address"
 
 
 class Route:

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -169,7 +169,6 @@ def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
 
 def test_add_bond_without_port():
     with bond_interface(name=BOND99, port=[]) as state:
-
         assert state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.PORT] == []
 
 
@@ -844,7 +843,6 @@ def bond99_with_2_port_and_lacp_rate(eth1_up, eth2_up):
 def test_bond_switch_mode_with_conflict_option(
     bond99_with_2_port_and_lacp_rate,
 ):
-
     state = bond99_with_2_port_and_lacp_rate
     bond_config = state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
     bond_config[Bond.MODE] = BondMode.ROUND_ROBIN

--- a/tests/integration/testlib/vlan.py
+++ b/tests/integration/testlib/vlan.py
@@ -27,7 +27,7 @@ from libnmstate.schema import VLAN
 
 
 @contextmanager
-def vlan_interface(ifname, vlan_id, base_iface):
+def vlan_interface(ifname, vlan_id, base_iface, protocol=None):
     desired_state = {
         Interface.KEY: [
             {
@@ -38,6 +38,10 @@ def vlan_interface(ifname, vlan_id, base_iface):
             }
         ]
     }
+    if protocol:
+        desired_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
+            VLAN.PROTOCOL
+        ] = protocol
     libnmstate.apply(desired_state)
     try:
         yield desired_state

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -334,19 +334,11 @@ def test_change_vlan_protocol(vlan_on_eth1):
     reason="Modifying VLAN protocol is not supported on NM 1.41-.",
 )
 def test_add_qinq_vlan(eth1_up):
-    qinq_state = {
-        Interface.KEY: [
-            {
-                Interface.NAME: VLAN_IFNAME,
-                Interface.TYPE: InterfaceType.VLAN,
-                Interface.STATE: InterfaceState.UP,
-                VLAN.CONFIG_SUBTREE: {
-                    VLAN.ID: 102,
-                    VLAN.BASE_IFACE: "eth1",
-                    VLAN.PROTOCOL: "802.1ad",
-                },
-            }
-        ]
-    }
-    libnmstate.apply(qinq_state)
-    assertlib.assert_state_match(qinq_state)
+    with vlan_interface(
+        VLAN_IFNAME,
+        102,
+        "eth1",
+        protocol="802.1ad",
+    ) as desired_state:
+        assertlib.assert_state_match(desired_state)
+    assertlib.assert_absent(VLAN_IFNAME)


### PR DESCRIPTION
Introducing two properties to base interface:
 * `identifier` -- `name` or `mac-address`, default to `name`
 * `profile-name`: string

When identifier been set to `mac-address`, nmstate will not use
`interface.name` for NIC matching but use the `interface.mac-address`, The
`interface.name` will be used for `profile-name` when storing the network
configuration in backend.

The `profile-name` will be hide if it is equal to interface name.

Example on creating MAC based profile:

```yml
---
interfaces:
- name: wan0
  type: ethernet
  state: up
  identifier: mac-address
  mac-address: 1e:bd:23:e9:fb:94
```

You may delete above profile using `name: wan0` or its real interface name.

Integration test cases included.