### PR TITLE
sriov: Use SR-IOV specific retry for VF parameter changes

### DIFF
--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -120,12 +120,11 @@ impl NetworkState {
         // hence when user want `enable-and-use` single-transaction for SR-IOV,
         // they need define the interface type. It is overkill to do resolve at
         // this point for this corner use case.
-        let pf_state =
-            if self.has_vf_count_change_and_missing_eth(&cur_net_state) {
-                self.get_sriov_pf_conf_state()
-            } else {
-                None
-            };
+        let pf_state = if self.has_sriov_and_missing_eth(&cur_net_state) {
+            self.get_sriov_pf_conf_state()
+        } else {
+            None
+        };
 
         if pf_state.is_none() {
             // Do early pre-apply validation before checkpoint.
@@ -142,9 +141,7 @@ impl NetworkState {
         // interface type defined, we need merged_state to have `unknown` type
         // resolved
         let verify_count = if pf_state.is_some()
-            || merged_state
-                .as_ref()
-                .map(|s| s.interfaces.has_vf_count_change())
+            || merged_state.as_ref().map(|s| s.interfaces.has_sriov())
                 == Some(true)
         {
             timeout = VERIFY_RETRY_COUNT_SRIOV as u32

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -628,7 +628,7 @@ fn test_sriov_enable_and_use_in_single_yaml() {
 }
 
 #[test]
-fn test_sriov_has_vf_count_change_and_missing_eth() {
+fn test_has_sriov_and_missing_eth() {
     let desired = serde_yaml::from_str::<NetworkState>(
         r#"---
         interfaces:
@@ -666,11 +666,11 @@ fn test_sriov_has_vf_count_change_and_missing_eth() {
     )
     .unwrap();
 
-    assert!(desired.has_vf_count_change_and_missing_eth(&current));
+    assert!(desired.has_sriov_and_missing_eth(&current));
 }
 
 #[test]
-fn test_sriov_has_vf_count_change_and_missing_eth_pf_none() {
+fn test_sriov_has_sriov_and_missing_eth_pf_none() {
     let desired = serde_yaml::from_str::<NetworkState>(
         r#"---
         interfaces:
@@ -700,7 +700,7 @@ fn test_sriov_has_vf_count_change_and_missing_eth_pf_none() {
     )
     .unwrap();
 
-    assert!(desired.has_vf_count_change_and_missing_eth(&current));
+    assert!(desired.has_sriov_and_missing_eth(&current));
 }
 
 #[test]
@@ -791,7 +791,7 @@ fn test_sriov_vf_revert_to_default() {
 }
 
 #[test]
-fn test_has_vf_change_with_unknown_iface_type() {
+fn test_has_sriov_with_unknown_iface_type() {
     let desired = serde_yaml::from_str::<Interfaces>(
         r#"---
         - name: eth1
@@ -818,5 +818,5 @@ fn test_has_vf_change_with_unknown_iface_type() {
     let merged_ifaces =
         MergedInterfaces::new(desired, current, false, false).unwrap();
 
-    assert!(merged_ifaces.has_vf_count_change());
+    assert!(merged_ifaces.has_sriov());
 }


### PR DESCRIPTION
Previously, we think only VF count changes need extra retry, but we
noticed when ethtool or other config applied to PF, a full activation is
required in NM where SR-IOV will be disable and re-enable. Hence we
change the verify count for any desire state has SR-IOV interface.

Unit test case updated, integration test case added.