### PR TITLE
Misc fixes on `cargo vendor-filterer`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,9 @@ dist: manpage $(SPEC_FILE) $(CLIB_HEADER)
 	mv $(TMPDIR)/$(TARBALL) ./
 	if [ $(RELEASE) == 1 ];then \
 		cd rust; \
-		cargo vendor-filterer \
-			--platform x86_64-unknown-linux-gnu \
-			--platform s390x-unknown-linux-gnu $(TMPDIR)/vendor; \
+		cargo vendor-filterer $(TMPDIR)/vendor || \
+		(echo -en "\nNot cargo-vendor-filterer, Please install via "; \
+		 echo -e "'cargo install cargo-vendor-filterer'\n";); \
 		cd $(TMPDIR); \
 		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL) vendor ; \
 	fi

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.x86_64-unknown-linux-gnu]
+[target.'cfg(target_os="linux")']
 rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,3 +4,9 @@ members = [
     "src/clib",
     "src/lib",
 ]
+
+[workspace.metadata.vendor-filter]
+# For now we only care about tier 1+2 Linux
+platforms = ["*-unknown-linux-gnu"]
+tier = "2"
+all-features = true


### PR DESCRIPTION
* Also fix SONAME on non-x86_64 linux build target.
* Store cargo vendor filterer into `Cargo.toml`.
* Guide user to run `cargo install cargo-vendor-filterer` when `cargo vendor-filterer` failed.