### PR TITLE
RPM SPEC: Remove runtime requirement of nmstate-libs

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -15,7 +15,6 @@ Source0:        https://github.com/%{srcname}/%{srcname}/releases/download/v%{ve
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-devel
 BuildRequires:  systemd
-Requires:       %{name}-libs%{?_isa} = %{version}-%{release}
 %if 0%{?rhel}
 BuildRequires:  rust-toolset
 %else


### PR DESCRIPTION
The `nmstate-libs` is not required for `nmstate` package.