### PR TITLE
Support generate new network state to revert

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -30,6 +30,7 @@ chrono = "0.4"
 nispor = { version = "1.2", optional = true }
 
 [features]
-default = ["query_apply", "gen_conf"]
+default = ["query_apply", "gen_conf", "gen_revert"]
 query_apply = ["nmstate/query_apply", "ctrlc", "nispor"]
 gen_conf = ["nmstate/gen_conf"]
+gen_revert = ["nmstate/gen_revert"]

--- a/rust/src/cli/format.rs
+++ b/rust/src/cli/format.rs
@@ -1,20 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use nmstate::NetworkState;
-use std::io::Read;
-
-use crate::error::CliError;
+use crate::{error::CliError, state::state_from_file};
 
 pub(crate) fn format(state_file: &str) -> Result<String, CliError> {
-    let mut content = String::new();
-    if state_file == "-" {
-        std::io::stdin().read_to_string(&mut content)?;
-    } else {
-        std::fs::File::open(state_file)?.read_to_string(&mut content)?;
-    };
-    // Replace non-breaking space '\u{A0}'  to normal space
-    let content = content.replace('\u{A0}', " ");
-
-    let state = NetworkState::new_from_yaml(&content)?;
-    Ok(serde_yaml::to_string(&state)?)
+    Ok(serde_yaml::to_string(&state_from_file(state_file)?)?)
 }

