### PR TITLE
Feature: Support DHCP hostname/FQDN option

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -109,6 +109,9 @@ pub struct NmSettingIp {
     pub dhcp_iaid: Option<String>,
     // IPv6 only
     pub token: Option<String>,
+    pub dhcp_send_hostname: Option<bool>,
+    pub dhcp_fqdn: Option<String>,
+    pub dhcp_hostname: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -143,6 +146,13 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             may_fail: _from_map!(v, "may-fail", bool::try_from)?,
             route_metric: _from_map!(v, "route-metric", i64::try_from)?,
             token: _from_map!(v, "token", String::try_from)?,
+            dhcp_send_hostname: _from_map!(
+                v,
+                "dhcp-send-hostname",
+                bool::try_from
+            )?,
+            dhcp_fqdn: _from_map!(v, "dhcp-fqdn", String::try_from)?,
+            dhcp_hostname: _from_map!(v, "dhcp-hostname", String::try_from)?,
             ..Default::default()
         };
 
@@ -264,6 +274,15 @@ impl ToDbusValue for NmSettingIp {
         }
         if let Some(v) = &self.token {
             ret.insert("token", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_send_hostname {
+            ret.insert("dhcp-send-hostname", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_fqdn {
+            ret.insert("dhcp-fqdn", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.dhcp_hostname {
+            ret.insert("dhcp-hostname", zvariant::Value::new(v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -71,9 +71,29 @@ fn gen_nm_ipv4_setting(
             iface_ip.auto_routes,
             iface_ip.auto_table_id,
         );
-        // No use case indicate we should support static routes with DHCP
-        // enabled.
+        // Clean old routes
         nm_setting.routes = Vec::new();
+        if Some(false) == iface_ip.dhcp_send_hostname {
+            nm_setting.dhcp_send_hostname = Some(false);
+        } else {
+            nm_setting.dhcp_send_hostname = Some(true);
+            if let Some(v) = iface_ip.dhcp_custom_hostname.as_deref() {
+                if v.is_empty() {
+                    nm_setting.dhcp_fqdn = None;
+                    nm_setting.dhcp_hostname = None;
+                } else {
+                    // We are not verifying full spec of FQDN, just check
+                    // whether it has do it not.
+                    if v.contains('.') {
+                        nm_setting.dhcp_fqdn = Some(v.to_string());
+                        nm_setting.dhcp_hostname = None;
+                    } else {
+                        nm_setting.dhcp_hostname = Some(v.to_string());
+                        nm_setting.dhcp_fqdn = None;
+                    }
+                }
+            }
+        }
     }
     nm_setting.gateway = None;
     if iface_ip.enabled {
@@ -172,9 +192,20 @@ fn gen_nm_ipv6_setting(
             iface_ip.auto_routes,
             iface_ip.auto_table_id,
         );
-        // No use case indicate we should support static routes with DHCP
-        // enabled.
+        // Clean old routes
         nm_setting.routes = Vec::new();
+        if Some(false) == iface_ip.dhcp_send_hostname {
+            nm_setting.dhcp_send_hostname = Some(false);
+        } else {
+            nm_setting.dhcp_send_hostname = Some(true);
+            if let Some(v) = iface_ip.dhcp_custom_hostname.as_deref() {
+                if v.is_empty() {
+                    nm_setting.dhcp_hostname = None;
+                } else {
+                    nm_setting.dhcp_hostname = Some(v.to_string());
+                }
+            }
+        }
     } else {
         nm_setting.token = None;
     }

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -9,6 +9,9 @@ impl InterfaceIpv4 {
             addrs.sort_unstable();
             addrs.dedup();
         }
+        if self.dhcp_custom_hostname.is_none() {
+            self.dhcp_custom_hostname = Some(String::new());
+        }
     }
 
     // Sort addresses and dedup
@@ -56,6 +59,12 @@ impl InterfaceIpv4 {
         if other.prop_list.contains(&"auto_route_metric") {
             self.auto_route_metric = other.auto_route_metric;
         }
+        if other.prop_list.contains(&"dhcp_send_hostname") {
+            self.dhcp_send_hostname = other.dhcp_send_hostname;
+        }
+        if other.prop_list.contains(&"dhcp_custom_hostname") {
+            self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
+        }
 
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {
@@ -76,6 +85,9 @@ impl InterfaceIpv6 {
         // None IPv6 token should be treat as "::"
         if self.token.is_none() {
             self.token = Some("::".to_string());
+        }
+        if self.dhcp_custom_hostname.is_none() {
+            self.dhcp_custom_hostname = Some(String::new());
         }
     }
 
@@ -134,6 +146,12 @@ impl InterfaceIpv6 {
         }
         if other.prop_list.contains(&"token") {
             self.token = other.token.clone();
+        }
+        if other.prop_list.contains(&"dhcp_send_hostname") {
+            self.dhcp_send_hostname = other.dhcp_send_hostname;
+        }
+        if other.prop_list.contains(&"dhcp_custom_hostname") {
+            self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
         }
         for other_prop_name in &other.prop_list {
             if !self.prop_list.contains(other_prop_name) {

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -140,6 +140,8 @@ class InterfaceIP:
     AUTO_ROUTE_METRIC = "auto-route-metric"
     MPTCP_FLAGS = "mptcp-flags"
     ALLOW_EXTRA_ADDRESS = "allow-extra-address"
+    DHCP_SEND_HOSTNAME = "dhcp-send-hostname"
+    DHCP_CUSTOM_HOSTNAME = "dhcp-custom-hostname"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1792,3 +1792,113 @@ def test_switch_auto_to_static_with_dynamic_ips(dhcpcli_up):
     assert not _poll_till_not(_has_ipv6_auto_gateway)
     assert _poll(_has_dhcpv4_addr)
     assert _poll(_has_dhcpv6_addr)
+
+
+def test_set_dhcp_fqdn_and_remove(dhcpcli_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv4.DHCP_CUSTOM_HOSTNAME: "dhcpcli.example.net",
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.DHCP: True,
+                    InterfaceIPv6.AUTOCONF: True,
+                    InterfaceIPv6.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv6.DHCP_CUSTOM_HOSTNAME: "dhcpcli.example.org",
+                },
+            }
+        ],
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv4.DHCP_CUSTOM_HOSTNAME: "",
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.DHCP: True,
+                    InterfaceIPv6.AUTOCONF: True,
+                    InterfaceIPv6.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv6.DHCP_CUSTOM_HOSTNAME: "",
+                },
+            }
+        ],
+    }
+    libnmstate.apply(desired_state)
+    desired_state[Interface.KEY][0][Interface.IPV4].pop(
+        InterfaceIPv4.DHCP_CUSTOM_HOSTNAME
+    )
+    desired_state[Interface.KEY][0][Interface.IPV6].pop(
+        InterfaceIPv6.DHCP_CUSTOM_HOSTNAME
+    )
+    assertlib.assert_state_match(desired_state)
+
+
+def test_dhcp_hostname_with_send_host_off(dhcpcli_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.DHCP_SEND_HOSTNAME: False,
+                    InterfaceIPv4.DHCP_CUSTOM_HOSTNAME: "dhcpcli.example.net",
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.DHCP: True,
+                    InterfaceIPv6.AUTOCONF: True,
+                    InterfaceIPv6.DHCP_SEND_HOSTNAME: False,
+                    InterfaceIPv6.DHCP_CUSTOM_HOSTNAME: "dhcpcli.example.org",
+                },
+            }
+        ],
+    }
+    libnmstate.apply(desired_state)
+    desired_state[Interface.KEY][0][Interface.IPV4].pop(
+        InterfaceIPv4.DHCP_CUSTOM_HOSTNAME
+    )
+    desired_state[Interface.KEY][0][Interface.IPV6].pop(
+        InterfaceIPv6.DHCP_CUSTOM_HOSTNAME
+    )
+    assertlib.assert_state_match(desired_state)
+
+
+def test_set_dhcp_host_name_and_remove(dhcpcli_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: DHCP_CLI_NIC,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv4.DHCP_CUSTOM_HOSTNAME: "dhcpcli",
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.DHCP: True,
+                    InterfaceIPv6.AUTOCONF: True,
+                    InterfaceIPv6.DHCP_SEND_HOSTNAME: True,
+                    InterfaceIPv6.DHCP_CUSTOM_HOSTNAME: "dhcpcli6",
+                },
+            }
+        ],
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
Introducing these two DHCP options:
 * `dhcp-send-hostname`: true of false, whether DHCP request should
   contain hostname/FQDN option. Default is true.
 * `dhcp-custom-hostname`: String. Customer hostname/FQDN in DHCP
   request.

For DHCPv4, if the hostname is FQDN, the 'Fully Qualified Domain Name
(FQDN)' option(81) defined in RFC 4702 will be used.
If the hostname is not FQDN, the 'Host Name' option(12) defined in RFC
2132 will be used.

For DHCPv6, custom string to override hostname used for DHCP request in
`Fully Qualified Domain Name (FQDN)` option(29) defined in RFC 4704 as
RFC 4704 allows empty domain name.

Example YAML:

```yml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    mtu: 1500
    ipv4:
      dhcp: true
      dhcp-client-id: iaid+duid
      enabled: true
      dhcp-send-hostname: true
      dhcp-custom-hostname: c9.example.org
    ipv6:
      dhcp: true
      autoconf: true
      enabled: true
      dhcp-send-hostname: true
      dhcp-custom-hostname: c9.example.net
```

Integration test cases included.