### PR TITLE
[nmstate-1.4] nm dns: Support appending static DNS before dynamic DNS

### DIFF
--- a/libnmstate/nispor/base_iface.py
+++ b/libnmstate/nispor/base_iface.py
@@ -219,7 +219,7 @@ class EthtoolInfo:
         np_features = self._np_ethtool.features
         if np_features:
             features = {}
-            for (key, value) in np_features.changeable.items():
+            for key, value in np_features.changeable.items():
                 if key in self._NISPOR_ETHTOOL_FEATURE_SUPPORTED:
                     features[key] = value
             info[Ethtool.Feature.CONFIG_SUBTREE] = features

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 import pytest
 
-from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import DNS
 from libnmstate.schema import Interface
@@ -144,8 +143,25 @@ class TestDnsState:
         ifaces = self._gen_dynamic_ifaces()
         route_state = self._gen_empty_route_state()
         dns_state = DnsState({DNS.CONFIG: DNS_CONFIG1}, {})
-        with pytest.raises(NmstateValueError):
-            ifaces.gen_dns_metadata(dns_state, route_state)
+        ifaces.gen_dns_metadata(dns_state, route_state)
+        ipv4_iface = ifaces.all_kernel_ifaces[IPV4_ROUTE_IFACE_NAME]
+        ipv6_iface = ifaces.all_kernel_ifaces[IPV6_ROUTE_IFACE_NAME]
+
+        assert dns_state.config == DNS_CONFIG1
+        assert ipv4_iface.to_dict()[Interface.IPV4][
+            BaseIface.DNS_METADATA
+        ] == {
+            DnsState.PRIORITY_METADATA: 0,
+            DNS.SERVER: [IPV4_DNS_SERVER1],
+            DNS.SEARCH: DNS_SEARCHES_1,
+        }
+        assert ipv6_iface.to_dict()[Interface.IPV6][
+            BaseIface.DNS_METADATA
+        ] == {
+            DnsState.PRIORITY_METADATA: 1,
+            DNS.SERVER: [IPV6_DNS_SERVER1],
+            DNS.SEARCH: [],
+        }
 
     @pytest.fixture
     def with_dns_metadata(self):


### PR DESCRIPTION
Previously, nmstate does not allow storing DNS to auto interface with
`auto-dns: True`. This prevent the use case where user want to append
static DNS before dynamic DNS(for example, place 127.0.0.1 before DHCP
provided nameserver for DNS caching).

This patch will treat interface with `auto-dns: true` is valid to store
DNS, but not preferred.

Meanwhile, to save us from saving DNS to interface, this patch will try
to use NetworkManager Global DNS as much as possible unless:

 1. Desire state has static DNS and static IP interface.
 2. Desire state has static DNS with auto IP interface with
    `auto-dns: true` defined explicit.

To append DNS before dynamic DNS server, you need:

```yml
---
dns-resolver:
  config:
    search:
    - example.com
    - example.org
    server:
    - 8.8.8.8
    - 2001:4860:4860::8888
interfaces:
  - name: eth1
    type: ethernet
    state: up
    mtu: 1500
    ipv4:
      enabled: true
      dhcp: true
      auto-dns: true
    ipv6:
      enabled: true
      dhcp: true
      autoconf: true
      auto-dns: true
```

Integration test case included for use case on appending static DNS to
dynamic DNS nameservers.