### PR TITLE
[nmstate-1.4] route-rule: Differentiate IP family for route table search

### DIFF
--- a/libnmstate/route_rule.py
+++ b/libnmstate/route_rule.py
@@ -208,28 +208,75 @@ class RouteRuleState:
                 }
             }
         """
-        route_rule_metadata = {}
+        route_rule_metadata = defaultdict(
+            lambda: {Interface.IPV4: [], Interface.IPV6: []}
+        )
         for route_table, rules in self._rules.items():
-            iface_name = self._iface_for_route_table(
-                route_state, route_table, ifaces
-            )
+            rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
+            cur_rules_ipfamily = {Interface.IPV4: set(), Interface.IPV6: set()}
+            for rule in self._cur_rules[route_table]:
+                cur_rules_ipfamily[
+                    Interface.IPV6 if rule.is_ipv6 else Interface.IPV4
+                ].add(rule)
+            for rule in rules:
+                rules_ipfamily[
+                    Interface.IPV6 if rule.is_ipv6 else Interface.IPV4
+                ].add(rule)
+            if len(rules_ipfamily[Interface.IPV4]) != 0:
+                self._add_rule_to_matadata(
+                    route_state,
+                    ifaces,
+                    Interface.IPV4,
+                    route_table,
+                    cur_rules_ipfamily,
+                    rules_ipfamily,
+                    route_rule_metadata,
+                )
+            if len(rules_ipfamily[Interface.IPV6]) != 0:
+                self._add_rule_to_matadata(
+                    route_state,
+                    ifaces,
+                    Interface.IPV6,
+                    route_table,
+                    cur_rules_ipfamily,
+                    rules_ipfamily,
+                    route_rule_metadata,
+                )
+        return route_rule_metadata
+
+    def _add_rule_to_matadata(
+        self,
+        route_state,
+        ifaces,
+        ip_family,
+        route_table,
+        cur_rules_ipfamily,
+        rules_ipfamily,
+        route_rule_metadata,
+    ):
+        iface_name = self._iface_for_route_table(
+            route_state, route_table, ifaces, ip_family
+        )
+        if route_rule_metadata.get(iface_name) is None:
             route_rule_metadata[iface_name] = {
                 Interface.IPV4: [],
                 Interface.IPV6: [],
             }
-            if rules != self._cur_rules[route_table]:
-                route_rule_metadata[iface_name][
-                    BaseIface.RULE_CHANGED_METADATA
-                ] = True
-            for rule in rules:
-                family = Interface.IPV6 if rule.is_ipv6 else Interface.IPV4
-                route_rule_metadata[iface_name][family].append(rule.to_dict())
-        return route_rule_metadata
+        if rules_ipfamily[ip_family] != cur_rules_ipfamily[ip_family]:
+            route_rule_metadata[iface_name][
+                BaseIface.RULE_CHANGED_METADATA
+            ] = True
+        for rule in rules_ipfamily[ip_family]:
+            route_rule_metadata[iface_name][ip_family].append(rule.to_dict())
 
-    def _iface_for_route_table(self, route_state, route_table, ifaces):
+    def _iface_for_route_table(
+        self, route_state, route_table, ifaces, ip_family
+    ):
         for routes in route_state.config_iface_routes.values():
             for route in routes:
-                if route.table_id == route_table:
+                if route.table_id == route_table and ifaces.get(
+                    route.next_hop_interface, {}
+                ).to_dict().get(ip_family, {}).get(InterfaceIP.ENABLED):
                     return route.next_hop_interface
 
         for iface in ifaces.values():

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -22,10 +22,6 @@ serde_yaml = "0.9"
 version = "1.2.10"
 optional = true
 
-[dependencies.ipnet]
-version = "2.5.0"
-default-features = false
-
 [dependencies.zvariant]
 version = "2.10.0"
 default-features = false

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -119,12 +119,3 @@ impl From<std::net::AddrParseError> for NmstateError {
         )
     }
 }
-
-impl From<ipnet::AddrParseError> for NmstateError {
-    fn from(e: ipnet::AddrParseError) -> Self {
-        NmstateError::new(
-            ErrorKind::InvalidArgument,
-            format!("Invalid IP network: {e}"),
-        )
-    }
-}

--- a/rust/src/lib/nm/nm_dbus/gen_conf/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ip.rs
@@ -8,7 +8,7 @@ impl ToKeyfile for NmSettingIp {
     fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
         for (k, v) in self.to_value()?.drain() {
-            if !vec!["address-data", "route-data", "dns", "routing-rules"]
+            if !["address-data", "route-data", "dns", "routing-rules"]
                 .contains(&k)
             {
                 ret.insert(k.to_string(), v);

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    unit_tests::testlib::new_eth_iface, BaseInterface, ErrorKind, Interface,
-    InterfaceState, Interfaces, MergedInterfaces,
+    ip::sanitize_ip_network, unit_tests::testlib::new_eth_iface, BaseInterface,
+    ErrorKind, Interface, InterfaceState, Interfaces, MergedInterfaces,
 };
 
 fn gen_test_eth_ifaces() -> Interfaces {
@@ -329,4 +329,89 @@ fn test_should_not_have_ipv4_in_ipv6_section() {
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
+}
+
+#[test]
+fn test_sanitize_ip_network_empty_str() {
+    let result = sanitize_ip_network("");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_str() {
+    let result = sanitize_ip_network("192.0.2.1/24/");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_ipv4_prefix_length() {
+    let result = sanitize_ip_network("192.0.2.1/33");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_invalid_ipv6_prefix_length() {
+    let result = sanitize_ip_network("::1/129");
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_gateway() {
+    assert_eq!(sanitize_ip_network("0.0.0.1/0").unwrap(), "0.0.0.0/0");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_gateway() {
+    assert_eq!(sanitize_ip_network("::1/0").unwrap(), "::/0");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_host_only() {
+    assert_eq!(sanitize_ip_network("192.0.2.1").unwrap(), "192.0.2.1/32");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_host_only() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::0").unwrap(),
+        "2001:db8:1::/128"
+    );
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_host_only_explicit() {
+    assert_eq!(sanitize_ip_network("192.0.2.1/32").unwrap(), "192.0.2.1/32");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_host_only_explicit() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::0/128").unwrap(),
+        "2001:db8:1::/128"
+    );
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv4_net() {
+    assert_eq!(sanitize_ip_network("192.0.3.1/23").unwrap(), "192.0.2.0/23");
+}
+
+#[test]
+fn test_sanitize_ip_network_ipv6_net() {
+    assert_eq!(
+        sanitize_ip_network("2001:db8:1::f/64").unwrap(),
+        "2001:db8:1::/64"
+    );
 }


### PR DESCRIPTION
User might using the same route table ID for IPv4 and IPv6 on different
interfaces, when user desiring a route rule, nmstate are expected to
find the correct interface for it.

Integration test case included.