### PR TITLE
test: Move eth1 and eth2 setup to pytest fixture

### DIFF
--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -458,7 +458,7 @@ fn get_bond_port_mac(iface: &Interface) -> Option<String> {
                 .get(iface.name())
                 .and_then(|i| i.bond_subordinate.as_ref())
                 .and_then(|b| {
-                    if b.perm_hwaddr.as_str().is_empty() {
+                    if b.perm_hwaddr.is_empty() {
                         None
                     } else {
                         Some(b.perm_hwaddr.clone())

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -35,12 +35,12 @@ mod tests {
     #[test]
     fn test_gen_conf_change_unknown_to_eth() {
         let mut ifaces: Interfaces = serde_yaml::from_str(
-            r#"---
+            r"---
 - name: foo
   state: up
   ethernet:
     speed: 1000
-"#,
+",
         )
         .unwrap();
 

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -60,7 +60,7 @@ impl SrIovConfig {
             return Ok(());
         };
         for vf in vfs {
-            if vf.iface_name.as_str().is_empty() {
+            if vf.iface_name.is_empty() {
                 let e = NmstateError::new(
                     ErrorKind::VerificationError,
                     format!(

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -10,7 +10,7 @@ use crate::{
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_undefined() {
     let iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -18,7 +18,7 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: active
-"#,
+",
     )
     .unwrap();
     let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
@@ -28,7 +28,7 @@ link-aggregation:
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_defined() {
     let iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -37,7 +37,7 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: active
-"#,
+",
     )
     .unwrap();
     let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
@@ -51,16 +51,16 @@ link-aggregation:
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_defined_for_exist_bond() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
 mac-address: 00:01:02:03:04:05
-"#,
+",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -68,7 +68,7 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: active
-"#,
+",
     )
     .unwrap();
     let mut merged_iface =
@@ -83,18 +83,18 @@ link-aggregation:
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_defined_changing_mode() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
 mac-address: 00:01:02:03:04:05
 link-aggregation:
   mode: 802.3ad
-"#,
+",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -102,7 +102,7 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: active
-"#,
+",
     )
     .unwrap();
     let mut merged_iface =
@@ -113,7 +113,7 @@ link-aggregation:
 #[test]
 fn test_bond_validate_mac_restricted_with_mac_defined_changing_opt() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -122,11 +122,11 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: follow
-"#,
+",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -134,7 +134,7 @@ link-aggregation:
   mode: active-backup
   options:
     fail_over_mac: active
-"#,
+",
     )
     .unwrap();
     let mut merged_iface =
@@ -145,11 +145,11 @@ link-aggregation:
 #[test]
 fn test_bond_validate_bond_mode_not_defined_for_new_iface() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
-"#,
+",
     )
     .unwrap();
     let mut merged_iface = MergedInterface::new(Some(des_iface), None).unwrap();
@@ -185,7 +185,7 @@ link-aggregation:
 #[test]
 fn test_bond_validate_miimon_and_arp_interval() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: bond99
 type: bond
 state: up
@@ -194,7 +194,7 @@ link-aggregation:
   options:
     miimon: 100
     arp_interval: 60
-"#,
+",
     )
     .unwrap();
     let mut merged_iface = MergedInterface::new(Some(des_iface), None).unwrap();
@@ -376,7 +376,7 @@ fn test_integer_bond_mode() {
 #[test]
 fn test_integer_bond_opts() {
     let ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond60
   type: bond
   state: up
@@ -390,7 +390,7 @@ fn test_integer_bond_opts() {
       arp_validate: 6
       fail_over_mac: 2
       primary_reselect: 2
-      xmit_hash_policy: 5"#,
+      xmit_hash_policy: 5",
     )
     .unwrap();
     if let Interface::Bond(bond_iface) = ifaces.to_vec()[0] {
@@ -430,7 +430,7 @@ fn test_integer_bond_opts() {
 #[test]
 fn test_bond_ports() {
     let ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond99
           type: bond
           state: up
@@ -439,7 +439,7 @@ fn test_bond_ports() {
             ports:
             - eth1
             - eth2
-        "#,
+        ",
     )
     .unwrap();
     assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
@@ -448,7 +448,7 @@ fn test_bond_ports() {
 #[test]
 fn test_balance_slb_invalid_mode_from_current() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -459,11 +459,11 @@ fn test_balance_slb_invalid_mode_from_current() {
           options:
             balance-slb: 1
             xmit_hash_policy: vlan+srcmac
-        "#,
+        ",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -472,7 +472,7 @@ fn test_balance_slb_invalid_mode_from_current() {
           ports:
           - eth1
           - eth2
-        "#,
+        ",
     )
     .unwrap();
     let mut merged_iface =
@@ -487,7 +487,7 @@ fn test_balance_slb_invalid_mode_from_current() {
 #[test]
 fn test_balance_slb_invalid_xmit_from_current() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -497,11 +497,11 @@ fn test_balance_slb_invalid_xmit_from_current() {
           - eth2
           options:
             balance-slb: 1
-        "#,
+        ",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -512,7 +512,7 @@ fn test_balance_slb_invalid_xmit_from_current() {
           - eth2
           options:
             xmit_hash_policy: layer2
-        "#,
+        ",
     )
     .unwrap();
     let mut merged_iface =
@@ -527,7 +527,7 @@ fn test_balance_slb_invalid_xmit_from_current() {
 #[test]
 fn test_balance_slb_valid_override_current() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -538,11 +538,11 @@ fn test_balance_slb_valid_override_current() {
           options:
             balance-slb: 1
             xmit_hash_policy: vlan+srcmac
-        "#,
+        ",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -553,7 +553,7 @@ fn test_balance_slb_valid_override_current() {
           - eth2
           options:
             xmit_hash_policy: layer2
-        "#,
+        ",
     )
     .unwrap();
     let mut merged_iface =
@@ -564,7 +564,7 @@ fn test_balance_slb_valid_override_current() {
 #[test]
 fn test_disable_balance_slb_valid_override_current() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -575,11 +575,11 @@ fn test_disable_balance_slb_valid_override_current() {
           options:
             balance-slb: 0
             xmit_hash_policy: layer2
-        "#,
+        ",
     )
     .unwrap();
     let cur_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond99
         type: bond
         state: up
@@ -591,7 +591,7 @@ fn test_disable_balance_slb_valid_override_current() {
           options:
             balance-slb: 1
             xmit_hash_policy: vlan+srcmac
-        "#,
+        ",
     )
     .unwrap();
     let mut merged_iface =

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -9,7 +9,7 @@ use crate::{
 #[test]
 fn test_linux_bridge_ignore_port() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -21,11 +21,11 @@ fn test_linux_bridge_ignore_port() {
   bridge:
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -39,7 +39,7 @@ fn test_linux_bridge_ignore_port() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -70,7 +70,7 @@ fn test_linux_bridge_ignore_port() {
 #[test]
 fn test_linux_bridge_verify_ignore_port() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -82,11 +82,11 @@ fn test_linux_bridge_verify_ignore_port() {
   bridge:
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -100,7 +100,7 @@ fn test_linux_bridge_verify_ignore_port() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -206,7 +206,7 @@ bridge:
 #[test]
 fn test_linux_bridge_partial_ignored() {
     let cur_ifaces = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -220,18 +220,18 @@ fn test_linux_bridge_partial_ignored() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let des_ifaces = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: br0
   type: linux-bridge
   state: up
 - name: eth1
   type: ethernet
   state: up
-"#,
+",
     )
     .unwrap();
     let merged_ifaces =
@@ -260,14 +260,14 @@ fn test_linux_bridge_partial_ignored() {
 #[test]
 fn test_linux_bridge_interger_multicast_router() {
     let iface: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: br0
 type: linux-bridge
 state: up
 bridge:
   options:
     multicast-router: 0
-"#,
+",
     )
     .unwrap();
 
@@ -286,7 +286,7 @@ bridge:
 #[test]
 fn test_linux_bridge_ports() {
     let ifaces = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: br0
   type: linux-bridge
   state: up
@@ -294,7 +294,7 @@ fn test_linux_bridge_ports() {
     ports:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
     assert_eq!(ifaces.to_vec()[0].ports(), Some(vec!["eth1", "eth2"]));
@@ -303,7 +303,7 @@ fn test_linux_bridge_ports() {
 #[test]
 fn test_linux_bridge_partially_disable_vlan_filtering() {
     let current = serde_yaml::from_str::<LinuxBridgeInterface>(
-        r#"---
+        r"---
 name: br0
 type: linux-bridge
 state: up
@@ -319,11 +319,11 @@ bridge:
         mode: trunk
         trunk-tags:
         - id: 500
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<LinuxBridgeInterface>(
-        r#"---
+        r"---
 name: br0
 type: linux-bridge
 state: up
@@ -332,7 +332,7 @@ bridge:
     - name: eth1
       vlan: {}
     - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -341,7 +341,7 @@ bridge:
 
 #[test]
 fn test_linux_bridge_vlan_trunk_tags_yaml_serilize() {
-    let yml_content = r#"name: br0
+    let yml_content = r"name: br0
 type: linux-bridge
 state: up
 bridge:
@@ -360,7 +360,7 @@ bridge:
       mode: trunk
       trunk-tags:
       - id: 500
-"#;
+";
     let iface: LinuxBridgeInterface =
         serde_yaml::from_str(yml_content).unwrap();
 
@@ -399,7 +399,7 @@ bridge:
     .unwrap();
 
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: br0
 type: linux-bridge
 state: up
@@ -407,7 +407,7 @@ bridge:
   port:
   - name: eth1
   - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -424,7 +424,7 @@ bridge:
 #[test]
 fn test_bridge_vlan_filter_trunk_tag_without_enable_native() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -444,7 +444,7 @@ fn test_bridge_vlan_filter_trunk_tag_without_enable_native() {
                   - id-range:
                       max: 500
                       min: 400
-        "#,
+        ",
     )
     .unwrap();
 
@@ -459,7 +459,7 @@ fn test_bridge_vlan_filter_trunk_tag_without_enable_native() {
 #[test]
 fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -476,7 +476,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
                       min: 600
                       max: 900
                   - id: 600
-        "#,
+        ",
     )
     .unwrap();
 
@@ -491,7 +491,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
 #[test]
 fn test_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -510,7 +510,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
                   - id-range:
                       min: 900
                       max: 1000
-        "#,
+        ",
     )
     .unwrap();
 
@@ -525,7 +525,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
 #[test]
 fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -540,7 +540,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
                 trunk-tags:
                   - id: 100
                   - id: 100
-        "#,
+        ",
     )
     .unwrap();
 
@@ -555,7 +555,7 @@ fn test_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
 #[test]
 fn test_bridge_vlan_filter_enable_native_with_access_mode() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -568,7 +568,7 @@ fn test_bridge_vlan_filter_enable_native_with_access_mode() {
               vlan:
                 enable-native: true
                 mode: access
-        "#,
+        ",
     )
     .unwrap();
 
@@ -583,7 +583,7 @@ fn test_bridge_vlan_filter_enable_native_with_access_mode() {
 #[test]
 fn test_bridge_vlan_filter_trunk_tags_with_access_mode() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -597,7 +597,7 @@ fn test_bridge_vlan_filter_trunk_tags_with_access_mode() {
                 mode: access
                 trunk-tags:
                   - id: 100
-        "#,
+        ",
     )
     .unwrap();
 
@@ -612,7 +612,7 @@ fn test_bridge_vlan_filter_trunk_tags_with_access_mode() {
 #[test]
 fn test_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -624,7 +624,7 @@ fn test_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
             - name: eth1
               vlan:
                 mode: trunk
-        "#,
+        ",
     )
     .unwrap();
 
@@ -639,7 +639,7 @@ fn test_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
 #[test]
 fn test_bridge_validate_diff_group_forward_mask_and_group_fwd_mask() {
     let mut desired: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -647,7 +647,7 @@ fn test_bridge_validate_diff_group_forward_mask_and_group_fwd_mask() {
           options:
             group-forward-mask: 1
             group-fwd-mask: 2
-        "#,
+        ",
     )
     .unwrap();
     let result = desired.sanitize(true);
@@ -664,7 +664,7 @@ fn test_bridge_validate_diff_group_forward_mask_and_group_fwd_mask() {
 #[test]
 fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
     let mut desired_both: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
@@ -672,46 +672,46 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
           options:
             group-forward-mask: 1
             group-fwd-mask: 1
-        "#,
+        ",
     )
     .unwrap();
     desired_both.sanitize(true).unwrap();
 
     let mut desired_old: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
         bridge:
           options:
             group-forward-mask: 1
-        "#,
+        ",
     )
     .unwrap();
     desired_old.sanitize(true).unwrap();
 
     let mut desired_new: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
         bridge:
           options:
             group-fwd-mask: 1
-        "#,
+        ",
     )
     .unwrap();
     desired_new.sanitize(true).unwrap();
 
     let expected: LinuxBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: linux-bridge
         state: up
         bridge:
           options:
             group-fwd-mask: 1
-        "#,
+        ",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -5,7 +5,7 @@ use crate::{DnsState, MergedDnsState};
 #[test]
 fn test_dns_verify_uncompressed_srvs() {
     let current: DnsState = serde_yaml::from_str(
-        r#"---
+        r"---
         config:
           server:
           - '3000::'
@@ -21,12 +21,12 @@ fn test_dns_verify_uncompressed_srvs() {
           - ::ffff:192.0.2.1
           - ::ffff:192.0.2.2
           - 3::4
-        "#,
+        ",
     )
     .unwrap();
 
     let desired: DnsState = serde_yaml::from_str(
-        r#"---
+        r"---
         config:
           server:
           - 3000:0000:0000:0000:0000:0000:0000:0000
@@ -42,7 +42,7 @@ fn test_dns_verify_uncompressed_srvs() {
           - 0:0:0:0:0:FFFF:192.0.2.1
           - ::FFFF:192.0.2.2
           - 03:0000:000:00:0::4
-        "#,
+        ",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -46,17 +46,17 @@ ethernet:
 #[test]
 fn test_veth_change_peer_away_from_ignored_peer() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: veth1
   type: veth
   state: up
   veth:
     peer: newpeer
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: veth1
   type: veth
   state: up
@@ -68,7 +68,7 @@ fn test_veth_change_peer_away_from_ignored_peer() {
   state: ignore
   veth:
     peer: veth1
-"#,
+",
     )
     .unwrap();
 
@@ -83,23 +83,23 @@ fn test_veth_change_peer_away_from_ignored_peer() {
 #[test]
 fn test_veth_change_peer_away_from_missing_peer() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: veth1
           type: veth
           state: up
           veth:
             peer: newpeer
-        "#,
+        ",
     )
     .unwrap();
     // The peer of veth1 does not exist in current state means the veth peer is
     // in another network namespace
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: veth1
           type: veth
           state: up
-        "#,
+        ",
     )
     .unwrap();
 
@@ -114,19 +114,19 @@ fn test_veth_change_peer_away_from_missing_peer() {
 #[test]
 fn test_eth_verify_absent_ignore_current_up() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: absent
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
-"#,
+",
     )
     .unwrap();
     let merged_ifaces =
@@ -139,17 +139,17 @@ fn test_eth_verify_absent_ignore_current_up() {
 #[test]
 fn test_eth_change_veth_peer() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: veth1
   type: veth
   state: up
   veth:
     peer: newpeer
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: veth1
   type: veth
   state: up
@@ -161,7 +161,7 @@ fn test_eth_change_veth_peer() {
   state: up
   veth:
     peer: veth1
-"#,
+",
     )
     .unwrap();
 
@@ -181,11 +181,11 @@ fn test_eth_change_veth_peer() {
 #[test]
 fn test_new_veth_without_peer_config() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: veth1
   type: veth
   state: up
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -117,10 +117,10 @@ ethtool:
 #[test]
 fn test_ethtool_sort_features_when_serialize() {
     let features: EthtoolFeatureConfig = serde_yaml::from_str(
-        r#"---
+        r"---
         b: true
         a: true
-        c: true"#,
+        c: true",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -137,12 +137,12 @@ fn test_check_orphan_vlan_change_parent() {
 #[test]
 fn test_ifaces_deny_unknonw_attribute() {
     let result = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
   foo: bar
-"#,
+",
     );
     assert!(result.is_err());
     if let Err(e) = result {
@@ -154,19 +154,19 @@ fn test_ifaces_deny_unknonw_attribute() {
 #[test]
 fn test_ifaces_resolve_unknown_bond_iface() {
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: bond99
   type: bond
   state: up
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: bond99
   link-aggregation:
     mode: balance-rr
-"#,
+",
     )
     .unwrap();
     let merged_iface =
@@ -195,25 +195,25 @@ fn test_ifaces_resolve_unknown_bond_iface() {
 #[test]
 fn test_ifaces_ignore_iface_in_desire() {
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
 - name: br0
   type: ovs-bridge
   state: up
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
 - name: br0
   type: ovs-bridge
   state: ignore
-"#,
+",
     )
     .unwrap();
 
@@ -236,22 +236,22 @@ fn test_ifaces_ignore_iface_in_desire() {
 #[test]
 fn test_ifaces_ignore_iface_in_current() {
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
 - name: br0
   type: ovs-bridge
   state: up
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: br0
   type: ovs-bridge
   state: ignore
-"#,
+",
     )
     .unwrap();
     let merged_ifaces =
@@ -273,7 +273,7 @@ fn test_ifaces_ignore_iface_in_current() {
 #[test]
 fn test_ifaces_ignore_iface_in_current_but_desired() {
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -283,11 +283,11 @@ fn test_ifaces_ignore_iface_in_current_but_desired() {
 - name: br0
   type: ovs-bridge
   state: up
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: down
@@ -297,7 +297,7 @@ fn test_ifaces_ignore_iface_in_current_but_desired() {
 - name: br0
   type: ovs-bridge
   state: ignore
-"#,
+",
     )
     .unwrap();
     let merged_ifaces =
@@ -320,14 +320,14 @@ fn test_ifaces_ignore_iface_in_current_but_desired() {
 #[test]
 fn test_ifaces_iter() {
     let ifaces = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
 - name: br0
   type: ovs-bridge
   state: up
-"#,
+",
     )
     .unwrap();
     let ifaces_vec: Vec<&Interface> = ifaces.iter().collect();
@@ -337,14 +337,14 @@ fn test_ifaces_iter() {
 #[test]
 fn test_ifaces_iter_mut() {
     let mut ifaces = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
 - name: br0
   type: ovs-bridge
   state: up
-"#,
+",
     )
     .unwrap();
     for iface in ifaces.iter_mut() {

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -589,7 +589,7 @@ fn test_iface_detach_controller_been_list_in_other_port_list() {
 #[test]
 fn test_auto_manage_ports() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br0
   type: linux-bridge
   state: up
@@ -597,18 +597,18 @@ fn test_auto_manage_ports() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
 - name: eth2
   type: ethernet
   state: ignore
-"#,
+",
     )
     .unwrap();
 
@@ -645,7 +645,7 @@ fn test_auto_manage_ports() {
 #[test]
 fn test_do_not_auto_manage_ports_if_current_has_ignore() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br0
   type: linux-bridge
   state: up
@@ -653,11 +653,11 @@ fn test_do_not_auto_manage_ports_if_current_has_ignore() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -673,7 +673,7 @@ fn test_do_not_auto_manage_ports_if_current_has_ignore() {
   bridge:
     port:
     - name: eth3
-"#,
+",
     )
     .unwrap();
 
@@ -700,9 +700,9 @@ fn test_do_not_auto_manage_ports_if_current_has_ignore() {
 #[test]
 fn test_absent_iface_holding_controller_and_ip() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: eth1
-          state: absent"#,
+          state: absent",
     )
     .unwrap();
 
@@ -710,7 +710,7 @@ fn test_absent_iface_holding_controller_and_ip() {
     // When user is removing this interface, we should not care about whether it
     // can hold IP or not.
     let mut cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: br0
           type: linux-bridge
           state: up
@@ -723,7 +723,7 @@ fn test_absent_iface_holding_controller_and_ip() {
           ipv6:
             enabled: true
             autoconf: true
-            dhcp: true"#,
+            dhcp: true",
     )
     .unwrap();
     if let Some(iface) = cur_ifaces.kernel_ifaces.get_mut("eth1") {

--- a/rust/src/lib/unit_tests/infiniband.rs
+++ b/rust/src/lib/unit_tests/infiniband.rs
@@ -8,11 +8,11 @@ use crate::{
 #[test]
 fn test_ib_autoremove_pkey_if_base_iface_removed() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: mlx5_ib2
   type: infiniband
   state: absent
-"#,
+",
     )
     .unwrap();
     let current: Interfaces = serde_yaml::from_str(
@@ -136,13 +136,13 @@ fn test_ib_port_of_bridge_in_desire() {
 #[test]
 fn test_ib_port_of_bridge_in_current() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br0
   type: linux-bridge
   bridge:
     port:
     - name: mlx5_ib2
-"#,
+",
     )
     .unwrap();
 
@@ -169,7 +169,7 @@ fn test_ib_port_of_bridge_in_current() {
 #[test]
 fn test_ib_port_of_bond_mode_in_desire() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0
   type: bond
   state: up
@@ -177,7 +177,7 @@ fn test_ib_port_of_bond_mode_in_desire() {
     mode: balance-rr
     port:
     - mlx5_ib2
-"#,
+",
     )
     .unwrap();
 
@@ -203,14 +203,14 @@ fn test_ib_port_of_bond_mode_in_desire() {
 #[test]
 fn test_ib_port_of_bond_mode_in_current() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0
   type: bond
   state: up
   link-aggregation:
     port:
     - mlx5_ib2
-"#,
+",
     )
     .unwrap();
 
@@ -243,14 +243,14 @@ fn test_ib_port_of_bond_mode_in_current() {
 #[test]
 fn test_ib_port_of_active_backup_bond_mode_in_current() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0
   type: bond
   state: up
   link-aggregation:
     port:
     - mlx5_ib2
-"#,
+",
     )
     .unwrap();
 
@@ -279,7 +279,7 @@ fn test_ib_port_of_active_backup_bond_mode_in_current() {
 #[test]
 fn test_ib_port_of_active_backup_bond_mode_in_both() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0
   type: bond
   state: up
@@ -287,7 +287,7 @@ fn test_ib_port_of_active_backup_bond_mode_in_both() {
     mode: active-backup
     port:
     - mlx5_ib2
-"#,
+",
     )
     .unwrap();
 
@@ -333,7 +333,7 @@ fn test_ib_port_of_active_backup_bond_mode_in_both() {
 #[test]
 fn test_ib_port_of_active_backup_bond_mode_in_desire() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0
   type: bond
   state: up
@@ -341,7 +341,7 @@ fn test_ib_port_of_active_backup_bond_mode_in_desire() {
     mode: active-backup
     port:
     - mlx5_ib2
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -309,7 +309,7 @@ fn test_should_not_have_ipv6_in_ipv4_section() {
 #[test]
 fn test_should_not_have_ipv4_in_ipv6_section() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
             - name: eth1
               type: ethernet
               state: up
@@ -318,7 +318,7 @@ fn test_should_not_have_ipv4_in_ipv6_section() {
                 dhcp: false
                 address:
                   - ip: 192.0.2.1
-                    prefix-length: 24"#,
+                    prefix-length: 24",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/mptcp.rs
+++ b/rust/src/lib/unit_tests/mptcp.rs
@@ -5,7 +5,7 @@ use crate::{BaseInterface, ErrorKind, Interface, MergedInterface};
 #[test]
 fn test_valid_mptcp_flags() {
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: eth1
 type: ethernet
 state: up
@@ -13,7 +13,7 @@ mptcp:
   address-flags:
   - signal
   - fullmesh
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/net_state.rs
+++ b/rust/src/lib/unit_tests/net_state.rs
@@ -5,9 +5,9 @@ use crate::NetworkState;
 #[test]
 fn test_invalid_top_key() {
     let result = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
 invalid_key: abc
-"#,
+",
     );
 
     assert!(result.is_err());
@@ -16,9 +16,9 @@ invalid_key: abc
 #[test]
 fn test_invalid_top_type() {
     let result = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
 - invalid_key: abc
-"#,
+",
     );
 
     assert!(result.is_err());

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -8,7 +8,7 @@ use crate::{
 #[test]
 fn test_dns_ignore_dns_purge_on_absent_iface() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
 dns-resolver:
   config:
     server: []
@@ -16,11 +16,11 @@ interfaces:
   - name: dummy0
     type: dummy
     state: absent
-"#,
+",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
 dns-resolver:
   config:
     search:
@@ -42,7 +42,7 @@ interfaces:
       dhcp: true
       autoconf: true
       auto-dns: false
-"#,
+",
     )
     .unwrap();
 
@@ -65,23 +65,23 @@ interfaces:
 #[test]
 fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             server:
             - fe80::deef:1%eth1
-        "#,
+        ",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
             state: up
             ipv6:
               enabled: false
-        "#,
+        ",
     )
     .unwrap();
 
@@ -95,17 +95,17 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
 #[test]
 fn test_two_dns_ipv6_link_local_iface() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             server:
             - fe80::deef:1%eth1
             - fe80::deef:2%eth2
-        "#,
+        ",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
@@ -123,7 +123,7 @@ fn test_two_dns_ipv6_link_local_iface() {
               dhcp: true
               autoconf: true
               auto-dns: false
-        "#,
+        ",
     )
     .unwrap();
     let result = MergedNetworkState::new(desired, current, false, false);
@@ -136,14 +136,14 @@ fn test_two_dns_ipv6_link_local_iface() {
 #[test]
 fn test_dns_iface_has_no_ip_stack_info() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
-        "#,
+        ",
     )
     .unwrap();
     let mut current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             search:
@@ -178,7 +178,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
           - destination: ::/0
             next-hop-address: 2001:db8:1::3
             next-hop-interface: eth1
-        "#,
+        ",
     )
     .unwrap();
     if let Some(ip) = current
@@ -231,7 +231,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
 #[test]
 fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             search:
@@ -239,11 +239,11 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
             - example.org
             server:
             - 2001:4860:4860::8844
-            - 2001:4860:4860::8888"#,
+            - 2001:4860:4860::8888",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: dummy0
             state: up
@@ -261,7 +261,7 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
               enabled: true
               dhcp: true
               autoconf: true
-              auto-dns: false"#,
+              auto-dns: false",
     )
     .unwrap();
 
@@ -278,7 +278,7 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
 #[test]
 fn test_dns_prefer_desired_over_current() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             search:
@@ -303,11 +303,11 @@ fn test_dns_prefer_desired_over_current() {
               dhcp: false
               address:
               - ip: fe80::db:1
-                prefix-length: 64"#,
+                prefix-length: 64",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: dummy1
             type: dummy
@@ -320,7 +320,7 @@ fn test_dns_prefer_desired_over_current() {
               enabled: true
               dhcp: true
               autoconf: true
-              auto-dns: false"#,
+              auto-dns: false",
     )
     .unwrap();
 
@@ -337,7 +337,7 @@ fn test_dns_prefer_desired_over_current() {
 #[test]
 fn test_copy_ip_stack_if_marked_for_dns() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         dns-resolver:
           config:
             search:
@@ -349,11 +349,11 @@ fn test_copy_ip_stack_if_marked_for_dns() {
         interfaces:
           - name: dummy0
             type: dummy
-            state: up"#,
+            state: up",
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: dummy0
             type: dummy
@@ -366,7 +366,7 @@ fn test_copy_ip_stack_if_marked_for_dns() {
               enabled: true
               dhcp: true
               autoconf: true
-              auto-dns: false"#,
+              auto-dns: false",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -146,7 +146,7 @@ fn test_absent_routes_with_iface_only() {
 #[test]
 fn test_route_ignore_absent_ifaces() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 interfaces:
 - name: br0
   state: absent
@@ -155,12 +155,12 @@ routes:
   config:
   - next-hop-interface: br0
     state: absent
-"#,
+",
     )
     .unwrap();
 
     let current: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 interfaces:
 - name: eth1
   type: ethernet
@@ -187,7 +187,7 @@ routes:
       next-hop-address: 192.0.2.1
       next-hop-interface: br0
       table-id: 254
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -87,7 +87,7 @@ fn test_add_rules_to_new_interface() {
 #[test]
 fn test_route_rule_ignore_absent_ifaces() {
     let desired: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 interfaces:
 - name: br0
   state: absent
@@ -96,12 +96,12 @@ route-rules:
   config:
   - route-table: 200
     state: absent
-"#,
+",
     )
     .unwrap();
 
     let current: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 interfaces:
 - name: eth1
   type: ethernet
@@ -132,7 +132,7 @@ route-rules:
   config:
     - ip-from: 192.51.100.2/32
       route-table: 200
-"#,
+",
     )
     .unwrap();
 
@@ -164,7 +164,7 @@ route-rules:
 #[test]
 fn test_route_rule_use_auto_route_table_id() {
     let current: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 ---
 interfaces:
   - name: br0
@@ -185,12 +185,12 @@ interfaces:
     bridge:
       port:
         - name: br0
-"#,
+",
     )
     .unwrap();
 
     let desired: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 ---
 route-rules:
   config:
@@ -200,19 +200,19 @@ route-rules:
     - route-table: 500
       priority: 3200
       ip-from: 192.0.3.0/24
-"#,
+",
     )
     .unwrap();
 
     let expected_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
-        r#"
+        r"
 - route-table: 500
   priority: 3200
   ip-to: 192.0.3.0/24
 - route-table: 500
   priority: 3200
   ip-from: 192.0.3.0/24
-"#,
+",
     )
     .unwrap();
 
@@ -239,7 +239,7 @@ route-rules:
 #[test]
 fn test_route_rule_use_default_auto_route_table_id() {
     let current: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 ---
 interfaces:
   - name: eth1
@@ -253,12 +253,12 @@ interfaces:
       auto-gateway: true
     ipv6:
       enabled: false
-"#,
+",
     )
     .unwrap();
 
     let desired: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 ---
 route-rules:
   config:
@@ -266,19 +266,19 @@ route-rules:
       ip-to: 192.0.3.0/24
     - priority: 3200
       ip-from: 192.0.3.0/24
-"#,
+",
     )
     .unwrap();
 
     let expected_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
-        r#"
+        r"
 - route-table: 254
   priority: 3200
   ip-to: 192.0.3.0/24
 - route-table: 254
   priority: 3200
   ip-from: 192.0.3.0/24
-"#,
+",
     )
     .unwrap();
 
@@ -304,7 +304,7 @@ route-rules:
 #[test]
 fn test_route_rule_use_loopback() {
     let current: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
 ---
 interfaces:
   - name: lo
@@ -321,12 +321,12 @@ interfaces:
       address:
       - ip: ::1
         prefix-length: 128
-"#,
+",
     )
     .unwrap();
 
     let desired: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         route-rules:
           config:
             - priority: 3200
@@ -334,23 +334,23 @@ interfaces:
               family: ipv4
             - priority: 3200
               route-table: 255
-              family: ipv6"#,
+              family: ipv6",
     )
     .unwrap();
 
     let expected_ipv4_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
-        r#"
+        r"
         - priority: 3200
           route-table: 255
-          family: ipv4"#,
+          family: ipv4",
     )
     .unwrap();
 
     let expected_ipv6_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
-        r#"
+        r"
         - priority: 3200
           route-table: 255
-          family: ipv6"#,
+          family: ipv6",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -9,31 +9,31 @@ use crate::{NmstateError, OvnConfiguration};
 #[test]
 fn test_ovsdb_merge_with_mappings() {
     let desired: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   state: present
   bridge: br1
-"#,
+",
     )
     .unwrap();
 
     let current: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings: []
-        "#,
+        ",
     )
     .unwrap();
 
     let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
 
     let expect: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   state: present
   bridge: br1
-"#,
+",
     )
     .unwrap();
 
@@ -46,31 +46,31 @@ bridge-mappings:
 #[test]
 fn test_ovsdb_merge_delete_existing_mappings() {
     let desired: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   state: absent
   bridge: br1
-"#,
+",
     )
     .unwrap();
 
     let current: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   state: present
   bridge: br1
-"#,
+",
     )
     .unwrap();
 
     let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
 
     let expect: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings: []
-"#,
+",
     )
     .unwrap();
 
@@ -83,23 +83,23 @@ bridge-mappings: []
 #[test]
 fn test_ovn_duplicate_localnet_keys_are_forbidden_on_desired_state() {
     let desired: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   bridge: br1
 - localnet: net1
   state: absent
-"#,
+",
     )
     .unwrap();
 
     let current: OvnConfiguration = serde_yaml::from_str(
-        r#"---
+        r"---
 bridge-mappings:
 - localnet: net1
   state: present
   bridge: br1
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -8,7 +8,7 @@ use crate::{
 #[test]
 fn test_ovs_bridge_ignore_port() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -21,11 +21,11 @@ fn test_ovs_bridge_ignore_port() {
   bridge:
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -39,7 +39,7 @@ fn test_ovs_bridge_ignore_port() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -76,7 +76,7 @@ fn test_ovs_bridge_ignore_port() {
 #[test]
 fn test_ovs_bridge_verify_ignore_port() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: ignore
@@ -88,11 +88,11 @@ fn test_ovs_bridge_verify_ignore_port() {
   bridge:
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -106,19 +106,19 @@ fn test_ovs_bridge_verify_ignore_port() {
     port:
     - name: eth1
     - name: eth2
-"#,
+",
     )
     .unwrap();
 
     let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
 - name: eth2
   type: ethernet
   state: up
-"#,
+",
     )
     .unwrap();
 
@@ -164,7 +164,7 @@ bridge:
 #[test]
 fn test_ovs_bridge_same_name_absent() {
     let current: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
 - name: br1
@@ -176,16 +176,16 @@ fn test_ovs_bridge_same_name_absent() {
     port:
     - name: br1
     - name: eth1
-"#,
+",
     )
     .unwrap();
 
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br1
   type: ovs-bridge
   state: absent
-"#,
+",
     )
     .unwrap();
 
@@ -219,7 +219,7 @@ fn test_ovs_bridge_same_name_absent() {
 #[test]
 fn test_ovs_bridge_resolve_user_space_iface_type() {
     let current: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br1
   type: ovs-interface
 - name: ovs-br1
@@ -228,15 +228,15 @@ fn test_ovs_bridge_resolve_user_space_iface_type() {
   bridge:
     port:
     - name: br1
-"#,
+",
     )
     .unwrap();
 
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: ovs-br1
   state: absent
-"#,
+",
     )
     .unwrap();
 
@@ -257,7 +257,7 @@ fn test_ovs_bridge_resolve_user_space_iface_type() {
 #[test]
 fn test_ovs_bridge_ports() {
     let ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: br0
   type: ovs-bridge
   state: up
@@ -271,7 +271,7 @@ fn test_ovs_bridge_ports() {
         ports:
           - name: eth3
           - name: eth4
-"#,
+",
     )
     .unwrap();
     assert_eq!(
@@ -312,7 +312,7 @@ bridge:
     .unwrap();
 
     let des_iface: Interface = serde_yaml::from_str(
-        r#"---
+        r"---
 name: br0
 type: ovs-bridge
 state: up
@@ -320,7 +320,7 @@ bridge:
   port:
   - name: eth1
   - name: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -340,7 +340,7 @@ bridge:
 #[test]
 fn test_ovs_bridge_vlan_filter_trunk_tag_without_enable_native() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -357,7 +357,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_without_enable_native() {
                   - id-range:
                       max: 500
                       min: 400
-        "#,
+        ",
     )
     .unwrap();
 
@@ -372,7 +372,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_without_enable_native() {
 #[test]
 fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -386,7 +386,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
                       min: 600
                       max: 900
                   - id: 600
-        "#,
+        ",
     )
     .unwrap();
 
@@ -401,7 +401,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_range() {
 #[test]
 fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -417,7 +417,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
                   - id-range:
                       min: 900
                       max: 1000
-        "#,
+        ",
     )
     .unwrap();
 
@@ -432,7 +432,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_range_vs_range() {
 #[test]
 fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -444,7 +444,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
                 trunk-tags:
                   - id: 100
                   - id: 100
-        "#,
+        ",
     )
     .unwrap();
 
@@ -459,7 +459,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tag_overlap_id_vs_id() {
 #[test]
 fn test_ovs_bridge_vlan_filter_enable_native_with_access_mode() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -469,7 +469,7 @@ fn test_ovs_bridge_vlan_filter_enable_native_with_access_mode() {
               vlan:
                 enable-native: true
                 mode: access
-        "#,
+        ",
     )
     .unwrap();
 
@@ -484,7 +484,7 @@ fn test_ovs_bridge_vlan_filter_enable_native_with_access_mode() {
 #[test]
 fn test_ovs_bridge_vlan_filter_trunk_tags_with_access_mode() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -495,7 +495,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tags_with_access_mode() {
                 mode: access
                 trunk-tags:
                   - id: 100
-        "#,
+        ",
     )
     .unwrap();
 
@@ -510,7 +510,7 @@ fn test_ovs_bridge_vlan_filter_trunk_tags_with_access_mode() {
 #[test]
 fn test_ovs_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
     let mut desired: OvsBridgeInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: br0
         type: ovs-bridge
         state: up
@@ -519,7 +519,7 @@ fn test_ovs_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
             - name: eth1
               vlan:
                 mode: trunk
-        "#,
+        ",
     )
     .unwrap();
 
@@ -534,14 +534,14 @@ fn test_ovs_bridge_vlan_filter_no_trunk_tags_with_trunk_mode() {
 #[test]
 fn test_validate_dpdk_n_rxq_desc() {
     let desired: OvsInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: ovs0
         type: ovs-interface
         state: up
         dpdk:
           devargs: 0000:af:00.1
           n_rxq_desc: 1025
-        "#,
+        ",
     )
     .unwrap();
 
@@ -557,14 +557,14 @@ fn test_validate_dpdk_n_rxq_desc() {
 #[test]
 fn test_validate_dpdk_n_txq_desc() {
     let desired: OvsInterface = serde_yaml::from_str(
-        r#"
+        r"
         name: ovs0
         type: ovs-interface
         state: up
         dpdk:
           devargs: 0000:af:00.1
           n_txq_desc: 1025
-        "#,
+        ",
     )
     .unwrap();
 
@@ -580,19 +580,19 @@ fn test_validate_dpdk_n_txq_desc() {
 #[test]
 fn test_ovs_orphan_check_on_bridge_with_same_name_iface() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"
+        r"
         - name: br0
           type: ovs-bridge
           state: up
           bridge:
             port:
               - name: ovs0
-        "#,
+        ",
     )
     .unwrap();
 
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"
+        r"
         - name: br0
           type: ovs-interface
         - name: br0
@@ -601,7 +601,7 @@ fn test_ovs_orphan_check_on_bridge_with_same_name_iface() {
           bridge:
             port:
               - name: br0
-        "#,
+        ",
     )
     .unwrap();
 
@@ -611,7 +611,7 @@ fn test_ovs_orphan_check_on_bridge_with_same_name_iface() {
 #[test]
 fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"
+        r"
         - name: br0
           type: ovs-interface
           state: up
@@ -621,12 +621,12 @@ fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
           bridge:
             port:
               - name: ovs0
-        "#,
+        ",
     )
     .unwrap();
 
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"
+        r"
         - name: br0
           type: ovs-interface
         - name: br0
@@ -635,7 +635,7 @@ fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
           bridge:
             port:
               - name: br0
-        "#,
+        ",
     )
     .unwrap();
 
@@ -645,7 +645,7 @@ fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
 #[test]
 fn test_ignore_patch_ports_for_verify() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
 - name: eth2
@@ -664,11 +664,11 @@ fn test_ignore_patch_ports_for_verify() {
     allow-extra-patch-ports: true
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -703,12 +703,12 @@ fn test_ignore_patch_ports_for_verify() {
   bridge:
     port:
     - name: patch1
-"#,
+",
     )
     .unwrap();
 
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -745,7 +745,7 @@ fn test_ignore_patch_ports_for_verify() {
     enabled: false
   patch:
     peer: patch0
-"#,
+",
     )
     .unwrap();
 
@@ -759,7 +759,7 @@ fn test_ignore_patch_ports_for_verify() {
 #[test]
 fn test_ignore_patch_ports_for_apply() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
 - name: eth2
@@ -778,11 +778,11 @@ fn test_ignore_patch_ports_for_apply() {
     allow-extra-patch-ports: true
     port:
     - name: eth2
-"#,
+",
     )
     .unwrap();
     let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -817,7 +817,7 @@ fn test_ignore_patch_ports_for_apply() {
   bridge:
     port:
     - name: patch1
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -4,7 +4,7 @@ use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
 
 fn get_current_ovsdb_config() -> OvsDbGlobalConfig {
     serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids:
   a: A0
   b: B0
@@ -15,7 +15,7 @@ other_config:
   e: E0
   f: F0
   g: G0
-"#,
+",
     )
     .unwrap()
 }
@@ -23,7 +23,7 @@ other_config:
 #[test]
 fn test_ovsdb_merge_with_override_and_delete() {
     let desired: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids:
   a: A
   b: B
@@ -32,7 +32,7 @@ other_config:
   d: null
   e: E
   f: F
-"#,
+",
     )
     .unwrap();
 
@@ -42,7 +42,7 @@ other_config:
         MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids:
   a: A
   b: B
@@ -51,7 +51,7 @@ other_config:
   e: E
   f: F
   g: G0
-"#,
+",
     )
     .unwrap();
 
@@ -71,10 +71,10 @@ fn test_ovsdb_merge_delete_all() {
     let current = get_current_ovsdb_config();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids: {}
 other_config: {}
-"#,
+",
     )
     .unwrap();
 
@@ -94,22 +94,22 @@ other_config: {}
 #[test]
 fn test_ovsdb_merge_delete_all_external_ids() {
     let desired: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids: {}
-"#,
+",
     )
     .unwrap();
     let current = get_current_ovsdb_config();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids: {}
 other_config:
   d: D0
   e: E0
   f: F0
   g: G0
-"#,
+",
     )
     .unwrap();
 
@@ -129,22 +129,22 @@ other_config:
 #[test]
 fn test_ovsdb_merge_delete_all_other_config() {
     let desired: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 other_config: {}
-"#,
+",
     )
     .unwrap();
     let current = get_current_ovsdb_config();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
-        r#"---
+        r"---
 external_ids:
   a: A0
   b: B0
   c: C0
   h: H0
 other_config: {}
-"#,
+",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -91,9 +91,9 @@ fn test_policy_capture_with_equal() {
 #[test]
 fn test_policy_capture_simple_store() {
     let cap_con = NetworkCaptureCommand::parse(
-        r#"
+        r"
         just store it
-        "#
+        "
         .trim(),
     )
     .unwrap();
@@ -149,7 +149,7 @@ fn test_policy_capture_retain_only() {
         NetworkCaptureCommand::parse(" dns-resolver.running").unwrap();
 
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
@@ -184,7 +184,7 @@ fn test_policy_capture_retain_only() {
             server:
             - 192.51.100.99
             - 2001:db8:1::99
-        "#,
+        ",
     )
     .unwrap();
 
@@ -217,7 +217,7 @@ fn test_policy_capture_route_rule() {
             .unwrap();
 
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         routes:
           config:
           - destination: 192.168.2.0/24
@@ -254,7 +254,7 @@ fn test_policy_capture_route_rule() {
               address:
               - ip: 2001:db8:1::1
                 prefix-length: 64
-        "#,
+        ",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/policy/error.rs
+++ b/rust/src/lib/unit_tests/policy/error.rs
@@ -375,9 +375,9 @@ fn test_policy_reference_capture_concatenate_with_prefix() {
     capture_results.insert(
         "void".to_string(),
         serde_yaml::from_str(
-            r#"
+            r"
             interfaces:
-              - name: eth1"#,
+              - name: eth1",
         )
         .unwrap(),
     );
@@ -399,9 +399,9 @@ fn test_policy_reference_capture_property_not_found() {
     capture_results.insert(
         "void".to_string(),
         serde_yaml::from_str(
-            r#"
+            r"
             interfaces:
-              - name: eth1"#,
+              - name: eth1",
         )
         .unwrap(),
     );
@@ -426,9 +426,9 @@ fn test_policy_reference_capture_property_not_array() {
     capture_results.insert(
         "void".to_string(),
         serde_yaml::from_str(
-            r#"
+            r"
             interfaces:
-              - name: eth1"#,
+              - name: eth1",
         )
         .unwrap(),
     );

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -29,7 +29,7 @@ desiredState:
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
@@ -45,7 +45,7 @@ desiredState:
             next-hop-address: 192.0.2.1
             next-hop-interface: eth1
           config: []
-        "#,
+        ",
     )
     .unwrap();
 
@@ -97,7 +97,7 @@ desiredState:
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
@@ -124,7 +124,7 @@ desiredState:
           - destination: 192.51.100.0/24
             next-hop-address: 192.0.2.1
             next-hop-interface: eth1
-        "#,
+        ",
     )
     .unwrap();
 
@@ -183,7 +183,7 @@ fn test_policy_convert_dhcp_to_static_with_dns() {
     )
     .unwrap();
     let current: NetworkState = serde_yaml::from_str(
-        r#"---
+        r"---
         interfaces:
           - name: eth1
             type: ethernet
@@ -218,7 +218,7 @@ fn test_policy_convert_dhcp_to_static_with_dns() {
             server:
             - 192.51.100.99
             - 2001:db8:1::99
-        "#,
+        ",
     )
     .unwrap();
 
@@ -273,24 +273,24 @@ fn test_policy_empty_policy() {
 #[test]
 fn test_policy_no_capture() {
     let policy: NetworkPolicy = serde_yaml::from_str(
-        r#"
+        r"
         desiredState:
           interfaces:
           - name: eth1
             type: ethernet
             state: up
-        "#,
+        ",
     )
     .unwrap();
 
     let state = NetworkState::try_from(policy).unwrap();
     let expected_state: NetworkState = serde_yaml::from_str(
-        r#"
+        r"
         interfaces:
           - name: eth1
             type: ethernet
             state: up
-        "#,
+        ",
     )
     .unwrap();
     assert_eq!(state, expected_state);

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -113,7 +113,7 @@ fn test_verify_current_has_more_routes() {
 #[test]
 fn test_route_ignore_iface() {
     let routes: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/0
   next-hop-address: 192.0.2.1
@@ -127,7 +127,7 @@ config:
 - destination: ::/0
   next-hop-address: 2001:db8:1::2
   next-hop-interface: eth2
-"#,
+",
     )
     .unwrap();
 
@@ -151,17 +151,17 @@ config:
 #[test]
 fn test_route_verify_ignore_iface() {
     let desire: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/0
   state: absent
 - destination: ::/0
   state: absent
-"#,
+",
     )
     .unwrap();
     let current: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/0
   next-hop-address: 192.0.2.1
@@ -169,7 +169,7 @@ config:
 - destination: ::/0
   next-hop-address: 2001:db8:1::2
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
 
@@ -281,14 +281,14 @@ fn test_route_not_allowing_empty_dst() {
 #[test]
 fn test_route_sanitize_ipv6_ecmp() {
     let mut route: RouteEntry = serde_yaml::from_str(
-        r#"
+        r"
         destination: 2001:db:1::/64
         metric: 150
         next-hop-address: 2001:db8::2
         next-hop-interface: eth1
         weight: 2
         table-id: 254
-        "#,
+        ",
     )
     .unwrap();
     let result = route.sanitize();
@@ -299,7 +299,7 @@ fn test_route_sanitize_ipv6_ecmp() {
 #[test]
 fn test_route_ipv4_ecmp_is_match() {
     let absent_route: RouteEntry = serde_yaml::from_str(
-        r#"
+        r"
         destination: 192.0.2.1
         metric: 150
         next-hop-address: 2001:db8::2
@@ -307,18 +307,18 @@ fn test_route_ipv4_ecmp_is_match() {
         weight: 2
         table-id: 254
         state: absent
-        "#,
+        ",
     )
     .unwrap();
     let route: RouteEntry = serde_yaml::from_str(
-        r#"
+        r"
         destination: 192.0.2.1
         metric: 150
         next-hop-address: 2001:db8::2
         next-hop-interface: eth1
         weight: 2
         table-id: 254
-        "#,
+        ",
     )
     .unwrap();
     assert!(absent_route.is_match(&route));
@@ -327,12 +327,12 @@ fn test_route_ipv4_ecmp_is_match() {
 #[test]
 fn test_route_valid_default_gateway() {
     let routes: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/0
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     routes.validate().unwrap();
@@ -341,12 +341,12 @@ config:
 #[test]
 fn test_route_invalid_destination() {
     let routes1: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/8
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     let result = routes1.validate();
@@ -354,12 +354,12 @@ config:
     assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
 
     let routes2: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0/f
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     let result = routes2.validate();
@@ -367,12 +367,12 @@ config:
     assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
 
     let routes3: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     let result = routes3.validate();
@@ -380,12 +380,12 @@ config:
     assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
 
     let routes4: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0.0/0
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     let result = routes4.validate();
@@ -393,12 +393,12 @@ config:
     assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
 
     let routes5: Routes = serde_yaml::from_str(
-        r#"
+        r"
 config:
 - destination: 0.0.0.0.0/7
   next-hop-address: 192.0.2.1
   next-hop-interface: eth1
-"#,
+",
     )
     .unwrap();
     let result = routes5.validate();
@@ -416,17 +416,17 @@ fn test_route_matching_empty_via_with_none() {
     )
     .unwrap();
     let not_match_route: RouteEntry = serde_yaml::from_str(
-        r#"
+        r"
         next-hop-address: 2001:db8::2
         next-hop-interface: eth1
-        "#,
+        ",
     )
     .unwrap();
     let match_route: RouteEntry = serde_yaml::from_str(
-        r#"
+        r"
         destination: 192.0.2.1
         next-hop-interface: eth1
-        "#,
+        ",
     )
     .unwrap();
     assert!(!absent_route.is_match(&not_match_route));

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -32,10 +32,10 @@ route-table: "129"
 #[test]
 fn test_route_rule_sanitize_ipv4_from_to() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-to: 192.0.3.1/24
 ip-from: 192.0.3.2/24
-"#,
+",
     )
     .unwrap();
 
@@ -48,10 +48,10 @@ ip-from: 192.0.3.2/24
 #[test]
 fn test_route_rule_sanitize_ipv6_from_to() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-to: 2001:db8:1::2/64
 ip-from: 2001:db8:2::ffff/64
-"#,
+",
     )
     .unwrap();
 
@@ -64,10 +64,10 @@ ip-from: 2001:db8:2::ffff/64
 #[test]
 fn test_route_rule_sanitize_ipv4_from_to_host() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-to: 192.0.3.1
 ip-from: 192.0.3.2
-"#,
+",
     )
     .unwrap();
 
@@ -80,10 +80,10 @@ ip-from: 192.0.3.2
 #[test]
 fn test_route_rule_sanitize_ipv6_from_to_host() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-to: 2001:db8:1::2
 ip-from: 2001:db8:2::ffff
-"#,
+",
     )
     .unwrap();
 
@@ -96,10 +96,10 @@ ip-from: 2001:db8:2::ffff
 #[test]
 fn test_route_rule_sanitize_none_compact_ipv6_from_to() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-to: 2001:db8:1:0000::2
 ip-from: 2001:db8:2:0000::ffff
-"#,
+",
     )
     .unwrap();
 
@@ -112,12 +112,12 @@ ip-from: 2001:db8:2:0000::ffff
 #[test]
 fn test_route_rule_sanitize_ipv6_family_ip_from() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-from: 2001:db8:b::/64
 priority: 30000
 route-table: 200
 family: ipv6
-"#,
+",
     )
     .unwrap();
 
@@ -127,12 +127,12 @@ family: ipv6
 #[test]
 fn test_route_rule_validate_ipv4_family_ip_from() {
     let mut rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
 ip-from: 192.168.2.0/24
 priority: 30000
 route-table: 200
 family: ipv4
-"#,
+",
     )
     .unwrap();
 
@@ -151,21 +151,21 @@ fn test_route_rule_matching_empty_ip_from_with_none() {
     .unwrap();
 
     let not_match_rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
         ip-from: 192.168.2.0/24
         priority: 30000
         route-table: 200
         family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
     let match_rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
         priority: 30000
         route-table: 200
         family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
@@ -185,21 +185,21 @@ fn test_route_rule_matching_empty_ip_to_with_none() {
     .unwrap();
 
     let not_match_rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
         ip-to: 192.168.2.0/24
         priority: 30000
         route-table: 200
         family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
     let match_rule: RouteRuleEntry = serde_yaml::from_str(
-        r#"
+        r"
         priority: 30000
         route-table: 200
         family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
@@ -210,7 +210,7 @@ fn test_route_rule_matching_empty_ip_to_with_none() {
 #[test]
 fn test_route_rule_auto_priority_increasing_from_desire() {
     let des_rules: RouteRules = serde_yaml::from_str(
-        r#"
+        r"
         config:
         - state: absent
           priority: 30001
@@ -226,12 +226,12 @@ fn test_route_rule_auto_priority_increasing_from_desire() {
           route-table: 200
           priority: 30001
           family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
     let cur_rules: RouteRules = serde_yaml::from_str(
-        r#"
+        r"
         config:
         - ip-to: 192.168.2.100
           priority: 100
@@ -245,7 +245,7 @@ fn test_route_rule_auto_priority_increasing_from_desire() {
           priority: 101
           route-table: 200
           family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 
@@ -281,7 +281,7 @@ fn test_route_rule_auto_priority_increasing_from_desire() {
 #[test]
 fn test_route_rule_auto_priority_increasing_from_empty() {
     let des_rules: RouteRules = serde_yaml::from_str(
-        r#"
+        r"
         config:
         - ip-to: 192.168.2.30
           route-table: 200
@@ -292,7 +292,7 @@ fn test_route_rule_auto_priority_increasing_from_empty() {
         - ip-to: 192.168.2.32
           route-table: 200
           family: ipv4
-        "#,
+        ",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -58,7 +58,7 @@ fn test_ignore_sriov_if_not_desired() {
     let mut pre_apply_cur_ifaces = Interfaces::new();
     pre_apply_cur_ifaces.push(new_eth_iface("eth1"));
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
@@ -75,16 +75,16 @@ fn test_ignore_sriov_if_not_desired() {
       - id: 1
         vlan-id: 101
         qos: 6
-"#,
+",
     )
     .unwrap();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
 - name: eth1
   type: ethernet
   state: up
   mtu: 1280
-"#,
+",
     )
     .unwrap();
 
@@ -97,7 +97,7 @@ fn test_ignore_sriov_if_not_desired() {
 
 fn gen_sriov_current_ifaces() -> Interfaces {
     let mut current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: eth1
           type: ethernet
           state: up
@@ -113,7 +113,7 @@ fn gen_sriov_current_ifaces() -> Interfaces {
         - name: eth1v1
           type: ethernet
           state: up
-        "#,
+        ",
     )
     .unwrap();
     let iface = current.kernel_ifaces.get_mut("eth1").unwrap();
@@ -148,7 +148,7 @@ fn gen_sriov_current_ifaces() -> Interfaces {
 fn test_resolve_sriov_name() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: sriov:eth1:0
           type: ethernet
           state: up
@@ -157,7 +157,7 @@ fn test_resolve_sriov_name() {
           type: ethernet
           state: up
           mtu: 1281
-        "#,
+        ",
     )
     .unwrap();
     desired.resolve_sriov_reference(&current).unwrap();
@@ -175,7 +175,7 @@ fn test_resolve_sriov_name() {
 fn test_resolve_sriov_name_duplicate() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: sriov:eth1:0
           type: ethernet
           state: up
@@ -184,7 +184,7 @@ fn test_resolve_sriov_name_duplicate() {
           type: ethernet
           state: up
           mtu: 1281
-        "#,
+        ",
     )
     .unwrap();
     let result = desired.resolve_sriov_reference(&current);
@@ -198,7 +198,7 @@ fn test_resolve_sriov_name_duplicate() {
 fn test_failed_to_resolve_sriov_in_ovs_port_list() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: ovs-br0
           type: ovs-bridge
           state: up
@@ -206,7 +206,7 @@ fn test_failed_to_resolve_sriov_in_ovs_port_list() {
             port:
             - name: sriov:eth1:2
             - name: sriov:eth1:1
-        "#,
+        ",
     )
     .unwrap();
     let result = desired.resolve_sriov_reference(&current);
@@ -220,11 +220,11 @@ fn test_failed_to_resolve_sriov_in_ovs_port_list() {
 fn test_verify_sriov_name() {
     let current = gen_sriov_current_ifaces();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: sriov:eth1:0
           type: ethernet
           state: up
-        "#,
+        ",
     )
     .unwrap();
     let merged_ifaces =
@@ -237,7 +237,7 @@ fn test_verify_sriov_name() {
 fn test_resolve_sriov_port_name_linux_bridge() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: br0
           type: linux-bridge
           state: up
@@ -247,7 +247,7 @@ fn test_resolve_sriov_port_name_linux_bridge() {
               vlan:
                 mode: access
                 tag: 305
-        "#,
+        ",
     )
     .unwrap();
     desired.resolve_sriov_reference(&current).unwrap();
@@ -273,7 +273,7 @@ fn test_resolve_sriov_port_name_linux_bridge() {
 fn test_resolve_sriov_port_name_bond() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: bond0
           type: bond
           state: up
@@ -282,7 +282,7 @@ fn test_resolve_sriov_port_name_bond() {
             port:
             - sriov:eth1:1
             - sriov:eth1:0
-        "#,
+        ",
     )
     .unwrap();
     desired.resolve_sriov_reference(&current).unwrap();
@@ -296,7 +296,7 @@ fn test_resolve_sriov_port_name_bond() {
 fn test_resolve_sriov_port_name_ovs_bridge() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: ovs-br0
           type: ovs-bridge
           state: up
@@ -304,7 +304,7 @@ fn test_resolve_sriov_port_name_ovs_bridge() {
             port:
             - name: sriov:eth1:0
             - name: sriov:eth1:1
-        "#,
+        ",
     )
     .unwrap();
     desired.resolve_sriov_reference(&current).unwrap();
@@ -320,7 +320,7 @@ fn test_resolve_sriov_port_name_ovs_bridge() {
 fn test_resolve_sriov_port_name_ovs_bond() {
     let current = gen_sriov_current_ifaces();
     let mut desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: ovs-br0
           type: ovs-bridge
           state: up
@@ -332,7 +332,7 @@ fn test_resolve_sriov_port_name_ovs_bond() {
                 port:
                   - name: eth2
                   - name: sriov:eth1:1
-        "#,
+        ",
     )
     .unwrap();
     desired.resolve_sriov_reference(&current).unwrap();
@@ -348,7 +348,7 @@ fn test_resolve_sriov_port_name_ovs_bond() {
 fn test_verify_sriov_port_name_linux_bridge() {
     let pre_apply_current = gen_sriov_current_ifaces();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: br0
           type: linux-bridge
           state: up
@@ -358,13 +358,13 @@ fn test_verify_sriov_port_name_linux_bridge() {
               vlan:
                 mode: access
                 tag: 305
-        "#,
+        ",
     )
     .unwrap();
     let mut current = gen_sriov_current_ifaces();
     current.push(
         serde_yaml::from_str::<Interface>(
-            r#"---
+            r"---
             name: br0
             type: linux-bridge
             state: up
@@ -374,7 +374,7 @@ fn test_verify_sriov_port_name_linux_bridge() {
                 vlan:
                   mode: access
                   tag: 305
-        "#,
+        ",
         )
         .unwrap(),
     );
@@ -389,7 +389,7 @@ fn test_verify_sriov_port_name_linux_bridge() {
 fn test_verify_sriov_port_name_bond() {
     let pre_apply_current = gen_sriov_current_ifaces();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: bond0
           type: bond
           state: up
@@ -397,13 +397,13 @@ fn test_verify_sriov_port_name_bond() {
             mode: balance-rr
             port:
             - sriov:eth1:1
-        "#,
+        ",
     )
     .unwrap();
     let mut current = gen_sriov_current_ifaces();
     current.push(
         serde_yaml::from_str::<Interface>(
-            r#"---
+            r"---
             name: bond0
             type: bond
             state: up
@@ -411,7 +411,7 @@ fn test_verify_sriov_port_name_bond() {
               mode: balance-rr
               port:
               - eth1v1
-        "#,
+        ",
         )
         .unwrap(),
     );
@@ -427,27 +427,27 @@ fn test_verify_sriov_port_name_bond() {
 fn test_verify_sriov_port_name_ovs_bridge() {
     let pre_apply_current = gen_sriov_current_ifaces();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: ovs-br0
           type: ovs-bridge
           state: up
           bridge:
             port:
             - name: sriov:eth1:1
-        "#,
+        ",
     )
     .unwrap();
     let mut current = gen_sriov_current_ifaces();
     current.push(
         serde_yaml::from_str::<Interface>(
-            r#"---
+            r"---
             name: ovs-br0
             type: ovs-bridge
             state: up
             bridge:
               port:
               - name: eth1v1
-            "#,
+            ",
         )
         .unwrap(),
     );
@@ -462,7 +462,7 @@ fn test_verify_sriov_port_name_ovs_bridge() {
 fn test_verify_sriov_port_name_ovs_bond() {
     let pre_apply_current = gen_sriov_current_ifaces();
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: ovs-br0
           type: ovs-bridge
           state: up
@@ -474,13 +474,13 @@ fn test_verify_sriov_port_name_ovs_bond() {
                 port:
                   - name: sriov:eth1:1
                   - name: sriov:eth1:0
-        "#,
+        ",
     )
     .unwrap();
     let mut current = gen_sriov_current_ifaces();
     current.push(
         serde_yaml::from_str::<Interface>(
-            r#"---
+            r"---
             name: ovs-br0
             type: ovs-bridge
             state: up
@@ -492,7 +492,7 @@ fn test_verify_sriov_port_name_ovs_bond() {
                   port:
                     - name: eth1v0
                     - name: eth1v1
-              "#,
+              ",
         )
         .unwrap(),
     );
@@ -590,7 +590,7 @@ fn test_sriov_vf_auto_fill_vf_conf() {
 #[test]
 fn test_sriov_enable_and_use_in_single_yaml() {
     let desired = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
         interfaces:
         - name: eth1
           type: ethernet
@@ -607,7 +607,7 @@ fn test_sriov_enable_and_use_in_single_yaml() {
         - name: eth1v1
           type: ethernet
           state: up
-        "#,
+        ",
     )
     .unwrap();
 
@@ -630,7 +630,7 @@ fn test_sriov_enable_and_use_in_single_yaml() {
 #[test]
 fn test_has_sriov_and_missing_eth() {
     let desired = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
         interfaces:
         - name: eth1
           type: ethernet
@@ -647,11 +647,11 @@ fn test_has_sriov_and_missing_eth() {
         - name: eth1v1
           type: ethernet
           state: up
-        "#,
+        ",
     )
     .unwrap();
     let current = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
         interfaces:
         - name: eth1
           type: ethernet
@@ -662,7 +662,7 @@ fn test_has_sriov_and_missing_eth() {
             auto-negotiation: false
             sr-iov:
               total-vfs: 0
-        "#,
+        ",
     )
     .unwrap();
 
@@ -672,7 +672,7 @@ fn test_has_sriov_and_missing_eth() {
 #[test]
 fn test_sriov_has_sriov_and_missing_eth_pf_none() {
     let desired = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
         interfaces:
         - name: eth1
           type: ethernet
@@ -687,16 +687,16 @@ fn test_sriov_has_sriov_and_missing_eth_pf_none() {
           state: up
         - name: eth1v1
           state: up
-        "#,
+        ",
     )
     .unwrap();
     let current = serde_yaml::from_str::<NetworkState>(
-        r#"---
+        r"---
         interfaces:
         - name: eth1
           type: ethernet
           state: up
-        "#,
+        ",
     )
     .unwrap();
 
@@ -706,7 +706,7 @@ fn test_sriov_has_sriov_and_missing_eth_pf_none() {
 #[test]
 fn test_sriov_vf_revert_to_default() {
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: eth1
           type: ethernet
           state: up
@@ -714,12 +714,12 @@ fn test_sriov_vf_revert_to_default() {
             sr-iov:
               total-vfs: 2
               vfs: []
-        "#,
+        ",
     )
     .unwrap();
 
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: eth1
           type: ethernet
           state: up
@@ -739,7 +739,7 @@ fn test_sriov_vf_revert_to_default() {
                   min-tx-rate: 1
                   max-tx-rate: 1000
                   mac-address: d4:Ee:01:25:42:5A
-        "#,
+        ",
     )
     .unwrap();
 
@@ -793,25 +793,25 @@ fn test_sriov_vf_revert_to_default() {
 #[test]
 fn test_has_sriov_with_unknown_iface_type() {
     let desired = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: eth1
           state: up
           ethernet:
             sr-iov:
               total-vfs: 2
-        "#,
+        ",
     )
     .unwrap();
 
     let current = serde_yaml::from_str::<Interfaces>(
-        r#"---
+        r"---
         - name: eth1
           type: ethernet
           state: up
           ethernet:
             sr-iov:
               total-vfs: 1
-        "#,
+        ",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -223,7 +223,7 @@ fn gen_rule_entry(
 
 pub(crate) fn new_test_nic_with_static_ip() -> Interface {
     serde_yaml::from_str(
-        r#"
+        r"
         name: eth1
         type: ethernet
         state: up
@@ -245,14 +245,14 @@ pub(crate) fn new_test_nic_with_static_ip() -> Interface {
           autoconf: false
           dhcp: false
           enabled: true
-        "#,
+        ",
     )
     .unwrap()
 }
 
 fn new_test_nic2_with_static_ip() -> Interface {
     serde_yaml::from_str(
-        r#"
+        r"
         name: eth2
         type: ethernet
         state: up
@@ -274,7 +274,7 @@ fn new_test_nic2_with_static_ip() -> Interface {
           autoconf: false
           dhcp: false
           enabled: true
-        "#,
+        ",
     )
     .unwrap()
 }

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -25,7 +25,7 @@ vlan:
 #[test]
 fn test_vlan_get_parent_up_priority_plus_one() {
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
 - name: bond0.100
   type: vlan
   vlan:
@@ -42,7 +42,7 @@ fn test_vlan_get_parent_up_priority_plus_one() {
     port:
     - bond0
     - bond0.100
-    route-table-id: 1000"#,
+    route-table-id: 1000",
     )
     .unwrap();
 
@@ -77,7 +77,7 @@ fn test_vlan_get_parent_up_priority_plus_one() {
 #[test]
 fn test_vlan_orphan_check_auto_absent() {
     let current: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0.100
           type: vlan
           vlan:
@@ -86,14 +86,14 @@ fn test_vlan_orphan_check_auto_absent() {
         - name: bond0
           type: bond
           link-aggregation:
-            mode: balance-rr"#,
+            mode: balance-rr",
     )
     .unwrap();
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0
           type: bond
-          state: absent"#,
+          state: absent",
     )
     .unwrap();
 
@@ -113,7 +113,7 @@ fn test_vlan_orphan_check_auto_absent() {
 #[test]
 fn test_vlan_orphan_but_desired() {
     let current: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0.100
           type: vlan
           vlan:
@@ -122,15 +122,15 @@ fn test_vlan_orphan_but_desired() {
         - name: bond0
           type: bond
           link-aggregation:
-            mode: balance-rr"#,
+            mode: balance-rr",
     )
     .unwrap();
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0.100
         - name: bond0
           type: bond
-          state: absent"#,
+          state: absent",
     )
     .unwrap();
 
@@ -149,7 +149,7 @@ fn test_vlan_orphan_but_desired() {
 #[test]
 fn test_vlan_orphan_has_now_parent() {
     let current: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0.100
           type: vlan
           vlan:
@@ -158,11 +158,11 @@ fn test_vlan_orphan_has_now_parent() {
         - name: bond0
           type: bond
           link-aggregation:
-            mode: balance-rr"#,
+            mode: balance-rr",
     )
     .unwrap();
     let desired: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: bond0.100
           state: up
           type: vlan
@@ -176,7 +176,7 @@ fn test_vlan_orphan_has_now_parent() {
             mode: balance-rr
         - name: bond0
           type: bond
-          state: absent"#,
+          state: absent",
     )
     .unwrap();
 
@@ -186,23 +186,23 @@ fn test_vlan_orphan_has_now_parent() {
 #[test]
 fn test_vlan_update() {
     let mut iface1: VlanInterface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond0.100
         type: vlan
         vlan:
           base-iface: bond0
-          id: 100"#,
+          id: 100",
     )
     .unwrap();
 
     let iface2: VlanInterface = serde_yaml::from_str(
-        r#"---
+        r"---
         name: bond0.100
         type: vlan
         vlan:
           base-iface: bond0
           id: 100
-          protocol: 802.1q"#,
+          protocol: 802.1q",
     )
     .unwrap();
 

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -40,7 +40,7 @@ fn test_vrf_ports() {
 #[test]
 fn test_vrf_on_bond_vlan_got_auto_remove() {
     let cur_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: test-bond0.100
           type: vlan
           vlan:
@@ -58,19 +58,19 @@ fn test_vrf_on_bond_vlan_got_auto_remove() {
             - test-bond0
             - test-bond0.100
             route-table-id: 100
-        "#,
+        ",
     )
     .unwrap();
 
     let des_ifaces: Interfaces = serde_yaml::from_str(
-        r#"---
+        r"---
         - name: test-bond0
           type: bond
           state: absent
         - name: test-vrf0
           type: vrf
           state: absent
-        "#,
+        ",
     )
     .unwrap();
 

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -20,7 +20,8 @@ def create_veth_pair(nic, nic_peer, peer_ns):
         f"ip link add {nic} type veth peer name {nic_peer}".split(),
         check=True,
     )
-    exec_cmd(f"ip netns add {peer_ns}".split(), check=True)
+    # namespace might already exist
+    exec_cmd(f"ip netns add {peer_ns}".split(), check=False)
     exec_cmd(f"ip link set {nic_peer} netns {peer_ns}".split(), check=True)
     exec_cmd(f"ip link set {nic} up".split(), check=True)
     exec_cmd(


### PR DESCRIPTION
Previously we were using run-tests.sh to setup the eth1 and eth2,
after moving this into pytest fixture, the `pytest` could works out of
box.