### PR TITLE
ovn: Tidy up the ovs/ovn code

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -478,10 +478,11 @@ pub struct BondConfig {
     pub port: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Deserialize and serialize from/to `ports-config`.
-    /// When applying, if defined, it will override current ports configuration.
-    /// Note that `port` is not required to set with `ports-config`. An error
-    /// will be raised during apply when the port names specified in `port` and
-    /// `ports-config` conflict with each other.
+    /// When applying, if defined, it will override current ports
+    /// configuration. Note that `port` is not required to set with
+    /// `ports-config`. An error will be raised during apply when the port
+    /// names specified in `port` and `ports-config` conflict with each
+    /// other.
     pub ports_config: Option<Vec<BondPortConfig>>,
 }
 

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -99,6 +99,7 @@ mod net_state;
 #[cfg(feature = "query_apply")]
 mod nispor;
 mod nm;
+#[allow(deprecated)]
 mod ovn;
 mod ovs;
 #[cfg(feature = "query_apply")]
@@ -159,8 +160,10 @@ pub use crate::lldp::{
 pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
 pub(crate) use crate::net_state::MergedNetworkState;
 pub use crate::net_state::NetworkState;
-#[cfg(feature = "query_apply")]
-pub use crate::ovn::OvnConfiguration;
+pub(crate) use crate::ovn::MergedOvnConfiguration;
+pub use crate::ovn::{
+    OvnBridgeMapping, OvnBridgeMappingState, OvnConfiguration,
+};
 pub(crate) use crate::ovs::MergedOvsDbGlobalConfig;
 pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -1,27 +1,75 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
-use crate::ovn::{
-    ovn_bridge_mappings_to_string, OvnBridgeMapping, OVN_BRIDGE_MAPPINGS,
-};
-use crate::ErrorKind::InvalidArgument;
-use crate::NmstateError;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{ErrorKind, MergedOvnConfiguration, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 #[non_exhaustive]
 pub struct OvsDbGlobalConfig {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "show_as_ordered_map"
+    )]
     // When the value been set as None, specified key will be removed instead
     // of merging.
     // To remove all settings of external_ids or other_config, use empty
     // HashMap
     pub external_ids: Option<HashMap<String, Option<String>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "show_as_ordered_map"
+    )]
     pub other_config: Option<HashMap<String, Option<String>>>,
     #[serde(skip)]
     pub(crate) prop_list: Vec<&'static str>,
