### PR TITLE
[nmstate-1.4] ip: Support treating string as int for `prefix-length`

### DIFF
--- a/libnmstate/ifaces/base_iface.py
+++ b/libnmstate/ifaces/base_iface.py
@@ -48,6 +48,7 @@ class IPState:
         self._info = info
         self._remove_stack_if_disabled()
         self._canonicalize_ip_addr()
+        self._canonicalize_ip_prefix()
         self._canonicalize_dynamic()
 
     def _canonicalize_dynamic(self):
@@ -69,6 +70,12 @@ class IPState:
         for addr in self.addresses:
             addr[InterfaceIP.ADDRESS_IP] = canonicalize_ip_address(
                 addr[InterfaceIP.ADDRESS_IP]
+            )
+
+    def _canonicalize_ip_prefix(self):
+        for addr in self.addresses:
+            addr[InterfaceIP.ADDRESS_PREFIX_LENGTH] = int(
+                addr[InterfaceIP.ADDRESS_PREFIX_LENGTH]
             )
 
     def sort_addresses(self):

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -615,7 +615,9 @@ definitions:
                   ip:
                     type: string
                   prefix-length:
-                    type: integer
+                    type:
+                      - integer
+                      - string
                   netmask:
                     type: string
             neighbor:
@@ -654,7 +656,9 @@ definitions:
                   ip:
                     type: string
                   prefix-length:
-                    type: integer
+                    type:
+                      - integer
+                      - string
             neighbor:
               type: array
               items:

--- a/tests/lib/ifaces/ip_state_test.py
+++ b/tests/lib/ifaces/ip_state_test.py
@@ -28,6 +28,7 @@ from libnmstate.schema import InterfaceIPv6
 
 from libnmstate.ifaces.base_iface import IPState
 
+from ..testlib.constants import IPV4_ADDRESS1
 from ..testlib.constants import IPV4_ADDRESSES
 from ..testlib.constants import IPV6_ADDRESS1
 from ..testlib.constants import IPV6_ADDRESS1_FULL
@@ -140,6 +141,53 @@ class TestIPState:
                     {
                         InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1_FULL,
                         InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+            },
+        )
+
+        assert ip_state.to_dict() == {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                }
+            ],
+        }
+
+    def test_treating_string_as_int_for_prefix_length(self):
+        ipv4_state = IPState(
+            Interface.IPV4,
+            {
+                InterfaceIPv4.ENABLED: True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: "24",
+                    }
+                ],
+            },
+        )
+
+        assert ipv4_state.to_dict() == {
+            InterfaceIPv6.ENABLED: True,
+            InterfaceIPv6.ADDRESS: [
+                {
+                    InterfaceIPv6.ADDRESS_IP: IPV4_ADDRESS1,
+                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 24,
+                }
+            ],
+        }
+
+        ip_state = IPState(
+            Interface.IPV6,
+            {
+                InterfaceIPv6.ENABLED: True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS1,
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: "64",
                     }
                 ],
             },


### PR DESCRIPTION
When the network role user is using the `network_state` variable to configure the network, and if they are using Jinja2 template to define the `prefix-length`, the type conversion
`prefix-length: "{{ __str_val | int }}"` does not work as expected, the type for `prefix-length` in the end is still string. Therefore, nmstate need to support treating string as int for `prefix-length` in order to make the apply succeed.