### PR TITLE
cli: Teach `persist-nic-names` to pin via kargs too

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -344,6 +344,16 @@ fn main() {
                         ),
                 )
                 .arg(
+                    clap::Arg::new("KARGSFILE")
+                        .long("kargs-out")
+                        .takes_value(true)
+                        .help(
+                            "When pinning, write kargs to append; \
+                            when cleaning up, write kargs to delete \
+                            (space-separated)",
+                        ),
+                )
+                .arg(
                     clap::Arg::new("ROOT")
                         .long("root")
                         .short('r')
@@ -448,6 +458,7 @@ fn main() {
             };
             print_result_and_exit(crate::persist_nic::run_persist_immediately(
                 matches.value_of("ROOT").unwrap(),
+                matches.value_of("KARGSFILE"),
                 action,
             ));
         }

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -380,6 +380,6 @@ const KERNEL_CMDLINE_FILE: &str = "/proc/cmdline";
 fn is_predictable_ifname_disabled() -> bool {
     std::fs::read(KERNEL_CMDLINE_FILE)
         .map(|v| String::from_utf8(v).unwrap_or_default())
-        .map(|c| c.contains("net.ifnames=0"))
+        .map(|c| c.split(' ').any(|x| x == "net.ifnames=0"))
         .unwrap_or_default()
 }

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -378,8 +378,12 @@ fn is_nmstate_generated_systemd_link_file(file_path: &PathBuf) -> bool {
 const KERNEL_CMDLINE_FILE: &str = "/proc/cmdline";
 
 fn is_predictable_ifname_disabled() -> bool {
+    has_any_kargs(&["net.ifnames=0"])
+}
+
+fn has_any_kargs(kargs: &[&str]) -> bool {
     std::fs::read(KERNEL_CMDLINE_FILE)
         .map(|v| String::from_utf8(v).unwrap_or_default())
-        .map(|c| c.split(' ').any(|x| x == "net.ifnames=0"))
+        .map(|c| c.split(' ').any(|x| kargs.contains(&x)))
         .unwrap_or_default()
 }


### PR DESCRIPTION
Pinning by kargs has the additional benefit of also covering the initramfs, which is relevant if networking is necessary there (for e.g. a Tang-pinned rootfs), and network kargs are in use that rely on a specific interface name.

To keep it simpler, we don't have nmstate itself call out to rpm-ostree. Instead, a new `--kargs-out` flag is added where nmstate can write out the kargs that the MCO should add/remove.

Related: https://github.com/openshift/machine-config-operator/pull/3684
Related: https://github.com/openshift/machine-config-operator/pull/3706