### PR TITLE
test: Remove test_new_bond_uses_mac_of_first_port_by_name from tier1

### DIFF
--- a/rust/src/lib/nm/nm_dbus/gen_conf/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ip.rs
@@ -8,7 +8,7 @@ impl ToKeyfile for NmSettingIp {
     fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
         let mut ret = HashMap::new();
         for (k, v) in self.to_value()?.drain() {
-            if !vec!["address-data", "route-data", "dns", "routing-rules"]
+            if !["address-data", "route-data", "dns", "routing-rules"]
                 .contains(&k)
             {
                 ret.insert(k.to_string(), v);

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -737,7 +737,10 @@ def _nmcli_simulate_boot(ifname):
     time.sleep(1)
 
 
-@pytest.mark.tier1
+# TODO: This test case has random failure in Github CI and NMCI environment,
+#       considering this is a ovirt use case which holds low priority,
+#       we remove it from tier1 temporary till issue been resolved.
+# @pytest.mark.tier1
 def test_new_bond_uses_mac_of_first_port_by_name(eth1_eth2_with_no_profile):
     """
     On system boot, NetworkManager will by default activate port in the


### PR DESCRIPTION
The `test_new_bond_uses_mac_of_first_port_by_name` test case has random
failure in Github CI and NMCI environment, considering this is a ovirt
use case which holds low priority,
Let's remove it from tier1 temporary till issue been resolved.