--- a/rust/src/cli/gen_conf.rs
+++ b/rust/src/cli/gen_conf.rs
@@ -1,18 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::Read;
-
-use nmstate::NetworkState;
-
-use crate::error::CliError;
+use crate::{error::CliError, state::state_from_file};
 
 pub(crate) fn gen_conf(file_path: &str) -> Result<String, CliError> {
-    let mut fd = std::fs::File::open(file_path)?;
-    let mut content = String::new();
-    // Replace non-breaking space '\u{A0}'  to normal space
-    fd.read_to_string(&mut content)?;
-    let content = content.replace('\u{A0}', " ");
-    let net_state: NetworkState = serde_yaml::from_str(&content)?;
+    let net_state = state_from_file(file_path)?;
     let confs = net_state.gen_conf()?;
     let escaped_string = serde_yaml::to_string(&confs)?;
     Ok(escaped_string.replace("\\n", "\n\n"))

--- a/rust/src/cli/gen_revert.rs
+++ b/rust/src/cli/gen_revert.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nmstate::NetworkState;
+
+use crate::{error::CliError, state::state_from_file};
+
+pub(crate) fn gen_revert(
+    matches: &clap::ArgMatches,
+) -> Result<String, CliError> {
+    let desired_state = if let Some(file_path) = matches.value_of("STATE_FILE")
+    {
+        state_from_file(file_path)?
+    } else {
+        state_from_file("-")?
+    };
+    let current_state =
+        if let Some(cur_state_file) = matches.value_of("CURRENT_STATE") {
+            state_from_file(cur_state_file)?
+        } else {
+            let mut net_state = NetworkState::new();
+            net_state.set_running_config_only(true);
+            net_state.retrieve()?;
+            net_state
+        };
+
+    let new_state = desired_state.generate_revert(&current_state)?;
+
+    Ok(if matches.is_present("JSON") {
+        serde_json::to_string_pretty(&new_state)?
+    } else {
+        serde_yaml::to_string(&new_state)?
+    })
+}

--- a/rust/src/cli/state.rs
+++ b/rust/src/cli/state.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nmstate::NetworkState;
+use std::io::Read;
+
+use crate::error::CliError;
+
+pub(crate) fn state_from_file(
+    file_path: &str,
+) -> Result<NetworkState, CliError> {
+    let mut content = String::new();
+    if file_path == "-" {
+        std::io::stdin().read_to_string(&mut content)?;
+    } else {
+        std::fs::File::open(file_path)?.read_to_string(&mut content)?;
+    };
+    // Replace non-breaking space '\u{A0}'  to normal space
+    let content = content.replace('\u{A0}', " ");
+
+    Ok(NetworkState::new_from_yaml(&content)?)
+}

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -60,6 +60,7 @@ features = ["feature", "hostname"]
 serde_yaml = "0.9"
 
 [features]
-default = ["query_apply", "gen_conf"]
+default = ["query_apply", "gen_conf", "gen_revert"]
 query_apply = ["nispor", "nix", "zbus"]
 gen_conf = []
+gen_revert = []

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -185,7 +185,7 @@ impl DnsClientState {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct MergedDnsState {
     desired: DnsState,
-    current: DnsState,
+    pub(crate) current: DnsState,
     pub(crate) servers: Vec<String>,
     pub(crate) searches: Vec<String>,
     pub(crate) options: Vec<String>,

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -108,6 +108,8 @@ mod ovsdb;
 mod policy;
 #[cfg(feature = "query_apply")]
 mod query_apply;
+#[cfg(feature = "gen_revert")]
+mod revert;
 mod route;
 mod route_rule;
 mod serializer;

--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -290,7 +290,9 @@ impl std::fmt::Display for OvnBridgeMapping {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 #[serde(rename_all = "lowercase", deny_unknown_fields)]
 #[non_exhaustive]
 pub enum OvnBridgeMappingState {

--- a/rust/src/lib/revert/dns.rs
+++ b/rust/src/lib/revert/dns.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DnsState, MergedDnsState};
+
+impl MergedDnsState {
+    pub(crate) fn generate_revert(&self) -> DnsState {
+        if self.is_changed() {
+            self.current.clone()
+        } else {
+            DnsState::new()
+        }
+    }
+}

--- a/rust/src/lib/revert/hostname.rs
+++ b/rust/src/lib/revert/hostname.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{HostNameState, MergedHostNameState};
+
+impl MergedHostNameState {
+    pub(crate) fn generate_revert(&self) -> Option<HostNameState> {
+        if self.desired.is_some() {
+            self.current.clone()
+        } else {
+            None
+        }
+    }
+}

--- a/rust/src/lib/revert/ifaces/base.rs
+++ b/rust/src/lib/revert/ifaces/base.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::BaseInterface;
+
+impl BaseInterface {
+    pub(crate) fn generate_revert_extra(
+        &mut self,
+        desired: &Self,
+        current: &Self,
+    ) {
+        if !desired.can_have_ip() && self.can_have_ip() {
+            self.ipv4 = current.ipv4.clone();
+            self.ipv6 = current.ipv6.clone();
+        }
+        // If desired switch from static IP to auto IP without mentioning
+        // `address` property, the auto-generated revert state will not
+        // contains `address` property. In this case, if we noticed
+        // static/auto flipping, we clone current IP state to revert.
+        if desired.ipv4.as_ref().map(|i| i.is_auto()) == Some(true)
+            && current.ipv4.as_ref().map(|i| !i.is_auto()) == Some(true)
+        {
+            self.ipv4 = current.ipv4.clone();
+        }
+
+        if desired.ipv6.as_ref().map(|i| i.is_auto()) == Some(true)
+            && current.ipv6.as_ref().map(|i| !i.is_auto()) == Some(true)
+        {
+            self.ipv6 = current.ipv6.clone();
+        }
+        self.ipv4.as_mut().and_then(|i| i.sanitize(false).ok());
+        self.ipv6.as_mut().and_then(|i| i.sanitize(false).ok());
+    }
+}

--- a/rust/src/lib/revert/ifaces/ethernet.rs
+++ b/rust/src/lib/revert/ifaces/ethernet.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{EthernetConfig, EthernetInterface, Interface, SrIovConfig};
+
+impl EthernetInterface {
+    pub(crate) fn generate_revert_extra(
+        &mut self,
+        desired: &Interface,
+        current: &Interface,
+    ) {
+        if let (Interface::Ethernet(desired), Interface::Ethernet(current)) =
+            (desired, current)
+        {
+            if desired.sriov_is_enabled() && !current.sriov_is_enabled() {
+                self.ethernet
+                    .get_or_insert(EthernetConfig::new())
+                    .sr_iov
+                    .get_or_insert(SrIovConfig {
+                        total_vfs: Some(0),
+                        ..Default::default()
+                    });
+            }
+        }
+    }
+}

--- a/rust/src/lib/revert/ifaces/iface.rs
+++ b/rust/src/lib/revert/ifaces/iface.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    revert::state::gen_revert_state, Interface, InterfaceState,
+    MergedInterface, NmstateError,
+};
+
+impl MergedInterface {
+    pub(crate) fn generate_revert(
+        &self,
+    ) -> Result<Option<Interface>, NmstateError> {
+        let apply_iface = match self.for_apply.as_ref() {
+            Some(i) => i,
+            None => return Ok(None),
+        };
+        if let Some(cur_iface) = self.current.as_ref() {
+            let revert_iface = apply_iface.generate_revert(cur_iface)?;
+            if !is_no_op(&revert_iface, apply_iface) {
+                Ok(Some(revert_iface))
+            } else {
+                Ok(None)
+            }
+        } else {
+            let mut revert_iface = apply_iface.clone_name_type_only();
+            revert_iface.base_iface_mut().state = InterfaceState::Absent;
+            Ok(Some(revert_iface))
+        }
+    }
+}
+
+impl Interface {
+    pub(crate) fn generate_revert(
+        &self,
+        current: &Self,
+    ) -> Result<Self, NmstateError> {
+        let mut revert_value =
+            serde_json::to_value(current.clone_name_type_only())?;
+        let desired_value = serde_json::to_value(self)?;
+        let current_value = serde_json::to_value(current)?;
+
+        gen_revert_state(&desired_value, &current_value, &mut revert_value);
+
+        let mut revert_iface: Interface = serde_json::from_value(revert_value)?;
+
+        revert_iface
+            .base_iface_mut()
+            .generate_revert_extra(self.base_iface(), current.base_iface());
+
+        if let Interface::Ethernet(ref mut eth_iface) = revert_iface {
+            eth_iface.generate_revert_extra(self, current);
+        }
+
+        Ok(revert_iface)
+    }
+}
+
+fn is_no_op(revert_iface: &Interface, desired_iface: &Interface) -> bool {
+    if let (Ok(revert_value), Ok(desired_value)) = (
+        serde_json::to_value(revert_iface),
+        serde_json::to_value(desired_iface),
+    ) {
+        revert_value == desired_value
+    } else {
+        false
+    }
+}

--- a/rust/src/lib/revert/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/revert/ifaces/inter_ifaces.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Interfaces, MergedInterfaces, NmstateError};
+
+impl MergedInterfaces {
+    pub(crate) fn generate_revert(&self) -> Result<Interfaces, NmstateError> {
+        let mut ret = Interfaces::default();
+        for iface in self
+            .kernel_ifaces
+            .values()
+            .chain(self.user_ifaces.values())
+            .filter(|i| i.is_desired() || i.is_changed())
+        {
+            if let Some(new_iface) = iface.generate_revert()? {
+                ret.push(new_iface);
+            }
+        }
+        Ok(ret)
+    }
+}

--- a/rust/src/lib/revert/ifaces/mod.rs
+++ b/rust/src/lib/revert/ifaces/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod base;
+mod ethernet;
+mod iface;
+mod inter_ifaces;

--- a/rust/src/lib/revert/mod.rs
+++ b/rust/src/lib/revert/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod dns;
+mod hostname;
+mod ifaces;
+mod net_state;
+mod ovn;
+mod ovsdb;
+mod route;
+mod route_rule;
+mod state;

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedNetworkState, NetworkState, NmstateError};
+
+impl NetworkState {
+    pub fn generate_revert(
+        &self,
+        current: &Self,
+    ) -> Result<Self, NmstateError> {
+        let merged_state = MergedNetworkState::new(
+            self.clone(),
+            current.clone(),
+            false,
+            false,
+        )?;
+        Ok(Self {
+            interfaces: merged_state.interfaces.generate_revert()?,
+            routes: merged_state.routes.generate_revert(),
+            rules: merged_state.rules.generate_revert(),
+            dns: merged_state.dns.generate_revert(),
+            ovsdb: merged_state.ovsdb.generate_revert(),
+            ovn: merged_state.ovn.generate_revert(),
+            hostname: merged_state.hostname.generate_revert(),
+            prop_list: vec!["interfaces"],
+            ..Default::default()
+        })
+    }
+}

--- a/rust/src/lib/revert/ovn.rs
+++ b/rust/src/lib/revert/ovn.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    MergedOvnConfiguration, OvnBridgeMapping, OvnBridgeMappingState,
+    OvnConfiguration,
+};
+
+impl MergedOvnConfiguration {
+    pub(crate) fn generate_revert(&self) -> OvnConfiguration {
+        let mut revert_maps: Vec<OvnBridgeMapping> = Vec::new();
+
+        let empty_vev: Vec<OvnBridgeMapping> = Vec::new();
+
+        for des_map in
+            self.desired.bridge_mappings.as_ref().unwrap_or(&empty_vev)
+        {
+            let mut found_match = false;
+            for cur_map in
+                self.current.bridge_mappings.as_ref().unwrap_or(&empty_vev)
+            {
+                if des_map.localnet.as_str() == cur_map.localnet.as_str() {
+                    found_match = true;
+                    revert_maps.push(cur_map.clone());
+                }
+            }
+            if !found_match {
+                let mut map = des_map.clone();
+                map.state = Some(OvnBridgeMappingState::Absent);
+                map.bridge = None;
+                revert_maps.push(map);
+            }
+        }
+
+        revert_maps.sort_unstable();
+
+        if revert_maps.is_empty() {
+            OvnConfiguration::default()
+        } else {
+            OvnConfiguration {
+                bridge_mappings: Some(revert_maps),
+            }
+        }
+    }
+}

