### PR TITLE
Validate prefix length for IP addresses

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -338,6 +338,19 @@ impl InterfaceIpv4 {
                         ),
                     ));
                 }
+                if let Some(addr) = addrs
+                    .iter()
+                    .find(|a| a.prefix_length as usize > IPV4_ADDR_LEN)
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Invalid IPv4 network prefix length '{}', \
+                            should be in the range of 0 to {IPV4_ADDR_LEN}",
+                            addr.prefix_length
+                        ),
+                    ));
+                }
             }
             addrs.retain(|a| !a.is_auto());
             addrs.iter_mut().for_each(|a| {
@@ -624,6 +637,19 @@ impl InterfaceIpv6 {
                         format!(
                             "Got IPv4 address {} in ipv6 config section",
                             addr
+                        ),
+                    ));
+                }
+                if let Some(addr) = addrs
+                    .iter()
+                    .find(|a| a.prefix_length as usize > IPV6_ADDR_LEN)
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Invalid IPv6 network prefix length '{}', \
+                            should be in the range of 0 to {IPV6_ADDR_LEN}",
+                            addr.prefix_length
                         ),
                     ));
                 }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -618,13 +618,15 @@ impl InterfaceIpv6 {
                 for addr in addrs.as_slice().iter().filter(|a| a.is_auto()) {
                     log::info!("Ignoring Auto IP address {}", addr);
                 }
-            }
-            if let Some(addr) = addrs.as_slice().iter().find(|a| a.ip.is_ipv4())
-            {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!("Got IPv4 address {} in ipv6 config section", addr),
-                ));
+                if let Some(addr) = addrs.iter().find(|a| a.ip.is_ipv4()) {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Got IPv4 address {} in ipv6 config section",
+                            addr
+                        ),
+                    ));
+                }
             }
             addrs.retain(|a| !a.is_auto());
             addrs.iter_mut().for_each(|a| {

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -332,6 +332,52 @@ fn test_should_not_have_ipv4_in_ipv6_section() {
 }
 
 #[test]
+fn test_ipv4_verify_valid_prefix() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv4:
+                enabled: true
+                dhcp: false
+                address:
+                  - ip: 192.0.2.1
+                    prefix-length: 33",
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidArgument);
+}
+
+#[test]
+fn test_ipv6_verify_valid_prefix() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r#"---
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv6:
+                enabled: true
+                dhcp: false
+                address:
+                  - ip: "2001:db8:2::1"
+                    prefix-length: 129"#,
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidArgument);
+}
+
+#[test]
 fn test_sanitize_ip_network_empty_str() {
     let result = sanitize_ip_network("");
     assert!(result.is_err());


### PR DESCRIPTION
Resolves: RHEL-1670

Add validation for the prefix_length field so the configuration is rejected if it's too high.

Without this, the invalid IP address is sent to NetworkManager to be configured. Then NetworkManager rejects to use it, but due to a bug it doesn't report an error back to nmstate.

Additionally, fix an existent minor bug that allowed an error to be reported in `sanitize` with `is_desired=false`.
