### PR TITLE
[nmstate-1.4] dns: Fix error when purging DNS

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -25,6 +25,8 @@ class DnsState:
         self._config_changed = False
         self._cur_dns_state = deepcopy(cur_dns_state) if cur_dns_state else {}
         self._dns_state = merge_dns(des_dns_state, cur_dns_state or {})
+        if self._dns_state == REMOVE_DNS_CONFIG:
+            self._config_changed = True
         if des_dns_state and des_dns_state.get(DNS.CONFIG):
             if cur_dns_state:
                 self._config_changed = _is_dns_config_changed(

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -189,3 +189,23 @@ def test_static_dns_search_with_auto_dns(auto_eth1):
         "nmcli -t -f ipv6.dns-search c show eth1".split(), check=True
     )[1]
     assert "ipv6.dns-search:example.org,example.net" in output
+
+
+def test_purge_global_dns():
+    desired_state = {
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: ["8.8.8.8", "2001:4860:4860::8888", "1.1.1.1"],
+            }
+        },
+    }
+    libnmstate.apply(desired_state)
+    libnmstate.apply(
+        {
+            DNS.KEY: {DNS.CONFIG: {}},
+        }
+    )
+    with open(GLOBAL_DNS_CONF_FILE) as fd:
+        content = fd.read()
+        for srv in desired_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]:
+            assert srv not in content


### PR DESCRIPTION
When user desire `config: {}` in DNS, nmstate will complain about
DNS mismatch, this is because we consider it as DNS not changed hence no
changes made to global DNS.

Fixed by considering purging action as DNS changed.

Integration test case included.