### PR TITLE
dns: Support DNS options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ doc/nmstate-autoconf.8
 
 nmstate-*.tar.gz
 nmstate-*.tar.gz.asc
+/tags

--- a/examples/dns_edit_eth1.yml
+++ b/examples/dns_edit_eth1.yml
@@ -7,6 +7,9 @@ dns-resolver:
     server:
       - 2001:4860:4860::8888
       - 8.8.8.8
+    options:
+      - rotate
+      - debug
 routes:
   config:
     - destination: 0.0.0.0/0

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -3,7 +3,7 @@
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
 use super::{
-    dns::{store_dns_config_to_iface, store_dns_search_only_to_iface},
+    dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
     profile::perpare_nm_conns,
     route::store_route_config,
     route_rule::store_route_rule_config,
@@ -28,8 +28,8 @@ pub(crate) fn nm_gen_conf(
     let mut merged_state = merged_state.clone();
     store_route_config(&mut merged_state)?;
     store_route_rule_config(&mut merged_state)?;
-    if merged_state.dns.is_search_only() {
-        store_dns_search_only_to_iface(&mut merged_state, &[], &[])?;
+    if merged_state.dns.is_search_or_option_only() {
+        store_dns_search_or_option_to_iface(&mut merged_state, &[], &[])?;
     } else {
         store_dns_config_to_iface(&mut merged_state, &[], &[])?;
     }

--- a/rust/src/lib/nm/nm_dbus/connection/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/dns.rs
@@ -89,6 +89,19 @@ pub(crate) fn parse_nm_dns_search(
     })
 }
 
+pub(crate) fn parse_nm_dns_options(
+    value: zvariant::OwnedValue,
+) -> Result<Vec<String>, NmError> {
+    Vec::<String>::try_from(value).map_err(|e| {
+        let e = NmError::new(
+            ErrorKind::InvalidArgument,
+            format!("In valid DNS options: {e}"),
+        );
+        log::error!("{}", e);
+        e
+    })
+}
+
 pub(crate) fn nm_ip_dns_to_value(
     dns_srvs: &[String],
 ) -> Result<zvariant::Value, NmError> {
@@ -145,6 +158,17 @@ pub(crate) fn nm_ip_dns_search_to_value(
         zvariant::Array::new(zvariant::Signature::from_str_unchecked("s"));
     for search in dns_searches {
         values.append(zvariant::Value::new(search))?;
+    }
+    Ok(zvariant::Value::Array(values))
+}
+
+pub(crate) fn nm_ip_dns_options_to_value(
+    dns_options: &[String],
+) -> Result<zvariant::Value, NmError> {
+    let mut values =
+        zvariant::Array::new(zvariant::Signature::from_str_unchecked("s"));
+    for option in dns_options {
+        values.append(zvariant::Value::new(option))?;
     }
     Ok(zvariant::Value::Array(values))
 }

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -9,8 +9,9 @@ use serde::Deserialize;
 
 use super::super::{
     connection::dns::{
-        nm_ip_dns_search_to_value, nm_ip_dns_to_value, parse_nm_dns,
-        parse_nm_dns_data, parse_nm_dns_search,
+        nm_ip_dns_options_to_value, nm_ip_dns_search_to_value,
+        nm_ip_dns_to_value, parse_nm_dns, parse_nm_dns_data,
+        parse_nm_dns_options, parse_nm_dns_search,
     },
     connection::route::{
         nm_ip_routes_to_value, parse_nm_ip_route_data, NmIpRoute,
@@ -90,6 +91,7 @@ pub struct NmSettingIp {
     pub dns_priority: Option<i32>,
     pub dns_search: Option<Vec<String>>,
     pub dns: Option<Vec<String>>,
+    pub dns_options: Option<Vec<String>>,
     pub ignore_auto_dns: Option<bool>,
     pub never_default: Option<bool>,
     pub ignore_auto_routes: Option<bool>,
@@ -128,6 +130,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
                 .unwrap_or_default(),
             dns_search: _from_map!(v, "dns-search", parse_nm_dns_search)?,
             dns_priority: _from_map!(v, "dns-priority", i32::try_from)?,
+            dns_options: _from_map!(v, "dns-options", parse_nm_dns_options)?,
             ignore_auto_dns: _from_map!(v, "ignore-auto-dns", bool::try_from)?,
             never_default: _from_map!(v, "never-default", bool::try_from)?,
             ignore_auto_routes: _from_map!(
@@ -229,6 +232,9 @@ impl ToDbusValue for NmSettingIp {
         }
         if let Some(dns_searches) = self.dns_search.as_ref() {
             ret.insert("dns-search", nm_ip_dns_search_to_value(dns_searches)?);
+        }
+        if let Some(dns_options) = self.dns_options.as_ref() {
+            ret.insert("dns-options", nm_ip_dns_options_to_value(dns_options)?);
         }
         if let Some(dns_priority) = self.dns_priority {
             ret.insert("dns-priority", zvariant::Value::new(dns_priority));

--- a/rust/src/lib/nm/nm_dbus/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/dns.rs
@@ -54,7 +54,11 @@ impl NmGlobalDnsConfig {
             && self.domains.is_empty()
     }
 
-    pub fn new_wildcard(searches: Vec<String>, servers: Vec<String>) -> Self {
+    pub fn new_wildcard(
+        searches: Vec<String>,
+        servers: Vec<String>,
+        options: Vec<String>,
+    ) -> Self {
         let mut domains = HashMap::new();
         domains.insert(
             "*".to_string(),
@@ -66,7 +70,7 @@ impl NmGlobalDnsConfig {
         Self {
             searches,
             domains,
-            options: Vec::new(),
+            options,
         }
     }
 

--- a/rust/src/lib/nm/settings/dns.rs
+++ b/rust/src/lib/nm/settings/dns.rs
@@ -11,4 +11,5 @@ pub(crate) fn apply_nm_dns_setting(
     nm_ip_setting.dns = dns_conf.server.clone();
     nm_ip_setting.dns_search = dns_conf.search.clone();
     nm_ip_setting.dns_priority = dns_conf.priority;
+    nm_ip_setting.dns_options = dns_conf.options.clone();
 }

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -62,6 +62,30 @@ impl MergedDnsState {
                 ),
             ));
         }
+        let mut des_opts = self.options.clone();
+        des_opts.sort_unstable();
+
+        let mut cur_opts: Vec<String> = current
+            .config
+            .as_ref()
+            .and_then(|c| c.options.as_ref())
+            .cloned()
+            .unwrap_or_default();
+
+        cur_opts.sort_unstable();
+
+        if des_opts != cur_opts {
+            return Err(NmstateError::new(
+                ErrorKind::VerificationError,
+                format!(
+                    "Failed to apply DNS config: desire options '{}', \
+                    got '{}'",
+                    des_opts.as_slice().join(" "),
+                    cur_opts.as_slice().join(" "),
+                ),
+            ));
+        }
+
         Ok(())
     }
 }

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -218,6 +218,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
                     "example.org".to_string(),
                 ]),
                 priority: Some(10),
+                ..Default::default()
             }
         })
     };

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -74,6 +74,7 @@ class DNS:
     CONFIG = "config"
     SERVER = "server"
     SEARCH = "search"
