### PR TITLE
bond: Add support of arp_missed_max option

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1170,6 +1170,12 @@ pub struct BondOptions {
         alias = "balance-slb"
     )]
     pub balance_slb: Option<bool>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u8_or_string"
+    )]
+    pub arp_missed_max: Option<u8>,
 }
 
 impl BondOptions {

--- a/rust/src/lib/nispor/bond.rs
+++ b/rust/src/lib/nispor/bond.rs
@@ -183,6 +183,7 @@ fn np_bond_options_to_nmstate(np_iface: &nispor::Iface) -> BondOptions {
                     None
                 }
             });
+        options.arp_missed_max = np_bond.arp_missed_max;
     }
     options
 }

--- a/rust/src/lib/nm/settings/bond.rs
+++ b/rust/src/lib/nm/settings/bond.rs
@@ -199,6 +199,12 @@ fn apply_bond_options(
             if *v { "1".to_string() } else { "0".to_string() },
         );
     }
+    if let Some(v) = bond_opts.arp_missed_max.as_ref() {
+        let v_parsed: u8 = *v;
+        nm_bond_set
+            .options
+            .insert("arp_missed_max".to_string(), v_parsed.to_string());
+    }
 
     // Remove all empty string option
     nm_bond_set.options.retain(|_, v| !v.is_empty());

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2018-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import os
 import time
@@ -1278,5 +1261,19 @@ def test_remove_bond_and_assign_ip_to_bond_port(bond99_with_2_port):
         """,
         Loader=yaml.SafeLoader,
     )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="bond arp_missed_max is not supported by "
+    "Github CI Ubuntu 5.15 kernel",
+)
+def test_change_bond_option_arp_missed_max(bond99_with_2_port):
+    desired_state = statelib.show_only((BOND99,))
+    iface_state = desired_state[Interface.KEY][0]
+    bond_options = iface_state[Bond.CONFIG_SUBTREE][Bond.OPTIONS_SUBTREE]
+    bond_options["arp_missed_max"] = 200
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
Example yaml:

```yml
---
interfaces:
- name: bond99
  type: bond
  state: up
  link-aggregation:
    mode: balance-xor
    options:
      arp_missed_max: 100
```

Integration test case included and been marked as skipped as Ubuntu 5.15
kernel in Github CI does not support this feature(need kernel 5.17+ or
backport).