### PR TITLE
route rule: Support suppress-prefix-length

### DIFF
--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -69,6 +69,7 @@ pub(crate) fn get_route_rules(
         rule.priority = np_rule.priority.map(i64::from);
         rule.fwmark = np_rule.fw_mark;
         rule.fwmask = np_rule.fw_mask;
+        rule.suppress_prefix_length = np_rule.suppress_prefix_len;
         rule.family = match np_rule.address_family {
             nispor::AddressFamily::IPv4 => Some(AddressFamily::IPv4),
             nispor::AddressFamily::IPv6 => Some(AddressFamily::IPv6),

--- a/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
@@ -34,6 +34,7 @@ pub struct NmIpRouteRule {
     pub fw_mask: Option<u32>,
     pub iifname: Option<String>,
     pub action: Option<NmIpRouteRuleAction>,
+    pub suppress_prefixlength: Option<i32>,
     _other: DbusDictionary,
 }
 
@@ -53,6 +54,11 @@ impl TryFrom<DbusDictionary> for NmIpRouteRule {
             iifname: _from_map!(v, "iifname", String::try_from)?,
             action: _from_map!(v, "action", u8::try_from)?
                 .map(NmIpRouteRuleAction::from),
+            suppress_prefixlength: _from_map!(
+                v,
+                "suppress-prefixlength",
+                i32::try_from
+            )?,
             _other: v,
         })
     }
