### PR TITLE
nmpolicy: Allowing remove a property or section

### DIFF
--- a/examples/policy/enable_lldp/current.yml
+++ b/examples/policy/enable_lldp/current.yml
@@ -1,0 +1,17 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 1c:c1:0c:32:3b:ff
+    ipv4:
+      address:
+        - ip: 192.0.2.251
+          prefix-length: 24
+      dhcp: false
+      enabled: true
+    lldp:
+      enabled: false
+    ethernet:
+      sr-iov:
+        total-vfs: 2

--- a/examples/policy/enable_lldp/expected.yml
+++ b/examples/policy/enable_lldp/expected.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    lldp:
+      enabled: true
+    mac-address: 1c:c1:0c:32:3b:ff
+    ipv4:
+      address:
+        - ip: 192.0.2.251
+          prefix-length: 24
+      dhcp: false
+      enabled: true

--- a/examples/policy/enable_lldp/policy.yml
+++ b/examples/policy/enable_lldp/policy.yml
@@ -1,0 +1,9 @@
+---
+capture:
+  ethernets: interfaces.type=="ethernet"
+  ethernets-up: capture.ethernets | interfaces.state=="up"
+  ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
+  ethernets-lldp-skip-eth-conf: >-
+    capture.ethernets-lldp | interfaces.ethernet := null
+desiredState:
+  interfaces: '{{ capture.ethernets-lldp-skip-eth-conf.interfaces }}'

--- a/rust/src/lib/policy/iface.rs
+++ b/rust/src/lib/policy/iface.rs
@@ -28,7 +28,7 @@ pub(crate) fn get_iface_match(
 
 pub(crate) fn update_ifaces(
     prop_path: &[String],
-    value: &str,
+    value: Option<&str>,
     state: &NetworkState,
     line: &str,
     pos: usize,

--- a/rust/src/lib/policy/json.rs
+++ b/rust/src/lib/policy/json.rs
@@ -175,7 +175,7 @@ fn get_leaf_array_value(
 pub(crate) fn update_json_value(
     item_name: &str,
     prop_path: &[String],
-    value: &str,
+    value: Option<&str>,
     data: &mut serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), NmstateError> {
     match prop_path.len().cmp(&1) {
@@ -191,23 +191,31 @@ pub(crate) fn update_json_value(
                     &prop_path[0],
                     item_name,
                     old_value,
-                    value
+                    value.unwrap_or("null")
                 );
                 data.insert(
                     prop_path[0].to_string(),
-                    serde_json::Value::String(value.to_string()),
+                    if let Some(v) = value {
+                        serde_json::Value::String(v.to_string())
+                    } else {
+                        serde_json::Value::Null
+                    },
                 );
                 Ok(())
             } else {
                 log::debug!(
                     "Inserting new property {}:{} to {}",
                     &prop_path[0],
-                    value,
+                    value.unwrap_or("null"),
                     item_name
                 );
                 data.insert(
                     prop_path[0].to_string(),
-                    serde_json::Value::String(value.to_string()),
+                    if let Some(v) = value {
+                        serde_json::Value::String(v.to_string())
+                    } else {
+                        serde_json::Value::Null
+                    },
                 );
                 Ok(())
             }
@@ -268,7 +276,7 @@ pub(crate) fn update_json_value(
 pub(crate) fn update_items<T>(
     item_name: &str,
     prop_path: &[String],
-    value: &str,
+    value: Option<&str>,
     items: &[T],
     line: &str,
     pos: usize,
@@ -300,7 +308,8 @@ where
                     NmstateError::new(
                         ErrorKind::Bug,
                         format!(
-                            "Failed to deserialize {item_value:?} into {item_name}: {e}"
+                            "Failed to deserialize {item_value:?} into \
+                            {item_name}: {e}"
                         ),
                     )
                 })?,

--- a/rust/src/lib/policy/route.rs
+++ b/rust/src/lib/policy/route.rs
@@ -56,7 +56,7 @@ pub(crate) fn get_route_match(
 
 pub(crate) fn update_routes(
     prop_path: &[String],
-    value: &str,
+    value: Option<&str>,
     state: &NetworkState,
     line: &str,
     pos: usize,

--- a/rust/src/lib/policy/route_rule.rs
+++ b/rust/src/lib/policy/route_rule.rs
@@ -45,7 +45,7 @@ pub(crate) fn get_route_rule_match(
 
 pub(crate) fn update_route_rules(
     prop_path: &[String],
-    value: &str,
+    value: Option<&str>,
     state: &NetworkState,
     line: &str,
     pos: usize,

--- a/rust/src/lib/policy/token.rs
+++ b/rust/src/lib/policy/token.rs
@@ -13,6 +13,7 @@ pub(crate) enum NetworkCaptureToken {
     Pipe(usize),              // |
     Replace(usize),           // :=
     Equal(usize),             // ==
+    Null(usize),              // Unquoted null or NULL or Null
 }
 
 impl Default for NetworkCaptureToken {
@@ -28,7 +29,8 @@ impl NetworkCaptureToken {
             | Self::Value(_, p)
             | Self::Pipe(p)
             | Self::Replace(p)
-            | Self::Equal(p) => *p,
+            | Self::Equal(p)
+            | Self::Null(p) => *p,
         }
     }
 }
@@ -167,7 +169,11 @@ pub(crate) fn parse_str_to_capture_tokens(
                         pos,
                     ));
                 } else if !block.is_empty() {
-                    ret.push(NetworkCaptureToken::Value(block, pos));
+                    if block.to_lowercase() == "null" {
+                        ret.push(NetworkCaptureToken::Null(pos));
+                    } else {
+                        ret.push(NetworkCaptureToken::Value(block, pos));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Allowing remove a property or section using `:= null`.

For example, this policy will generate a desire state with ethernet
section removed.

```yml
capture:
  ethernets: interfaces.type=="ethernet"
  ethernets-skip-eth-conf: capture.ethernets | interfaces.ethernet := null
desiredState:
  interfaces: '{{ capture.ethernets-skip-eth-conf.interfaces }}'
```

Example added and tested.