### PR TITLE
CI: Fix error when running test locally

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -77,6 +77,8 @@ function container_pre_test_setup {
     create_container
 
     container_exec "ulimit -c unlimited"
+    container_exec "git config --global --add safe.directory \
+        $CONTAINER_WORKSPACE"
 }
 
 function copy_workspace_container {


### PR DESCRIPTION
When running `automation/run-tests.sh` with `sudo`, we get failure on

    fatal: detected dubious ownership in repository at '/workspace/nmstate'
    To add an exception for this directory, call:

        git config --global --add safe.directory /workspace/nmstate

Fixed by run the `git config` in `container_pre_test_setup()`.