### PR TITLE
nm dns: Support appending static DNS before dynamic DNS

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -184,7 +184,7 @@ impl DnsClientState {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct MergedDnsState {
-    desired: DnsState,
+    pub(crate) desired: DnsState,
     pub(crate) current: DnsState,
     pub(crate) servers: Vec<String>,
     pub(crate) searches: Vec<String>,

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -147,6 +147,9 @@ pub struct InterfaceIpv4 {
     pub addresses: Option<Vec<InterfaceIpAddr>>,
     /// Whether to apply DNS resolver information retrieved from DHCP server.
     /// Serialize and deserialize to/from `auto-dns`.
+    /// If you want to append static DNS name server before DHCP provided
+    /// servers, please set `auto-dns: true` explicitly a along with static
+    /// DNS server.
     pub auto_dns: Option<bool>,
     /// Whether to set default gateway retrieved from DHCP server.
     /// Serialize and deserialize to/from `auto-gateway`.
@@ -534,6 +537,9 @@ pub struct InterfaceIpv6 {
     /// Whether to apply DNS resolver information retrieved from DHCPv6 or
     /// autoconf.
     /// Serialize and deserialize to/from `auto-dns`.
+    /// If you want to append static DNS name server before DHCP/Autoconf
+    /// provided servers, please set `auto-dns: true` explicitly a along with
+    /// static DNS server.
     pub auto_dns: Option<bool>,
     /// Whether to set default gateway retrieved from autoconf.
     /// Serialize and deserialize to/from `auto-gateway`.


### PR DESCRIPTION
Previously, nmstate does not allow storing DNS to auto interface with
`auto-dns: True`. This prevent the use case where user want to append
static DNS before dynamic DNS(for example, place 127.0.0.1 before DHCP
provided nameserver for DNS caching).

This patch will treat interface with `auto-dns: true` is valid to store
DNS, but not preferred.

Meanwhile, to save us from saving DNS to interface, this patch will try
to use NetworkManager Global DNS as much as possible unless:

 1. Desire state has IPv6 link-local nameserver, e.g. `fe80::deef:1%eth1`
 2. Desire state has static DNS and static IP interface.
 3. Desire state has static DNS with auto IP interface with
    `auto-dns: true` defined explicit.

To append DNS before dynamic DNS server, you need:

```yml
---
dns-resolver:
  config:
    search:
    - example.com
    - example.org
    server:
    - 8.8.8.8
    - 2001:4860:4860::8888
interfaces:
  - name: eth1
    type: ethernet
    state: up
    mtu: 1500
    ipv4:
      enabled: true
      dhcp: true
      auto-dns: true
    ipv6:
      enabled: true
      dhcp: true
      autoconf: true
      auto-dns: true
```

Integration test case included for use case on appending static DNS to
dynamic DNS nameservers.