### PR TITLE
cli: Fix `persist-nic-names` on bond port

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -27,8 +27,9 @@ serde_json = "1.0.75"
 ctrlc = { version = "3.2.1", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
 chrono = "0.4"
+nispor = { version = "1.2", optional = true }
 
 [features]
 default = ["query_apply", "gen_conf"]
-query_apply = ["nmstate/query_apply", "ctrlc"]
+query_apply = ["nmstate/query_apply", "ctrlc", "nispor"]
 gen_conf = ["nmstate/gen_conf"]

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -127,7 +127,6 @@ pub struct BaseInterface {
     /// Ethtool configurations
     pub ethtool: Option<EthtoolConfig>,
     #[serde(skip)]
-    /// TODO: internal use, hide it.
     pub controller_type: Option<InterfaceType>,
     // The interface lowest up_priority will be activated first.
     // The up_priority should be its controller's up_priority


### PR DESCRIPTION
When interface been attached to bond, all bond ports might holding the
same MAC address of bond.

Invoking `persist-nic-names` on bond port which does not have permanence
MAC address will cause nmstatectl using this incorrect MAC to persistent
the NIC name.

To fix this problem, for bond port, we find its permanence MAC address
first, if failed, we use MAC address stored in netlink
`IFLA_BOND_PORT_PERM_HWADDR` message. The current MAC address will never
been use for bond port.

In order to retrieve the `IFLA_BOND_PORT_PERM_HWADDR`, we introduce
dependency on `nispor` to get such information. Considering `nmstate` crate
also depend on `nispor`, we are not expanding our dependency chain.