--- a/rust/src/lib/revert/ovsdb.rs
+++ b/rust/src/lib/revert/ovsdb.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
+
+impl MergedOvsDbGlobalConfig {
+    pub(crate) fn generate_revert(&self) -> OvsDbGlobalConfig {
+        let mut revert_external_ids: HashMap<String, Option<String>> =
+            HashMap::new();
+        let empty_hash: HashMap<String, Option<String>> = HashMap::new();
+        for eid_key in self
+            .desired
+            .external_ids
+            .as_ref()
+            .unwrap_or(&empty_hash)
+            .keys()
+        {
+            revert_external_ids.insert(
+                eid_key.to_string(),
+                self.current
+                    .external_ids
+                    .as_ref()
+                    .and_then(|c| c.get(eid_key))
+                    .cloned()
+                    .flatten(),
+            );
+        }
+
+        let mut revert_other_configs: HashMap<String, Option<String>> =
+            HashMap::new();
+        let empty_hash: HashMap<String, Option<String>> = HashMap::new();
+        for cfg_key in self
+            .desired
+            .other_config
+            .as_ref()
+            .unwrap_or(&empty_hash)
+            .keys()
+        {
+            revert_other_configs.insert(
+                cfg_key.to_string(),
+                self.current
+                    .other_config
+                    .as_ref()
+                    .and_then(|c| c.get(cfg_key))
+                    .cloned()
+                    .flatten(),
+            );
+        }
+
+        if revert_external_ids.is_empty() && revert_other_configs.is_empty() {
+            OvsDbGlobalConfig::default()
+        } else {
+            OvsDbGlobalConfig {
+                external_ids: Some(revert_external_ids),
+                other_config: Some(revert_other_configs),
+                ..Default::default()
+            }
+        }
+    }
+}

