### PR TITLE
Kargs output and inspect

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -344,6 +344,16 @@ fn main() {
                         ),
                 )
                 .arg(
+                    clap::Arg::new("KARGSFILE")
+                        .long("kargs-out")
+                        .takes_value(true)
+                        .help(
+                            "When pinning, write kargs to append; \
+                            when cleaning up, write kargs to delete \
+                            (space-separated)",
+                        ),
+                )
+                .arg(
                     clap::Arg::new("ROOT")
                         .long("root")
                         .short('r')
@@ -448,6 +458,7 @@ fn main() {
             };
             print_result_and_exit(crate::persist_nic::run_persist_immediately(
                 matches.value_of("ROOT").unwrap(),
+                matches.value_of("KARGSFILE"),
                 action,
             ));
         }

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -127,15 +127,12 @@ fn run_persist_immediately(
         let iface_name = iface.name();
         let karg = format_ifname_karg(iface_name, mac);
         log::info!("Will persist the interface {iface_name} with MAC {mac}");
-        if with_kargs {
-            log::info!("Will append kernel argument {karg}");
-        }
         if !dry_run {
             persist_iface_name_via_systemd_link(root, mac, iface_name)?;
-            if with_kargs {
-                log::info!("Kernel argument {karg} appended");
-                kargs.push(karg);
-            }
+        }
+        if with_kargs {
+            log::info!("Kernel argument added: {karg}");
+            kargs.push(karg);
         }
         changed = true;
     }
@@ -268,19 +265,17 @@ pub(crate) fn clean_up(
             };
             let karg = format_ifname_karg(&iface_name, mac);
             log::info!("Will remove generated file {}", file_path.display());
