### PR TITLE
bridge: add support to default-vlan-pvid

### DIFF
--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -25,7 +25,7 @@ pub use bond::{
     BondOptions, BondPrimaryReselect, BondXmitHashPolicy,
 };
 pub use bridge_vlan::{
-    BridgePortTunkTag, BridgePortVlanConfig, BridgePortVlanMode,
+    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange,
 };
 pub use dummy::DummyInterface;

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -128,7 +128,7 @@ pub use crate::ifaces::{
     BaseInterface, BondAdSelect, BondAllPortsActive, BondArpAllTargets,
     BondArpValidate, BondConfig, BondFailOverMac, BondInterface, BondLacpRate,
     BondMode, BondOptions, BondPrimaryReselect, BondXmitHashPolicy,
-    BridgePortTunkTag, BridgePortVlanConfig, BridgePortVlanMode,
+    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange, DummyInterface, EthernetConfig, EthernetDuplex,
     EthernetInterface, EthtoolCoalesceConfig, EthtoolConfig,
     EthtoolFeatureConfig, EthtoolPauseConfig, EthtoolRingConfig,

--- a/rust/src/lib/nispor/linux_bridge.rs
+++ b/rust/src/lib/nispor/linux_bridge.rs
@@ -54,10 +54,15 @@ pub(crate) fn append_bridge_port_config(
                 .and_then(|br_info| br_info.vlan_filtering)
                 == Some(true)
             {
-                port_conf.vlan = np_port_info
-                    .vlans
-                    .as_ref()
-                    .and_then(|v| parse_port_vlan_conf(v.as_slice()));
+                port_conf.vlan = np_port_info.vlans.as_ref().and_then(|v| {
+                    parse_port_vlan_conf(
+                        v.as_slice(),
+                        np_iface
+                            .bridge
+                            .as_ref()
+                            .and_then(|br_info| br_info.default_pvid),
+                    )
+                });
             }
         }
         port_confs.push(port_conf);
@@ -134,6 +139,7 @@ fn np_bridge_options_to_nmstate(
                     None
                 }
             });
+        options.vlan_default_pvid = np_bridge.default_pvid;
     }
     Ok(options)
 }

--- a/rust/src/lib/nispor/linux_bridge_port_vlan.rs
+++ b/rust/src/lib/nispor/linux_bridge_port_vlan.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BridgePortTunkTag, BridgePortVlanConfig, BridgePortVlanMode,
+    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange,
 };
 