--- a/rust/src/lib/revert/route.rs
+++ b/rust/src/lib/revert/route.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedRoutes, RouteEntry, RouteState, Routes};
+
+impl MergedRoutes {
+    pub(crate) fn generate_revert(&self) -> Routes {
+        let mut revert_rts: Vec<RouteEntry> = Vec::new();
+
+        let empty_vec: Vec<RouteEntry> = Vec::new();
+
+        let current_rts = self.current.config.as_ref().unwrap_or(&empty_vec);
+
+        // Delete added routes
+        if let Some(config_rts) = self.desired.config.as_ref() {
+            for config_rt in config_rts.iter().filter(|r| !r.is_absent()) {
+                let mut rt = config_rt.clone();
+                rt.state = Some(RouteState::Absent);
+                revert_rts.push(rt);
+            }
+        }
+
+        // Add back the deleted routes
+        if let Some(config_rts) = self.desired.config.as_ref() {
+            for config_rt in config_rts.iter().filter(|r| r.is_absent()) {
+                for cur_rt in current_rts
+                    .iter()
+                    .filter(|cur_rt| config_rt.is_match(cur_rt))
+                {
+                    let rt = cur_rt.clone();
+                    revert_rts.push(rt);
+                }
+            }
+        }
+
+        revert_rts.sort_unstable();
+
+        if revert_rts.is_empty() {
+            Routes::default()
+        } else {
+            Routes {
+                config: Some(revert_rts),
+                ..Default::default()
+            }
+        }
+    }
+}

