### PR TITLE
gen_conf: Fix ECMP route

### DIFF
--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use super::super::NmIpRoute;
 
@@ -20,10 +21,12 @@ impl NmIpRoute {
                 (None, None) => vec![dest],
             };
             ret.insert("".to_string(), rt_line.join(","));
-            ret.insert(
-                "options".to_string(),
-                format!("table={}", self.table.unwrap_or(DEFAULT_ROUTE_TABLE)),
-            );
+            let mut opt_string =
+                format!("table={}", self.table.unwrap_or(DEFAULT_ROUTE_TABLE));
+            if let Some(weight) = self.weight {
+                write!(opt_string, ",weight={}", weight).ok();
+            }
+            ret.insert("options".to_string(), opt_string);
         }
         ret
     }

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2022 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
 
@@ -26,12 +9,15 @@ import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceType
 from libnmstate.schema import OVSBridge
+from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
-from ..testlib.env import is_k8s
 from ..testlib import iprule
-from ..testlib.statelib import show_only
+from ..testlib.env import is_k8s
+from ..testlib.env import nm_minor_version
 from ..testlib.genconf import gen_conf_apply
+from ..testlib.route import assert_routes
+from ..testlib.statelib import show_only
 
 
 NM_CONFIG_FOLDER = "/etc/NetworkManager/system-connections"
@@ -155,3 +141,42 @@ def verify_ovs_ports(bridge_name, port_names):
     ]
     cur_ports.sort()
     assert cur_ports == port_names
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 41, reason="ECMP route is only support on NM 1.41+"
+)
+def test_gen_conf_ecmp_routes():
+    desired_state = load_yaml(
+        """---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+
+        routes:
+          config:
+          - destination: 198.51.100.0/24
+            metric: 150
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+            weight: 1
+            table-id: 254
+          - destination: 198.51.100.0/24
+            metric: 150
+            next-hop-address: 192.0.2.2
+            next-hop-interface: eth1
+            weight: 256
+            table-id: 254
+        """
+    )
+    with gen_conf_apply(desired_state):
+        desired_routes = desired_state[Route.KEY][Route.CONFIG]
+        cur_state = libnmstate.show()
+        assert_routes(desired_routes, cur_state)


### PR DESCRIPTION
The `gen_conf` should include ECMP weight.

Integration test case included.