### PR TITLE
ovs: New `allow-extra-patch-ports` option

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -731,8 +731,17 @@ impl MergedInterfaces {
         self.user_ifaces.values().chain(self.kernel_ifaces.values())
     }
 
+    pub(crate) fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut MergedInterface> {
+        self.user_ifaces
+            .values_mut()
+            .chain(self.kernel_ifaces.values_mut())
+    }
+
     // Contains all the smart modifications, validations among interfaces
     fn process(&mut self) -> Result<(), NmstateError> {
+        self.process_allow_extra_ovs_patch_ports_for_apply();
         self.apply_copy_mac_from()?;
         self.validate_controller_and_port_list_confliction()?;
         self.handle_changed_ports()?;

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -348,6 +348,7 @@ class OVSInterface(OvsDB):
 
 class OVSBridge(Bridge, OvsDB):
     TYPE = "ovs-bridge"
+    ALLOW_EXTRA_PATCH_PORTS = "allow-extra-patch-ports"
 
     class Options:
         FAIL_MODE = "fail-mode"

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2098,3 +2098,18 @@ def test_netdev_data_path(eth1_up):
         libnmstate.apply(desired_state)
     assertlib.assert_absent(BRIDGE0)
     assertlib.assert_absent(PORT1)
+
+
+@pytest.mark.tier1
+def test_allow_extra_ovs_patch_ports(ovs_bridge_with_patch_ports):
+    bridge = Bridge(BRIDGE1)
+    bridge.add_system_port("eth1")
+    desired_state = bridge.state
+    desired_state[Interface.KEY][0][OVSBridge.CONFIG_SUBTREE][
+        OVSBridge.ALLOW_EXTRA_PATCH_PORTS
+    ] = True
+    libnmstate.apply(desired_state)
+
+    patch1_state = statelib.show_only((PATCH1,))
+
+    assert patch1_state[Interface.KEY][0][Interface.CONTROLLER] == BRIDGE1

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019-2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
 import copy


### PR DESCRIPTION
Introducing `allow-extra-patch-ports` to OVS bridge section which will
allows extra OVS patch port found when applying or verifying. For
example:

```yml
- name: br0
  type: ovs-bridge
  state: up
  bridge:
    allow-extra-patch-ports: true
    port:
    - name: eth1
```

This YAML will not remove existing patch port of `br0` when applying,
and also ignore extra OVS patch found during verification.

Unit test cases and integration test case included.