### PR TITLE
nm: Do not wait DHCP in rollback

### DIFF
--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -321,7 +321,6 @@ impl<'a> NmApi<'a> {
             let nm_devs = self.devices_get()?;
             for nm_dev in &nm_devs {
                 if nm_dev.state_reason == NmDeviceStateReason::NewActivation
-                    || nm_dev.state == NmDeviceState::IpConfig
                     || nm_dev.state == NmDeviceState::Deactivating
                 {
                     waiting_nm_dev.push(nm_dev);


### PR DESCRIPTION
When rollback, the `wait_checkpoint_rollback()` will continue the wait on
IP_CONFIG which might cause rollback blocked when there is no DHCP server

Manual test required, hence no auto CI test case.