### PR TITLE
Support generate statistic data

### DIFF
--- a/rust/src/cli/statistic.rs
+++ b/rust/src/cli/statistic.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+
+use nmstate::NetworkState;
+
+use crate::error::CliError;
+
+pub(crate) fn statistic(
+    matches: &clap::ArgMatches,
+) -> Result<String, crate::error::CliError> {
+    let desired_state = if let Some(file_path) = matches.value_of("STATE_FILE")
+    {
+        state_from_file(file_path)?
+    } else {
+        state_from_file("-")?
+    };
+    let current_state =
+        if let Some(cur_state_file) = matches.value_of("CURRENT_STATE") {
+            state_from_file(cur_state_file)?
+        } else {
+            let mut net_state = NetworkState::new();
+            net_state.set_running_config_only(true);
+            net_state.retrieve()?;
+            net_state
+        };
+
+    let statistic = desired_state.statistic(&current_state)?;
+
+    Ok(if matches.is_present("JSON") {
+        serde_json::to_string_pretty(&statistic)?
+    } else {
+        serde_yaml::to_string(&statistic)?
+    })
+}
+
+fn state_from_file(file_path: &str) -> Result<NetworkState, CliError> {
+    let mut content = String::new();
+    if file_path == "-" {
+        std::io::stdin().read_to_string(&mut content)?;
+    } else {
+        std::fs::File::open(file_path)?.read_to_string(&mut content)?;
+    };
+    // Replace non-breaking space '\u{A0}'  to normal space
+    let content = content.replace('\u{A0}', " ");
+
+    Ok(NetworkState::new_from_yaml(&content)?)
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -115,6 +115,8 @@ mod route;
 mod route_rule;
 mod serializer;
 mod state;
+#[cfg(feature = "query_apply")]
+mod statistic;
 mod unit_tests;
 
 pub use crate::dispatch::DispatchConfig;
@@ -180,3 +182,5 @@ pub(crate) use crate::route_rule::MergedRouteRules;
 pub use crate::route_rule::{
     RouteRuleAction, RouteRuleEntry, RouteRuleState, RouteRules,
 };
+#[cfg(feature = "query_apply")]
+pub use crate::statistic::{NmstateFeature, NmstateStatistic};

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::hash_map::Entry;
+
 use crate::{
-    ErrorKind, Interface, InterfaceType, Interfaces, NmstateError, SrIovConfig,
+    BaseInterface, ErrorKind, EthernetConfig, EthernetInterface, Interface,
+    InterfaceType, Interfaces, NmstateError, SrIovConfig, SrIovVfConfig,
 };
 
 impl SrIovConfig {
     // * Set 'vfs: []' to None which is just reverting all VF config to default.
+    // * Set `vf.iface_name` empty string,
     pub(crate) fn sanitize_desired_for_verify(&mut self) {
         if let Some(vfs) = self.vfs.as_mut() {
+            for vf in vfs.iter_mut() {
+                vf.iface_name = String::new();
+            }
             if vfs.is_empty() {
                 self.vfs = None;
             }
@@ -81,5 +88,111 @@ impl SrIovConfig {
             }
         }
         Ok(())
+    }
+}
+
+impl Interfaces {
+    pub(crate) fn has_sriov_naming(&self) -> bool {
+        self.kernel_ifaces
+            .values()
+            .any(|i| i.name().starts_with(SrIovConfig::VF_NAMING_PREFIX))
+    }
+
+    pub(crate) fn use_pseudo_sriov_vf_name(&self, current: &mut Self) {
+        let mut new_vf_names: Vec<String> = Vec::new();
+
+        for (des_iface, des_sriov_count) in
+            self.kernel_ifaces.values().filter_map(|i| {
+                if let Interface::Ethernet(eth_iface) = i {
+                    let sriov_count = eth_iface
+                        .ethernet
+                        .as_ref()
+                        .and_then(|e| e.sr_iov.as_ref())
+                        .and_then(|s| s.total_vfs)
+                        .unwrap_or_default();
+                    if sriov_count > 0 {
+                        Some((eth_iface, sriov_count))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        {
+            let cur_iface: &mut Interface = match current
+                .kernel_ifaces
+                .entry(des_iface.base.name.clone())
+            {
+                Entry::Occupied(o) => o.into_mut(),
+                Entry::Vacant(v) => {
+                    v.insert(Interface::Ethernet(des_iface.clone()))
+                }
+            };
+
+            let des_sriov_conf = if let Some(c) =
+                des_iface.ethernet.as_ref().and_then(|e| e.sr_iov.as_ref())
+            {
+                c
+            } else {
+                continue;
+            };
+
+            let cur_iface = if let Interface::Ethernet(i) = cur_iface {
+                i
+            } else {
+                continue;
+            };
+
+            // Only add psudo VF if current SRIOV setting differs
+            let cur_sriov_count = cur_iface
+                .ethernet
+                .as_ref()
+                .and_then(|e| e.sr_iov.as_ref())
+                .and_then(|s| s.total_vfs)
+                .unwrap_or_default();
+            if cur_sriov_count < des_sriov_count {
+                let cur_vfs = cur_iface
+                    .ethernet
+                    .get_or_insert(EthernetConfig {
+                        sr_iov: Some(des_sriov_conf.clone()),
+                        ..Default::default()
+                    })
+                    .sr_iov
+                    .get_or_insert(SrIovConfig::default())
+                    .vfs
+                    .get_or_insert(Vec::new());
+                for vfid in cur_sriov_count..des_sriov_count {
+                    let psudo_vf_name =
+                        format!("{}v{vfid}", des_iface.base.name);
+                    new_vf_names.push(psudo_vf_name.clone());
+                    match cur_vfs.get_mut(vfid as usize) {
+                        Some(vf) => {
+                            vf.id = vfid;
+                            if vf.iface_name.is_empty() {
+                                vf.iface_name = psudo_vf_name;
+                            }
+                        }
+                        None => {
+                            cur_vfs.push(SrIovVfConfig {
+                                id: vfid,
+                                iface_name: psudo_vf_name,
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        for psudo_vf_name in new_vf_names {
+            current.push(Interface::Ethernet(EthernetInterface {
+                base: BaseInterface {
+                    name: psudo_vf_name,
+                    iface_type: InterfaceType::Ethernet,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }));
+        }
     }
 }

--- a/rust/src/lib/statistic/feature/dns.rs
+++ b/rust/src/lib/statistic/feature/dns.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedDnsState, NmstateFeature};
+
+impl MergedDnsState {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret = Vec::new();
+        if let Some(dns_config) = self.desired.config.as_ref() {
+            if dns_config.server.is_some() {
+                ret.push(NmstateFeature::StaticDnsNameServer);
+            }
+            if dns_config.search.is_some() {
+                ret.push(NmstateFeature::StaticDnsSearch);
+            }
+            if dns_config.options.is_some() {
+                ret.push(NmstateFeature::StaticDnsOption);
+            }
+        }
+        ret
+    }
+}

--- a/rust/src/lib/statistic/feature/ethernet.rs
+++ b/rust/src/lib/statistic/feature/ethernet.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{EthernetInterface, NmstateFeature};
+
+impl EthernetInterface {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret = Vec::new();
+        if self.ethernet.as_ref().map(|e| e.sr_iov.is_some()) == Some(true) {
+            ret.push(NmstateFeature::Sriov)
+        }
+        ret
+    }
+}

--- a/rust/src/lib/statistic/feature/features.rs
+++ b/rust/src/lib/statistic/feature/features.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+
+#[derive(
+    Clone, Copy, Hash, Debug, Serialize, PartialEq, Eq, Ord, PartialOrd,
+)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+// Please sort this list
+pub enum NmstateFeature {
+    Dhcpv4CustomHostname,
+    Dhcpv6CustomHostname,
+    IfaceNameReferedBySriovVfId,
+    Lldp,
+    MacBasedIdentifier,
+    Mptcp,
+    OvnMapping,
+    OvsBond,
+    OvsDbGlobal,
+    OvsDbInterface,
+    OvsDpdk,
+    OvsPatch,
+    Sriov,
+    StaticDnsNameServer,
+    StaticDnsOption,
+    StaticDnsSearch,
+    StaticHostname,
+    StaticRoute,
+    StaticRouteRule,
+    StaticRouteRuleSuppressPrefixLength,
+    IfaceCount10Plus,
+    IfaceCount50Plus,
+    IfaceCount100Plus,
+    IfaceCount200Plus,
+    IfaceCount500Plus,
+}

--- a/rust/src/lib/statistic/feature/hostname.rs
+++ b/rust/src/lib/statistic/feature/hostname.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedHostNameState, NmstateFeature};
+
+impl MergedHostNameState {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if self.desired.as_ref().map(|d| d.config.is_some()) == Some(true) {
+            vec![NmstateFeature::StaticHostname]
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/rust/src/lib/statistic/feature/iface.rs
+++ b/rust/src/lib/statistic/feature/iface.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    BaseInterface, Interface, InterfaceIdentifier, MergedInterface,
+    NmstateFeature,
+};
+
+impl MergedInterface {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret: Vec<NmstateFeature> = Vec::new();
+        if self.desired.as_ref().map(|i| i.base_iface().identifier)
+            == Some(InterfaceIdentifier::MacAddress)
+        {
+            ret.push(NmstateFeature::MacBasedIdentifier);
+        }
+        if self.desired.as_ref().map(|i| i.base_iface().lldp.is_some())
+            == Some(true)
+        {
+            ret.push(NmstateFeature::Lldp);
+        }
+
+        if let Some(iface) = self.for_apply.as_ref() {
+            ret.append(&mut iface.base_iface().get_features());
+            match iface {
+                Interface::OvsBridge(iface) => {
+                    ret.append(&mut iface.get_features());
+                }
+                Interface::OvsInterface(iface) => {
+                    ret.append(&mut iface.get_features());
+                }
+                Interface::Ethernet(iface) => {
+                    ret.append(&mut iface.get_features());
+                }
+                _ => (),
+            }
+        }
+        ret
+    }
+}
+
+impl BaseInterface {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret = Vec::new();
+        if self.ovsdb.as_ref().map(|o| !o.is_empty()) == Some(true) {
+            ret.push(NmstateFeature::OvsDbInterface);
+        }
+        if let Some(i) = self.ipv4.as_ref() {
+            ret.append(&mut i.get_features());
+        }
+        if let Some(i) = self.ipv6.as_ref() {
+            ret.append(&mut i.get_features());
+        }
+        ret
+    }
+}

--- a/rust/src/lib/statistic/feature/inter_ifaces.rs
+++ b/rust/src/lib/statistic/feature/inter_ifaces.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use crate::{MergedInterfaces, NmstateFeature};
+
+impl MergedInterfaces {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret: HashSet<NmstateFeature> = HashSet::new();
+        for iface in self
+            .kernel_ifaces
+            .values()
+            .chain(self.user_ifaces.values())
+            .filter(|i| i.is_desired() || i.is_changed())
+        {
+            for feature in iface.get_features() {
+                ret.insert(feature);
+            }
+        }
+
+        let iface_count = self
+            .kernel_ifaces
+            .values()
+            .chain(self.user_ifaces.values())
+            .filter(|i| i.merged.is_up() && (i.is_desired()))
+            .count();
+        if iface_count >= 500 {
+            ret.insert(NmstateFeature::IfaceCount500Plus);
+        } else if iface_count >= 200 {
+            ret.insert(NmstateFeature::IfaceCount200Plus);
+        } else if iface_count >= 100 {
+            ret.insert(NmstateFeature::IfaceCount100Plus);
+        } else if iface_count >= 50 {
+            ret.insert(NmstateFeature::IfaceCount50Plus);
+        } else if iface_count >= 10 {
+            ret.insert(NmstateFeature::IfaceCount10Plus);
+        }
+
+        ret.drain().collect()
+    }
+}

--- a/rust/src/lib/statistic/feature/ip.rs
+++ b/rust/src/lib/statistic/feature/ip.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{InterfaceIpv4, InterfaceIpv6, NmstateFeature};
+
+impl InterfaceIpv4 {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if self.dhcp_custom_hostname.is_some() {
+            vec![NmstateFeature::Dhcpv4CustomHostname]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl InterfaceIpv6 {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if self.dhcp_custom_hostname.is_some() {
+            vec![NmstateFeature::Dhcpv6CustomHostname]
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/rust/src/lib/statistic/feature/mod.rs
+++ b/rust/src/lib/statistic/feature/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod dns;
+mod ethernet;
+mod features;
+mod hostname;
+mod iface;
+mod inter_ifaces;
+mod ip;
+mod ovs;
+mod route;
+mod route_rule;
+
+pub use self::features::NmstateFeature;

--- a/rust/src/lib/statistic/feature/ovs.rs
+++ b/rust/src/lib/statistic/feature/ovs.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    MergedOvnConfiguration, MergedOvsDbGlobalConfig, NmstateFeature,
+    OvsBridgeInterface, OvsDbIfaceConfig, OvsInterface,
+};
+
+impl MergedOvsDbGlobalConfig {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if !self.desired.is_none() {
+            vec![NmstateFeature::OvsDbGlobal]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl MergedOvnConfiguration {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if !self.desired.is_none() {
+            vec![NmstateFeature::OvnMapping]
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+impl OvsDbIfaceConfig {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.get_external_ids().is_empty() && self.get_other_config().is_empty()
+    }
+}
+
+impl OvsBridgeInterface {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret = Vec::new();
+        if let Some(ports) =
+            self.bridge.as_ref().and_then(|b| b.ports.as_deref())
+        {
+            if ports.iter().any(|p| p.bond.is_some()) {
+                ret.push(NmstateFeature::OvsBond);
+            }
+        }
+        ret
+    }
+}
+
+impl OvsInterface {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        let mut ret = Vec::new();
+        if self.dpdk.is_some() {
+            ret.push(NmstateFeature::OvsDpdk);
+        }
+        if self.patch.is_some() {
+            ret.push(NmstateFeature::OvsPatch);
+        }
+        ret
+    }
+}

--- a/rust/src/lib/statistic/feature/route.rs
+++ b/rust/src/lib/statistic/feature/route.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedRoutes, NmstateFeature};
+
+impl MergedRoutes {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if self.desired.config.is_some() {
+            vec![NmstateFeature::StaticRoute]
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/rust/src/lib/statistic/feature/route_rule.rs
+++ b/rust/src/lib/statistic/feature/route_rule.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedRouteRules, NmstateFeature};
+
+impl MergedRouteRules {
+    pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
+        if let Some(rts) = self.desired.config.as_ref() {
+            if !rts.is_empty() {
+                let mut ret = vec![NmstateFeature::StaticRouteRule];
+                if rts.iter().any(|r| {
+                    (!r.is_absent()) && r.suppress_prefix_length.is_some()
+                }) {
+                    ret.push(
+                        NmstateFeature::StaticRouteRuleSuppressPrefixLength,
+                    );
+                }
+                ret
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        }
+    }
+}

--- a/rust/src/lib/statistic/inter_ifaces.rs
+++ b/rust/src/lib/statistic/inter_ifaces.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{InterfaceType, MergedInterface, MergedInterfaces};
+
+impl MergedInterfaces {
+    pub(crate) fn gen_topoligies(&self) -> Vec<String> {
+        let mut ret = Vec::new();
+        for iface in self
+            .kernel_ifaces
+            .values()
+            .chain(self.user_ifaces.values())
+            .filter(|i| i.merged.is_up() && (i.is_desired() || i.is_changed()))
+        {
+            let new_top = self.get_topoligy(iface).join(" -> ").to_string();
+            if !ret.contains(&new_top) {
+                ret.push(new_top);
+            }
+        }
+        let mut dups = Vec::new();
+        ret.sort_unstable_by_key(|t| t.len());
+        for (i, top) in ret.iter().enumerate() {
+            if ret[i + 1..].iter().any(|t| t.contains(top.as_str())) {
+                dups.push(top.clone());
+            }
+        }
+        ret.retain(|t| !dups.contains(t));
+        ret
+    }
+
+    fn get_topoligy(&self, iface: &MergedInterface) -> Vec<String> {
+        let mut ret = self.get_superior_types(iface);
+        ret.push(iface.merged.iface_type().to_string());
+        ret.append(&mut self.get_subordinate_types(iface));
+        ret
+    }
+
+    fn get_superior_types(&self, iface: &MergedInterface) -> Vec<String> {
+        let mut ret: Vec<String> = Vec::new();
+        if iface.merged.iface_type() == InterfaceType::OvsInterface {
+            if let Some(i) = iface.get_ip_topology() {
+                ret.push(i);
+            }
+        } else if let (Some(ctrl_name), Some(ctrl_type)) = (
+            iface.merged.base_iface().controller.as_ref(),
+            iface.merged.base_iface().controller_type.as_ref(),
+        ) {
+            if let Some(ctrl_iface) =
+                self.get_iface(ctrl_name, ctrl_type.clone())
+            {
+                ret.append(&mut self.get_superior_types(ctrl_iface));
+                ret.push(ctrl_type.to_string());
+            }
+        } else if let Some(i) = iface.get_ip_topology() {
+            ret.push(i);
+        }
+        ret
+    }
+
+    // To build up the topology, we are considering the vlan parent as
+    // an subordinate of VLAN.
+    fn get_subordinate_types(&self, iface: &MergedInterface) -> Vec<String> {
+        let mut ret: Vec<String> = Vec::new();
+        if let Some(parent) = iface.merged.parent() {
+            let parent_iface =
+                if iface.merged.iface_type() == InterfaceType::OvsInterface {
+                    self.get_iface(parent, InterfaceType::OvsBridge)
+                } else {
+                    self.kernel_ifaces.get(parent)
+                };
+            if let Some(parent_iface) = parent_iface {
+                ret.push(parent_iface.merged.iface_type().to_string());
+                ret.append(&mut self.get_subordinate_types(parent_iface));
+            }
+        } else if let Some(ports) = iface.merged.ports() {
+            // for all the ports, we took the one holding the most complex
+            // topology.
+            let mut most_complex_top = Vec::new();
+
+            // TODO: We do not support showing ovs-bond yet.
+            for port in ports {
+                if let Some(port_iface) =
+                    self.kernel_ifaces.get(&port.to_string())
+                {
+                    if port_iface.merged.iface_type()
+                        == InterfaceType::OvsInterface
+                    {
+                        continue;
+                    }
+                    let mut port_subs =
+                        vec![port_iface.merged.iface_type().to_string()];
+                    port_subs
+                        .append(&mut self.get_subordinate_types(port_iface));
+                    if port_subs.len() > most_complex_top.len() {
+                        most_complex_top = port_subs;
+                    }
+                }
+            }
+            ret.append(&mut most_complex_top);
+        }
+        ret
+    }
+}

--- a/rust/src/lib/statistic/ip.rs
+++ b/rust/src/lib/statistic/ip.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MergedInterface;
+
+impl MergedInterface {
+    pub(crate) fn get_ip_topology(&self) -> Option<String> {
+        let mut ret: Vec<&str> = Vec::new();
+        if let Some(ip4) = self.merged.base_iface().ipv4.as_ref() {
+            if ip4.is_static() {
+                ret.push("static_ip4")
+            }
+            if ip4.is_auto() {
+                ret.push("auto_ip4")
+            }
+        }
+        if let Some(ip6) = self.merged.base_iface().ipv6.as_ref() {
+            if ip6.is_static() {
+                ret.push("static_ip6")
+            }
+            if ip6.is_auto() {
+                ret.push("auto_ip6")
+            }
+        }
+
+        if ret.is_empty() {
+            None
+        } else {
+            Some(ret.as_slice().join(","))
+        }
+    }
+}

--- a/rust/src/lib/statistic/mod.rs
+++ b/rust/src/lib/statistic/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod feature;
+mod inter_ifaces;
+mod ip;
+mod net_state;
+
+pub use self::feature::NmstateFeature;
+pub use self::net_state::NmstateStatistic;

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+
+use crate::{MergedNetworkState, NetworkState, NmstateError, NmstateFeature};
+
+#[derive(Clone, Debug, Serialize, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NmstateStatistic {
+    pub topology: Vec<String>,
+    pub features: Vec<NmstateFeature>,
+}
+
+impl NetworkState {
+    pub fn statistic(
+        &self,
+        current: &Self,
+    ) -> Result<NmstateStatistic, NmstateError> {
+        let mut current = current.clone();
+        let mut features = Vec::new();
+
+        // The MergedNetworkState will try to resolve SRIOV VF names,
+        // To detect IfaceNameReferedBySriovVfId feature, we need to
+        // do it before MergedNetworkState
+        if self.interfaces.has_sriov_naming() {
+            features.push(NmstateFeature::IfaceNameReferedBySriovVfId);
+            // Need to use pseudo VF interface to bypass all checks in
+            // MergedNetworkState::new().
+            self.interfaces
+                .use_pseudo_sriov_vf_name(&mut current.interfaces);
+        }
+        let merged_state =
+            MergedNetworkState::new(self.clone(), current, false, false)?;
+
+        features.append(&mut merged_state.interfaces.get_features());
+        features.append(&mut merged_state.dns.get_features());
+        features.append(&mut merged_state.routes.get_features());
+        features.append(&mut merged_state.rules.get_features());
+        features.append(&mut merged_state.ovsdb.get_features());
+        features.append(&mut merged_state.ovn.get_features());
+        features.append(&mut merged_state.hostname.get_features());
+
+        features.sort_unstable();
+
+        Ok(NmstateStatistic {
+            topology: merged_state.interfaces.gen_topoligies(),
+            features,
+        })
+    }
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -49,6 +49,8 @@ mod route_rule;
 #[cfg(test)]
 mod sriov;
 #[cfg(test)]
+mod statistic;
+#[cfg(test)]
 mod testlib;
 #[cfg(test)]
 mod vlan;

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    unit_tests::testlib::new_eth_iface, BridgePortVlanMode, ErrorKind,
-    EthernetConfig, EthernetDuplex, Interface, InterfaceType, Interfaces,
-    MergedInterfaces, NetworkState, SrIovConfig, SrIovVfConfig,
+    state::get_json_value_difference, unit_tests::testlib::new_eth_iface,
+    BridgePortVlanMode, ErrorKind, EthernetConfig, EthernetDuplex, Interface,
+    InterfaceType, Interfaces, MergedInterfaces, NetworkState, SrIovConfig,
+    SrIovVfConfig,
 };
 
 #[test]
@@ -575,15 +576,20 @@ fn test_sriov_vf_auto_fill_vf_conf() {
         .for_apply
         .as_ref()
         .unwrap();
+    let cur_iface = cur_ifaces
+        .get_iface("eth1", InterfaceType::Ethernet)
+        .unwrap();
 
+    // The cur_iface will has extra property `iface_name` comparing to
+    // desire iface, hence we use get_json_value_difference() to
+    // compare matches.
     assert_eq!(
-        serde_yaml::to_string(iface).unwrap(),
-        serde_yaml::to_string(
-            cur_ifaces
-                .get_iface("eth1", InterfaceType::Ethernet)
-                .unwrap()
-        )
-        .unwrap()
+        get_json_value_difference(
+            "interfaces".to_string(),
+            &serde_json::to_value(iface).unwrap(),
+            &serde_json::to_value(cur_iface).unwrap()
+        ),
+        None
     );
 }
 

--- a/rust/src/lib/unit_tests/statistic.rs
+++ b/rust/src/lib/unit_tests/statistic.rs
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    BaseInterface, DummyInterface, Interface, InterfaceType, NetworkState,
+    NmstateFeature,
+};
+
+const CUR_STATE_STR: &str = r"---
+    interfaces:
+    - name: eth1
+      type: ethernet
+      state: up
+      mac-address: 01:23:45:67:89:AB
+    - name: eth2
+      type: ethernet
+      state: up
+      mac-address: 01:23:45:67:89:AC";
+
+#[test]
+fn test_statistic_topology_static_ip() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+        - name: br0.101
+          type: vlan
+          vlan:
+            base-iface: br0
+            id: 101
+          ipv4:
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 24
+            - ip: 192.0.2.251
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          ipv6:
+            address:
+              - ip: 2001:db8:2::1
+                prefix-length: 64
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+            autoconf: false
+            dhcp: false
+            enabled: true
+        - name: bond1
+          type: bond
+          link-aggregation:
+            mode: 1
+            ports:
+              - eth1
+              - eth2
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: bond1",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.topology.as_slice(),
+        ["static_ip4,static_ip6 -> vlan -> linux-bridge -> bond -> ethernet"]
+    )
+}
+
+#[test]
+fn test_statistic_feature_dns() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        dns-resolver:
+          config:
+            options:
+            - rotate
+            - debug
+            - ndots:8
+            search:
+            - example.com
+            - example.org
+            server:
+            - 2001:db8:1::1
+            - 2001:db8:1::2
+            - 192.0.2.251",
+    )
+    .unwrap();
+    let current = NetworkState::default();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [
+            NmstateFeature::StaticDnsNameServer,
+            NmstateFeature::StaticDnsOption,
+            NmstateFeature::StaticDnsSearch,
+        ],
+    )
+}
+
+#[test]
+fn test_statistic_feature_route() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            mtu: 1500
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.168.1.1
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+            metric: 103
+        ",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(stat.features.as_slice(), [NmstateFeature::StaticRoute])
+}
+
+#[test]
+fn test_statistic_feature_route_rule() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        route-rules:
+          config:
+            - ip-from: 192.168.3.2/32
+              suppress-prefix-length: 0
+              route-table: 200
+            - ip-from: 2001:db8:b::/64
+              suppress-prefix-length: 1
+              route-table: 200
+        ",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [
+            NmstateFeature::StaticRouteRule,
+            NmstateFeature::StaticRouteRuleSuppressPrefixLength
+        ]
+    )
+}
+
+#[test]
+fn test_statistic_feature_hostname() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        hostname:
+          config: hosta.example.org",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(stat.features.as_slice(), [NmstateFeature::StaticHostname])
+}
+
+#[test]
+fn test_statistic_feature_sriov() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ethernet:
+              sr-iov:
+                total-vfs: 2
+          - name: sriov:eth1:1
+            type: ethernet
+            state: up",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [
+            NmstateFeature::IfaceNameReferedBySriovVfId,
+            NmstateFeature::Sriov,
+        ]
+    )
+}
+
+#[test]
+fn test_statistic_feature_ovs_dpdk_with_bond() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+        - name: ovs0
+          type: ovs-interface
+          state: up
+          mtu: 9000
+          dpdk:
+            devargs: "0000:ab:cd.0"
+            rx-queue: 100
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              datapath: "netdev"
+            port:
+            - name: ovs0
+            - name: bond99
+              link-aggregation:
+                mode: balance-slb
+                ports:
+                  - name: eth2
+                  - name: eth1
+        ovs-db:
+          other_config:
+            dpdk-init: "true"
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [
+            NmstateFeature::OvsBond,
+            NmstateFeature::OvsDbGlobal,
+            NmstateFeature::OvsDpdk,
+        ]
+    )
+}
+
+#[test]
+fn test_statistic_feature_ovs_patch_with_iface_ovsdb() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+        - name: patch0
+          type: ovs-interface
+          state: up
+          ovs-db:
+            external_ids:
+              gris: abc
+          patch:
+            peer: patch1
+        - name: ovs-br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: patch0
+        - name: patch1
+          type: ovs-interface
+          state: up
+          patch:
+            peer: patch0
+        - name: ovs-br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: patch1
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [NmstateFeature::OvsDbInterface, NmstateFeature::OvsPatch,]
+    )
+}
+
+#[test]
+fn test_statistic_feature_ovn_map() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        ovn:
+          bridge-mappings:
+            - localnet: blue
+              bridge: ovsbr1
+            - localnet: red
+              bridge: ovsbr2
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(stat.features.as_slice(), [NmstateFeature::OvnMapping])
+}
+
+#[test]
+fn test_statistic_feature_mac_based_iface_id() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: wan0
+            type: ethernet
+            state: up
+            identifier: mac-address
+            mac-address: 01:23:45:67:89:AB
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [NmstateFeature::MacBasedIdentifier]
+    )
+}
+
+#[test]
+fn test_statistic_feature_dhcp_hostname() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              dhcp: true
+              dhcp-client-id: iaid+duid
+              enabled: true
+              dhcp-send-hostname: true
+              dhcp-custom-hostname: c9.example.org
+            ipv6:
+              dhcp: true
+              autoconf: true
+              enabled: true
+              dhcp-send-hostname: true
+              dhcp-custom-hostname: c9.example.net
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(
+        stat.features.as_slice(),
+        [
+            NmstateFeature::Dhcpv4CustomHostname,
+            NmstateFeature::Dhcpv6CustomHostname,
+        ]
+    )
+}
+
+#[test]
+fn test_statistic_feature_lldp() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            lldp:
+              enabled: true
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+    let stat = desired.statistic(&current).unwrap();
+
+    assert_eq!(stat.features.as_slice(), [NmstateFeature::Lldp,])
+}
+
+#[test]
+fn test_statistic_feature_iface_count() {
+    for (count, feature) in [
+        (11, NmstateFeature::IfaceCount10Plus),
+        (51, NmstateFeature::IfaceCount50Plus),
+        (101, NmstateFeature::IfaceCount100Plus),
+        (499, NmstateFeature::IfaceCount200Plus),
+        (500, NmstateFeature::IfaceCount500Plus),
+    ] {
+        let desired: NetworkState = gen_dummy_ifaces(count);
+        let current: NetworkState =
+            serde_yaml::from_str(CUR_STATE_STR).unwrap();
+
+        let stat = desired.statistic(&current).unwrap();
+
+        assert_eq!(stat.features.as_slice(), [feature])
+    }
+}
+
+fn gen_dummy_ifaces(iface_count: usize) -> NetworkState {
+    let mut ret = NetworkState::default();
+
+    for i in 0..iface_count {
+        ret.interfaces.push(Interface::Dummy(DummyInterface {
+            base: BaseInterface {
+                name: format!("dummy{i}"),
+                iface_type: InterfaceType::Dummy,
+                ..Default::default()
+            },
+        }));
+    }
+    ret
+}


### PR DESCRIPTION
Introducing new subcommand of CLI `nmstatectl st` to generate statistic data. This is the example output:

```yml
topology:
- static_ip4,static_ip6 -> linux-bridge -> bond -> ethernet
- static_ip4,static_ip6 -> vlan -> linux-bridge -> bond -> ethernet
features:
- sriov
- mac-based-identifier
```

The statistics only count desired or impacted interfaces. The rust API is `NetworkState::statistic(&self, current: &Self)`.

Unit test cases included.