### PR TITLE
nm: Use activated connection when referring parent or controller

### DIFF
--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -122,12 +122,14 @@ pub(crate) fn perpare_nm_conns(
         &mut nm_conns_to_update,
         &merged_state.interfaces,
         exist_nm_conns,
+        nm_acs,
     )?;
 
     use_uuid_for_parent_reference(
         &mut nm_conns_to_update,
         &merged_state.interfaces,
         exist_nm_conns,
+        nm_acs,
     );
 
     Ok(PerparedNmConnections {

--- a/rust/src/lib/nm/unit_tests/profiles.rs
+++ b/rust/src/lib/nm/unit_tests/profiles.rs
@@ -79,7 +79,7 @@ fn test_use_uuid_for_controller_reference_with_ovs_bond() {
     let merged_ifaces =
         MergedInterfaces::new(ifaces, Interfaces::new(), false, false).unwrap();
 
-    use_uuid_for_controller_reference(&mut nm_conns, &merged_ifaces, &[])
+    use_uuid_for_controller_reference(&mut nm_conns, &merged_ifaces, &[], &[])
         .unwrap();
 
     println!("nm_conns {nm_conns:?}");

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import time
+
+import pytest
+
+import libnmstate
+
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import VLAN
+
+from ..testlib import cmdlib
+
+TEST_VLAN = "test_vlan0"
+TEST_PROFILE_NAME = "0eth1"
+
+
+@pytest.fixture
+def eth1_up_with_two_profiles(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.UP,
+                }
+            ]
+        }
+    )
+    cmdlib.exec_cmd(
+        "nmcli c add type ethernet ifname eth1 "
+        f"connection.id {TEST_PROFILE_NAME} ipv4.method disabled "
+        "ipv6.method disabled".split(),
+        check=True,
+    )
+    cmdlib.exec_cmd(f"nmcli c up {TEST_PROFILE_NAME}".split(), check=True)
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+    cmdlib.exec_cmd(f"nmcli c del {TEST_PROFILE_NAME}".split())
+
+
+# To reproduce the ordinal issue in https://bugzilla.redhat.com/2202999 ,
+# multiple try is required
+def test_vlan_parent_has_two_profiles(eth1_up_with_two_profiles):
+    try:
+        for _ in range(0, 5):
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: TEST_VLAN,
+                            Interface.TYPE: InterfaceType.VLAN,
+                            Interface.STATE: InterfaceState.UP,
+                            VLAN.CONFIG_SUBTREE: {
+                                VLAN.ID: 101,
+                                VLAN.BASE_IFACE: "eth1",
+                            },
+                        }
+                    ]
+                }
+            )
+            time.sleep(1)
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VLAN,
+                        Interface.TYPE: InterfaceType.VLAN,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
+        )


### PR DESCRIPTION
When a interface has multiple NM profiles, creating a VLAN or bridge
above it will get failure on

    libnmstate.error.NmstateInternalError: Manager(UnknownDevice):
    Failed to find a compatible device for this connection

The root cause of this is `use_uuid_for_controller_reference()` and
`use_uuid_for_parent_reference()` is searching all existing NM
connections if not desired, this might lead to nmstate choosing the
inactivate profile as parent/controller.

To fix it, patched `use_uuid_for_parent_reference()` and
`use_uuid_for_controller_reference()` to prefer activated NM profiles
over other existing ones.

Resolves: RHBZ#2202999