--- a/rust/src/lib/revert/route_rule.rs
+++ b/rust/src/lib/revert/route_rule.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{MergedRouteRules, RouteRuleEntry, RouteRuleState, RouteRules};
+
+impl MergedRouteRules {
+    pub(crate) fn generate_revert(&self) -> RouteRules {
+        let mut revert_rules: Vec<RouteRuleEntry> = Vec::new();
+        let empty_vec: Vec<RouteRuleEntry> = Vec::new();
+
+        for des_rule in
+            self.desired.config.as_ref().unwrap_or(&empty_vec).iter()
+        {
+            if des_rule.is_absent() {
+                for cur_rule in self
+                    .current
+                    .config
+                    .as_ref()
+                    .unwrap_or(&empty_vec)
+                    .iter()
+                    .filter(|r| des_rule.is_match(r))
+                {
+                    revert_rules.push(cur_rule.clone());
+                }
+            } else {
+                let mut rule = des_rule.clone();
+                rule.state = Some(RouteRuleState::Absent);
+                revert_rules.push(rule);
+            }
+        }
+
+        revert_rules.sort_unstable();
+
+        if revert_rules.is_empty() {
+            RouteRules::default()
+        } else {
+            RouteRules {
+                config: Some(revert_rules),
+                ..Default::default()
+            }
+        }
+    }
+}

