### PR TITLE
macsec: rename parent property to base-iface

### DIFF
--- a/examples/macsec0_up.yml
+++ b/examples/macsec0_up.yml
@@ -5,7 +5,7 @@ interfaces:
     state: up
     macsec:
       encrypt: true
-      parent: eth1
+      base-iface: eth1
       mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
       mka-ckn: f2b4297d39da7330910a74abc0449feb45b5c0b9fc23df1430e1898fcf1c4550
       port: 0

--- a/rust/src/lib/ifaces/macsec.rs
+++ b/rust/src/lib/ifaces/macsec.rs
@@ -19,7 +19,7 @@ use crate::{
 ///     state: up
 ///     macsec:
 ///       encrypt: true
-///       parent: eth1
+///       base-iface: eth1
 ///       mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
 ///       mka-ckn: f2b4297d39da7330910a74abc0449feb45b5c0b9fc23df1430e1898fcf1c4550
 ///       port: 0
@@ -93,7 +93,7 @@ impl MacSecInterface {
     }
 
     pub(crate) fn parent(&self) -> Option<&str> {
-        self.macsec.as_ref().map(|cfg| cfg.parent.as_str())
+        self.macsec.as_ref().map(|cfg| cfg.base_iface.as_str())
     }
 }
 
@@ -105,7 +105,7 @@ pub struct MacSecConfig {
     /// Wether the transmitted traffic must be encrypted.
     pub encrypt: bool,
     /// The parent interface used by the MACsec interface.
-    pub parent: String,
+    pub base_iface: String,
     /// The pre-shared CAK (Connectivity Association Key) for MACsec Key
     /// Agreement. Must be a string of 32 hexadecimal characters.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/lib/nispor/macsec.rs
+++ b/rust/src/lib/nispor/macsec.rs
@@ -26,7 +26,7 @@ pub(crate) fn np_macsec_to_nmstate(
             port: np_macsec_info.port.into(),
             validation: np_macsec_info.validate.into(),
             send_sci: np_macsec_info.send_sci,
-            parent: np_macsec_info.base_iface.clone().unwrap_or_default(),
+            base_iface: np_macsec_info.base_iface.clone().unwrap_or_default(),
             mka_cak: None,
             mka_ckn: None,
         });

--- a/rust/src/lib/nm/settings/macsec.rs
+++ b/rust/src/lib/nm/settings/macsec.rs
@@ -9,7 +9,7 @@ pub(crate) fn gen_nm_macsec_setting(
     let mut nm_macsec_set =
         nm_conn.macsec.as_ref().cloned().unwrap_or_default();
     if let Some(macsec_conf) = iface.macsec.as_ref() {
-        nm_macsec_set.parent = Some(macsec_conf.parent.clone());
+        nm_macsec_set.parent = Some(macsec_conf.base_iface.clone());
         nm_macsec_set.encrypt = Some(macsec_conf.encrypt);
         nm_macsec_set.mka_cak = macsec_conf.mka_cak.clone();
         nm_macsec_set.mka_ckn = macsec_conf.mka_ckn.clone();

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -443,7 +443,7 @@ class MacVtap(MacVlan):
 class MacSec:
     CONFIG_SUBTREE = "macsec"
     ENCRYPT = "encrypt"
-    PARENT = "parent"
+    BASE_IFACE = "base-iface"
     MKA_CAK = "mka-cak"
     MKA_CKN = "mka-ckn"
     PORT = "port"

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -248,7 +248,7 @@ def test_gen_conf_for_examples():
 
 
 @pytest.mark.tier1
-def test_add_macsec_and_remove(eth1_up):
+def test_add_macsec_and_remove_example(eth1_up):
     with example_state(
         "macsec0_up.yml", cleanup="macsec0_absent.yml"
     ) as desired_state:

--- a/tests/integration/macsec_test.py
+++ b/tests/integration/macsec_test.py
@@ -26,7 +26,7 @@ def test_add_macsec_and_remove(eth1_up):
                 Interface.TYPE: InterfaceType.MACSEC,
                 Interface.STATE: InterfaceState.UP,
                 MacSec.CONFIG_SUBTREE: {
-                    MacSec.PARENT: ETH1,
+                    MacSec.BASE_IFACE: ETH1,
                     MacSec.ENCRYPT: True,
                     MacSec.MKA_CAK: MKA_CAK,
                     MacSec.MKA_CKN: MKA_CKN,
@@ -56,7 +56,7 @@ def test_add_macsec_and_modify(eth1_up):
                 Interface.TYPE: InterfaceType.MACSEC,
                 Interface.STATE: InterfaceState.UP,
                 MacSec.CONFIG_SUBTREE: {
-                    MacSec.PARENT: ETH1,
+                    MacSec.BASE_IFACE: ETH1,
                     MacSec.ENCRYPT: True,
                     MacSec.MKA_CAK: MKA_CAK,
                     MacSec.MKA_CKN: MKA_CKN,


### PR DESCRIPTION
Rename the parent property to base-iface to be consistent with other interfaces like VLAN or VXLAN.