### PR TITLE
[nmstate-1.4] dns: Support DNS options

### DIFF
--- a/examples/dns_edit_eth1.yml
+++ b/examples/dns_edit_eth1.yml
@@ -7,6 +7,9 @@ dns-resolver:
     server:
       - 2001:4860:4860::8888
       - 8.8.8.8
+    options:
+      - rotate
+      - debug
 routes:
   config:
     - destination: 0.0.0.0/0

--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -82,13 +82,16 @@ class NetState:
                     )
                     self.use_global_dns = True
             else:
-                if self._is_iface_dns_prefered():
+                if self.dns.is_purge() or self._is_iface_dns_prefered():
                     try:
                         self._ifaces.gen_dns_metadata(
                             self._dns, self._route, ignored_dns_ifaces
                         )
                     except NmstateValueError as e:
-                        if gen_conf_mode or self._dns.is_search_only_config():
+                        if (
+                            gen_conf_mode
+                            or self._dns.is_search_or_option_only()
+                        ):
                             raise e
                         else:
                             logging.warning(
@@ -147,7 +150,7 @@ class NetState:
     # Nmstate 1.4 does not support IPv6 link-local nameserver, hence not
     # special handling for it.
     def _is_iface_dns_prefered(self):
-        if self._dns.is_search_only_config():
+        if self._dns.is_search_or_option_only():
             return True
         for iface in self.desire_state.get(Interface.KEY, []):
             ipv4_info = iface.get(Interface.IPV4, {})

--- a/libnmstate/nm/ipv4.py
+++ b/libnmstate/nm/ipv4.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import socket
 
@@ -47,6 +30,7 @@ def create_setting(config, base_con_profile):
             setting_ipv4.clear_routing_rules()
             setting_ipv4.clear_dns()
             setting_ipv4.clear_dns_searches()
+            setting_ipv4.clear_dns_options(False)
             setting_ipv4.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ipv4:

--- a/libnmstate/nm/ipv6.py
+++ b/libnmstate/nm/ipv6.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import logging
 import socket
@@ -101,6 +84,7 @@ def create_setting(config, base_con_profile):
             setting_ip.props.route_metric = Route.USE_DEFAULT_METRIC
             setting_ip.clear_dns()
             setting_ip.clear_dns_searches()
+            setting_ip.clear_dns_options(False)
             setting_ip.props.dns_priority = nm_dns.DEFAULT_DNS_PRIORITY
 
     if not setting_ip:

--- a/libnmstate/nm/profiles.py
+++ b/libnmstate/nm/profiles.py
@@ -53,10 +53,12 @@ class NmProfiles:
         if net_state.dns.config_changed:
             if net_state.use_global_dns:
                 apply_global_dns(
-                    net_state.dns.config_servers, net_state.dns.config_searches
+                    net_state.dns.config_servers,
+                    net_state.dns.config_searches,
+                    net_state.dns.config_options,
                 )
             else:
-                apply_global_dns([], [])
+                apply_global_dns([], [], [])
 
         self._prepare_state_for_profiles(net_state)
         # The activation order on bridge/bond ports determins their controler's

--- a/libnmstate/schema.py
+++ b/libnmstate/schema.py
@@ -1,21 +1,4 @@
-#
-# Copyright (c) 2018-2021 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import warnings
 
@@ -91,6 +74,7 @@ class DNS:
     CONFIG = "config"
     SERVER = "server"
     SEARCH = "search"
+    OPTIONS = "options"
 
 
 class Constants:

--- a/libnmstate/schemas/operational-state.yaml
+++ b/libnmstate/schemas/operational-state.yaml
@@ -952,6 +952,10 @@ definitions:
         type: array
         items:
           type: string
+      options:
+        type: array
+        items:
+          type: string
   bridge-port-vlan:
     type: object
     properties:

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -209,3 +209,24 @@ def test_purge_global_dns():
         content = fd.read()
         for srv in desired_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]:
             assert srv not in content
+
+
+def test_global_dns_with_dns_options():
+    try:
+        libnmstate.apply(
+            {
+                DNS.KEY: {
+                    DNS.CONFIG: {
+                        DNS.SERVER: ["8.8.8.8", "2620:fe::9", "1.1.1.1"],
+                        DNS.SEARCH: ["example.org", "example.net"],
+                        DNS.OPTIONS: ["rotate", "debug"],
+                    }
+                },
+            }
+        )
+    finally:
+        libnmstate.apply(
+            {
+                DNS.KEY: {DNS.CONFIG: {}},
+            }
+        )

--- a/tests/lib/dns_test.py
+++ b/tests/lib/dns_test.py
@@ -34,14 +34,19 @@ IPV6_DNS_SERVER3 = "2001:db8:a::3"
 DNS_SEARCHES_1 = ["example.com", "example.org"]
 DNS_SEARCHES_2 = ["example.info", "example.net"]
 
