### PR TITLE
test: Remove verify_change=False for absent action

### DIFF
--- a/tests/integration/testlib/dummy.py
+++ b/tests/integration/testlib/dummy.py
@@ -27,7 +27,6 @@ def nm_unmanaged_dummy(name):
                         }
                     ]
                 },
-                verify_change=False,
             )
         except Exception:
             # dummy1 might not became managed by NM, hence removal might fail

--- a/tests/integration/testlib/genconf.py
+++ b/tests/integration/testlib/genconf.py
@@ -46,7 +46,7 @@ def gen_conf_apply(desire_state):
                     Interface.STATE: InterfaceState.ABSENT,
                 }
             )
-        libnmstate.apply(absent_state, verify_change=False)
+        libnmstate.apply(absent_state)
         for file_path in file_paths:
             try:
                 os.unlink(file_path)

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -131,7 +131,7 @@ class Bridge:
                     self._ifaces, InterfaceState.ABSENT
                 )
             }
-            libnmstate.apply(desired_state, verify_change=False)
+            libnmstate.apply(desired_state)
 
     def apply(self):
         libnmstate.apply(self.state)

--- a/tests/integration/testlib/vxlan.py
+++ b/tests/integration/testlib/vxlan.py
@@ -75,7 +75,7 @@ def vxlan_interfaces(*vxlans, create=True):
     try:
         yield setup_state
     finally:
-        libnmstate.apply(vxlans_absent(vxlans), verify_change=False)
+        libnmstate.apply(vxlans_absent(vxlans))
 
 
 def vxlans_up(vxlans):


### PR DESCRIPTION
For test `test_create_ovs_with_internal_ports_in_reverse_order` which
check absent of interface right after the `state: absent` applied,
if we use `verify_change=False`, nmstate will not wait till interface
gone.

This patch removed all `verify_change=False` for absent action.