### PR TITLE
Ovn bridge mappings api

### DIFF
--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nmstate::{
-    DnsState, HostNameState, NetworkState, OvsDbGlobalConfig, RouteRules,
-    Routes,
+    DnsState, HostNameState, NetworkState, OvnConfiguration, OvsDbGlobalConfig,
+    RouteRules, Routes,
 };
 use serde::Serialize;
 use serde_yaml::Value;
@@ -21,6 +21,8 @@ pub(crate) struct SortedNetworkState {
     interfaces: Vec<Value>,
     #[serde(rename = "ovs-db")]
     ovsdb: OvsDbGlobalConfig,
+    #[serde(rename = "ovn")]
+    ovn: OvnConfiguration,
 }
 
 const IFACE_TOP_PRIORTIES: [&str; 2] = ["name", "type"];
@@ -91,6 +93,7 @@ pub(crate) fn sort_netstate(
             rules: net_state.rules,
             dns: net_state.dns,
             ovsdb: net_state.ovsdb,
+            ovn: net_state.ovn,
         });
     }
 
@@ -101,6 +104,7 @@ pub(crate) fn sort_netstate(
         rules: net_state.rules,
         dns: net_state.dns,
         ovsdb: net_state.ovsdb,
+        ovn: net_state.ovn,
     })
 }
 

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -99,6 +99,7 @@ mod net_state;
 #[cfg(feature = "query_apply")]
 mod nispor;
 mod nm;
+mod ovn;
 mod ovs;
 #[cfg(feature = "query_apply")]
 mod ovsdb;
