### PR TITLE
nm: Do not use `Other` interface type

### DIFF
--- a/rust/src/lib/nm/nm_dbus/device.rs
+++ b/rust/src/lib/nm/nm_dbus/device.rs
@@ -346,4 +346,5 @@ pub struct NmDevice {
     pub is_mac_vtap: bool,
     pub obj_path: String,
     pub real: bool,
+    pub mac_address: String,
 }

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -117,9 +117,13 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
                 .iter()
                 .find(|c| c.iface_name() == Some(iface.name())),
         ) {
-            if let (Some(base_iface), Interface::OvsInterface(ovs_iface)) =
+            if let (Some(mut base_iface), Interface::OvsInterface(ovs_iface)) =
                 (nm_conn_to_base_iface(nm_dev, nm_conn, None, None), iface)
             {
+                base_iface.iface_type = InterfaceType::OvsInterface;
+                if !base_iface.prop_list.contains(&"iface_type") {
+                    base_iface.prop_list.push("iface_type");
+                }
                 ovs_iface.base = base_iface;
             }
         }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -70,6 +70,7 @@ impl NetworkState {
         if !self.include_secrets {
             self.hide_secrets();
         }
+
         // Purge user space ignored interfaces
         self.interfaces
             .user_ifaces

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2156,3 +2156,25 @@ def test_allow_extra_ovs_patch_ports(ovs_bridge_with_patch_ports):
     patch1_state = statelib.show_only((PATCH1,))
 
     assert patch1_state[Interface.KEY][0][Interface.CONTROLLER] == BRIDGE1
+
+
+@pytest.fixture
+def ovs_bridge_with_geneve(bridge_with_ports):
+    cmdlib.exec_cmd(
+        "ovs-vsctl add-port br1 gen0 -- set interface gen0 type=geneve "
+        "options:remote_ip=192.0.2.1 options:key=123".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd(
+        "ovs-vsctl del-port br1 gen0".split(),
+        check=True,
+    )
+
+
+@pytest.mark.tier1
+def test_ignore_ovs_geneve_iface(ovs_bridge_with_geneve):
+    cur_state = statelib.show_only(("genev_sys_6081",))
+    assert (
+        cur_state[Interface.KEY][0][Interface.STATE] == InterfaceState.IGNORE
+    )


### PR DESCRIPTION
For OVS geneve interface, nmstate is incorrect showing it as managed
even NM marked it as unmanaged.

The root cause is NM is using `InterfaceType::Other("generic")` for this
kind of interface, while nispor is showing it as Ethernet interface.
Since `InterfaceType::Other` is treated as user space interface, the
merging will not working correctly.

To fix the issue, for NM unknown interface, we set the interface type to
`InterfaceType::Unknown` which is a kernel interface.

Reference bug: https://bugzilla.redhat.com/show_bug.cgi?id=2232578

Tier1 test case included.