### PR TITLE
cli: Delete `persist-nic-names` stamp file after cleanup

### DIFF
--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -163,6 +163,9 @@ pub(crate) fn clean_up(root: &str, dry_run: bool) -> Result<String, CliError> {
 
     if pinned_ifaces.is_empty() {
         log::info!("No persisted NICs found");
+        if !dry_run {
+            std::fs::remove_file(stamp_path)?;
+        }
         return Ok("".to_string());
     }
 
@@ -209,6 +212,9 @@ pub(crate) fn clean_up(root: &str, dry_run: bool) -> Result<String, CliError> {
                 file_path.display()
             );
         }
+    }
+    if !dry_run {
+        std::fs::remove_file(stamp_path)?;
     }
     Ok("".to_string())
 }


### PR DESCRIPTION
This makes the `--cleanup` operation idempotent since it alreayd knows to no-op if the stamp file is missing. But also, the MCO can use the presence of the stamp file to know to even call `--cleanup`. Finally, this "resets" the state so that we could in the future do this whole dance again for another RHEL transition.

The MCO logs will remember whether whether this logic was invoked, and the link files are prefixed by `98-nmstate`, so there's no mistaking that it was nmstate that wrote them.