### PR TITLE
Upgrade dependency `env_logger`

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -21,7 +21,7 @@ nmstate = {path = "../lib", version = "2.2", default-features = false}
 serde_yaml = "0.9"
 clap = { version = "3.1", features = ["cargo"] }
 serde = { version = "1.0", features = ["derive"] }
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 log = "0.4.14"
 serde_json = "1.0.75"
 ctrlc = { version = "3.2.1", optional = true }


### PR DESCRIPTION
Upgrade `env_logger` to latest 0.10.0 as requested by Fedora.