### PR TITLE
README: Remove IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ interfaces:
 
 *Nmstate* [GitHub Issues pages][github_issue_url] for discussion.
 
-You may find us in `#nmstate` on [Libera IRC](https://libera.chat/) also.
-
 ## Contributing
 
 Yay! We are happy to accept new contributors to the Nmstate project. Please


### PR DESCRIPTION
Most questions on IRC are ignored, therefore it does not make sense to mention it in the README.