### PR TITLE
ci: Support Fedora latest and rawhide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,7 @@ jobs:
           - job_type: "c9s-nm_1.42-integ_tier1"
           - job_type: "c9s-nm_1.42-integ_tier2"
           - job_type: "c9s-nm_1.42-integ_slow"
+          - job_type: "fed-nm_stable-integ_tier1"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -21,36 +21,26 @@ TEST_ARG="--test-type $TEST_TYPE"
 
 CUSTOMIZE_ARG=""
 COPR_ARG=""
-RPM_DIR="rpms/el8"
 
 if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
+    TEST_ARG="$TEST_ARG --compiled-rpms-dir rpms/el8"
+elif [ $OS_TYPE == "fed" ];then
+    CONTAINER_IMAGE="quay.io/nmstate/fed-nmstate-dev:latest"
 elif [ $OS_TYPE == "c9s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c9s-nmstate-dev"
-    RPM_DIR="rpms/el9"
-elif [ $OS_TYPE == "ovs2_11" ];then
-    CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
-    CUSTOMIZE_ARG='--customize=
-        dnf remove -y openvswitch2.11 python3-openvswitch2.11;
-        dnf install -y openvswitch2.13 python3-openvswitch2.13;
-        systemctl restart openvswitch'
-elif [ $OS_TYPE == "vdsm_el8" ]; then
-    CONTAINER_IMAGE="quay.io/ovirt/vdsm-network-tests-functional"
+    TEST_ARG="$TEST_ARG --compiled-rpms-dir rpms/el9"
 else
     echo "Invalid OS type ${OS_TYPE}"
     exit 1
 fi
 
 if [ $NM_TYPE == "nm_main" ];then
-    COPR_ARG="--copr networkmanager/NetworkManager-main"
+    TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-main"
 fi
 
 if [ $NM_TYPE == "nm_1.42" ];then
-    COPR_ARG="--copr networkmanager/NetworkManager-1.42"
-fi
-
-if [ $TEST_TYPE == "vdsm" ];then
-    TEST_ARG="--test-vdsm"
+    TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-1.42"
 fi
 
 mkdir $TEST_ARTIFACTS_DIR || exit 1
@@ -72,5 +62,4 @@ env \
     $TEST_CMD \
         $TEST_ARG \
         --artifacts-dir $TEST_ARTIFACTS_DIR \
-        --compiled-rpms-dir $RPM_DIR \
-        $COPR_ARG "$CUSTOMIZE_ARG"
+        "$CUSTOMIZE_ARG"

--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -5,7 +5,7 @@ PROJECT_DIR="$(dirname $EXEC_DIR)"
 TEST_CMD="${EXEC_DIR}/run-tests.sh"
 
 options=$(getopt --options "" \
-    --long "copr:,rpm-dir:,help,debug-shell,el8,el9" \
+    --long "copr:,rpm-dir:,help,debug-shell,el8,el9,fed,rawhide" \
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -14,6 +14,12 @@ while true; do
         use_el8="1"
         ;;
     --el9)
+        ;;
+    --fed)
+        use_fed="1"
+        ;;
+    --rawhide)
+        use_rawhide="1"
         ;;
     --copr)
         shift
@@ -29,7 +35,7 @@ while true; do
     --help)
         set +x
         echo -n "$0 [--copr=...] [--rpm-dir=...] [--debug-shell] "
-        echo -n "[--el8] [--el9]"
+        echo -n "[--el8] [--el9] [--fed] [--rawhide]"
         echo
         exit
         ;;
@@ -59,6 +65,10 @@ fi
 
 if [[ -v use_el8 ]];then
     ARGS="$ARGS --el8"
+elif [[ -v use_fed ]];then
+    ARGS="$ARGS --fed"
+elif [[ -v use_rawhide ]];then
+    ARGS="$ARGS --rawhide"
 else
     ARGS="$ARGS --el9"
 fi

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -16,7 +16,8 @@ TEST_TYPE_INTEG_TIER1="integ_tier1"
 TEST_TYPE_INTEG_TIER2="integ_tier2"
 TEST_TYPE_INTEG_SLOW="integ_slow"
 