+    OPTIONS = "options"
 
 
 class Constants:

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -190,3 +190,24 @@ def test_static_dns_search_with_auto_dns(auto_eth1):
         "nmcli -t -f ipv6.dns-search c show eth1".split(), check=True
     )[1]
     assert "ipv6.dns-search:example.org,example.net" in output
+
+
+def test_global_dns_with_dns_options():
+    try:
+        libnmstate.apply(
+            {
+                DNS.KEY: {
+                    DNS.CONFIG: {
+                        DNS.SERVER: ["8.8.8.8", "2620:fe::9", "1.1.1.1"],
+                        DNS.SEARCH: ["example.org", "example.net"],
+                        DNS.OPTIONS: ["rotate", "debug"],
+                    }
+                },
+            }
+        )
+    finally:
+        libnmstate.apply(
+            {
+                DNS.KEY: {DNS.CONFIG: {}},
+            }
+        )


### PR DESCRIPTION
Example on DNS options:

```yml
---
dns-resolver:
  config:
    options:
      - rotate
      - debug
```

Nmstate only support these DNS options:
 * `attempts`
 * `debug`
 * `edns0`
 * `inet6`
 * `ip6-bytestring`
 * `ip6-dotint`
 * `ndots`
 * `no-aaaa`
 * `no-check-names`
 * `no-ip6-dotint`
 * `no-reload`
 * `no-tld-query`
 * `rotate`
 * `single-request-reopen`
 * `single-request`
 * `timeout`
 * `trust-ad`
 * `use-vc`

Example YAML updated.
Integration test case included.