### PR TITLE
CI: Add container image for Fedora

### DIFF
--- a/packaging/Dockerfile.c8s-nmstate-build
+++ b/packaging/Dockerfile.c8s-nmstate-build
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream8
 
-RUN echo "2023-05-04" > /build_time
+RUN echo "2023-09-08" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
        git make rust-toolset rpm-build python3 python3-devel && \

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream8
 
-RUN echo "2023-05-04" > /build_time
+RUN echo "2023-09-08" > /build_time
 
 RUN sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
     -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \

--- a/packaging/Dockerfile.c9s-nmstate-build
+++ b/packaging/Dockerfile.c9s-nmstate-build
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN echo "2023-05-04" > /build_time
+RUN echo "2023-09-08" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
        systemd git make rust-toolset rpm-build python3 python3-devel && \

--- a/packaging/Dockerfile.fed_latest-nmstate-dev
+++ b/packaging/Dockerfile.fed_latest-nmstate-dev
@@ -1,14 +1,11 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.fedoraproject.org/fedora:latest
 
 RUN echo "2023-09-08" > /build_time
 
 RUN dnf update -y && \
-    dnf -y install dnf-plugins-core epel-release \
-        centos-release-nfv-openvswitch && \
-    dnf config-manager --set-enabled crb && \
     dnf -y install --setopt=install_weak_deps=False \
-        systemd make go rust-toolset NetworkManager NetworkManager-ovs \
-        NetworkManager-config-server openvswitch2.17 systemd-udev \
+        systemd make go rust NetworkManager NetworkManager-ovs \
+        NetworkManager-config-server openvswitch systemd-udev \
         python3-devel python3-pyyaml python3-setuptools dnsmasq git \
         iproute rpm-build python3-pytest python3-virtualenv python3-tox \
         tcpreplay wpa_supplicant hostapd libndp procps-ng dpdk nispor \

--- a/packaging/Dockerfile.fed_rawhide-nmstate-dev
+++ b/packaging/Dockerfile.fed_rawhide-nmstate-dev
@@ -1,14 +1,10 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.fedoraproject.org/fedora:rawhide
 
 RUN echo "2023-09-08" > /build_time
 
-RUN dnf update -y && \
-    dnf -y install dnf-plugins-core epel-release \
-        centos-release-nfv-openvswitch && \
-    dnf config-manager --set-enabled crb && \
-    dnf -y install --setopt=install_weak_deps=False \
-        systemd make go rust-toolset NetworkManager NetworkManager-ovs \
-        NetworkManager-config-server openvswitch2.17 systemd-udev \
+RUN dnf -y install --setopt=install_weak_deps=False \
+        systemd make go rust NetworkManager NetworkManager-ovs \
+        NetworkManager-config-server openvswitch systemd-udev \
         python3-devel python3-pyyaml python3-setuptools dnsmasq git \
         iproute rpm-build python3-pytest python3-virtualenv python3-tox \
         tcpreplay wpa_supplicant hostapd libndp procps-ng dpdk nispor \


### PR DESCRIPTION
NMCI would like to run test on Fedora, hence including Dockerfile for:
 * Fedora Rawhide
 * Fedora latest stable

The Fedora ELN does not have openvswitch yet, hence we skip it for now.