@@ -128,6 +134,12 @@ impl NmIpRouteRule {
             ret.append(
                 zvariant::Value::new("action"),
                 zvariant::Value::new(zvariant::Value::new(u8::from(*v))),
+            )?;
+        }
+        if let Some(v) = &self.suppress_prefixlength {
+            ret.append(
+                zvariant::Value::new("suppress-prefixlength"),
+                zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }
 

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
@@ -49,6 +49,10 @@ impl NmIpRouteRule {
                 keys.push(from_str);
             }
 
+            if let Some(v) = self.suppress_prefixlength {
+                keys.push(format!("suppress_prefixlength {v}"));
+            }
+
             let mut table_str = format!("table {DEFAULT_ROUTE_TABLE}");
             if let Some(table) = self.table {
                 table_str = format!("table {table}");

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::convert::TryFrom;
 use std::ops::BitXor;
 
 use super::super::nm_dbus::{
@@ -302,6 +303,17 @@ fn nm_rules_to_nmstate(
         }
         if let Some(v) = nm_rule.iifname.as_ref() {
             rule.iif = Some(v.to_string());
+        }
+        if let Some(v) = nm_rule.suppress_prefixlength {
+            match u32::try_from(v) {
+                Ok(i) => rule.suppress_prefix_length = Some(i),
+                Err(e) => {
+                    log::warn!(
+                        "BUG: Failed to convert `suppress_prefixlength` \
+                        got from NM: {v} to u32: {e}"
+                    );
+                }
+            }
         }
         if let Some(v) = nm_rule.action.as_ref() {
             rule.action = Some(match v {

--- a/rust/src/lib/nm/settings/route_rule.rs
+++ b/rust/src/lib/nm/settings/route_rule.rs
@@ -72,6 +72,18 @@ pub(crate) fn gen_nm_ip_rules(
         if let Some(action) = rule.action.as_ref() {
             nm_rule.action = Some(u8::from(*action).into());
         }
+        if let Some(v) = rule.suppress_prefix_length.as_ref() {
+            nm_rule.suppress_prefixlength =
+                Some(i32::try_from(*v).map_err(|e| {
+                    NmstateError::new(
+                        ErrorKind::NotSupportedError,
+                        format!(
+                            "Specified suppress-prefix-length {v} is \
+                            not supported by NetworkManager: {e}"
+                        ),
+                    )
+                })?);
+        }
 
         ret.push(nm_rule);
     }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -65,6 +65,7 @@ class RouteRule:
     ACTION_BLACKHOLE = "blackhole"
     ACTION_UNREACHABLE = "unreachable"
     ACTION_PROHIBIT = "prohibit"
+    SUPPRESS_PREFIX_LENGTH = "suppress-prefix-length"
 
 
 class DNS:

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -152,16 +152,8 @@ def test_add_remove_route_rule(eth1_up):
     with example_state(
         "eth1_add_route_rule.yml", cleanup="eth1_del_all_route_rules.yml"
     ) as desired_state:
-        rule = desired_state[RouteRule.KEY][RouteRule.CONFIG][0]
-        iprule.ip_rule_exist_in_os(
-            rule.get(RouteRule.IP_FROM),
-            rule.get(RouteRule.IP_TO),
-            rule.get(RouteRule.PRIORITY),
-            rule.get(RouteRule.ROUTE_TABLE),
-            rule.get(RouteRule.FWMARK),
-            rule.get(RouteRule.FWMASK),
-            rule.get(RouteRule.FAMILY),
-        )
+        for rule in desired_state[RouteRule.KEY][RouteRule.CONFIG]:
+            iprule.ip_rule_exist_in_os(rule)
 
 
 @pytest.mark.skipif(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1259,15 +1259,7 @@ def test_add_route_rule_to_ovs_interface_dhcp_auto_route_table(
     desired_state = {RouteRule.KEY: {RouteRule.CONFIG: [route_rule]}}
     libnmstate.apply(desired_state)
 
-    iprule.ip_rule_exist_in_os(
-        route_rule.get(RouteRule.IP_FROM),
-        route_rule.get(RouteRule.IP_TO),
-        route_rule.get(RouteRule.PRIORITY),
-        route_rule.get(RouteRule.ROUTE_TABLE),
-        route_rule.get(RouteRule.FWMARK),
-        route_rule.get(RouteRule.FWMASK),
-        route_rule.get(RouteRule.FAMILY),
-    )
+    iprule.ip_rule_exist_in_os(route_rule)
 
 
 @pytest.fixture

--- a/tests/integration/testlib/genconf.py
+++ b/tests/integration/testlib/genconf.py
@@ -7,6 +7,8 @@ import libnmstate
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
+from libnmstate.schema import Route
+from libnmstate.schema import RouteRule
 
 from .cmdlib import exec_cmd
 
@@ -29,7 +31,14 @@ def gen_conf_apply(desire_state):
         activate_all_nm_connections()
         yield
     finally:
-        absent_state = {DNS.KEY: {DNS.CONFIG: {}}, Interface.KEY: []}
+        absent_state = {
+            DNS.KEY: {DNS.CONFIG: {}},
+            Interface.KEY: [],
+            Route.KEY: {Route.CONFIG: [{Route.STATE: Route.STATE_ABSENT}]},
+            RouteRule.KEY: {
+                RouteRule.CONFIG: [{RouteRule.STATE: RouteRule.STATE_ABSENT}]
+            },
+        }
         for iface_name in iface_names:
             absent_state[Interface.KEY].append(
                 {

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -4,20 +4,22 @@ import json
 import logging
 
 from libnmstate import iplib
+from libnmstate.schema import RouteRule
 from . import cmdlib
 
 
-def ip_rule_exist_in_os(
-    ip_from,
-    ip_to,
-    priority,
-    table,
-    fwmark,
-    fwmask,
-    family,
-    iif=None,
-    action=None,
-):
+def ip_rule_exist_in_os(rule):
+    ip_from = rule.get(RouteRule.IP_FROM)
+    ip_to = rule.get(RouteRule.IP_TO)
+    priority = rule.get(RouteRule.PRIORITY)
+    table = rule.get(RouteRule.ROUTE_TABLE)
+    fwmark = rule.get(RouteRule.FWMARK)
+    fwmask = rule.get(RouteRule.FWMASK)
+    family = rule.get(RouteRule.FAMILY)
+    iif = rule.get(RouteRule.IIF)
+    action = rule.get(RouteRule.ACTION)
+    suppress_prefix_len = rule.get(RouteRule.SUPPRESS_PREFIX_LENGTH)
+
     expected_rule = locals()
     logging.debug("Checking ip rule for {}".format(expected_rule))
     cmds = ["ip"]
@@ -67,10 +69,16 @@ def ip_rule_exist_in_os(
         if fwmask is not None and rule["fwmask"] != hex(fwmask):
             found = False
             continue
-        if iif is not None and rule["iif"] != iif:
+        if iif is not None and rule.get("iif") != iif:
             found = False
             continue
         if action is not None and rule["action"] != action:
+            found = False
+            continue
+        if (
+            suppress_prefix_len is not None
+            and rule.get("suppress_prefixlen") != suppress_prefix_len
+        ):
             found = False
             continue
         if found:


### PR DESCRIPTION
Adding support of ip route rule `suppress-prefix-length` which equal to
`suppress_prefixlength` option in `ip route` command.

Example:

```
route-rules:
  config:
    - ip-from: 192.168.3.2/32
      suppress-prefix-length: 0
      route-table: 200
    - ip-from: 2001:db8:b::/64
      suppress-prefix-length: 1
      route-table: 200
```

Integration test cases included.