### PR TITLE
CI: Fix random failure on `test_ignore_interface_mentioned_in_port_list`

### DIFF
--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -789,9 +789,18 @@ def bridge0_with_tap_port():
     exec_cmd(f"ip link set {TEST_BRIDGE0} up".split(), check=True)
     yield
     exec_cmd(f"ip link del {TEST_TAP0}".split())
-    exec_cmd(f"ip link del {TEST_BRIDGE0}".split())
     exec_cmd(f"nmcli c del {TEST_TAP0}".split())
-    exec_cmd(f"nmcli c del {TEST_BRIDGE0}".split())
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_BRIDGE0,
+                    Interface.TYPE: InterfaceType.LINUX_BRIDGE,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
 
 
 def test_ignore_unmanged_tap_as_bridge_port(bridge0_with_tap_port, port0_up):

--- a/tests/integration/nm/veth_test.py
+++ b/tests/integration/nm/veth_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import pytest
 
@@ -64,9 +47,21 @@ def veth1_with_ignored_peer():
         f"nmcli d set {VETH1PEER} managed false".split(), check=True
     )
     yield
-    cmdlib.exec_cmd(f"nmcli c del {VETH1}".split())
-    cmdlib.exec_cmd(f"nmcli c del {VETH1PEER}".split())
     cmdlib.exec_cmd(f"ip link del {VETH1}".split())
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: VETH1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+                {
+                    Interface.NAME: VETH1PEER,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -68,7 +68,6 @@ def linux_bridge(
                     }
                 ]
             },
-            verify_change=False,
             kernel_only=kernel_mode,
         )
 

--- a/tests/integration/testlib/dummy.py
+++ b/tests/integration/testlib/dummy.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 
@@ -50,6 +33,17 @@ def create_veth_pair(nic, nic_peer, peer_ns):
 def remove_veth_pair(nic, peer_ns):
     exec_cmd(f"ip link del {nic}".split())
     exec_cmd(f"ip netns del {peer_ns}".split())
+    # Use nmstate to ensure nic is deleted instead of using `ip link del`
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: nic,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
 
 
 @contextmanager
@@ -78,4 +72,4 @@ def veth_interface(ifname, peer, kernel_mode=False):
                 Interface.STATE: InterfaceState.ABSENT,
             }
         )
-        libnmstate.apply(d_state, kernel_only=kernel_mode, verify_change=False)
+        libnmstate.apply(d_state, kernel_only=kernel_mode)

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2021-2022 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -114,10 +114,24 @@ def unmanaged_port_up():
     )
     cmdlib.exec_cmd(f"ip link set {TEST_VRF_VETH0} up".split())
     cmdlib.exec_cmd(f"ip link set {TEST_VRF_VETH1} up".split())
-    try:
-        yield TEST_VRF_VETH0
-    finally:
-        cmdlib.exec_cmd(f"ip link del {TEST_VRF_VETH0}".split())
+    yield TEST_VRF_VETH0
+    cmdlib.exec_cmd(f"ip link del {TEST_VRF_VETH0}".split())
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: TEST_VRF_VETH0,
+                    Interface.TYPE: InterfaceType.VETH,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+                {
+                    Interface.NAME: TEST_VRF0,
+                    Interface.TYPE: InterfaceType.VRF,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
In https://github.com/nmstate/nmstate/actions/runs/5000804973/jobs/8958880385
we noticed the `setup of test_ignore_interface_mentioned_in_port_list`
will fail as `ip link add brtest0 type bridge` return 2 indicating a
bridge with the same name exists.

This is because in previous test, the clean up is using
`verify_change=False` which does not grantee the linux bridge is removed
by absent action.

To fix that, we remove `verify_change=False` and the clean up of
`linux_bridge()` should make sure the bridge is removed.

The `ip link del` command does not guarantee on link been removed on
exit, hence we use nmstate to replace all `ip link del` command in
tests.