### PR TITLE
OVS: Support OVS `netdev` datapath

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -60,6 +60,9 @@ pub enum InterfaceType {
     /// [IP over InfiniBand interface](https://docs.kernel.org/infiniband/ipoib.html)
     /// Deserialize and serialize from/to 'infiniband'.
     InfiniBand,
+    /// TUN interface. Only used for query, will be ignored when applying.
+    /// Deserialize and serialize from/to 'tun'.
+    Tun,
     /// Unknown interface.
     Unknown,
     /// Reserved for future use.
@@ -89,6 +92,7 @@ impl From<&str> for InterfaceType {
             "vrf" => InterfaceType::Vrf,
             "vxlan" => InterfaceType::Vxlan,
             "infiniband" => InterfaceType::InfiniBand,
+            "tun" => InterfaceType::Tun,
             "unknown" => InterfaceType::Unknown,
             _ => InterfaceType::Other(s.to_string()),
         }
@@ -116,6 +120,7 @@ impl std::fmt::Display for InterfaceType {
                 InterfaceType::Vxlan => "vxlan",
                 InterfaceType::InfiniBand => "infiniband",
                 InterfaceType::Unknown => "unknown",
+                InterfaceType::Tun => "tun",
                 InterfaceType::Other(ref s) => s,
             }
         )

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -24,6 +24,7 @@ fn np_iface_type_to_nmstate(
         nispor::IfaceType::Vrf => InterfaceType::Vrf,
         nispor::IfaceType::Vxlan => InterfaceType::Vxlan,
         nispor::IfaceType::Ipoib => InterfaceType::InfiniBand,
+        nispor::IfaceType::Tun => InterfaceType::Tun,
         _ => InterfaceType::Other(format!("{np_iface_type:?}")),
     }
 }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -39,12 +39,16 @@ pub(crate) fn nispor_retrieve(
         .map_err(np_error_to_nmstate)?;
 
     for (_, np_iface) in np_state.ifaces.iter() {
-        let base_iface = np_iface_to_base_iface(np_iface, running_config_only);
         // The `ovs-system` is reserved for OVS kernel datapath
         if np_iface.name == "ovs-system" {
             continue;
         }
+        // The `ovs-netdev` is reserved for OVS netdev datapath
+        if np_iface.name == "ovs-netdev" {
+            continue;
+        }
 
+        let base_iface = np_iface_to_base_iface(np_iface, running_config_only);
         let iface = match &base_iface.iface_type {
             InterfaceType::LinuxBridge => {
                 let mut br_iface = np_bridge_to_nmstate(np_iface, base_iface)?;

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -7,7 +7,7 @@ mod ieee8021x;
 mod ip;
 mod lldp;
 mod mptcp;
-mod ovs;
+pub(crate) mod ovs;
 mod profile;
 mod route;
 mod user;

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::{NmApi, NmConnection};
+use super::super::nm_dbus::{NmApi, NmConnection, NmDevice};
 use super::super::{
     query_apply::profile::delete_profiles,
     settings::{get_exist_profile, NM_SETTING_OVS_PORT_SETTING_NAME},
+    show::nm_conn_to_base_iface,
 };
 
-use crate::{InterfaceType, MergedInterface, MergedInterfaces, NmstateError};
+use crate::{
+    Interface, InterfaceType, MergedInterface, MergedInterfaces, NetworkState,
+    NmstateError,
+};
 
 // When OVS system interface got detached from OVS bridge, we should remove its
 // ovs port also.
@@ -82,4 +86,42 @@ fn iface_was_ovs_sys_iface(iface: &MergedInterface) -> bool {
         .as_ref()
         .and_then(|i| i.base_iface().controller_type.as_ref())
         == Some(&InterfaceType::OvsBridge)
+}
+
+pub(crate) fn merge_ovs_netdev_tun_iface(
+    net_state: &mut NetworkState,
+    nm_devs: &[NmDevice],
+    nm_conns: &[NmConnection],
+) {
+    let tun_nm_devs: Vec<&NmDevice> = nm_devs
+        .iter()
+        .filter(|d| d.iface_type.as_str() == "tun")
+        .collect();
+    let tun_nm_conns: Vec<&NmConnection> = nm_conns
+        .iter()
+        .filter(|c| c.iface_type() == Some("tun"))
+        .collect();
+    for iface in net_state
+        .interfaces
+        .kernel_ifaces
+        .values_mut()
+        .filter(|i| i.iface_type() == InterfaceType::OvsInterface)
+    {
+        if let (Some(nm_dev), Some(nm_conn)) = (
+            tun_nm_devs
+                .as_slice()
+                .iter()
+                .find(|d| d.name.as_str() == iface.name()),
+            tun_nm_conns
+                .as_slice()
+                .iter()
+                .find(|c| c.iface_name() == Some(iface.name())),
+        ) {
+            if let (Some(base_iface), Interface::OvsInterface(ovs_iface)) =
+                (nm_conn_to_base_iface(nm_dev, nm_conn, None, None), iface)
+            {
+                ovs_iface.base = base_iface;
+            }
+        }
+    }
 }

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -15,7 +15,8 @@ use super::{
         device::nm_dev_iface_type_to_nmstate, dns::nm_global_dns_to_nmstate,
         get_description, get_lldp, is_lldp_enabled, is_mptcp_supported,
         nm_802_1x_to_nmstate, nm_ip_setting_to_nmstate4,
-        nm_ip_setting_to_nmstate6, query_nmstate_wait_ip, retrieve_dns_info,
+        nm_ip_setting_to_nmstate6, ovs::merge_ovs_netdev_tun_iface,
+        query_nmstate_wait_ip, retrieve_dns_info,
     },
     settings::{
         get_bond_balance_slb, NM_SETTING_VETH_SETTING_NAME,
@@ -190,10 +191,12 @@ pub(crate) fn nm_retrieve(
 
     set_ovs_iface_controller_info(&mut net_state.interfaces);
 
+    merge_ovs_netdev_tun_iface(&mut net_state, &nm_devs, &nm_conns);
+
     Ok(net_state)
 }
 
-fn nm_conn_to_base_iface(
+pub(crate) fn nm_conn_to_base_iface(
     nm_dev: &NmDevice,
     nm_conn: &NmConnection,
     nm_saved_conn: Option<&NmConnection>,

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -206,7 +206,7 @@ impl Interface {
                     );
                 }
             }
-            Self::Unknown(_) | Self::Dummy(_) | Self::Loopback(_) => (),
+            _ => (),
         }
     }
 }

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -17,6 +17,11 @@ impl InterfaceIpv4 {
         if self.enabled && self.addresses.is_none() {
             self.addresses = Some(Vec::new());
         }
+
+        // No DHCP means off
+        if self.enabled && self.dhcp.is_none() {
+            self.dhcp = Some(false);
+        }
     }
 
     // Sort addresses and dedup
@@ -98,6 +103,16 @@ impl InterfaceIpv6 {
         // No IP address means empty.
         if self.enabled && self.addresses.is_none() {
             self.addresses = Some(Vec::new());
+        }
+
+        // No DHCP means off
+        if self.enabled && self.dhcp.is_none() {
+            self.dhcp = Some(false);
+        }
+
+        // No autoconf means off
+        if self.enabled && self.autoconf.is_none() {
+            self.autoconf = Some(false);
         }
     }
 


### PR DESCRIPTION
The OVS `netdev` datapath will use TUN interface for OVS internal
interface, nmstate should merge this kernel TUN interface state with
user space OVS interface state, otherwise verification failure will
happen.

The `netdev` datapath is used for OVS DPDK.  Manually tested with OVS 
DPDK on Intel E810-C card.


Integration test case included.