### PR TITLE
ovs: Deny unknown field for global and iface ovsdb

### DIFF
--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -36,15 +36,23 @@ impl<'de> Deserialize<'de> for OvsDbGlobalConfig {
         D: Deserializer<'de>,
     {
         let mut ret = Self::default();
-        let v = serde_json::Value::deserialize(deserializer)?;
-        if let Some(v) = v.as_object() {
-            if let Some(v) = v.get("external_ids") {
+        let mut v = serde_json::Value::deserialize(deserializer)?;
+        if let Some(v) = v.as_object_mut() {
+            if let Some(v) = v.remove("external_ids") {
                 ret.prop_list.push("external_ids");
-                ret.external_ids = Some(value_to_hash_map(v));
+                ret.external_ids = Some(value_to_hash_map(&v));
             }
-            if let Some(v) = v.get("other_config") {
+            if let Some(v) = v.remove("other_config") {
                 ret.prop_list.push("other_config");
-                ret.other_config = Some(value_to_hash_map(v));
+                ret.other_config = Some(value_to_hash_map(&v));
+            }
+            if !v.is_empty() {
+                let remain_keys: Vec<String> = v.keys().cloned().collect();
+                return Err(serde::de::Error::custom(format!(
+                    "Unsupported section names '{}', only supports \
+                    `external_ids` and `other_config`",
+                    remain_keys.join(", ")
+                )));
             }
         } else {
             return Err(serde::de::Error::custom(format!(
@@ -101,13 +109,21 @@ impl<'de> Deserialize<'de> for OvsDbIfaceConfig {
         D: Deserializer<'de>,
     {
         let mut ret = Self::default();
-        let v = serde_json::Value::deserialize(deserializer)?;
-        if let Some(v) = v.as_object() {
-            if let Some(v) = v.get("external_ids") {
-                ret.external_ids = Some(value_to_hash_map(v));
+        let mut v = serde_json::Value::deserialize(deserializer)?;
+        if let Some(v) = v.as_object_mut() {
+            if let Some(v) = v.remove("external_ids") {
+                ret.external_ids = Some(value_to_hash_map(&v));
             }
-            if let Some(v) = v.get("other_config") {
-                ret.other_config = Some(value_to_hash_map(v));
+            if let Some(v) = v.remove("other_config") {
+                ret.other_config = Some(value_to_hash_map(&v));
+            }
+            if !v.is_empty() {
+                let remain_keys: Vec<String> = v.keys().cloned().collect();
+                return Err(serde::de::Error::custom(format!(
+                    "Unsupported section names '{}', only supports \
+                    `external_ids` and `other_config`",
+                    remain_keys.join(", ")
+                )));
             }
         } else {
             return Err(serde::de::Error::custom(format!(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1017,13 +1017,17 @@ class TestOvsPatch:
                     {
                         Interface.NAME: PATCH0,
                         OvsDB.KEY: {
-                            "foo": "abc",
+                            OvsDB.EXTERNAL_IDS: {
+                                "foo": "abc",
+                            }
                         },
                     },
                     {
                         Interface.NAME: PATCH1,
                         OvsDB.KEY: {
-                            "foo": "abd",
+                            OvsDB.EXTERNAL_IDS: {
+                                "foo": "abd",
+                            }
                         },
                     },
                 ]

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2182,3 +2182,32 @@ def test_ignore_ovs_geneve_iface(ovs_bridge_with_geneve):
     assert (
         cur_state[Interface.KEY][0][Interface.STATE] == InterfaceState.IGNORE
     )
+
+
+def test_raise_error_on_unknown_ovsdb_iface_section(bridge_with_ports):
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: PORT1,
+                        OvsDB.KEY: {
+                            "foo": "abc",
+                            "bar": "abd",
+                        },
+                    },
+                ]
+            }
+        )
+
+
+def test_raise_error_on_unknown_ovsdb_global_section():
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                OvsDB.KEY: {
+                    "foo": "abc",
+                    "bar": "abd",
+                },
+            }
+        )


### PR DESCRIPTION
Since we using customized deserializer for ovsdb, we should deny unknown
field by ourselves.

Integration test case included.