### PR TITLE
test: Change `test_add_iface_with_same_static_ipv4_address_to_existing` to tier2

### DIFF
--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -261,7 +261,6 @@ def test_add_ifaces_with_same_static_ipv4_address_in_one_transaction(
     assertlib.assert_state(desired_state)
 
 
-@pytest.mark.tier1
 def test_add_iface_with_same_static_ipv4_address_to_existing(
     setup_eth1_ipv4, eth2_up
 ):


### PR DESCRIPTION
The use case of `test_add_iface_with_same_static_ipv4_address_to_existing`
does not have actual use case attached, change to tier2.