+}
+
+impl OvsDbGlobalConfig {
+    pub(crate) const OVN_BRIDGE_MAPPINGS_KEY: &'static str =
+        "ovn-bridge-mappings";
+
+    // User want to remove all settings except OVN.
+    pub(crate) fn is_purge(&self) -> bool {
+        self.prop_list.is_empty()
+    }
+
+    pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
+        if self
+            .external_ids
+            .as_ref()
+            .map(|e| e.contains_key(Self::OVN_BRIDGE_MAPPINGS_KEY))
+            == Some(true)
+        {
+            Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "The `{}` is reserved for OVN mapping, please use \
+                    `ovn` section instead of `ovs-db` section",
+                    Self::OVN_BRIDGE_MAPPINGS_KEY
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn show_as_ordered_map<S>(
+    v: &Option<HashMap<String, Option<String>>>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(v) = v {
+        let ordered: BTreeMap<_, _> = v.iter().collect();
+        ordered.serialize(s)
+    } else {
+        s.serialize_none()
+    }
 }
 
 impl OvsDbGlobalConfig {
@@ -169,6 +217,7 @@ pub(crate) struct MergedOvsDbGlobalConfig {
     pub(crate) current: OvsDbGlobalConfig,
     pub(crate) external_ids: HashMap<String, Option<String>>,
     pub(crate) other_config: HashMap<String, Option<String>>,
+    pub(crate) is_changed: bool,
 }
 
 impl MergedOvsDbGlobalConfig {
@@ -179,75 +228,96 @@ impl MergedOvsDbGlobalConfig {
     pub(crate) fn new(
         desired: OvsDbGlobalConfig,
         current: OvsDbGlobalConfig,
-        current_ovn_mappings: Option<Vec<OvnBridgeMapping>>,
+        merged_ovn: &MergedOvnConfiguration,
     ) -> Result<Self, NmstateError> {
-        if desired.prop_list.is_empty() {
-            // User want to remove all settings
-            Ok(Self {
-                desired,
-                current,
-                external_ids: HashMap::new(),
-                other_config: HashMap::new(),
-            })
-        } else {
-            let mut external_ids =
-                current.external_ids.as_ref().cloned().unwrap_or_default();
-            let mut other_config =
-                current.other_config.as_ref().cloned().unwrap_or_default();
+        let mut external_ids: HashMap<String, Option<String>> = HashMap::new();
+        let mut other_config: HashMap<String, Option<String>> = HashMap::new();
 
-            if let Some(ex_ids) = desired.external_ids.as_ref() {
-                if ex_ids.is_empty() {
-                    external_ids.clear();
-                    if let Some(current_bridge_mappings) = current_ovn_mappings
-                    {
-                        if !current_bridge_mappings.is_empty() {
-                            external_ids.insert(
-                                OVN_BRIDGE_MAPPINGS.to_string(),
-                                Some(ovn_bridge_mappings_to_string(
-                                    current_bridge_mappings,
-                                )),
-                            );
-                        }
-                    };
-                } else {
-                    if ex_ids.get(OVN_BRIDGE_MAPPINGS).is_some() {
-                        const INVALID_EXTERNAL_IDS_KEY: &str = "Cannot use the `ovn-bridge-mappings`\
-                         external_ids key directly. Please use ovn.bridge-mappings API instead";
-                        return Err(NmstateError::new(
-                            InvalidArgument,
-                            INVALID_EXTERNAL_IDS_KEY.to_string(),
-                        ));
-                    }
-                    for (k, v) in ex_ids {
-                        if v.is_none() {
-                            external_ids.remove(k);
-                        } else {
-                            external_ids.insert(k.clone(), v.clone());
-                        }
-                    }
+        let empty_map: HashMap<String, Option<String>> = HashMap::new();
+
+        if !desired.is_purge() {
+            desired.sanitize()?;
+
+            merge_ovsdb_confs(
+                desired.external_ids.as_ref(),
+                current.external_ids.as_ref().unwrap_or(&empty_map),
+                &mut external_ids,
+            );
+
+            merge_ovsdb_confs(
+                desired.other_config.as_ref(),
+                current.other_config.as_ref().unwrap_or(&empty_map),
+                &mut other_config,
+            );
+        }
+
+        if let Some(v) = merged_ovn.to_ovsdb_external_id_value() {
+            external_ids.insert(
+                OvsDbGlobalConfig::OVN_BRIDGE_MAPPINGS_KEY.to_string(),
+                Some(v),
+            );
+        }
+
+        let mut cur_external_ids: HashMap<String, Option<String>> =
+            current.external_ids.as_ref().unwrap_or(&empty_map).clone();
+
+        if let Some(v) = merged_ovn.current.to_ovsdb_external_id_value() {
+            cur_external_ids.insert(
+                OvsDbGlobalConfig::OVN_BRIDGE_MAPPINGS_KEY.to_string(),
+                Some(v),
+            );
+        }
+
+        let cur_other_config: HashMap<String, Option<String>> =
+            current.other_config.as_ref().unwrap_or(&empty_map).clone();
+
+        let is_changed = cur_other_config != other_config
+            || cur_external_ids != external_ids;
+
+        Ok(Self {
+            desired,
+            current,
+            external_ids,
+            other_config,
+            is_changed,
+        })
+    }
+}
+
+fn merge_ovsdb_confs(
+    desired: Option<&HashMap<String, Option<String>>>,
+    current: &HashMap<String, Option<String>>,
+    output: &mut HashMap<String, Option<String>>,
+) {
+    if let Some(desired) = desired {
+        // User want to purge this section
+        if desired.is_empty() {
+            return;
+        }
+
+        let removed_keys: Vec<&str> = desired
+            .iter()
+            .filter_map(
+                |(k, v)| if v.is_none() { Some(k.as_str()) } else { None },
+            )
+            .collect();
+
+        for (cur_k, cur_v) in current.iter() {
+            if let Some(cur_v) = cur_v {
+                if !removed_keys.contains(&cur_k.as_str()) {
+                    output.insert(cur_k.to_string(), Some(cur_v.to_string()));
                 }
             }
-
-            if let Some(cfgs) = desired.other_config.as_ref() {
-                if cfgs.is_empty() {
-                    other_config.clear();
-                } else {
-                    for (k, v) in cfgs {
-                        if v.is_none() {
-                            other_config.remove(k);
-                        } else {
-                            other_config.insert(k.clone(), v.clone());
-                        }
-                    }
-                }
+        }
+        for (des_k, des_v) in desired.iter() {
+            if let Some(des_v) = des_v {
+                output.insert(des_k.to_string(), Some(des_v.to_string()));
             }
-
-            Ok(Self {
-                desired,
-                current,
-                external_ids,
-                other_config,
-            })
+        }
+    } else {
+        // User never mentioned this section, hence copy from current
+        for (cur_k, cur_v) in current.iter() {
+            output.insert(cur_k.to_string(), cur_v.clone());
         }
     }
 }

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -28,7 +28,6 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
     ret.prop_list.push("interfaces");
     ret.prop_list.push("ovsdb");
-    ret.prop_list.push("ovn");
     let mut cli = OvsDbConnection::new()?;
     let ovsdb_ifaces = cli.get_ovs_ifaces()?;
     let ovsdb_brs = cli.get_ovs_bridges()?;

--- a/rust/src/lib/query_apply/ovn.rs
+++ b/rust/src/lib/query_apply/ovn.rs
@@ -1,38 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ovn::{MergedOvnConfiguration, OvnBridgeMapping};
-use crate::state::get_json_value_difference;
-use crate::ErrorKind::InvalidArgument;
-use crate::{ErrorKind, NmstateError, OvnConfiguration};
-use std::str::FromStr;
+use crate::{
+    state::get_json_value_difference, ErrorKind, MergedOvnConfiguration,
+    NmstateError, OvnConfiguration,
+};
 
 impl MergedOvnConfiguration {
     pub(crate) fn verify(
         &self,
         current: &OvnConfiguration,
     ) -> Result<(), NmstateError> {
-        let mut ovn_bridge_mappings: Vec<OvnBridgeMapping> =
-            self.bridge_mappings.clone();
+        let mut desired = self.desired.clone();
+        if let Some(maps) = desired.bridge_mappings.as_mut() {
+            maps.retain(|map| !map.is_absent());
+            maps.sort_unstable();
+        }
 
-        let desired = OvnConfiguration {
-            bridge_mappings: match ovn_bridge_mappings.is_empty() {
-                true => None,
-                false => {
-                    ovn_bridge_mappings
-                        .sort_by(|v1, v2| v1.localnet.cmp(&v2.localnet));
-                    Some(ovn_bridge_mappings)
-                }
-            },
-        };
+        let mut current = current.clone();
+        if let Some(maps) = current.bridge_mappings.as_mut() {
+            // Only keep desired in new current to verify
+            maps.retain(|map| {
+                desired
+                    .bridge_mappings
+                    .as_ref()
+                    .map(|des_maps| {
+                        des_maps
+                            .iter()
+                            .any(|des_map| des_map.localnet == map.localnet)
+                    })
+                    .unwrap_or_default()
+            });
+            maps.sort_unstable();
+        } else {
+            current.bridge_mappings = Some(Vec::new());
+        }
 
         let desired_value = serde_json::to_value(desired)?;
-        let current_value = if current.is_none() {
-            serde_json::to_value(OvnConfiguration {
-                bridge_mappings: Some(Vec::new()),
-            })?
-        } else {
-            serde_json::to_value(current)?
-        };
+        let current_value = serde_json::to_value(current)?;
 
         if let Some((reference, desire, current)) = get_json_value_difference(
             "ovn".to_string(),
@@ -49,27 +53,5 @@ impl MergedOvnConfiguration {
         } else {
             Ok(())
         }
-    }
-}
-
-pub fn string_to_ovn_bridge_mappings(
-    mappings_string: String,
-) -> Result<Vec<OvnBridgeMapping>, NmstateError> {
-    if mappings_string.is_empty() {
-        return Ok(Vec::default());
-    }
-    let mut mappings: Vec<OvnBridgeMapping> = Vec::new();
-    for mapping_str in mappings_string.split(',') {
-        match OvnBridgeMapping::from_str(mapping_str) {
-            Ok(mapping) => mappings.push(mapping),
-            Err(e) => {
-                return Err(NmstateError::new(InvalidArgument, e.to_string()))
-            }
-        }
-    }
-    if mappings.is_empty() {
-        Ok(Vec::default())
-    } else {
-        Ok(mappings)
     }
 }

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -1,20 +1,19 @@
-use crate::ovn::{
-    ovn_bridge_mappings_to_string, MergedOvnConfiguration, OvnBridgeMapping,
-    OvnBridgeMappingState,
+// SPDX-License-Identifier: Apache-2.0
+
+use std::convert::TryFrom;
+
+use crate::{
+    ErrorKind, MergedOvnConfiguration, OvnBridgeMapping, OvnBridgeMappingState,
+    OvnConfiguration,
 };
-use crate::query_apply::ovn::string_to_ovn_bridge_mappings;
-use crate::ErrorKind::InvalidArgument;
-use crate::{NmstateError, OvnConfiguration};
 
 #[test]
 fn test_ovsdb_merge_with_mappings() {
     let desired: OvnConfiguration = serde_yaml::from_str(
         r"---
-bridge-mappings:
-- localnet: net1
-  state: present
-  bridge: br1
-",
+        bridge-mappings:
+        - localnet: net1
+          bridge: br1",
     )
     .unwrap();
 
@@ -27,19 +26,9 @@ bridge-mappings: []
 
     let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
 
-    let expect: OvnConfiguration = serde_yaml::from_str(
-        r"---
-bridge-mappings:
-- localnet: net1
-  state: present
-  bridge: br1
-",
-    )
-    .unwrap();
-
     assert_eq!(
-        merged_ovsdb.bridge_mappings,
-        expect.bridge_mappings.unwrap()
+        merged_ovsdb.to_ovsdb_external_id_value().unwrap(),
+        "net1:br1"
     );
 }
 
@@ -47,133 +36,119 @@ bridge-mappings:
 fn test_ovsdb_merge_delete_existing_mappings() {
     let desired: OvnConfiguration = serde_yaml::from_str(
         r"---
-bridge-mappings:
-- localnet: net1
-  state: absent
-  bridge: br1
-",
+        bridge-mappings:
+        - localnet: net1
+          state: absent
+          bridge: br1",
     )
     .unwrap();
 
     let current: OvnConfiguration = serde_yaml::from_str(
         r"---
-bridge-mappings:
-- localnet: net1
-  state: present
-  bridge: br1
-",
+        bridge-mappings:
+        - localnet: net1
+          bridge: br1",
     )
     .unwrap();
 
     let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
-
-    let expect: OvnConfiguration = serde_yaml::from_str(
-        r"---
-bridge-mappings: []
-",
-    )
-    .unwrap();
-
-    assert_eq!(
-        merged_ovsdb.bridge_mappings,
-        expect.bridge_mappings.unwrap_or_default()
-    );
+    assert_eq!(merged_ovsdb.to_ovsdb_external_id_value(), None);
 }
 
 #[test]
 fn test_ovn_duplicate_localnet_keys_are_forbidden_on_desired_state() {
     let desired: OvnConfiguration = serde_yaml::from_str(
         r"---
-bridge-mappings:
-- localnet: net1
-  bridge: br1
-- localnet: net1
-  state: absent
-",
+        bridge-mappings:
+        - localnet: net1
+          bridge: br1
+        - localnet: net1
+          state: absent",
     )
     .unwrap();
 
     let current: OvnConfiguration = serde_yaml::from_str(
         r"---
-bridge-mappings:
-- localnet: net1
-  state: present
-  bridge: br1
-",
+        bridge-mappings:
+        - localnet: net1
+          bridge: br1",
     )
     .unwrap();
 
-    assert_eq!(
-        MergedOvnConfiguration::new(desired, current),
-        Err(NmstateError::new(
-            InvalidArgument,
-            "Duplicated `localnet` keys in the provided ovn.bridge-mappings"
-                .to_string()
-        ))
-    )
+    let result = MergedOvnConfiguration::new(desired, current);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }
 
 #[test]
 fn test_ovsdb_empty_string_to_ovn_bridge_mappings() {
     let input_string = "";
-    assert_eq!(
-        string_to_ovn_bridge_mappings(input_string.to_string()),
-        Ok(Vec::new())
-    )
+    let result = OvnBridgeMapping::try_from(input_string);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }
 
 #[test]
 fn test_ovsdb_string_without_localnet_to_ovn_bridge_mappings() {
     let input_string = ":br1";
-    assert_eq!(
-        string_to_ovn_bridge_mappings(input_string.to_string()),
-        Err(NmstateError::new(
-            InvalidArgument,
-            "expected `<localnet>:<bridge>`, got: :br1".to_string()
-        ))
-    )
+    let result = OvnConfiguration::try_from(input_string);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }
 
 #[test]
 fn test_ovsdb_string_without_bridge_to_ovn_bridge_mappings() {
     let input_string = "net1:";
-    assert_eq!(
-        string_to_ovn_bridge_mappings(input_string.to_string()),
-        Err(NmstateError::new(
-            InvalidArgument,
-            "expected `<localnet>:<bridge>`, got: net1:".to_string()
-        ))
-    )
+    let result = OvnConfiguration::try_from(input_string);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }
 
 #[test]
 fn test_ovsdb_string_to_ovn_bridge_mappings() {
     let input_string = "net1:br1";
+
     assert_eq!(
-        string_to_ovn_bridge_mappings(input_string.to_string()),
-        Ok(vec!(OvnBridgeMapping {
+        OvnBridgeMapping::try_from(input_string).unwrap(),
+        OvnBridgeMapping {
             localnet: "net1".to_string(),
             bridge: Some("br1".to_string()),
-            state: Some(OvnBridgeMappingState::Present)
-        }))
+            state: None
+        }
     )
 }
 
 #[test]
 fn test_ovsdb_string_to_multiple_ovn_bridge_mappings() {
     let input_string = "net1:br1,net32:br1";
+    let conf = OvnConfiguration::try_from(input_string).unwrap();
     assert_eq!(
-        string_to_ovn_bridge_mappings(input_string.to_string()),
-        Ok(vec!(
+        conf.bridge_mappings,
+        Some(vec!(
             OvnBridgeMapping {
                 localnet: "net1".to_string(),
                 bridge: Some("br1".to_string()),
-                state: Some(OvnBridgeMappingState::Present)
+                state: None
             },
             OvnBridgeMapping {
                 localnet: "net32".to_string(),
                 bridge: Some("br1".to_string()),
-                state: Some(OvnBridgeMappingState::Present)
+                state: None
             },
         ))
     )
@@ -181,70 +156,77 @@ fn test_ovsdb_string_to_multiple_ovn_bridge_mappings() {
 
 #[test]
 fn test_empty_mappings() {
-    assert_eq!(ovn_bridge_mappings_to_string(Vec::new()), "")
+    assert_eq!(
+        OvnConfiguration::try_from("").unwrap(),
+        OvnConfiguration::default()
+    )
 }
 
 #[test]
 fn test_mappings_missing_bridge() {
-    let mappings: Vec<OvnBridgeMapping> = vec![OvnBridgeMapping {
-        localnet: "localnet1".to_string(),
-        state: Default::default(),
-        bridge: None,
-    }];
-    assert_eq!(ovn_bridge_mappings_to_string(mappings), "")
+    let conf = OvnConfiguration {
+        bridge_mappings: Some(vec![OvnBridgeMapping {
+            localnet: "localnet1".to_string(),
+            state: Default::default(),
+            bridge: None,
+        }]),
+    };
+    assert_eq!(conf.to_ovsdb_external_id_value().unwrap(), "")
 }
 
 #[test]
 fn test_mappings_with_required_data() {
-    let mappings: Vec<OvnBridgeMapping> = vec![OvnBridgeMapping {
-        localnet: "localnet1".to_string(),
-        state: Default::default(),
-        bridge: Some("br1".to_string()),
-    }];
-    assert_eq!(ovn_bridge_mappings_to_string(mappings), "localnet1:br1")
+    let conf = OvnConfiguration {
+        bridge_mappings: Some(vec![OvnBridgeMapping {
+            localnet: "localnet1".to_string(),
+            state: Default::default(),
+            bridge: Some("br1".to_string()),
+        }]),
+    };
+    assert_eq!(conf.to_ovsdb_external_id_value().unwrap(), "localnet1:br1")
 }
 
 #[test]
 fn test_multiple_mappings_with_required_data() {
-    let mappings: Vec<OvnBridgeMapping> = vec![
-        OvnBridgeMapping {
-            localnet: "localnet1".to_string(),
-            state: Default::default(),
-            bridge: Some("br1".to_string()),
-        },
-        OvnBridgeMapping {
-            localnet: "localnet2".to_string(),
-            state: Default::default(),
-            bridge: Some("br2".to_string()),
-        },
-    ];
+    let conf = OvnConfiguration {
+        bridge_mappings: Some(vec![
+            OvnBridgeMapping {
+                localnet: "localnet1".to_string(),
+                state: Default::default(),
+                bridge: Some("br1".to_string()),
+            },
+            OvnBridgeMapping {
+                localnet: "localnet2".to_string(),
+                state: Default::default(),
+                bridge: Some("br2".to_string()),
+            },
+        ]),
+    };
     assert_eq!(
-        ovn_bridge_mappings_to_string(mappings),
+        conf.to_ovsdb_external_id_value().unwrap(),
         "localnet1:br1,localnet2:br2"
     )
 }
 
 #[test]
 fn test_sanitize_mapping_add_without_bridge() {
-    let mapping = OvnBridgeMapping {
+    let mut mapping = OvnBridgeMapping {
         localnet: "localnet1".to_string(),
         state: Default::default(),
         bridge: None,
     };
-    assert_eq!(
-        mapping.sanitize(),
-        Err(
-            NmstateError::new(
-                InvalidArgument,
-                "mapping for `localnet` key localnet1 missing the `bridge` attribute".to_string()
-            )
-        )
-    )
+    let result = mapping.sanitize();
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }
 
 #[test]
 fn test_sanitize_correct_mapping_add() {
-    let mapping = OvnBridgeMapping {
+    let mut mapping = OvnBridgeMapping {
         localnet: "localnet1".to_string(),
         state: Default::default(),
         bridge: Some("bridge".to_string()),
@@ -254,10 +236,32 @@ fn test_sanitize_correct_mapping_add() {
 
 #[test]
 fn test_sanitize_correct_mapping_remove() {
-    let mapping = OvnBridgeMapping {
+    let mut mapping = OvnBridgeMapping {
         localnet: "localnet1".to_string(),
         state: Some(OvnBridgeMappingState::Absent),
         bridge: None,
     };
     assert_eq!(mapping.sanitize(), Ok(()))
+}
+
+#[test]
+fn test_ovn_map_support_state_present() {
+    let mut desired: OvnConfiguration = serde_yaml::from_str(
+        r"---
+        bridge-mappings:
+        - localnet: net1
+          state: present
+          bridge: br1",
+    )
+    .unwrap();
+    desired.sanitize().unwrap();
+
+    assert_eq!(
+        desired.bridge_mappings.unwrap(),
+        vec![OvnBridgeMapping {
+            localnet: "net1".to_string(),
+            state: None,
+            bridge: Some("br1".to_string())
+        }]
+    )
 }

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -39,7 +39,8 @@ other_config:
     let current = get_current_ovsdb_config();
 
     let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
+        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
+            .unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r"---
@@ -79,7 +80,8 @@ other_config: {}
     .unwrap();
 
     let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
+        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
+            .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -114,7 +116,8 @@ other_config:
     .unwrap();
 
     let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
+        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
+            .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -149,7 +152,8 @@ other_config: {}
     .unwrap();
 
     let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, None).unwrap();
+        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
+            .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -167,8 +171,12 @@ fn test_ovsdb_verify_null_current() {
     let pre_apply_current = desired.clone();
     let current = desired.clone();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, pre_apply_current, None).unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        desired,
+        pre_apply_current,
+        &Default::default(),
+    )
+    .unwrap();
 
     merged_ovsdb.verify(&current).unwrap();
 }

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -694,6 +694,7 @@ def test_ovsdb_global_config_add_delete_mapping():
     libnmstate.apply({Ovn.KEY: desired_ovs_config})
     current_ovs_config = libnmstate.show()[Ovn.KEY]
 
+    remove_ovn_state_present(desired_ovs_config)
     assert state_match(desired_ovs_config, current_ovs_config)
 
     desired_ovs_config = {
@@ -716,7 +717,6 @@ def ovn_bridge_mapping_net1():
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
                 Ovn.BridgeMappings.BRIDGE: "br1",
-                Ovn.BridgeMappings.STATE: "present",
             },
         ]
     }
@@ -783,6 +783,7 @@ def test_ovn_global_config_add_delete_single_mapping(ovn_bridge_mapping_net1):
         desired_ovs_config[Ovn.BRIDGE_MAPPINGS],
         key=lambda mapping: mapping[Ovn.BridgeMappings.LOCALNET],
     )
+    remove_ovn_state_present(desired_ovs_config)
     assert state_match(
         desired_ovs_config,
         current_ovs_config,
@@ -2211,3 +2212,8 @@ def test_raise_error_on_unknown_ovsdb_global_section():
                 },
             }
         )
+
+
+def remove_ovn_state_present(state):
+    for ovn_map in state.get(Ovn.BRIDGE_MAPPINGS, []):
+        ovn_map.pop(Ovn.BridgeMappings.STATE, None)


### PR DESCRIPTION
* Remove the extensive use of `clone()`.
 * Use Trait instead C-like functions for dedup and sort.
 * Remove the use of `unwrap()` which will crash the library user.
 * Less public API.
 * Deprecated `OvnBridgeMappingState::Present` and hide it from query.
 * Isolate code to modules, for example, NetState should not hold code
   require knowledge of detail implementation of OVN.
 * Sort HashMap of ovsdb `external_ids` and `other_config` when
   serializing.