+DNS_OPTOINS1 = ["debug", "rotate"]
+DNS_OPTOINS2 = ["debug", "single-request"]
+
 DNS_CONFIG1 = {
     DNS.SERVER: [IPV4_DNS_SERVER1, IPV6_DNS_SERVER1],
     DNS.SEARCH: DNS_SEARCHES_1,
+    DNS.OPTIONS: DNS_OPTOINS1,
 }
 
 DNS_CONFIG2 = {
     DNS.SERVER: [IPV6_DNS_SERVER2, IPV4_DNS_SERVER2],
     DNS.SEARCH: DNS_SEARCHES_2,
+    DNS.OPTIONS: DNS_OPTOINS2,
 }
 
 
@@ -64,7 +69,11 @@ class TestDnsState:
     def test_merge_by_discarding_current(self):
         dns_state = DnsState({DNS.CONFIG: {}}, {DNS.CONFIG: DNS_CONFIG1})
 
-        assert dns_state.config == {DNS.SERVER: [], DNS.SEARCH: []}
+        assert dns_state.config == {
+            DNS.SERVER: [],
+            DNS.SEARCH: [],
+            DNS.OPTIONS: [],
+        }
         assert dns_state.current_config == DNS_CONFIG1
 
     def test_gen_metadadata_use_default_gateway_ipv4_server_prefered(self):
@@ -82,6 +91,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: [IPV4_DNS_SERVER1],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
         assert ipv6_iface.to_dict()[Interface.IPV6][
             BaseIface.DNS_METADATA
@@ -89,6 +99,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 1,
             DNS.SERVER: [IPV6_DNS_SERVER1],
             DNS.SEARCH: [],
+            DNS.OPTIONS: [],
         }
 
     def test_gen_metadadata_use_default_gateway_ipv6_server_prefered(self):
@@ -106,6 +117,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 1,
             DNS.SERVER: [IPV4_DNS_SERVER2],
             DNS.SEARCH: [],
+            DNS.OPTIONS: [],
         }
         assert ipv6_iface.to_dict()[Interface.IPV6][
             BaseIface.DNS_METADATA
@@ -113,6 +125,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: [IPV6_DNS_SERVER2],
             DNS.SEARCH: DNS_SEARCHES_2,
+            DNS.OPTIONS: DNS_OPTOINS2,
         }
 
     def test_gen_metadata_use_dynamic_interface(self):
@@ -130,6 +143,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: [IPV4_DNS_SERVER1],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
         assert ipv6_iface.to_dict()[Interface.IPV6][
             BaseIface.DNS_METADATA
@@ -137,6 +151,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 1,
             DNS.SERVER: [IPV6_DNS_SERVER1],
             DNS.SEARCH: [],
+            DNS.OPTIONS: [],
         }
 
     def test_gen_metadata_with_auto_interface_only(self):
@@ -154,6 +169,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: [IPV4_DNS_SERVER1],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
         assert ipv6_iface.to_dict()[Interface.IPV6][
             BaseIface.DNS_METADATA
@@ -161,6 +177,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 1,
             DNS.SERVER: [IPV6_DNS_SERVER1],
             DNS.SEARCH: [],
+            DNS.OPTIONS: [],
         }
 
     @pytest.fixture
@@ -179,6 +196,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: [IPV4_DNS_SERVER1],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
         assert ipv6_iface.to_dict()[Interface.IPV6][
             BaseIface.DNS_METADATA
@@ -186,6 +204,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 1,
             DNS.SERVER: [IPV6_DNS_SERVER1],
             DNS.SEARCH: [],
+            DNS.OPTIONS: [],
         }
         yield ipv4_iface, ipv6_iface
 
@@ -207,6 +226,7 @@ class TestDnsState:
 
     def test_verify_not_match(self):
         dns_state = DnsState({DNS.CONFIG: DNS_CONFIG1}, {})
+        print("HAHA ", dns_state.config_changed)
         with pytest.raises(NmstateVerificationError):
             dns_state.verify({DNS.CONFIG: DNS_CONFIG2})
 
@@ -274,6 +294,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: dns_config[DNS.SERVER],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
 
     def test_3_dns_ipv6_servers(self):
@@ -297,6 +318,7 @@ class TestDnsState:
             DnsState.PRIORITY_METADATA: 0,
             DNS.SERVER: dns_config[DNS.SERVER],
             DNS.SEARCH: DNS_SEARCHES_1,
+            DNS.OPTIONS: DNS_OPTOINS1,
         }
 
     def _gen_dynamic_ifaces_with_no_auto_dns(self):
@@ -364,6 +386,7 @@ class TestDnsState:
         cur_config = {
             DNS.CONFIG: {
                 DNS.SERVER: [IPV4_DNS_SERVER1, IPV6_DNS_SERVER1],
+                DNS.OPTIONS: DNS_OPTOINS1,
             }
         }
         dns_state = DnsState(des_config, cur_config)


### PR DESCRIPTION
Example on DNS options:

```yml
---
dns-resolver:
 config:
   options:
     - rotate
     - debug
```

Nmstate only support these DNS options:
 * `attempts`
 * `debug`
 * `edns0`
 * `inet6`
 * `ip6-bytestring`
 * `ip6-dotint`
 * `ndots`
 * `no-aaaa`
 * `no-check-names`
 * `no-ip6-dotint`
 * `no-reload`
 * `no-tld-query`
 * `rotate`
 * `single-request-reopen`
 * `single-request`
 * `timeout`
 * `trust-ad`
 * `use-vc`

Example YAML updated. Integration test case included.