### PR TITLE
ovn, ovsdb: mappings changes do not clear ext ids keys

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -173,6 +173,9 @@ impl<'de> Deserialize<'de> for NetworkState {
             net_state.prop_list.push("ovn");
             net_state.ovn = OvnConfiguration::deserialize(ovn_value)
                 .map_err(serde::de::Error::custom)?;
+            if net_state.ovn.bridge_mappings.as_ref().is_some() {
+                net_state.ovsdb.prop_list.push("mappings");
+            }
         }
         if let Some(hostname_value) = v.remove("hostname") {
             net_state.prop_list.push("hostname");

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -843,6 +843,21 @@ def ovsdb_global_config_external_ids():
     )
 
 
+def test_mappings_update_does_not_clear_other_ext_ids(
+    ovsdb_global_config_external_ids,
+    ovn_bridge_mapping_net1,
+):
+    current_ovs_config = libnmstate.show()[OvsDB.KEY]
+    assert current_ovs_config.pop(OvsDB.OTHER_CONFIG) == {}
+    assert (
+        ovsdb_global_config_external_ids[OvsDB.EXTERNAL_IDS].items()
+        <= current_ovs_config[OvsDB.EXTERNAL_IDS].items()
+    )
+
+    current_ovn_config = libnmstate.show()[Ovn.KEY]
+    assert current_ovn_config == ovn_bridge_mapping_net1
+
+
 def test_ovsdb_global_config_untouched_if_not_defined(
     ovsdb_global_config_external_ids,
 ):


### PR DESCRIPTION
When adding/deleting a mapping (and not changing anything under the ovsdb key) we were causing the external IDs / other config of the ovsdb to be cleared, since the ovsdb property list was empty - [0].

This commit changes that, and ensures that when mappings are provided, the ovsdb properly list has something, which in turn will prevent the external ids, and other_config maps from being cleared.

[0] - https://github.com/nmstate/nmstate/blob/6a87b702f8c130fe9825f738177105f7913e9918/rust/src/lib/ovs.rs#L168

Fixes: #2395 