### PR TITLE
ip: Fix error when DHCP with auto IP address on STP enabled bridge

### DIFF
--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -12,6 +12,11 @@ impl InterfaceIpv4 {
         if self.dhcp_custom_hostname.is_none() {
             self.dhcp_custom_hostname = Some(String::new());
         }
+
+        // No IP address means empty.
+        if self.enabled && self.addresses.is_none() {
+            self.addresses = Some(Vec::new());
+        }
     }
 
     // Sort addresses and dedup
@@ -89,6 +94,11 @@ impl InterfaceIpv6 {
         if self.dhcp_custom_hostname.is_none() {
             self.dhcp_custom_hostname = Some(String::new());
         }
+
+        // No IP address means empty.
+        if self.enabled && self.addresses.is_none() {
+            self.addresses = Some(Vec::new());
+        }
     }
 
     // Sort addresses and dedup
@@ -96,9 +106,6 @@ impl InterfaceIpv6 {
         if let Some(addrs) = self.addresses.as_mut() {
             addrs.sort_unstable();
             addrs.dedup();
-            if addrs.is_empty() {
-                self.addresses = None;
-            }
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1902,3 +1902,32 @@ def test_set_dhcp_host_name_and_remove(dhcpcli_up):
     }
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.tier1
+def test_auto_ip_with_pre_exist_address_without_dhcp_srv(eth1_up):
+    ipv4_state = _create_ipv4_state(enabled=True, dhcp=True)
+    ipv4_state[InterfaceIPv4.ADDRESS] = [
+        create_ipv4_address_state(
+            IPV4_ADDRESS4, 24, valid_left="30sec", preferred_left="30sec"
+        ),
+    ]
+    ipv6_state = _create_ipv6_state(enabled=True, dhcp=True, autoconf=True)
+    ipv6_state[InterfaceIPv6.ADDRESS] = [
+        create_ipv6_address_state(
+            IPV6_ADDRESS4, 64, valid_left="30sec", preferred_left="30sec"
+        ),
+    ]
+
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: ipv4_state,
+                Interface.IPV6: ipv6_state,
+            }
+        ]
+    }
+
+    libnmstate.apply(desired_state)


### PR DESCRIPTION
When DHCP enabled with auto IP address on STP enabled bridge, nmstate
will fail with verification error:

    Verification failure: br0.interface.ipv4.address desire '[]',
    current 'null'

The root cause is STP suspended the DHCP action which cause current
state shows null IP address. And nmstate incorrectly treat [] != null
for IP address.

Fixed in `sanitize_current_for_verify()` to set empty array if None.

To reproduce this problem, we just enable DHCP with auto IP address
where no DHCP server exists. Integration test case included.