--- a/rust/src/lib/revert/state.rs
+++ b/rust/src/lib/revert/state.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::{Map, Value};
+
+pub(crate) fn gen_revert_state(
+    desired: &Value,
+    current: &Value,
+    revert: &mut Value,
+) {
+    match desired {
+        Value::Object(des_obj) => {
+            let cur_obj = if let Some(c) = current.as_object() {
+                c
+            } else {
+                log::debug!("Current is not Value::Object but {current:?}");
+                return;
+            };
+            let rev_obj = if let Some(r) = revert.as_object_mut() {
+                r
+            } else {
+                log::debug!("Current is not Value::Object but {current:?}");
+                return;
+            };
+            for (key, des_value) in des_obj.iter() {
+                let cur_value = if let Some(c) = cur_obj.get(key) {
+                    c
+                } else {
+                    log::debug!(
+                        "Current does not have key {key}, \
+                        desired value {des_value} full current: \
+                        {current:?}"
+                    );
+                    continue;
+                };
+                if des_value.is_object() {
+                    let mut rev_sub_value = Value::Object(Map::new());
+                    gen_revert_state(des_value, cur_value, &mut rev_sub_value);
+                    rev_obj.insert(key.clone(), rev_sub_value);
+                } else {
+                    rev_obj.insert(key.clone(), cur_value.clone());
+                }
+            }
+        }
+        _ => {
+            log::error!(
+                "BUG: gen_revert_state() got desired non-object value: {:?}",
+                desired
+            );
+        }
+    }
+}

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -508,8 +508,8 @@ impl From<RouteRuleAction> for u8 {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct MergedRouteRules {
-    desired: RouteRules,
-    current: RouteRules,
+    pub(crate) desired: RouteRules,
+    pub(crate) current: RouteRules,
     // The `for_apply` will hold two type of route rule:
     //  * Desired route rules
     //  * Current route rules been marked as absent

--- a/rust/src/lib/unit_tests/gen_revert.rs
+++ b/rust/src/lib/unit_tests/gen_revert.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NetworkState;
+
+const TEST_DATA_FOLDER_PATH: &str = "unit_tests/gen_revert_test_files";
+const DESIRED_FILE_NAME: &str = "desired.yml";
+const CURRENT_FILE_NAME: &str = "current.yml";
+const REVERT_FILE_NAME: &str = "revert.yml";
+
+#[test]
+fn test_gen_revert() {
+    let folded_path =
+        std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join(TEST_DATA_FOLDER_PATH);
+
+    for entry in std::fs::read_dir(folded_path).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        let current = load_state(&path.join(CURRENT_FILE_NAME));
+        let desired = load_state(&path.join(DESIRED_FILE_NAME));
+        let expected_revert =
+            serde_yaml::to_string(&load_state(&path.join(REVERT_FILE_NAME)))
+                .unwrap();
+        let revert =
+            serde_yaml::to_string(&desired.generate_revert(&current).unwrap())
+                .unwrap();
+        if expected_revert != revert {
+            panic!(
+                "FAIL: {:?}\nExpected:\n\n{}\nGot:\n\n{}",
+                entry.file_name(),
+                expected_revert,
+                revert
+            );
+        }
+        println!("PASS: {:?}", entry.file_name());
+    }
+}
+
+fn load_state(file_path: &std::path::Path) -> NetworkState {
+    let fd = std::fs::File::open(file_path).unwrap();
+    match serde_yaml::from_reader(fd) {
+        Ok(n) => n,
+        Err(e) => {
+            panic!("FAIL to load NetworkState from {:?}: {}", file_path, e);
+        }
+    }
+}

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/current.yml
@@ -1,0 +1,2 @@
+---
+interfaces: []

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/desired.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+- name: dummy1
+  type: dummy
+  state: up

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_new_dummy/revert.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+- name: dummy1
+  type: dummy
+  state: absent

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route/current.yml
@@ -1,0 +1,34 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:2::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route/desired.yml
@@ -1,0 +1,8 @@
+---
+routes:
+  config:
+  - destination: 198.51.100.0/24
+    metric: 150
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    table-id: 254

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route/revert.yml
@@ -1,0 +1,9 @@
+---
+routes:
+  config:
+  - destination: 198.51.100.0/24
+    state: absent
+    metric: 150
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    table-id: 254

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/current.yml
@@ -1,0 +1,31 @@
+---
+routes:
+  config:
+  - destination: 198.51.100.0/24
+    metric: 108
+    next-hop-address: 192.0.2.3
+    next-hop-interface: eth1
+    table-id: 200
+  - destination: 2001:db8:a::/64
+    metric: 108
+    next-hop-address: 2001:db8:1::2
+    next-hop-interface: eth1
+    table-id: 201
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mtu: 1500
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+    ipv6:
+      enabled: true
+      dhcp: false
+      autoconf: false
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/desired.yml
@@ -1,0 +1,7 @@
+---
+route-rules:
+  config:
+    - ip-from: 198.51.100.0/24
+      route-table: 200
+    - ip-from: 2001:db8:b::/64
+      route-table: 201

--- a/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/add_route_rule/revert.yml
@@ -1,0 +1,9 @@
+---
+route-rules:
+  config:
+    - ip-from: 2001:db8:b::/64
+      route-table: 201
+      state: absent
+    - ip-from: 198.51.100.0/24
+      route-table: 200
+      state: absent

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/current.yml
@@ -1,0 +1,42 @@
+---
+dns-resolver:
+  running:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+    - 8.8.4.4
+    - 8.8.8.8
+  config: {}
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+        valid-left: 300sec
+        preferred-left: 300sec
+      dhcp: true
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+        valid-left: 300sec
+        preferred-left: 300sec
+      dhcp: true
+      enabled: true
+      autoconf: true
+routes:
+  running:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+  config: []

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/desired.yml
@@ -1,0 +1,36 @@
+---
+dns-resolver:
+  running:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+    - 8.8.4.4
+    - 8.8.8.8
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: true
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_auto_dns_to_static/revert.yml
@@ -1,0 +1,30 @@
+---
+routes:
+  config:
+  - state: absent
+    destination: ::/0
+    next-hop-interface: eth1
+    next-hop-address: 2001:db8:1::3
+  - state: absent
+    destination: 0.0.0.0/0
+    next-hop-interface: eth1
+    next-hop-address: 192.0.2.1
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      dhcp: true
+      enabled: true
+      address: []
+      auto-dns: true
+      auto-gateway: true
+      auto-routes: true
+    ipv6:
+      dhcp: true
+      enabled: true
+      autoconf: true
+      address: []
+      auto-dns: true
+      auto-gateway: true
+      auto-routes: true

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/current.yml
@@ -1,0 +1,28 @@
+---
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    metric: 101
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::2
+    next-hop-interface: eth1
+    metric: 102
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/desired.yml
@@ -1,0 +1,32 @@
+---
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.2
+    next-hop-interface: eth1
+    metric: 102
+  - destination: ::/0
+    state: absent
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+    metric: 103
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_gateway/revert.yml
@@ -1,0 +1,21 @@
+---
+routes:
+  config:
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+    metric: 103
+    state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.2
+    next-hop-interface: eth1
+    metric: 102
+    state: absent
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::2
+    next-hop-interface: eth1
+    metric: 102
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    metric: 101

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/current.yml
@@ -1,0 +1,41 @@
+---
+interfaces:
+- name: br0
+  type: ovs-bridge
+  profile-name: br0-br
+  state: up
+  wait-ip: any
+  bridge:
+    port:
+    - name: eth1
+    - name: ovs0
+- name: eth1
+  type: ethernet
+  state: up
+  mtu: 1500
+  controller: br0
+- name: ovs0
+  type: ovs-interface
+  profile-name: ovs0-if
+  state: up
+  mtu: 1500
+  min-mtu: 68
+  max-mtu: 65535
+  wait-ip: any
+  ipv4:
+    enabled: false
+    dhcp: false
+  ipv6:
+    enabled: false
+    dhcp: false
+    autoconf: false
+  controller: br0
+  accept-all-mac-addresses: false
+  lldp:
+    enabled: false
+ovs-db:
+  external_ids:
+    foo: 'bar'
+    bar: 'foo'
+  other_config:
+    stats-update-interval: '1000'

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/desired.yml
@@ -1,0 +1,8 @@
+---
+ovs-db:
+  external_ids:
+    foo: null
+    bar: 'foo2'
+    new: 'new'
+  other_config:
+    stats-update-interval: '1001'

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_global_ovsdb/revert.yml
@@ -1,0 +1,8 @@
+---
+ovs-db:
+  external_ids:
+    foo: 'bar'
+    bar: 'foo'
+    new: null
+  other_config:
+    stats-update-interval: '1000'

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/current.yml
@@ -1,0 +1,4 @@
+---
+hostname:
+  running: test.example.com
+  config: test.example.com

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/desired.yml
@@ -1,0 +1,4 @@
+---
+hostname:
+  running: test2.example.com
+  config: test2.example.com

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_hostname/revert.yml
@@ -1,0 +1,4 @@
+---
+hostname:
+  running: test.example.com
+  config: test.example.com

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/current.yml
@@ -1,0 +1,35 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mtu: 1500
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: true
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: true
+      address:
+        - ip: 2001:db8:2::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/desired.yml
@@ -1,0 +1,4 @@
+---
+interfaces:
+  - name: eth1
+    mtu: 1280

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_mtu/revert.yml
@@ -1,0 +1,6 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  mtu: 1500

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/current.yml
@@ -1,0 +1,7 @@
+---
+ovn:
+  bridge-mappings:
+    - localnet: blue
+      bridge: ovsbr1
+    - localnet: red
+      bridge: ovsbr2

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/desired.yml
@@ -1,0 +1,9 @@
+---
+ovn:
+  bridge-mappings:
+    - localnet: red
+      state: absent
+    - localnet: blue
+      bridge: ovsbr2
+    - localnet: green
+      bridge: ovsbr3

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/revert.yml
@@ -1,0 +1,9 @@
+---
+ovn:
+  bridge-mappings:
+    - localnet: green
+      state: absent
+    - localnet: blue
+      bridge: ovsbr1
+    - localnet: red
+      bridge: ovsbr2

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/current.yml
@@ -1,0 +1,53 @@
+route-rules:
+  config:
+  - family: ipv6
+    ip-from: 2001:db8:b::/64
+    priority: 30001
+    route-table: 201
+  - family: ipv4
+    ip-from: 198.51.100.0/24
+    priority: 30000
+    route-table: 200
+routes:
+  running:
+  - destination: 2001:db8:a::/64
+    next-hop-interface: eth1
+    next-hop-address: 2001:db8:1::2
+    metric: 108
+    table-id: 201
+  - destination: 198.51.100.0/24
+    next-hop-interface: eth1
+    next-hop-address: 192.0.2.3
+    metric: 108
+    table-id: 200
+  config:
+  - destination: 2001:db8:a::/64
+    next-hop-interface: eth1
+    next-hop-address: 2001:db8:1::2
+    metric: 108
+    table-id: 201
+  - destination: 198.51.100.0/24
+    next-hop-interface: eth1
+    next-hop-address: 192.0.2.3
+    metric: 108
+    table-id: 200
+interfaces:
+- name: eth1
+  type: veth
+  state: up
+  ipv4:
+    enabled: true
+    dhcp: false
+    address:
+    - ip: 192.0.2.251
+      prefix-length: 24
+  ipv6:
+    enabled: true
+    dhcp: false
+    autoconf: false
+    address:
+    - ip: 2001:db8:1::1
+      prefix-length: 64
+    - ip: fe80::307f:71ff:fe50:d691
+      prefix-length: 64
+    addr-gen-mode: eui64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/desired.yml
@@ -1,0 +1,12 @@
+---
+route-rules:
+  config:
+  - state: absent
+    route-table: 200
+  - state: absent
+    route-table: 201
+  - ip-to: 198.51.100.0/24
+    route-table: 200
+  - ip-to: 2001:db8:b::/64
+    route-table: 201
+

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_route_rule/revert.yml
@@ -1,0 +1,17 @@
+---
+route-rules:
+  config:
+  - ip-to: 2001:db8:b::/64
+    route-table: 201
+    state: absent
+  - ip-to: 198.51.100.0/24
+    route-table: 200
+    state: absent
+  - family: ipv6
+    ip-from: 2001:db8:b::/64
+    priority: 30001
+    route-table: 201
+  - family: ipv4
+    ip-from: 198.51.100.0/24
+    priority: 30000
+    route-table: 200

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/current.yml
@@ -1,0 +1,36 @@
+---
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+    - 8.8.4.4
+    - 8.8.8.8
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/desired.yml
@@ -1,0 +1,18 @@
+---
+dns-resolver:
+  config: {}
+routes:
+  config:
+    - next-hop-interface: eth1
+      state: absent
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      dhcp: true
+      enabled: true
+    ipv6:
+      dhcp: true
+      enabled: true
+      autoconf: true

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_dns_to_auto_dns/revert.yml
@@ -1,0 +1,36 @@
+---
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+    - 8.8.4.4
+    - 8.8.8.8
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/current.yml
@@ -1,0 +1,36 @@
+---
+dns-resolver:
+  config:
+    search:
+    - example.com
+    - example.org
+    server:
+    - 2001:4860:4860::8888
+    - 2001:4860:4860::8844
+    - 8.8.4.4
+    - 8.8.8.8
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/desired.yml
@@ -1,0 +1,12 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      dhcp: true
+      enabled: true
+    ipv6:
+      dhcp: true
+      enabled: true
+      autoconf: true

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_static_ip_to_auto/revert.yml
@@ -1,0 +1,18 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/current.yml
@@ -1,0 +1,11 @@
+---
+interfaces:
+  - name: vlan1
+    type: vlan
+    state: up
+    vlan:
+      id: 99
+      base-iface: eth1
+  - name: eth1
+    type: ethernet
+    state: up

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/desired.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: vlan1
+    type: vlan
+    state: up
+    vlan:
+      id: 100
+      base-iface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_vlan_id/revert.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: vlan1
+    type: vlan
+    state: up
+    vlan:
+      id: 99
+      base-iface: eth1

--- a/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/current.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up

--- a/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/desired.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ethernet:
+      sr-iov:
+        total-vfs: 2

--- a/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/enable_sriov/revert.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ethernet:
+      sr-iov:
+        total-vfs: 0

--- a/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/current.yml
@@ -1,0 +1,34 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:2::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/desired.yml
@@ -1,0 +1,21 @@
+---
+interfaces:
+  - name: br0
+    type: linux-bridge
+    state: up
+    bridge:
+      port:
+        - name: eth1
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/move_ip_to_linux_bridge/revert.yml
@@ -1,0 +1,21 @@
+---
+interfaces:
+- name: br0
+  type: linux-bridge
+  state: absent
+- name: eth1
+  type: ethernet
+  state: up
+  ipv4:
+    address:
+    - ip: 192.0.2.251
+      prefix-length: 24
+    dhcp: false
+    enabled: true
+  ipv6:
+    enabled: true
+    autoconf: false
+    dhcp: false
+    address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/no_op/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/no_op/current.yml
@@ -1,0 +1,34 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:2::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/no_op/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/no_op/desired.yml
@@ -1,0 +1,34 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:1::1
+          prefix-length: 64
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      enabled: true
+      autoconf: false
+      dhcp: false
+      address:
+        - ip: 2001:db8:2::1
+          prefix-length: 64

--- a/rust/src/lib/unit_tests/gen_revert_test_files/no_op/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/no_op/revert.yml
@@ -1,0 +1,2 @@
+---
+interfaces: []

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -11,6 +11,8 @@ mod ethernet;
 #[cfg(test)]
 mod ethtool;
 #[cfg(test)]
+mod gen_revert;
+#[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;


### PR DESCRIPTION
Introducing `NetworkState::generate_revert(current)` to generate a new network state for reverting desired state.

This requires cargo feature `query_apply` which is enabled by default.

For CLI, subcommand `gr` is introduced:

    nmstatectl gr desired_state.yml [-c current.yml]

Unit test case included with test files stored in
`unit_tests/gen_revert_test_files` sub-folders.