-FEDORA_IMAGE_DEV="docker.io/nmstate/fedora-nmstate-dev"
+FEDORA_IMAGE_DEV="quay.io/nmstate/fed-nmstate-dev:latest"
+RAWHIDE_IMAGE_DEV="quay.io/nmstate/fed-nmstate-dev:rawhide"
 CENTOS_8_STREAM_IMAGE_DEV="quay.io/nmstate/c8s-nmstate-dev"
 CENTOS_9_STREAM_IMAGE_DEV="quay.io/nmstate/c9s-nmstate-dev"
 
@@ -255,7 +256,7 @@ function run_customize_command {
 
 options=$(getopt --options "" \
     --long "customize:,pytest-args:,help,debug-shell,test-type:,\
-    el8,el9,centos-stream,copr:,artifacts-dir:,test-vdsm,machine,k8s,\
+    el8,el9,fed,rawhide,copr:,artifacts-dir:,test-vdsm,machine,k8s,\
     use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:" \
     -- "${@}")
 eval set -- "$options"
@@ -290,8 +291,11 @@ while true; do
     --el9)
         CONTAINER_IMAGE=$CENTOS_9_STREAM_IMAGE_DEV
         ;;
-    --centos-stream)
-        CONTAINER_IMAGE=$CENTOS_8_STREAM_IMAGE_DEV
+    --fed)
+        CONTAINER_IMAGE=$FEDORA_IMAGE_DEV
+        ;;
+    --rawhide)
+        CONTAINER_IMAGE=$RAWHIDE_IMAGE_DEV
         ;;
     --artifacts-dir)
         shift

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -1,9 +1,10 @@
-FROM registry.fedoraproject.org/fedora:rawhide
+FROM registry.fedoraproject.org/fedora:latest
 
 RUN echo "2023-09-08" > /build_time
 
-RUN dnf -y install --setopt=install_weak_deps=False \
-        systemd make go rust NetworkManager NetworkManager-ovs \
+RUN dnf update -y && \
+    dnf -y install --setopt=install_weak_deps=False \
+        systemd make go rust cargo NetworkManager NetworkManager-ovs \
         NetworkManager-config-server openvswitch systemd-udev \
         python3-devel python3-pyyaml python3-setuptools dnsmasq git \
         iproute rpm-build python3-pytest python3-virtualenv python3-tox \

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -1,10 +1,9 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:rawhide
 
 RUN echo "2023-09-08" > /build_time
 
-RUN dnf update -y && \
-    dnf -y install --setopt=install_weak_deps=False \
-        systemd make go rust NetworkManager NetworkManager-ovs \
+RUN dnf -y install --setopt=install_weak_deps=False \
+        systemd make go rust cargo NetworkManager NetworkManager-ovs \
         NetworkManager-config-server openvswitch systemd-udev \
         python3-devel python3-pyyaml python3-setuptools dnsmasq git \
         iproute rpm-build python3-pytest python3-virtualenv python3-tox \

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -32,7 +32,6 @@ from .testlib.bridgelib import generate_vlan_id_config
 from .testlib.bridgelib import generate_vlan_id_range_config
 from .testlib.bridgelib import linux_bridge
 from .testlib.cmdlib import exec_cmd
-from .testlib.env import is_fedora
 from .testlib.env import is_ubuntu_kernel
 from .testlib.env import nm_major_minor_version
 from .testlib.ifacelib import get_mac_address
@@ -250,15 +249,6 @@ def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.xfail(
-    is_fedora(),
-    reason=(
-        "On Fedora 31+, users need to explicitly configure the port MAC "
-        "due to changes to the default systemd config."
-    ),
-    raises=AssertionError,
-    strict=True,
-)
 def test_linux_bridge_uses_the_port_mac_implicitly(
     port0_up, bridge0_with_port0
 ):


### PR DESCRIPTION
Both `run-tests-in-nmci.sh` and `run-tests.sh` supports:
 * `--fed` to run test in Fedora latest
 * `--rawhide` to run test in Fedora rawhide

This patch is only for NMCI to utilize.

Will only enable Fedora test in nmstate CI till confirmed as stable and
all pass.