### PR TITLE
Support invoking dispatch script

### DIFF
--- a/rust/src/lib/dispatch.rs
+++ b/rust/src/lib/dispatch.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, MergedInterfaces, NmstateError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct DispatchConfig {
+    /// Dispatch bash script content to be invoked after interface activation
+    /// finished by network backend. Nmstate will append additional lines
+    /// to make sure this script is only invoked for specified interface when
+    /// backend interface activation finished.
+    /// Setting to empty string will remove the dispatch script
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_activation: Option<String>,
+    /// Dispatch bash script content to be invoked after interface deactivation
+    /// finished by network backend. Nmstate will append additional lines
+    /// to make sure this script is only invoked for specified interface when
+    /// backend interface deactivation finished.
+    /// Setting to empty string will remove the dispatch script
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub post_deactivation: Option<String>,
+}
+
+impl MergedInterfaces {
+    pub(crate) fn validate_dispatch_script_has_no_checkpoint(
+        &self,
+    ) -> Result<(), NmstateError> {
+        if self.kernel_ifaces.values().any(|i| {
+            i.is_desired()
+                && i.for_apply
+                    .as_ref()
+                    .map(|f| f.base_iface().dispatch.is_some())
+                    .unwrap_or_default()
+        }) {
+            if self.gen_conf_mode {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Dispatch script is not supported in gc(gen_conf) mode"
+                        .to_string(),
+                ));
+            } else {
+                log::info!(
+                    "Dispatch script is not protected by checkpoint, please \
+                    backup your original nmstate created dispatch scripts"
+                )
+            }
+        }
+        Ok(())
+    }
+}

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -756,6 +756,7 @@ impl MergedInterfaces {
         self.check_infiniband_as_ports()?;
         self.mark_orphan_interface_as_absent()?;
         self.process_veth_peer_changes()?;
+        self.validate_dispatch_script_has_no_checkpoint()?;
         for iface in self
             .kernel_ifaces
             .values_mut()

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -84,6 +84,7 @@
 //! ```
 
 mod deserializer;
+mod dispatch;
 mod dns;
 mod error;
 #[cfg(feature = "gen_conf")]
@@ -116,6 +117,7 @@ mod serializer;
 mod state;
 mod unit_tests;
 
+pub use crate::dispatch::DispatchConfig;
 pub(crate) use crate::dns::MergedDnsState;
 pub use crate::dns::{DnsClientState, DnsState};
 pub use crate::error::{ErrorKind, NmstateError};

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -14,6 +14,7 @@ use super::super::{
     query_apply::{
         activate_nm_profiles, create_index_for_nm_conns_by_name_type,
         deactivate_nm_profiles, delete_exist_profiles, delete_orphan_ovs_ports,
+        dispatch::apply_dispatch_script,
         dns::{purge_global_dns_config, store_dns_config_via_global_api},
         is_mptcp_flags_changed, is_mptcp_supported, is_route_removed,
         is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
@@ -159,6 +160,8 @@ pub(crate) fn nm_apply(
     activate_nm_profiles(&mut nm_api, nm_conns_to_activate.as_slice())?;
 
     deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
+
+    apply_dispatch_script(&merged_state.interfaces)?;
 
     Ok(())
 }

--- a/rust/src/lib/nm/query_apply/dispatch.rs
+++ b/rust/src/lib/nm/query_apply/dispatch.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
+
+use crate::{DispatchConfig, ErrorKind, MergedInterfaces, NmstateError};
+
+const DEFAULT_DISPATCH_DIR: &str = "/etc/NetworkManager/dispatcher.d";
+
+const SCRIPT_START_COMMENT: &str = "## NMSTATE DISPATCH SCRIPT START";
+const SCRIPT_END_COMMENT: &str = "## NMSTATE DISPATCH SCRIPT END";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NmAction {
+    Up,
+    Down,
+}
+
+impl std::fmt::Display for NmAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Up => "up",
+                Self::Down => "down",
+            }
+        )
+    }
+}
+
+pub(crate) fn apply_dispatch_script(
+    merged_ifaces: &MergedInterfaces,
+) -> Result<(), NmstateError> {
+    for iface in merged_ifaces.kernel_ifaces.values().filter_map(|i| {
+        if i.is_desired() {
+            i.for_apply.as_ref()
+        } else {
+            None
+        }
+    }) {
+        if iface.is_absent() {
+            delete_dispatch_script(iface.name(), NmAction::Up)?;
+            delete_dispatch_script(iface.name(), NmAction::Down)?;
+        } else if let Some(dispatch_conf) = iface.base_iface().dispatch.as_ref()
+        {
+            let iface_name = iface.name();
+            if let Some(post_up) = dispatch_conf.post_activation.as_deref() {
+                if post_up.is_empty() {
+                    delete_dispatch_script(iface_name, NmAction::Up)?;
+                } else {
+                    create_dispatch_script(iface_name, post_up, NmAction::Up)?;
+                }
+            }
+            if let Some(post_down) = dispatch_conf.post_deactivation.as_deref()
+            {
+                if post_down.is_empty() {
+                    delete_dispatch_script(iface_name, NmAction::Down)?;
+                } else {
+                    create_dispatch_script(
+                        iface_name,
+                        post_down,
+                        NmAction::Down,
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn create_dispatch_script(
+    iface_name: &str,
+    content: &str,
+    nm_action: NmAction,
+) -> Result<(), NmstateError> {
+    let file_path = gen_file_path(iface_name, nm_action);
+    let action_condition_line = match nm_action {
+        NmAction::Up => r#"{ [ "$2" == "up" ] || [ "$2" == "reapply" ]; }"#,
+        NmAction::Down => r#"[ "$2" == "down" ]"#,
+    };
+
+    let script_content = format!(
+        r#"#!/usr/bin/bash
+if [ "$1" == "{iface_name}" ] && {action_condition_line}; then
+{SCRIPT_START_COMMENT}
+{content}
+{SCRIPT_END_COMMENT}
+fi
+"#
+    );
+
+    if let Err(e) =
+        write_execute_file(file_path.as_str(), script_content.as_str())
+    {
+        return Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Failed to create NetworkManager dispatch script \
+                {file_path}: {e}"
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn write_execute_file(file_path: &str, content: &str) -> std::io::Result<()> {
+    let mut fd = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o744)
+        .open(file_path)?;
+    fd.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+pub(crate) fn get_dispatches() -> HashMap<String, DispatchConfig> {
+    let mut ret: HashMap<String, DispatchConfig> = HashMap::new();
+    let dir = std::env::var("NMSTATE_NM_DISPATCH_DIR")
+        .unwrap_or(DEFAULT_DISPATCH_DIR.to_string());
+
+    if let Ok(fd) = std::fs::read_dir(&dir) {
+        for entry in fd.filter_map(Result::ok) {
+            let file_name = if let Ok(s) = entry.file_name().into_string() {
+                if s.starts_with("nmstate-") {
+                    s
+                } else {
+                    continue;
+                }
+            } else {
+                continue;
+            };
+            let file_path = format!("{dir}/{file_name}");
+            let parts: Vec<&str> = file_name.split('-').collect();
+            if parts.len() == 3 {
+                let iface_name = parts[1];
+                if !["up.sh", "down.sh"].contains(&parts[2]) {
+                    log::debug!("Got unknown dispatch action for {file_name}");
+                    continue;
+                }
+                let script_content =
+                    if let Some(s) = read_dispatch_script(&file_path) {
+                        s
+                    } else {
+                        continue;
+                    };
+                let conf = match ret.entry(iface_name.to_string()) {
+                    Entry::Occupied(o) => o.into_mut(),
+                    Entry::Vacant(v) => v.insert(DispatchConfig::default()),
+                };
+                match parts[2] {
+                    "up.sh" => conf.post_activation = Some(script_content),
+                    "down.sh" => conf.post_deactivation = Some(script_content),
+                    _ => (),
+                }
+            }
+        }
+    }
+    ret
+}
+
+fn read_dispatch_script(file_path: &str) -> Option<String> {
+    if let Ok(mut fd) = std::fs::File::open(file_path) {
+        let mut script_content: Vec<&str> = Vec::new();
+        let mut content = String::new();
+        fd.read_to_string(&mut content).ok();
+        let mut begin = false;
+        for line in content.split('\n') {
+            if begin {
+                if line == SCRIPT_END_COMMENT {
+                    break;
+                } else {
+                    script_content.push(line);
+                }
+            } else if line == SCRIPT_START_COMMENT {
+                begin = true;
+                continue;
+            }
+        }
+        if !script_content.is_empty() {
+            return Some(script_content.join("\n"));
+        }
+    }
+    None
+}
+
+fn delete_dispatch_script(
+    iface_name: &str,
+    nm_action: NmAction,
+) -> Result<(), NmstateError> {
+    let file_path = gen_file_path(iface_name, nm_action);
+    let path = std::path::Path::new(&file_path);
+
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(path) {
+            return Err(NmstateError::new(
+                ErrorKind::PermissionError,
+                format!(
+                    "Failed to remove dispatch script {file_path}, error: {e}"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn gen_file_path(iface_name: &str, nm_action: NmAction) -> String {
+    let dir = std::env::var("NMSTATE_NM_DISPATCH_DIR")
+        .unwrap_or(DEFAULT_DISPATCH_DIR.to_string());
+
+    format!("{dir}/nmstate-{iface_name}-{nm_action}.sh")
+}

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -2,6 +2,7 @@
 
 mod apply;
 pub(crate) mod device;
+pub(crate) mod dispatch;
 pub(crate) mod dns;
 mod ieee8021x;
 mod ip;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -12,11 +12,12 @@ use super::{
     error::nm_error_to_nmstate,
     query_apply::{
         create_index_for_nm_conns_by_name_type,
-        device::nm_dev_iface_type_to_nmstate, dns::nm_global_dns_to_nmstate,
-        get_description, get_lldp, is_lldp_enabled, is_mptcp_supported,
-        nm_802_1x_to_nmstate, nm_ip_setting_to_nmstate4,
-        nm_ip_setting_to_nmstate6, ovs::merge_ovs_netdev_tun_iface,
-        query_nmstate_wait_ip, retrieve_dns_info,
+        device::nm_dev_iface_type_to_nmstate, dispatch::get_dispatches,
+        dns::nm_global_dns_to_nmstate, get_description, get_lldp,
+        is_lldp_enabled, is_mptcp_supported, nm_802_1x_to_nmstate,
+        nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6,
+        ovs::merge_ovs_netdev_tun_iface, query_nmstate_wait_ip,
+        retrieve_dns_info,
     },
     settings::{
         get_bond_balance_slb, NM_SETTING_OVS_IFACE_SETTING_NAME,
@@ -199,6 +200,15 @@ pub(crate) fn nm_retrieve(
     net_state.dns.sanitize().ok();
     if running_config_only {
         net_state.dns.running = None;
+    }
+
+    for (iface_name, conf) in get_dispatches().drain() {
+        if let Some(iface) =
+            net_state.interfaces.kernel_ifaces.get_mut(&iface_name)
+        {
+            iface.base_iface_mut().prop_list.push("dispatch");
+            iface.base_iface_mut().dispatch = Some(conf);
+        }
     }
 
     set_ovs_iface_controller_info(&mut net_state.interfaces);

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -20,6 +20,13 @@ impl BaseInterface {
         if self.ovsdb.is_none() {
             self.ovsdb = Some(OvsDbIfaceConfig::new_empty());
         }
+        // dispatch script None equal to empty
+        if self.dispatch.is_none() {
+            self.dispatch = Some(Default::default());
+        }
+        if let Some(dispatch_conf) = self.dispatch.as_mut() {
+            dispatch_conf.sanitize_current_for_verify();
+        }
     }
 
     pub(crate) fn sanitize_desired_for_verify(&mut self) {
@@ -129,6 +136,9 @@ impl BaseInterface {
             if !self.prop_list.contains(other_prop_name) {
                 self.prop_list.push(other_prop_name)
             }
+        }
+        if other.prop_list.contains(&"dispatch") {
+            self.dispatch = other.dispatch.clone();
         }
     }
 }

--- a/rust/src/lib/query_apply/dispatch.rs
+++ b/rust/src/lib/query_apply/dispatch.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::DispatchConfig;
+
+impl DispatchConfig {
+    // For current in verify, None means empty string
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if self.post_activation.is_none() {
+            self.post_activation = Some(String::new());
+        }
+        if self.post_deactivation.is_none() {
+            self.post_deactivation = Some(String::new());
+        }
+    }
+}

--- a/rust/src/lib/query_apply/mod.rs
+++ b/rust/src/lib/query_apply/mod.rs
@@ -2,6 +2,7 @@
 
 mod base;
 mod bond;
+mod dispatch;
 mod dns;
 mod ethernet;
 mod hostname;

--- a/tests/integration/nm/dispath_test.py
+++ b/tests/integration/nm/dispath_test.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+
+import libnmstate
+
+from ..testlib.yaml import load_yaml
+
+NM_DISPATCH_FOLDER = "/etc/NetworkManager/dispatcher.d"
+
+
+def gen_file_path(iface_name, action):
+    return f"{NM_DISPATCH_FOLDER}/nmstate-{iface_name}-{action}.sh"
+
+
+def assert_dispatch_script(iface_name, action, expected_content):
+    file_path = gen_file_path(iface_name, action)
+    with open(file_path, "r") as fd:
+        content = fd.read()
+    assert expected_content in content
+
+
+def assert_dispatch_script_not_exist(iface_name, action):
+    assert not os.path.exists(gen_file_path(iface_name, action))
+
+
+@pytest.fixture
+def eth1_up_with_dispatch_script(eth1_up):
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: eth1
+              dispatch:
+                post-activation: |
+                  echo post-up-eth1 | systemd-cat
+                post-deactivation: |
+                  echo post-down-eth1 | systemd-cat
+            """
+        ),
+    )
+
+
+def test_add_and_remove_dispatch_script(eth1_up_with_dispatch_script):
+    assert_dispatch_script("eth1", "up", "echo post-up-eth1 | systemd-cat")
+    assert_dispatch_script("eth1", "down", "echo post-down-eth1 | systemd-cat")
+
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: eth1
+              dispatch:
+                post-activation: ''
+                post-deactivation: ''
+            """
+        ),
+    )
+    assert_dispatch_script_not_exist("eth1", "up")
+    assert_dispatch_script_not_exist("eth1", "down")
+
+
+def test_remove_dispatch_script_on_iface_absent(eth1_up):
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: eth1
+              state: absent
+            """
+        ),
+    )
+    assert_dispatch_script_not_exist("eth1", "up")
+    assert_dispatch_script_not_exist("eth1", "down")
+
+
+def test_modify_dispatch_script(eth1_up):
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: eth1
+              dispatch:
+                post-activation: |
+                  echo new-post-up-eth1 | systemd-cat
+                post-deactivation: |
+                  echo new-post-down-eth1 | systemd-cat
+            """
+        ),
+    )
+    assert_dispatch_script("eth1", "up", "echo new-post-up-eth1 | systemd-cat")
+    assert_dispatch_script(
+        "eth1", "down", "echo new-post-down-eth1 | systemd-cat"
+    )


### PR DESCRIPTION
Example yaml:

```yaml
---
interfaces:
- name: eth1
  type: ethernet
  state: up
  dispatch:
    post-activation: |
      echo post-up-eth1 | systemd-cat
    post-deactivation: |
      echo post-down-eth1 | systemd-cat
```

The `post-activation` holds the content of script to be invoked after
activation.
The `post-deactivation` holds the content of script to be invoked after
deactivation.
Empty string will remove the dispatch script.
When interface been marked as `state: absent`, the dispatch script will be removed.

Nmstate might append additional lines to make sure this script is only
invoked for specified interface.

By default, we are storing the dispatch script to
`/etc/NetworkManager/dispatcher.d` folder, please use system variable
`NMSTATE_NM_DISPATCH_DIR` to change that.

The dispatch script is not protected by checkpoint, user will get a INFO
log message when they try to modify dispatch script.

Integration test cases included.