@@ -22,9 +22,9 @@ pub(crate) fn parse_port_vlan_conf(
             ret.tag = Some(vlan_max);
             is_native = true;
         } else if vlan_min == vlan_max {
-            trunk_tags.push(BridgePortTunkTag::Id(vlan_min));
+            trunk_tags.push(BridgePortTrunkTag::Id(vlan_min));
         } else {
-            trunk_tags.push(BridgePortTunkTag::IdRange(BridgePortVlanRange {
+            trunk_tags.push(BridgePortTrunkTag::IdRange(BridgePortVlanRange {
                 max: vlan_max,
                 min: vlan_min,
             }));

--- a/rust/src/lib/nispor/linux_bridge_port_vlan.rs
+++ b/rust/src/lib/nispor/linux_bridge_port_vlan.rs
@@ -5,6 +5,7 @@ use crate::{
 
 pub(crate) fn parse_port_vlan_conf(
     np_vlan_entries: &[nispor::BridgeVlanEntry],
+    default_pvid: Option<u16>,
 ) -> Option<BridgePortVlanConfig> {
     let mut ret = BridgePortVlanConfig::new();
     let mut is_native = false;
@@ -12,8 +13,12 @@ pub(crate) fn parse_port_vlan_conf(
     let is_access_port = is_access_port(np_vlan_entries);
 
     for np_vlan_entry in np_vlan_entries {
+        let mut def_pvid = 1;
+        if let Some(pvid) = default_pvid {
+            def_pvid = pvid;
+        }
         let (vlan_min, vlan_max) = get_vlan_tag_range(np_vlan_entry);
-        if vlan_min == 1 && vlan_max == 1 {
+        if vlan_min == def_pvid && vlan_max == def_pvid {
             continue;
         }
         if is_access_port {

--- a/rust/src/lib/nm/settings/bridge.rs
+++ b/rust/src/lib/nm/settings/bridge.rs
@@ -5,7 +5,7 @@ use crate::nm::nm_dbus::{
 };
 
 use crate::{
-    BridgePortTunkTag, BridgePortVlanConfig, BridgePortVlanMode, Interface,
+    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode, Interface,
     LinuxBridgeInterface, LinuxBridgeOptions, LinuxBridgeStpOptions,
     MergedInterface, VlanProtocol,
 };
@@ -183,7 +183,7 @@ fn nmstate_port_vlans_to_nm_vlan_range(
 }
 
 fn trunk_tag_to_nm_vlan_range(
-    trunk_tag: &BridgePortTunkTag,
+    trunk_tag: &BridgePortTrunkTag,
 ) -> NmSettingBridgeVlanRange {
     let mut ret = NmSettingBridgeVlanRange::default();
     let (vid_min, vid_max) = trunk_tag.get_vlan_tag_range();

--- a/rust/src/lib/nm/settings/bridge.rs
+++ b/rust/src/lib/nm/settings/bridge.rs
@@ -97,6 +97,9 @@ fn apply_br_options(
             VlanProtocol::Ieee8021Ad => Some(NmVlanProtocol::Dot1Ad),
         }
     }
+    if let Some(v) = br_opts.vlan_default_pvid.as_ref() {
+        nm_br_set.vlan_default_pvid = Some((*v).into());
+    }
 
     if let Some(stp_opts) = br_opts.stp.as_ref() {
         apply_stp_setting(nm_br_set, stp_opts);

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -10,7 +10,7 @@ use super::super::nm_dbus::{
 use super::super::settings::connection::gen_nm_conn_setting;
 
 use crate::{
-    BaseInterface, BridgePortTunkTag, Interface, InterfaceType, NmstateError,
+    BaseInterface, BridgePortTrunkTag, Interface, InterfaceType, NmstateError,
     OvsBridgeBondMode, OvsBridgeInterface, OvsBridgePortConfig,
     OvsDbIfaceConfig, OvsInterface, UnknownInterface,
 };
@@ -83,7 +83,7 @@ pub(crate) fn create_ovs_port_nm_conn(
     Ok(nm_conn)
 }
 
-fn trunk_tag_to_nm_range(trunk_tag: &BridgePortTunkTag) -> NmRange {
+fn trunk_tag_to_nm_range(trunk_tag: &BridgePortTrunkTag) -> NmRange {
     let mut ret = NmRange::default();
     let (vid_min, vid_max) = trunk_tag.get_vlan_tag_range();
     ret.start = vid_min.into();

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 use serde_json::Value;
 
 use crate::{
-    BridgePortTunkTag, BridgePortVlanConfig, BridgePortVlanMode,
+    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange, Interface, InterfaceType, Interfaces, NetworkState,
     NmstateError, OvsBridgeBondConfig, OvsBridgeBondMode,
     OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
@@ -241,7 +241,7 @@ fn parse_ovs_vlan_conf(
             {
                 if let Some(tag) = trunk_tag.as_u64() {
                     ret.trunk_tags =
-                        Some(vec![BridgePortTunkTag::Id(tag as u16)]);
+                        Some(vec![BridgePortTrunkTag::Id(tag as u16)]);
                 }
             }
         }
@@ -251,7 +251,7 @@ fn parse_ovs_vlan_conf(
     }
 }
 
-fn compress_vlan_trunk_tags(tags: &[Value]) -> Vec<BridgePortTunkTag> {
+fn compress_vlan_trunk_tags(tags: &[Value]) -> Vec<BridgePortTrunkTag> {
     let mut ranges: Vec<BridgePortVlanRange> = Vec::new();
     for tag in tags {
         if let Value::Number(tag) = tag {
@@ -282,9 +282,9 @@ fn compress_vlan_trunk_tags(tags: &[Value]) -> Vec<BridgePortTunkTag> {
     let mut ret = Vec::new();
     for range in ranges {
         if range.min == range.max {
-            ret.push(BridgePortTunkTag::Id(range.min))
+            ret.push(BridgePortTrunkTag::Id(range.min))
         } else {
-            ret.push(BridgePortTunkTag::IdRange(range))
+            ret.push(BridgePortTrunkTag::IdRange(range))
         }
     }
 

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    BridgePortTunkTag, BridgePortVlanRange, ErrorKind, Interface,
+    BridgePortTrunkTag, BridgePortVlanRange, ErrorKind, Interface,
     InterfaceType, Interfaces, LinuxBridgeInterface,
     LinuxBridgeMulticastRouterType, MergedInterface, MergedInterfaces,
 };
@@ -170,11 +170,11 @@ bridge:
     assert_eq!(vlan_conf.tag, Some(102));
     assert_eq!(
         &vlan_conf.trunk_tags.as_ref().unwrap()[0],
-        &BridgePortTunkTag::Id(103)
+        &BridgePortTrunkTag::Id(103)
     );
     assert_eq!(
         &vlan_conf.trunk_tags.as_ref().unwrap()[1],
-        &BridgePortTunkTag::IdRange(BridgePortVlanRange {
+        &BridgePortTrunkTag::IdRange(BridgePortVlanRange {
             max: 1024,
             min: 105
         })

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -230,6 +230,7 @@ class LinuxBridge(Bridge):
         MULTICAST_STARTUP_QUERY_COUNT = "multicast-startup-query-count"
         MULTICAST_STARTUP_QUERY_INTERVAL = "multicast-startup-query-interval"
         VLAN_PROTOCOL = "vlan-protocol"
+        VLAN_DEFAULT_PVID = "vlan-default-pvid"
 
         # Read only properties begin
         HELLO_TIMER = "hello-timer"

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -640,6 +640,20 @@ class TestVlanFiltering:
             )
             libnmstate.apply(desired_state)
 
+    def test_linux_bridge_option_vlan_default_pvid_on_trunk_mode(
+        self,
+        bridge_with_trunk_port_and_native_config,
+    ):
+        bridge_state = bridge_with_trunk_port_and_native_config[Interface.KEY][
+            0
+        ]
+        bridge_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.OPTIONS_SUBTREE][
+            LinuxBridge.Options.VLAN_DEFAULT_PVID
+        ] = 5
+
+        libnmstate.apply({Interface.KEY: [bridge_state]})
+        assertlib.assert_state_match({Interface.KEY: [bridge_state]})
+
 
 @pytest.fixture
 def bridge_unmanaged_port():
@@ -734,6 +748,20 @@ def test_linux_bridge_option_integer_rounded_on_ubuntu_kernel(
     desired_state = {Interface.KEY: [iface_state]}
 
     with pytest.raises(NmstateKernelIntegerRoundedError):
+        libnmstate.apply(desired_state)
+
+
+def test_linux_bridge_option_vlan_default_pvid_no_filtering(
+    bridge0_with_port0,
+):
+    iface_state = bridge0_with_port0[Interface.KEY][0]
+    iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.OPTIONS_SUBTREE][
+        LinuxBridge.Options.VLAN_DEFAULT_PVID
+    ] = 5
+
+    desired_state = {Interface.KEY: [iface_state]}
+
+    with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
 
 


### PR DESCRIPTION
Add support to default-vlan-pvid, currently the nm_dbus part was already done, so it didn't require much work.

Add integration test.