### PR TITLE
test: add test for bond port revive

### DIFF
--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -4,16 +4,39 @@ import os
 
 import pytest
 
+import libnmstate
 from libnmstate.schema import Bond
 from libnmstate.schema import BondMode
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceIPv4
+from libnmstate.schema import InterfaceIPv6
 
 from ..testlib import assertlib
 from ..testlib import cmdlib
+from ..testlib import statelib
 from ..testlib.bondlib import bond_interface
+from ..testlib.env import is_el8
+from ..testlib.env import is_k8s
 from ..testlib.env import nm_minor_version
+from ..testlib.nmplugin import nm_service_restart
+from ..testlib.retry import retry_till_true_or_timeout
+from ..testlib.vlan import vlan_interface
 
 
 BOND0 = "bondtest0"
+TEST_VLAN = "bondtest.101"
+TEST_VLAN_ID = 101
+IPV4_ADDRESS1 = "192.0.2.251"
+IPV6_ADDRESS1 = "2001:db8:1::1"
+RETRY_TIMEOUT = 10
+
+IGNORE_CARRIER_CFG_FILE = "/etc/NetworkManager/conf.d/ignore_carrier.conf"
+IGNORE_CARRIER_CFG_CONTENT = """
+[main]
+ignore-carrier=no
+"""
 
 
 def test_bond_all_zero_ad_actor_system():
@@ -71,3 +94,122 @@ def test_bond_balance_slb():
             assert "balance-slb=0" in output
 
     assertlib.assert_absent(BOND0)
+
+
+@pytest.fixture
+def ignore_carrier_no():
+    with open(IGNORE_CARRIER_CFG_FILE, "w") as fd:
+        fd.write(IGNORE_CARRIER_CFG_CONTENT)
+    with nm_service_restart():
+        yield
+        os.unlink(IGNORE_CARRIER_CFG_FILE)
+
+
+@pytest.fixture
+def vlan_over_bond_with_port_down(eth1_up, eth2_up):
+    with bond_interface(name=BOND0, port=["eth1", "eth2"], create=True):
+        with vlan_interface(TEST_VLAN, TEST_VLAN_ID, BOND0):
+            vlan_iface = {
+                Interface.NAME: TEST_VLAN,
+                Interface.STATE: InterfaceState.UP,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: False,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                },
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: True,
+                    InterfaceIPv6.DHCP: False,
+                    InterfaceIPv6.AUTOCONF: False,
+                    InterfaceIPv6.ADDRESS: [
+                        {
+                            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        }
+                    ],
+                },
+            }
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: BOND0,
+                            Interface.TYPE: InterfaceType.BOND,
+                            Interface.STATE: InterfaceState.UP,
+                        },
+                        vlan_iface,
+                    ]
+                }
+            )
+            # Apply the simple configure again is the key reproducer
+            libnmstate.apply(
+                {
+                    Interface.KEY: [
+                        {
+                            Interface.NAME: BOND0,
+                            Interface.TYPE: InterfaceType.BOND,
+                        },
+                        vlan_iface,
+                    ]
+                }
+            )
+            assert retry_till_true_or_timeout(
+                RETRY_TIMEOUT, vlan_is_up_with_ip
+            )
+            cmdlib.exec_cmd("ip link set eth1 down".split(), check=True)
+            cmdlib.exec_cmd("ip link set eth2 down".split(), check=True)
+            assert retry_till_true_or_timeout(
+                RETRY_TIMEOUT, vlan_is_down_without_ip
+            )
+            yield
+
+
+def vlan_is_down_without_ip():
+    current_state = statelib.show_only((TEST_VLAN,))
+    iface_state = current_state[Interface.KEY][0]
+    return (
+        iface_state[Interface.IPV4][InterfaceIPv4.ENABLED] is False
+        and iface_state[Interface.IPV6][InterfaceIPv6.ENABLED] is False
+    )
+
+
+def vlan_is_up_with_ip():
+    current_state = statelib.show_only((TEST_VLAN,))
+    iface_state = current_state[Interface.KEY][0]
+    return (
+        iface_state[Interface.STATE] == InterfaceState.UP
+        and iface_state[Interface.IPV4].get(InterfaceIPv4.ADDRESS, [])
+        == [
+            {
+                InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+            }
+        ]
+        and {
+            InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        }
+        in iface_state[Interface.IPV6].get(InterfaceIPv6.ADDRESS, [])
+    )
+
+
+@pytest.mark.skipif(
+    is_k8s(), reason="K8S cannot restart NetworkManager daemon"
+)
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    is_el8(), reason="CentOS Stream 8 does not have the fix yet"
+)
+# Detailed context is https://bugzilla.redhat.com/show_bug.cgi?id=2207690
+def test_vlan_over_bond_reconnect_on_link_revive(
+    ignore_carrier_no, vlan_over_bond_with_port_down
+):
+    cmdlib.exec_cmd("ip link set eth1 up".split(), check=True)
+    cmdlib.exec_cmd("ip link set eth2 up".split(), check=True)
+    assert retry_till_true_or_timeout(RETRY_TIMEOUT, vlan_is_up_with_ip)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1033,7 +1033,7 @@ def test_set_static_to_ovs_interface_with_the_same_name_bridge(
             }
         ]
 
-    retry_till_true_or_timeout(RETRY_TIMEOUT, _ovs_iface_got_ip)
+    assert retry_till_true_or_timeout(RETRY_TIMEOUT, _ovs_iface_got_ip)
 
 
 @pytest.fixture

--- a/tests/integration/testlib/retry.py
+++ b/tests/integration/testlib/retry.py
@@ -8,6 +8,7 @@ def retry_till_true_or_timeout(timeout, func, *args, **kwargs):
     while timeout > 0:
         if ret:
             break
+        print(f"Got False return from {func.__name__}: retrying")
         time.sleep(1)
         timeout -= 1
         ret = func(*args, **kwargs)


### PR DESCRIPTION
Add test case to simulate the import use case in
https://bugzilla.redhat.com/show_bug.cgi?id=2207690

The IP on VLAN of bond should be assigned back when bond port link
revived.