### PR TITLE
sriov: Fix regression on waiting SRIOV

### DIFF
--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -116,7 +116,7 @@ impl NetworkState {
         self.has_vf_count_change(current) && self.has_missing_eth(current)
     }
 
-    fn has_vf_count_change(&self, current: &Self) -> bool {
+    pub(crate) fn has_vf_count_change(&self, current: &Self) -> bool {
         for iface in
             self.interfaces.kernel_ifaces.values().filter(|i| i.is_up())
         {

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     ErrorKind, EthernetConfig, EthernetInterface, Interface, InterfaceType,
-    Interfaces, NetworkState, NmstateError, SrIovConfig, VethConfig,
+    Interfaces, MergedInterfaces, NetworkState, NmstateError, SrIovConfig,
+    VethConfig,
 };
 
 impl EthernetInterface {
@@ -49,6 +50,20 @@ impl EthernetInterface {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn is_vf_count_changed(&self, cur_iface: &Self) -> bool {
+        let pf_count = self
+            .ethernet
+            .as_ref()
+            .and_then(|e| e.sr_iov.as_ref())
+            .and_then(|s| s.total_vfs);
+        let cur_pf_count = cur_iface
+            .ethernet
+            .as_ref()
+            .and_then(|e| e.sr_iov.as_ref())
+            .and_then(|s| s.total_vfs);
+        pf_count.is_some() && pf_count != cur_pf_count
     }
 }
 
@@ -125,17 +140,7 @@ impl NetworkState {
                 Some(Interface::Ethernet(cur_iface)),
             ) = (iface, current.interfaces.kernel_ifaces.get(iface.name()))
             {
-                let pf_count = iface
-                    .ethernet
-                    .as_ref()
-                    .and_then(|e| e.sr_iov.as_ref())
-                    .and_then(|s| s.total_vfs);
-                let cur_pf_count = cur_iface
-                    .ethernet
-                    .as_ref()
-                    .and_then(|e| e.sr_iov.as_ref())
-                    .and_then(|s| s.total_vfs);
-                if pf_count.is_some() && pf_count != cur_pf_count {
+                if iface.is_vf_count_changed(cur_iface) {
                     return true;
                 }
             }
@@ -193,5 +198,24 @@ impl NetworkState {
             }
             Some(pf_state)
         }
+    }
+}
+
+impl MergedInterfaces {
+    pub(crate) fn has_vf_count_change(&self) -> bool {
+        for iface in self.kernel_ifaces.values().filter(|i| {
+            i.is_desired() && i.merged.iface_type() == InterfaceType::Ethernet
+        }) {
+            if let (
+                Some(Interface::Ethernet(des_iface)),
+                Some(Interface::Ethernet(cur_iface)),
+            ) = (iface.for_apply.as_ref(), iface.current.as_ref())
+            {
+                if des_iface.is_vf_count_changed(cur_iface) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -135,7 +135,15 @@ impl NetworkState {
         }
 
         let mut timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
-        let verify_count = if self.has_vf_count_change(&cur_net_state) {
+        // We need to use merge state in case PF does not have
+        // interface type defined, we need merged_state to have `unknown` type
+        // resolved
+        let verify_count = if pf_state.is_some()
+            || merged_state
+                .as_ref()
+                .map(|s| s.interfaces.has_vf_count_change())
+                == Some(true)
+        {
             timeout = VERIFY_RETRY_COUNT_SRIOV as u32
                 * VERIFY_RETRY_INTERVAL_MILLISECONDS as u32
                 / 1000;

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -13,7 +13,7 @@ use crate::{
 const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;
 const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
 const VERIFY_RETRY_COUNT: usize = 5;
-const VERIFY_RETRY_COUNT_SRIOV: usize = 60;
+const VERIFY_RETRY_COUNT_SRIOV: usize = 300;
 const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
 const RETRY_NM_COUNT: usize = 2;
 const RETRY_NM_INTERVAL_MILLISECONDS: u64 = 2000;
@@ -123,7 +123,16 @@ impl NetworkState {
                 None
             };
 
-        let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
+        let mut timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
+        let verify_count = if self.has_vf_count_change(&cur_net_state) {
+            timeout = VERIFY_RETRY_COUNT_SRIOV as u32
+                * VERIFY_RETRY_INTERVAL_MILLISECONDS as u32
+                / 1000;
+            VERIFY_RETRY_COUNT_SRIOV
+        } else {
+            VERIFY_RETRY_COUNT
+        };
+
         let checkpoint = match nm_checkpoint_create(timeout) {
             Ok(c) => c,
             Err(e) => {
@@ -141,12 +150,6 @@ impl NetworkState {
 
         log::info!("Created checkpoint {}", &checkpoint);
 
-        let verify_count = if pf_state.is_some() {
-            VERIFY_RETRY_COUNT_SRIOV
-        } else {
-            VERIFY_RETRY_COUNT
-        };
-
         with_nm_checkpoint(&checkpoint, self.no_commit, || {
             if let Some(pf_state) = pf_state {
                 let pf_merged_state = MergedNetworkState::new(
@@ -160,6 +163,7 @@ impl NetworkState {
                     &cur_net_state,
                     &checkpoint,
                     verify_count,
+                    timeout,
                 )?;
                 // Refresh current state
                 cur_net_state.retrieve()?;
@@ -178,6 +182,7 @@ impl NetworkState {
                 &cur_net_state,
                 &checkpoint,
                 verify_count,
+                timeout,
             )
         })
     }
@@ -188,8 +193,8 @@ impl NetworkState {
         cur_net_state: &Self,
         checkpoint: &str,
         retry_count: usize,
+        timeout: u32,
     ) -> Result<(), NmstateError> {
-        let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
         // NM might have unknown race problem found by verify stage,
         // we try to apply the state again if so.
         with_retry(RETRY_NM_INTERVAL_MILLISECONDS, RETRY_NM_COUNT, || {

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -789,3 +789,34 @@ fn test_sriov_vf_revert_to_default() {
         panic!("Expecting a Ethernet interface, but got {:?}", verify_iface);
     }
 }
+
+#[test]
+fn test_has_vf_change_with_unknown_iface_type() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r#"---
+        - name: eth1
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 2
+        "#,
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r#"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 1
+        "#,
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    assert!(merged_ifaces.has_vf_count_change());
+}


### PR DESCRIPTION
The 20871bac introduced a regression causing SR-IOV verification error
when enabling large mount(60+) VF.

The root cause is we only retry verification
`VERIFY_RETRY_COUNT_SRIOV(60)` times when VF changed with missing ethernet
VF. Fixed by use `VERIFY_RETRY_COUNT_SRIOV` when we have VF count
changed.

In test with ixgbe, we noticed 60 seconds is not enough, hence increase
to 300 seconds for verification retry.

Integration test case included and manually tested on ixgbe card.