### PR TITLE
test: Skip vxlan test on Fedora

### DIFF
--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -273,7 +273,7 @@ fn save_dns_to_iface(
     let prefer_ipv6_srv = merged_state
         .dns
         .servers
-        .get(0)
+        .first()
         .map(|s| is_ipv6_addr(s.as_str()))
         .unwrap_or_default();
     for srv in merged_state.dns.servers.as_slice() {

--- a/rust/src/lib/nm/nm_dbus/connection/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/dns.rs
@@ -106,7 +106,7 @@ pub(crate) fn nm_ip_dns_to_value(
     dns_srvs: &[String],
 ) -> Result<zvariant::Value, NmError> {
     let mut is_ipv6 = false;
-    let mut dns_values = if let Some(dns_srv) = dns_srvs.get(0) {
+    let mut dns_values = if let Some(dns_srv) = dns_srvs.first() {
         if dns_srv.contains(':') {
             // is IPv6
             is_ipv6 = true;

--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -111,7 +111,7 @@ impl OvsDbConnection {
         )? {
             Value::Array(reply) => {
                 if let Some(entries) = reply
-                    .get(0)
+                    .first()
                     .and_then(|v| v.as_object())
                     .and_then(|v| v.get("rows"))
                     .and_then(|v| v.as_array())
@@ -228,11 +228,11 @@ impl OvsDbConnection {
         )? {
             Value::Array(reply) => {
                 if let Some(global_conf) = reply
-                    .get(0)
+                    .first()
                     .and_then(|v| v.as_object())
                     .and_then(|v| v.get("rows"))
                     .and_then(|v| v.as_array())
-                    .and_then(|v| v.get(0))
+                    .and_then(|v| v.first())
                     .and_then(|v| v.as_object())
                 {
                     Ok(global_conf.into())
@@ -334,7 +334,7 @@ impl TryFrom<&Value> for OvsDbEntry {
 
 pub(crate) fn parse_str_map(v: &[Value]) -> HashMap<String, String> {
     let mut ret = HashMap::new();
-    if let Some(Value::String(value_type)) = v.get(0) {
+    if let Some(Value::String(value_type)) = v.first() {
         match value_type.as_str() {
             "map" => {
                 if let Some(ids) = v.get(1).and_then(|i| i.as_array()) {
@@ -343,7 +343,7 @@ pub(crate) fn parse_str_map(v: &[Value]) -> HashMap<String, String> {
                             if let (
                                 Some(Value::String(k)),
                                 Some(Value::String(v)),
-                            ) = (kv.get(0), kv.get(1))
+                            ) = (kv.first(), kv.get(1))
                             {
                                 if k == NM_RESERVED_EXTERNAL_ID {
                                     continue;
@@ -364,7 +364,7 @@ pub(crate) fn parse_str_map(v: &[Value]) -> HashMap<String, String> {
 
 pub(crate) fn parse_uuid_array(v: &[Value]) -> Vec<String> {
     let mut ret = Vec::new();
-    if let Some(Value::String(value_type)) = v.get(0) {
+    if let Some(Value::String(value_type)) = v.first() {
         match value_type.as_str() {
             "set" => {
                 if let Some(vs) = v.get(1).and_then(|i| i.as_array()) {
@@ -373,7 +373,7 @@ pub(crate) fn parse_uuid_array(v: &[Value]) -> Vec<String> {
                             if let (
                                 Some(Value::String(k)),
                                 Some(Value::String(v)),
-                            ) = (kv.get(0), kv.get(1))
+                            ) = (kv.first(), kv.get(1))
                             {
                                 if k != "uuid" {
                                     continue;

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -217,7 +217,7 @@ impl NetworkCaptureCommand {
                 ));
             };
 
-        match keys.get(0).map(String::as_str) {
+        match keys.first().map(String::as_str) {
             Some("routes") => {
                 ret.routes = match self.action {
                     NetworkCaptureAction::Equal => get_route_match(
@@ -363,7 +363,7 @@ fn get_input_capture_source(
     line: &str,
     pipe_token: &NetworkCaptureToken,
 ) -> Result<String, NmstateError> {
-    match tokens.get(0) {
+    match tokens.first() {
         Some(NetworkCaptureToken::Path(path, pos)) => {
             if path.len() != 2 || path[0] != "capture" {
                 Err(NmstateError::new_policy_error(
@@ -409,8 +409,8 @@ fn get_condition_key(
     action_token: &NetworkCaptureToken,
 ) -> Result<(NetworkCaptureToken, Option<(String, usize)>), NmstateError> {
     if tokens.len() == 1 {
-        if let Some(NetworkCaptureToken::Path(path, pos)) = tokens.get(0) {
-            if path.get(0) == Some(&"capture".to_string()) {
+        if let Some(NetworkCaptureToken::Path(path, pos)) = tokens.first() {
+            if path.first() == Some(&"capture".to_string()) {
                 if path.len() <= 2 {
                     return Err(NmstateError::new_policy_error(
                         "No property path after capture name".to_string(),
@@ -469,7 +469,7 @@ fn get_condition_value(
 
     match tokens[0] {
         NetworkCaptureToken::Path(ref path, pos) => {
-            Ok(if path.get(0) == Some(&"capture".to_string()) {
+            Ok(if path.first() == Some(&"capture".to_string()) {
                 if path.len() < 3 {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
@@ -566,7 +566,7 @@ fn process_tokens_without_pipe(
             ret.value_capture = Some(cap_name);
             ret.value_capture_pos = pos;
         }
-    } else if let Some(NetworkCaptureToken::Path(_, _)) = tokens.get(0) {
+    } else if let Some(NetworkCaptureToken::Path(_, _)) = tokens.first() {
         // User just want to remove all information except the defined one
         ret.action = NetworkCaptureAction::None;
         ret.key = tokens[0].clone()

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -30,7 +30,7 @@ ethernet:
 
     let eth_conf = iface.ethernet.unwrap();
     let sriov_conf = eth_conf.sr_iov.as_ref().unwrap();
-    let vf_conf = sriov_conf.vfs.as_ref().unwrap().get(0).unwrap();
+    let vf_conf = sriov_conf.vfs.as_ref().unwrap().first().unwrap();
 
     assert_eq!(eth_conf.speed, Some(1000));
     assert_eq!(sriov_conf.total_vfs, Some(64));

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2019-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
 
@@ -33,6 +16,7 @@ from .testlib.bondlib import bond_interface
 from .testlib.cmdlib import RC_SUCCESS
 from .testlib.cmdlib import exec_cmd
 from .testlib.cmdlib import format_exec_cmd_result
+from .testlib.env import is_fedora
 from .testlib.env import is_k8s
 from .testlib.env import nm_major_minor_version
 from .testlib.vxlan import VxlanState
@@ -45,6 +29,11 @@ VXLAN1_ID = 201
 VXLAN2_ID = 202
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_and_remove_vxlan(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -56,6 +45,11 @@ def test_add_and_remove_vxlan(eth1_up):
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
@@ -71,6 +65,11 @@ def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     assertlib.assert_absent(vxlan_interfaces_name)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_without_base_if():
     with vxlan_interfaces(
@@ -82,6 +81,11 @@ def test_add_and_remove_vxlan_without_base_if():
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_nolearning():
     with vxlan_interfaces(
@@ -93,6 +97,11 @@ def test_add_and_remove_vxlan_nolearning():
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 @pytest.mark.xfail(
     is_k8s(),
@@ -121,6 +130,11 @@ def test_rollback_for_vxlans(eth1_up):
     assert current_state == current_state_after_apply
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_set_vxlan_iface_down(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=ifname, remote="192.168.100.1")
@@ -130,6 +144,11 @@ def test_set_vxlan_iface_down(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_new_bond_iface_with_vxlan(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     bond_name = "bond0"
@@ -148,6 +167,11 @@ def test_add_new_bond_iface_with_vxlan(eth1_up):
     assertlib.assert_absent(bond_name)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_show_vxlan_with_no_remote(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=eth_name, remote="")
@@ -166,6 +190,11 @@ def test_show_vxlan_with_no_remote(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_with_no_remote():
     with vxlan_interfaces(
@@ -177,6 +206,11 @@ def test_add_and_remove_vxlan_with_no_remote():
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 def test_add_vxlan_and_modify_vxlan_id(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
@@ -192,6 +226,11 @@ def test_add_vxlan_and_modify_vxlan_id(eth1_up):
     assertlib.assert_absent(vxlan1_ifname)
 
 
+@pytest.mark.skipif(
+    is_fedora(),
+    reason="Unknown bug of nmstate on Fedora "
+    "https://issues.redhat.com/browse/RHEL-5001",
+)
 @pytest.mark.tier1
 @pytest.mark.skipif(
     nm_major_minor_version() < 1.31,


### PR DESCRIPTION
It is known bug of rust-netlink which will fail Fedora VxLAN tests:

    https://issues.redhat.com/browse/RHEL-5001

Marking all vxlan tests as skipped in Fedora.