### PR TITLE
ip: Remove dependency on ipnet crate

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -22,10 +22,6 @@ serde_yaml = "0.9"
 version = "1.2.10"
 optional = true
 
-[dependencies.ipnet]
-version = "2.5.0"
-default-features = false
-
 [dependencies.zvariant]
 version = "2.10.0"
 default-features = false

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -119,12 +119,3 @@ impl From<std::net::AddrParseError> for NmstateError {
         )
     }
 }
-
-impl From<ipnet::AddrParseError> for NmstateError {
-    fn from(e: ipnet::AddrParseError) -> Self {
-        NmstateError::new(
-            ErrorKind::InvalidArgument,
-            format!("Invalid IP network: {e}"),
-        )
-    }
-}

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    unit_tests::testlib::new_eth_iface, BaseInterface, ErrorKind, Interface,
-    InterfaceState, Interfaces, MergedInterfaces,
+    ip::sanitize_ip_network, unit_tests::testlib::new_eth_iface, BaseInterface,
+    ErrorKind, Interface, InterfaceState, Interfaces, MergedInterfaces,
 };
 
 fn gen_test_eth_ifaces() -> Interfaces {
@@ -329,4 +329,89 @@ fn test_should_not_have_ipv4_in_ipv6_section() {
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
+}
+
+#[test]
+fn test_sanitize_ip_network_empty_str() {
+    let result = sanitize_ip_network("");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_str() {
+    let result = sanitize_ip_network("192.0.2.1/24/");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_ipv4_prefix_length() {
+    let result = sanitize_ip_network("192.0.2.1/33");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_ipv6_prefix_length() {
+    let result = sanitize_ip_network("::1/129");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_gateway() {
+    assert_eq!(sanitize_ip_network("0.0.0.1/0").unwrap(), "0.0.0.0/0");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_gateway() {
+    assert_eq!(sanitize_ip_network("::1/0").unwrap(), "::/0");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_host_only() {
+    assert_eq!(sanitize_ip_network("192.0.2.1").unwrap(), "192.0.2.1/32");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_host_only() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::0").unwrap(),
+        "2001:db8:1::/128"
+    );
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_host_only_explicit() {
+    assert_eq!(sanitize_ip_network("192.0.2.1/32").unwrap(), "192.0.2.1/32");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_host_only_explicit() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::0/128").unwrap(),
+        "2001:db8:1::/128"
+    );
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_net() {
+    assert_eq!(sanitize_ip_network("192.0.3.1/23").unwrap(), "192.0.2.0/23");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_net() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::f/64").unwrap(),
+        "2001:db8:1::/64"
+    );
 }


### PR DESCRIPTION
The new ipnet 2.8 release breaks our compiling. Considering we only use
a very few functions from ipnet, I have replace the ipnet usage to self
maintaining code.

Unit test cases included.