@@ -157,6 +158,8 @@ pub use crate::lldp::{
 pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
 pub(crate) use crate::net_state::MergedNetworkState;
 pub use crate::net_state::NetworkState;
+#[cfg(feature = "query_apply")]
+pub use crate::ovn::OvnConfiguration;
 pub(crate) use crate::ovs::MergedOvsDbGlobalConfig;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -404,7 +404,7 @@ impl MergedNetworkState {
             current.ovsdb,
             current.ovn.clone().bridge_mappings,
         )?;
-        let ovn_config = MergedOvnConfiguration::new(desired.ovn, current.ovn);
+        let ovn_config = MergedOvnConfiguration::new(desired.ovn, current.ovn)?;
         if let Some(updated_mapping_value) =
             ovn_config.clone().mappings_ext_id_value
         {

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -400,7 +400,7 @@ impl MergedNetworkState {
             MergedHostNameState::new(desired.hostname, current.hostname);
 
         let mut ovsdb =
-            MergedOvsDbGlobalConfig::new(desired.ovsdb, current.ovsdb);
+            MergedOvsDbGlobalConfig::new(desired.ovsdb, current.ovsdb)?;
         let ovn_config = MergedOvnConfiguration::new(desired.ovn, current.ovn);
         if let Some(updated_mapping_value) =
             ovn_config.clone().mappings_ext_id_value

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -399,8 +399,11 @@ impl MergedNetworkState {
         let hostname =
             MergedHostNameState::new(desired.hostname, current.hostname);
 
-        let mut ovsdb =
-            MergedOvsDbGlobalConfig::new(desired.ovsdb, current.ovsdb)?;
+        let mut ovsdb = MergedOvsDbGlobalConfig::new(
+            desired.ovsdb,
+            current.ovsdb,
+            current.ovn.clone().bridge_mappings,
+        )?;
         let ovn_config = MergedOvnConfiguration::new(desired.ovn, current.ovn);
         if let Some(updated_mapping_value) =
             ovn_config.clone().mappings_ext_id_value

--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+pub const OVN_BRIDGE_MAPPINGS: &str = "ovn-bridge-mappings";
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(deny_unknown_fields)]
+/// Global OVN bridge mapping configuration. Example yaml output of [crate::NetworkState]:
+/// ```yml
+/// ---
+/// ovn:
+///   bridge-mappings:
+///   - localnet: tenantblue
+///     bridge: ovsbr1
+///     state: present
+///   - localnet: tenantred
+///     bridge: ovsbr1
+///     state: absent
+/// ```
+pub struct OvnConfiguration {
+    #[serde(
+        rename = "bridge-mappings",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub bridge_mappings: Option<Vec<OvnBridgeMapping>>,
+}
+
+impl OvnConfiguration {
+    pub fn is_none(&self) -> bool {
+        self.bridge_mappings.is_none()
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct MergedOvnConfiguration {
+    pub(crate) desired: OvnConfiguration,
+    pub(crate) current: OvnConfiguration,
+    pub(crate) bridge_mappings: Vec<OvnBridgeMapping>,
+    pub(crate) mappings_ext_id_value: Option<String>,
+}
+
+impl MergedOvnConfiguration {
+    // Partial editing for ovn:
+    //  * Merge desire with current and do overriding.
+    //  * To remove a particular ovn-bridge-mapping, do `state: absent`
+    pub(crate) fn new(
+        desired: OvnConfiguration,
+        current: OvnConfiguration,
+    ) -> Self {
+        let current_mappings: Vec<OvnBridgeMapping> =
+            current.bridge_mappings.clone().unwrap_or_default();
+
+        let mut indexed_current_mappings: HashMap<String, OvnBridgeMapping> =
+            HashMap::new();
+        for mapping in current_mappings.clone() {
+            indexed_current_mappings
+                .insert(mapping.clone().localnet, mapping.clone());
+        }
+
+        if let Some(mappings) = desired.bridge_mappings.clone() {
+            for mapping in &mappings {
+                indexed_current_mappings
+                    .insert(mapping.clone().localnet, mapping.clone());
+            }
+        }
+
+        let ovn_bridge_mappings: Vec<OvnBridgeMapping> =
+            indexed_current_mappings
+                .clone()
+                .iter()
+                .filter(|(_, v)| {
+                    v.state.unwrap_or_default()
+                        == OvnBridgeMappingState::Present
+                })
+                .map(|(_, v)| v.clone())
+                .collect();
+
+        if desired.clone().bridge_mappings.unwrap_or(Vec::new())
+            != current_mappings
+        {
+            let updated_ovn_bridge_mappings_ext_ids_value: Option<String> =
+                match ovn_bridge_mappings.is_empty() {
+                    true => Some("".to_string()),
+                    false => Some(ovn_bridge_mappings_to_string(
+                        ovn_bridge_mappings.clone(),
+                    )),
+                };
+
+            return Self {
+                desired,
+                current,
+                bridge_mappings: ovn_bridge_mappings,
+                mappings_ext_id_value:
+                    updated_ovn_bridge_mappings_ext_ids_value,
+            };
+        }
+
+        Self {
+            desired,
+            current,
+            bridge_mappings: ovn_bridge_mappings,
+            mappings_ext_id_value: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OvnBridgeMapping {
+    pub localnet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<OvnBridgeMappingState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OvnBridgeMappingError {
+    mapping_wannabe: String,
+}
+
+impl std::error::Error for OvnBridgeMappingError {}
+impl OvnBridgeMappingError {
+    fn new(reason: &str) -> Self {
+        Self {
+            mapping_wannabe: reason.to_string(),
+        }
+    }
+}
+impl fmt::Display for OvnBridgeMappingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "expected `<localnet>:<bridge>`, got: {}",
+            self.mapping_wannabe
+        )
+    }
+}
+
+impl FromStr for OvnBridgeMapping {
+    type Err = OvnBridgeMappingError;
+    fn from_str(s: &str) -> Result<OvnBridgeMapping, OvnBridgeMappingError> {
+        let vec: Vec<&str> = s.split(':').collect();
+        if vec.len() != 2 {
+            return Err(OvnBridgeMappingError::new(s));
+        }
+        let physnet: String = vec[0].to_string();
+        let bridge: String = vec[1].to_string();
+        if physnet.is_empty() || bridge.is_empty() {
+            return Err(OvnBridgeMappingError::new(s));
+        }
+        Ok(OvnBridgeMapping {
+            localnet: physnet,
+            bridge: Some(bridge),
+            state: Some(OvnBridgeMappingState::Present),
+        })
+    }
+}
+
+impl ToString for OvnBridgeMapping {
+    fn to_string(&self) -> String {
+        format!(
+            "{}:{}",
+            self.localnet,
+            self.bridge.clone().unwrap_or("".to_string())
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
+#[non_exhaustive]
+pub enum OvnBridgeMappingState {
+    Present,
+    Absent,
+}
+
+impl Default for OvnBridgeMappingState {
+    fn default() -> Self {
+        Self::Present
+    }
+}
+
+pub fn ovn_bridge_mappings_to_string(
+    ovn_bridge_mappings: Vec<OvnBridgeMapping>,
+) -> String {
+    if ovn_bridge_mappings.is_empty() {
+        return "".to_string();
+    }
+    ovn_bridge_mappings
+        .iter()
+        .filter(|mapping| mapping.bridge.is_some())
+        .map(|mapping| mapping.to_string())
+        .fold("".to_string(), |mappings, mapping| {
+            if mappings.is_empty() {
+                mapping
+            } else {
+                format!("{mappings},{mapping}")
+            }
+        })
+}

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -28,6 +28,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
     ret.prop_list.push("interfaces");
     ret.prop_list.push("ovsdb");
+    ret.prop_list.push("ovn");
     let mut cli = OvsDbConnection::new()?;
     let ovsdb_ifaces = cli.get_ovs_ifaces()?;
     let ovsdb_brs = cli.get_ovs_bridges()?;

--- a/rust/src/lib/query_apply/mod.rs
+++ b/rust/src/lib/query_apply/mod.rs
@@ -14,6 +14,7 @@ mod mac_vlan;
 mod mac_vtap;
 mod mptcp;
 mod net_state;
+pub(crate) mod ovn;
 mod ovs;
 mod route;
 mod route_rule;

--- a/rust/src/lib/query_apply/ovn.rs
+++ b/rust/src/lib/query_apply/ovn.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ovn::{MergedOvnConfiguration, OvnBridgeMapping};
+use crate::state::get_json_value_difference;
+use crate::ErrorKind::InvalidArgument;
+use crate::{ErrorKind, NmstateError, OvnConfiguration};
+use std::str::FromStr;
+
+impl MergedOvnConfiguration {
+    pub(crate) fn verify(
+        &self,
+        current: &OvnConfiguration,
+    ) -> Result<(), NmstateError> {
+        let mut ovn_bridge_mappings: Vec<OvnBridgeMapping> =
+            self.bridge_mappings.clone();
+
+        let desired = OvnConfiguration {
+            bridge_mappings: match ovn_bridge_mappings.is_empty() {
+                true => None,
+                false => {
+                    ovn_bridge_mappings
+                        .sort_by(|v1, v2| v1.localnet.cmp(&v2.localnet));
+                    Some(ovn_bridge_mappings)
+                }
+            },
+        };
+
+        let desired_value = serde_json::to_value(desired)?;
+        let current_value = if current.is_none() {
+            serde_json::to_value(OvnConfiguration {
+                bridge_mappings: Some(Vec::new()),
+            })?
+        } else {
+            serde_json::to_value(current)?
+        };
+
+        if let Some((reference, desire, current)) = get_json_value_difference(
+            "ovn".to_string(),
+            &desired_value,
+            &current_value,
+        ) {
+            Err(NmstateError::new(
+                ErrorKind::VerificationError,
+                format!(
+                    "Verification failure: {reference} desire '{desire}', \
+                    current '{current}'"
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub fn string_to_ovn_bridge_mappings(
+    mappings_string: String,
+) -> Result<Vec<OvnBridgeMapping>, NmstateError> {
+    if mappings_string.is_empty() {
+        return Ok(Vec::default());
+    }
+    let mut mappings: Vec<OvnBridgeMapping> = Vec::new();
+    for mapping_str in mappings_string.split(',') {
+        match OvnBridgeMapping::from_str(mapping_str) {
+            Ok(mapping) => mappings.push(mapping),
+            Err(e) => {
+                return Err(NmstateError::new(InvalidArgument, e.to_string()))
+            }
+        }
+    }
+    if mappings.is_empty() {
+        Ok(Vec::default())
+    } else {
+        Ok(mappings)
+    }
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -31,6 +31,8 @@ mod net_state;
 #[cfg(test)]
 mod nm;
 #[cfg(test)]
+mod ovn;
+#[cfg(test)]
 mod ovs;
 #[cfg(test)]
 mod ovsdb;

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -223,3 +223,41 @@ fn test_multiple_mappings_with_required_data() {
         "localnet1:br1,localnet2:br2"
     )
 }
+
+#[test]
+fn test_sanitize_mapping_add_without_bridge() {
+    let mapping = OvnBridgeMapping {
+        localnet: "localnet1".to_string(),
+        state: Default::default(),
+        bridge: None,
+    };
+    assert_eq!(
+        mapping.sanitize(),
+        Err(
+            NmstateError::new(
+                InvalidArgument,
+                "mapping for `localnet` key localnet1 missing the `bridge` attribute".to_string()
+            )
+        )
+    )
+}
+
+#[test]
+fn test_sanitize_correct_mapping_add() {
+    let mapping = OvnBridgeMapping {
+        localnet: "localnet1".to_string(),
+        state: Default::default(),
+        bridge: Some("bridge".to_string()),
+    };
+    assert_eq!(mapping.sanitize(), Ok(()))
+}
+
+#[test]
+fn test_sanitize_correct_mapping_remove() {
+    let mapping = OvnBridgeMapping {
+        localnet: "localnet1".to_string(),
+        state: Some(OvnBridgeMappingState::Absent),
+        bridge: None,
+    };
+    assert_eq!(mapping.sanitize(), Ok(()))
+}

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -1,0 +1,192 @@
+use crate::ovn::{
+    ovn_bridge_mappings_to_string, MergedOvnConfiguration, OvnBridgeMapping,
+    OvnBridgeMappingState,
+};
+use crate::query_apply::ovn::string_to_ovn_bridge_mappings;
+use crate::ErrorKind::InvalidArgument;
+use crate::{NmstateError, OvnConfiguration};
+
+#[test]
+fn test_ovsdb_merge_with_mappings() {
+    let desired: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings:
+- localnet: net1
+  state: present
+  bridge: br1
+"#,
+    )
+    .unwrap();
+
+    let current: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings: []
+        "#,
+    )
+    .unwrap();
+
+    let merged_ovsdb = MergedOvnConfiguration::new(desired, current);
+
+    let expect: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings:
+- localnet: net1
+  state: present
+  bridge: br1
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        merged_ovsdb.bridge_mappings,
+        expect.bridge_mappings.unwrap()
+    );
+}
+
+#[test]
+fn test_ovsdb_merge_delete_existing_mappings() {
+    let desired: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings:
+- localnet: net1
+  state: absent
+  bridge: br1
+"#,
+    )
+    .unwrap();
+
+    let current: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings:
+- localnet: net1
+  state: present
+  bridge: br1
+"#,
+    )
+    .unwrap();
+
+    let merged_ovsdb = MergedOvnConfiguration::new(desired, current);
+
+    let expect: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+bridge-mappings: []
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        merged_ovsdb.bridge_mappings,
+        expect.bridge_mappings.unwrap_or_default()
+    );
+}
+
+#[test]
+fn test_ovsdb_empty_string_to_ovn_bridge_mappings() {
+    let input_string = "";
+    assert_eq!(
+        string_to_ovn_bridge_mappings(input_string.to_string()),
+        Ok(Vec::new())
+    )
+}
+
+#[test]
+fn test_ovsdb_string_without_localnet_to_ovn_bridge_mappings() {
+    let input_string = ":br1";
+    assert_eq!(
+        string_to_ovn_bridge_mappings(input_string.to_string()),
+        Err(NmstateError::new(
+            InvalidArgument,
+            "expected `<localnet>:<bridge>`, got: :br1".to_string()
+        ))
+    )
+}
+
+#[test]
+fn test_ovsdb_string_without_bridge_to_ovn_bridge_mappings() {
+    let input_string = "net1:";
+    assert_eq!(
+        string_to_ovn_bridge_mappings(input_string.to_string()),
+        Err(NmstateError::new(
+            InvalidArgument,
+            "expected `<localnet>:<bridge>`, got: net1:".to_string()
+        ))
+    )
+}
+
+#[test]
+fn test_ovsdb_string_to_ovn_bridge_mappings() {
+    let input_string = "net1:br1";
+    assert_eq!(
+        string_to_ovn_bridge_mappings(input_string.to_string()),
+        Ok(vec!(OvnBridgeMapping {
+            localnet: "net1".to_string(),
+            bridge: Some("br1".to_string()),
+            state: Some(OvnBridgeMappingState::Present)
+        }))
+    )
+}
+
+#[test]
+fn test_ovsdb_string_to_multiple_ovn_bridge_mappings() {
+    let input_string = "net1:br1,net32:br1";
+    assert_eq!(
+        string_to_ovn_bridge_mappings(input_string.to_string()),
+        Ok(vec!(
+            OvnBridgeMapping {
+                localnet: "net1".to_string(),
+                bridge: Some("br1".to_string()),
+                state: Some(OvnBridgeMappingState::Present)
+            },
+            OvnBridgeMapping {
+                localnet: "net32".to_string(),
+                bridge: Some("br1".to_string()),
+                state: Some(OvnBridgeMappingState::Present)
+            },
+        ))
+    )
+}
+
+#[test]
+fn test_empty_mappings() {
+    assert_eq!(ovn_bridge_mappings_to_string(Vec::new()), "")
+}
+
+#[test]
+fn test_mappings_missing_bridge() {
+    let mappings: Vec<OvnBridgeMapping> = vec![OvnBridgeMapping {
+        localnet: "localnet1".to_string(),
+        state: Default::default(),
+        bridge: None,
+    }];
+    assert_eq!(ovn_bridge_mappings_to_string(mappings), "")
+}
+
+#[test]
+fn test_mappings_with_required_data() {
+    let mappings: Vec<OvnBridgeMapping> = vec![OvnBridgeMapping {
+        localnet: "localnet1".to_string(),
+        state: Default::default(),
+        bridge: Some("br1".to_string()),
+    }];
+    assert_eq!(ovn_bridge_mappings_to_string(mappings), "localnet1:br1")
+}
+
+#[test]
+fn test_multiple_mappings_with_required_data() {
+    let mappings: Vec<OvnBridgeMapping> = vec![
+        OvnBridgeMapping {
+            localnet: "localnet1".to_string(),
+            state: Default::default(),
+            bridge: Some("br1".to_string()),
+        },
+        OvnBridgeMapping {
+            localnet: "localnet2".to_string(),
+            state: Default::default(),
+            bridge: Some("br2".to_string()),
+        },
+    ];
+    assert_eq!(
+        ovn_bridge_mappings_to_string(mappings),
+        "localnet1:br1,localnet2:br2"
+    )
+}

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -38,7 +38,8 @@ other_config:
 
     let current = get_current_ovsdb_config();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r#"---
@@ -77,7 +78,8 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -111,7 +113,8 @@ other_config:
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -145,7 +148,8 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -164,7 +168,7 @@ fn test_ovsdb_verify_null_current() {
     let current = desired.clone();
 
     let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, pre_apply_current).unwrap();
+        MergedOvsDbGlobalConfig::new(desired, pre_apply_current, None).unwrap();
 
     merged_ovsdb.verify(&current).unwrap();
 }

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -38,7 +38,7 @@ other_config:
 
     let current = get_current_ovsdb_config();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current);
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r#"---
@@ -77,7 +77,7 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current);
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -111,7 +111,7 @@ other_config:
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current);
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -145,7 +145,7 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current);
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, current).unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -163,7 +163,8 @@ fn test_ovsdb_verify_null_current() {
     let pre_apply_current = desired.clone();
     let current = desired.clone();
 
-    let merged_ovsdb = MergedOvsDbGlobalConfig::new(desired, pre_apply_current);
+    let merged_ovsdb =
+        MergedOvsDbGlobalConfig::new(desired, pre_apply_current).unwrap();
 
     merged_ovsdb.verify(&current).unwrap();
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -316,6 +316,21 @@ class OvsDB:
     OTHER_CONFIG = "other_config"
 
 
+class Ovn:
+    KEY = "ovn"
+    OVN_SUBTREE = "ovn"
+    BRIDGE_MAPPINGS = "bridge-mappings"
+
+    class BridgeMappings:
+        LOCALNET = "localnet"
+        BRIDGE = "bridge"
+        STATE = "state"
+
+    class BridgeMappingsState:
+        PRESENT = "present"
+        ABSENT = "absent"
+
+
 class OVSInterface(OvsDB):
     TYPE = InterfaceType.OVS_INTERFACE
     PATCH_CONFIG_SUBTREE = "patch"

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -792,6 +792,16 @@ def test_ovn_global_config_modify_and_delete_mappings(
     assert state_match(desired_ovs_config, current_ovs_config)
 
 
+def test_ovsdb_global_config_cannot_use_ovn_bridge_mappings_external_id():
+    desired_ovs_config = {
+        OvsDB.EXTERNAL_IDS: {
+            TEST_EXTERNAL_IDS_MAPPING_KEY: TEST_EXTERNAL_IDS_MAPPING_VALUE,
+        }
+    }
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply({OvsDB.KEY: desired_ovs_config})
+
+
 @pytest.fixture
 def ovsdb_global_config_external_ids():
     ovs_config = {

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -814,6 +814,23 @@ def test_ovsdb_global_config_clearing_ext_ids_preserves_existing_mappings(
     assert current_ovs_config == ovn_bridge_mapping_net1
 
 
+def test_ovn_bridge_mappings_cannot_have_duplicate_localnet_keys():
+    desired_ovs_config = {
+        Ovn.BRIDGE_MAPPINGS: [
+            {
+                Ovn.BridgeMappings.LOCALNET: "net1",
+                Ovn.BridgeMappings.BRIDGE: "br321",
+            },
+            {
+                Ovn.BridgeMappings.LOCALNET: "net1",
+                Ovn.BridgeMappings.STATE: "absent",
+            },
+        ]
+    }
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply({Ovn.KEY: desired_ovs_config})
+
+
 @pytest.fixture
 def ovsdb_global_config_external_ids():
     ovs_config = {

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -802,6 +802,18 @@ def test_ovsdb_global_config_cannot_use_ovn_bridge_mappings_external_id():
         libnmstate.apply({OvsDB.KEY: desired_ovs_config})
 
 
+def test_ovsdb_global_config_clearing_ext_ids_preserves_existing_mappings(
+    ovn_bridge_mapping_net1,
+):
+    desired_ovs_config = {
+        OvsDB.EXTERNAL_IDS: {},
+    }
+    libnmstate.apply({OvsDB.KEY: desired_ovs_config})
+    current_ovs_config = libnmstate.show()[Ovn.KEY]
+
+    assert current_ovs_config == ovn_bridge_mapping_net1
+
+
 @pytest.fixture
 def ovsdb_global_config_external_ids():
     ovs_config = {


### PR DESCRIPTION
This PR introduces syntactic sugar for the OVN API to configure the bridge mappings through which OVN packets enter the underlay.

It addresses [this RFE](https://bugzilla.redhat.com/show_bug.cgi?id=2209690), which hopes to simplify (and make less error prone...) the configuration of the underlay for OVN-Kubernetes multi-networks.
More information about the OVN bridge mappings can be found [here](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/networking_guide/bridge-mappings).
