### PR TITLE
test: Fix failure on `test_change_loopback_mtu_and_restore_back`

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -25,4 +25,3 @@ jobs:
     metadata:
       targets:
         - centos-stream-9-x86_64
-        - epel-9-x86_64

--- a/.packit.yml
+++ b/.packit.yml
@@ -6,6 +6,9 @@ enable_net: true
 srpm_build_deps:
   - make
   - git
+notifications:
+  pull_request:
+    successful_build: true
 actions:
   post-upstream-clone:
     - "make packaging/nmstate.spec"


### PR DESCRIPTION
The `test_change_loopback_mtu_and_restore_back` is asserting MTU been
restored to default MTU of loopback interface right after profile been
deleted, actually NetworkManager might take a small time to restore the MTU
after profile deletion. Hence we use `retry_till_true_or_timeout` for this
test.