### PR TITLE
CI: Fix random failure on `test_ignore_interface_mentioned_in_port_list`

### DIFF
--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -68,7 +68,6 @@ def linux_bridge(
                     }
                 ]
             },
-            verify_change=False,
             kernel_only=kernel_mode,
         )
 


### PR DESCRIPTION
In https://github.com/nmstate/nmstate/actions/runs/5000804973/jobs/8958880385
we noticed the `setup of test_ignore_interface_mentioned_in_port_list`
will fail as `ip link add brtest0 type bridge` return 2 indicating a
bridge with the same name exists.

This is because in previous test, the clean up is using
`verify_change=False` which does not grantee the linux bridge is removed
by absent action.

To fix that, we remove `verify_change=False` and the clean up of
`linux_bridge()` should make sure the bridge is removed.