-            if with_kargs {
-                log::info!("Will remove kernel argument {karg}");
-            }
+
             if !dry_run {
                 std::fs::remove_file(&file_path)?;
                 log::info!(
                     "Removed systemd network link file {}",
                     file_path.display()
                 );
-                if with_kargs {
-                    log::info!("Kernel argument {karg} removed");
-                    kargs.push(karg);
-                }
+            }
+            if with_kargs {
+                log::info!("Kernel argument removed: {karg}");
+                kargs.push(karg);
             }
         } else {
             log::info!(

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -380,6 +380,6 @@ const KERNEL_CMDLINE_FILE: &str = "/proc/cmdline";
 fn is_predictable_ifname_disabled() -> bool {
     std::fs::read(KERNEL_CMDLINE_FILE)
         .map(|v| String::from_utf8(v).unwrap_or_default())
-        .map(|c| c.contains("net.ifnames=0"))
+        .map(|c| c.split(' ').any(|x| x == "net.ifnames=0"))
         .unwrap_or_default()
 }

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -378,8 +378,12 @@ fn is_nmstate_generated_systemd_link_file(file_path: &PathBuf) -> bool {
 const KERNEL_CMDLINE_FILE: &str = "/proc/cmdline";
 
 fn is_predictable_ifname_disabled() -> bool {
+    has_any_kargs(&["net.ifnames=0"])
+}
+
+fn has_any_kargs(kargs: &[&str]) -> bool {
     std::fs::read(KERNEL_CMDLINE_FILE)
         .map(|v| String::from_utf8(v).unwrap_or_default())
-        .map(|c| c.split(' ').any(|x| x == "net.ifnames=0"))
+        .map(|c| c.split(' ').any(|x| kargs.contains(&x)))
         .unwrap_or_default()
 }

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -182,12 +182,12 @@ pub(crate) fn clean_up(
         log::info!("{} does not exist, no need to clean up", netdir.display());
     }
     let stamp_path = netdir.join(NMSTATE_PERSIST_STAMP);
-    if !stamp_path.exists() {
+    let cleanup_pending = stamp_path.exists();
+    if !cleanup_pending {
         log::info!(
-            "{} does not exist, no prior persisted state, no need to clean up",
+            "{} does not exist, no need to clean up",
             stamp_path.display()
         );
-        return Ok("".to_string());
     }
 
     let mut pinned_ifaces: HashMap<String, PathBuf> = HashMap::new();
@@ -212,6 +212,12 @@ pub(crate) fn clean_up(
         if !dry_run {
             std::fs::remove_file(stamp_path)?;
         }
+        return Ok("".to_string());
+    }
+
+    // If there wasn't a stamp file, at this point we've just printed out
+    // whether there were any persisted NICs found, and we're done.
+    if !cleanup_pending {
         return Ok("".to_string());
     }
 

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -145,6 +145,11 @@ fn run_persist_immediately(
     }
 
     if !dry_run {
+        if let Some(parent) = stamp_path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir(parent)?;
+            }
+        }
         std::fs::write(stamp_path, b"")?;
         if !kargs.is_empty() {
             if let Some(path) = kargsfile {


### PR DESCRIPTION
This replaces https://github.com/nmstate/nmstate/pull/2356 because I don't have permission to push to that PR.

---
cli: Teach `persist-nic-names` to pin via kargs too

Pinning by kargs has the additional benefit of also covering the
initramfs, which is relevant if networking is necessary there (for
e.g. a Tang-pinned rootfs), and network kargs are in use that rely on a
specific interface name.

To keep it simpler, we don't have nmstate itself call out to rpm-ostree.
Instead, a new `--kargs-out` flag is added where nmstate can write out
the kargs that the MCO should add/remove.

Related: https://github.com/openshift/machine-config-operator/pull/3684
Related: https://github.com/openshift/machine-config-operator/pull/3706

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Mention kargs in persist_nic doc and minor tweaks

Add kernel arguments to the `persist_nic` module docstring. Fix a typo
in the predictable ifname function name. Don't capitalize systemd at the
beginning of sentences.

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Simplify and make consistent logging in `persist-nic-names`

In the pinning path, we used "would", which would be more appropriate
for dry run mode, but we also used it in non-dry run mode. In the
cleanup path, we used "will" only in dry run mode.

Since "will" works for both dry run mode and non-dry run mode, tweak
things so we always say "will". This simplifies things since we don't
need different logging for each mode.

In the cleanup path, log when we actually remove the link file for
consistency with the pinning path.

While we're here, merge the kernel arg and link file logging.

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Strengthen karg checking for net.ifnames=0

A karg like `foonet.ifnames=0` will make this function think that
predictable ifnames are disabled. We need the check to be word boundary-
aware.

Split the kernel cmdline on whitespace and check for each element.

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Split out `has_any_kargs` helper function

Prep for checking for another karg.

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Only append `ifname` kargs if `rd.neednet` is used

If networking isn't required in the initramfs, then there's no need to
append `ifname` kargs. Key off of the `rd.neednet` karg to know if that's
the case.

Signed-off-by: Jonathan Lebon <jonathan@jlebon.com>
Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Readd `perist-nic-names --inspect`, rework internals

Today the logs from this invocation may end up either
in the systemd journal or in a container log.

And after that one run, they will quickly get lost back in the
shuffle.

The original motivation behind `--inspect` is to be able
to quickly and conveniently see the state of the system; it's
something we can run every time the OpenShift machine-config-daemon
starts up on a node.

That way, we'll always be able to look at the logs and see what
happened with NIC persistence.

In the implementation of this, rework things such that "dry_run"
is a bool passed down instead of augmenting the action.

This makes the code flow much more clearly; instead of having
an early return in `run_persist_immediately` if the action is
to cleanup we separate the persist action into its own function
too, and then just dispatch to one or the other.

Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Ensure stamp path parent exists

Fixes https://issues.redhat.com/browse/OCPBUGS-14298

Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Deduplicate karg logging

In `--dry-run` mode we don't actually write to `--karg-file`
anyways, so move the kargs handling outside of the `!dry_run`
conditional, which allows us to deduplicate the logging.

Signed-off-by: Colin Walters <walters@verbum.org>

---

cli: Make `persist-nic-names --cleanup` still print state

This way, we get the equivalent of `--inspect`.  The MCO can just
run `--cleanup` on every boot and not have to care about
any implementation details.

Signed-off-by: Colin Walters <walters@verbum.org>

---

