### PR TITLE
ethtool: Sort features when serialize (rust api break)

### DIFF
--- a/rust/src/lib/nispor/ethtool.rs
+++ b/rust/src/lib/nispor/ethtool.rs
@@ -18,7 +18,7 @@ fn gen_ethtool_config(ethtool_info: &nispor::EthtoolInfo) -> EthtoolConfig {
         ret.pause = Some(pause_config);
     }
     if let Some(feature) = &ethtool_info.features {
-        ret.feature = Some(feature.changeable.clone());
+        ret.feature = Some(feature.changeable.clone().into());
     }
     if let Some(coalesce) = &ethtool_info.coalesce {
         let mut coalesce_config = EthtoolCoalesceConfig::new();

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::EthernetInterface;
+use crate::{EthernetInterface, EthtoolFeatureConfig};
 
 #[test]
 fn test_ethtool_stringlized_attributes() {
@@ -112,4 +112,18 @@ ethtool:
     assert_eq!(ring.rx_mini_max, Some(205));
     assert_eq!(ring.tx, Some(206));
     assert_eq!(ring.tx_max, Some(207));
+}
+
+#[test]
+fn test_ethtool_sort_features_when_serialize() {
+    let features: EthtoolFeatureConfig = serde_yaml::from_str(
+        r#"---
+        b: true
+        a: true
+        c: true"#,
+    )
+    .unwrap();
+
+    let yml_out = serde_yaml::to_string(&features).unwrap();
+    assert_eq!(yml_out, "a: true\nb: true\nc: true\n");
 }


### PR DESCRIPTION
In order to sort the features when serialize, we need to change
definition of `EthtoolFeatureConfig` from type alias of `HashMap` to a
private struct.

In order to minimize the impact, has implemented these:

 * `From<HashMap<String, bool>> for EthtoolFeatureConfig`
   Rust API use can simply add `.into()` to their code converting
   HashMap to `EthtoolFeatureConfig`.

 * `impl<'a> IntoIterator for &'a EthtoolFeatureConfig`
   Rust API can still use iterator over &EthtoolFeatureConfig like the
   did.

 * `remove()`, `insert()`, `get()`.

Unit test case included for checking serialize.