### PR TITLE
test: Fix random failure of `test_new_bond_uses_mac_of_first_port_by_name`

### DIFF
--- a/tests/integration/testlib/bondlib.py
+++ b/tests/integration/testlib/bondlib.py
@@ -1,21 +1,5 @@
-#
-# Copyright (c) 2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from contextlib import contextmanager
 
 import libnmstate
@@ -64,5 +48,4 @@ def bond_interface(name, port, extra_iface_state=None, create=True):
                     }
                 ]
             },
-            verify_change=False,
         )


### PR DESCRIPTION
The `test_new_bond_uses_mac_of_first_port_by_name` has random failure
with 1% rate, it is caused by nmstate not properly clean up in previous
test as it is instructed to delete interface with `verify=False` which
cause nmstate return when interface might be still deleting by
NetworkManager.