### PR TITLE
nm: Fix `gc` mode for route rule action

### DIFF
--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod dns;
 mod error;
 #[cfg(feature = "gen_conf")]
 mod gen_conf;
+#[allow(unused_imports)]
 mod nm_dbus;
 mod profile;
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
@@ -211,3 +211,14 @@ impl From<NmIpRouteRuleAction> for u8 {
         }
     }
 }
+
+impl std::fmt::Display for NmIpRouteRuleAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NmIpRouteRuleAction::Blackhole => write!(f, "blackhole"),
+            NmIpRouteRuleAction::Unreachable => write!(f, "unreachable"),
+            NmIpRouteRuleAction::Prohibit => write!(f, "prohibit"),
+            NmIpRouteRuleAction::Other(d) => write!(f, "{}", d),
+        }
+    }
+}

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
@@ -48,9 +48,14 @@ impl NmIpRouteRule {
             if !from_str.is_empty() {
                 keys.push(from_str);
             }
-
+            if let Some(iif) = self.iifname.as_ref() {
+                keys.push(format!("iif {iif}"));
+            }
             if let Some(v) = self.suppress_prefixlength {
                 keys.push(format!("suppress_prefixlength {v}"));
+            }
+            if let Some(action) = self.action.as_ref() {
+                keys.push(format!("type {action}"));
             }
 
             let mut table_str = format!("table {DEFAULT_ROUTE_TABLE}");


### PR DESCRIPTION
The `gc` mode does not support `action: blackhole` for route rule.

Integration test case included.