### PR TITLE
test: Use correct config for ignore carrier

### DIFF
--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -35,7 +35,8 @@ RETRY_TIMEOUT = 10
 
 IGNORE_CARRIER_CFG_FILE = "/etc/NetworkManager/conf.d/ignore_carrier.conf"
 IGNORE_CARRIER_CFG_CONTENT = """
-[main]
+[device]
+match-device=interface-name:*
 ignore-carrier=no
 """
 


### PR DESCRIPTION
This is the preferred config for ignore carrier on all interfaces.

```
[device]
match-device=interface-name:*
ignore-carrier=no
```