### PR TITLE
nm: Preserve gateway when not desired

### DIFF
--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -72,6 +72,7 @@ fn gen_nm_ipv4_setting(
             iface_ip.auto_table_id,
         );
         // Clean old routes
+        nm_setting.gateway = None;
         nm_setting.routes = Vec::new();
         if Some(false) == iface_ip.dhcp_send_hostname {
             nm_setting.dhcp_send_hostname = Some(false);
@@ -95,14 +96,15 @@ fn gen_nm_ipv4_setting(
             }
         }
     }
-    nm_setting.gateway = None;
     if iface_ip.enabled {
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, false)?;
+            nm_setting.gateway = None;
         }
     } else {
         // Clean up static routes if ip is disabled
         nm_setting.routes = Vec::new();
+        nm_setting.gateway = None;
     }
     if let Some(rules) = iface_ip.rules.as_ref() {
         nm_setting.route_rules = gen_nm_ip_rules(rules, false)?;
@@ -193,6 +195,7 @@ fn gen_nm_ipv6_setting(
             iface_ip.auto_table_id,
         );
         // Clean old routes
+        nm_setting.gateway = None;
         nm_setting.routes = Vec::new();
         if Some(false) == iface_ip.dhcp_send_hostname {
             nm_setting.dhcp_send_hostname = Some(false);
@@ -209,14 +212,15 @@ fn gen_nm_ipv6_setting(
     } else {
         nm_setting.token = None;
     }
-    nm_setting.gateway = None;
     if iface_ip.enabled {
         if let Some(routes) = routes {
             nm_setting.routes = gen_nm_ip_routes(routes, true)?;
+            nm_setting.gateway = None;
         }
     } else {
         // Clean up static routes if ip is disabled
         nm_setting.routes = Vec::new();
+        nm_setting.gateway = None;
     }
     if let Some(rules) = iface_ip.rules.as_ref() {
         nm_setting.route_rules = gen_nm_ip_rules(rules, true)?;

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from libnmstate.schema import Route
+import libnmstate
+import pytest
+import yaml
+
+from ..testlib.cmdlib import exec_cmd
+from ..testlib.route import assert_routes
+
+TEST_GATEAY4 = "192.0.2.1"
+TEST_GATEAY6 = "2001:db8:2::"
+
+
+@pytest.fixture
+def eth1_with_old_gateway_format():
+    libnmstate.apply(
+        yaml.load(
+            """---
+            dns-resolver:
+              config: {}
+            interfaces:
+            - name: eth1
+              state: up
+              mtu: 1500
+              ipv4:
+                address:
+                - ip: 192.0.2.252
+                  prefix-length: 24
+                dhcp: false
+                enabled: true
+              ipv6:
+                address:
+                  - ip: 2001:db8:2::1
+                    prefix-length: 64
+                autoconf: false
+                dhcp: false
+                enabled: true
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+    exec_cmd(
+        f"nmcli c modify eth1 ipv4.gateway {TEST_GATEAY4} "
+        f"ipv6.gateway {TEST_GATEAY6}".split(),
+        check=True,
+    )
+    exec_cmd("nmcli c up eth1".split(), check=True)
+
+
+def test_preserve_old_gateway(eth1_with_old_gateway_format):
+    libnmstate.apply(
+        yaml.load(
+            """---
+            dns-resolver:
+              config:
+                server:
+                - 2001:4860:4860::8888
+                - 8.8.8.8
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+    cur_state = libnmstate.show()
+    assert_routes(
+        [
+            {
+                Route.NEXT_HOP_INTERFACE: "eth1",
+                Route.DESTINATION: "0.0.0.0/0",
+                Route.NEXT_HOP_ADDRESS: TEST_GATEAY4,
+            },
+            {
+                Route.NEXT_HOP_INTERFACE: "eth1",
+                Route.DESTINATION: "::/0",
+                Route.NEXT_HOP_ADDRESS: TEST_GATEAY6,
+            },
+        ],
+        cur_state,
+    )

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import copy
+
+from libnmstate.schema import Route
+
+
+def _assert_in_current_route(route, current_routes):
+    route_in_current_routes = False
+    for current_route in current_routes:
+        current_route.pop(Route.METRIC, None)
+        table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
+        if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
+            current_route = copy.deepcopy(current_route)
+            current_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+
+        if route == current_route:
+            route_in_current_routes = True
+            break
+    assert route_in_current_routes
+
+
+def assert_routes(routes, state, nic="eth1"):
+    routes = copy.deepcopy(routes)
+    for route in routes:
+        # Ignore metric difference like nmstate production code
+        route.pop(Route.METRIC, None)
+        if Route.TABLE_ID not in route:
+            route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+    routes.sort(key=_route_sort_key)
+    config_routes = []
+    for config_route in state[Route.KEY][Route.CONFIG]:
+        if config_route[Route.NEXT_HOP_INTERFACE] == nic:
+            config_routes.append(config_route)
+
+    # The kernel routes contains more route entries than desired config
+    # The kernel routes also has different metric and table id for
+    # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
+    config_routes.sort(key=_route_sort_key)
+    for route in routes:
+        _assert_in_current_route(route, config_routes)
+    running_routes = state[Route.KEY][Route.RUNNING]
+    for route in routes:
+        _assert_in_current_route(route, running_routes)
+
+
+def _route_sort_key(route):
+    return (
+        route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE),
+        route.get(Route.NEXT_HOP_INTERFACE, ""),
+        route.get(Route.DESTINATION, ""),
+    )


### PR DESCRIPTION
Nmstate is using `routes` instead of `gateway` for storing gateway.
When a NM connection has IP config change without route changes, the
gateway stored in `gateway` property will lose.

To fix that, we do not reset `gateway` property unless IP been disabled
or has route changes.

Integration test case included.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2212741