### PR TITLE
ovs: Align STP property of OVS bridge and Linux bridge

### DIFF
--- a/examples/ovsbridge_bond_create.yml
+++ b/examples/ovsbridge_bond_create.yml
@@ -5,7 +5,8 @@ interfaces:
     state: up
     bridge:
       options:
-        stp: false
+        stp:
+          enabled: false
       port:
         - name: ovs-bond1
           link-aggregation:

--- a/examples/ovsbridge_create.yml
+++ b/examples/ovsbridge_create.yml
@@ -19,7 +19,8 @@ interfaces:
         fail-mode: ''
         mcast-snooping-enable: false
         rstp: false
-        stp: true
+        stp:
+          enabled: true
       port:
         - name: eth1
         - name: ovs0

--- a/examples/ovsbridge_patch_create.yml
+++ b/examples/ovsbridge_patch_create.yml
@@ -10,7 +10,8 @@ interfaces:
     state: up
     bridge:
       options:
-        stp: true
+        stp:
+          enabled: true
       port:
         - name: patch0
   - name: patch1
@@ -23,6 +24,7 @@ interfaces:
     state: up
     bridge:
       options:
-        stp: true
+        stp:
+          enabled: true
       port:
         - name: patch1

--- a/examples/policy/ovs-slb-bond-primary-secondary/expected.yml
+++ b/examples/policy/ovs-slb-bond-primary-secondary/expected.yml
@@ -12,7 +12,8 @@ interfaces:
     state: up
     bridge:
       options:
-        stp: false
+        stp:
+          enabled: false
         mcast-snooping-enable: false
         rstp: false
       port:

--- a/examples/policy/ovs-slb-bond-primary-secondary/policy.yml
+++ b/examples/policy/ovs-slb-bond-primary-secondary/policy.yml
@@ -14,7 +14,8 @@ desiredState:
       state: up
       bridge:
         options:
-          stp: false
+          stp:
+            enabled: false
           mcast-snooping-enable: false
           rstp: false
         port:

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -51,7 +51,7 @@ pub use macsec::{MacSecConfig, MacSecInterface, MacSecValidate};
 pub use ovs::{
     OvsBridgeBondConfig, OvsBridgeBondMode, OvsBridgeBondPortConfig,
     OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
-    OvsDpdkConfig, OvsInterface, OvsPatchConfig,
+    OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
 };
 pub use sriov::{SrIovConfig, SrIovVfConfig};
 pub use vlan::{VlanConfig, VlanInterface, VlanProtocol};

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -145,10 +145,10 @@ pub use crate::ifaces::{
     MacVlanConfig, MacVlanInterface, MacVlanMode, MacVtapConfig,
     MacVtapInterface, MacVtapMode, OvsBridgeBondConfig, OvsBridgeBondMode,
     OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
-    OvsBridgeOptions, OvsBridgePortConfig, OvsDpdkConfig, OvsInterface,
-    OvsPatchConfig, SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig,
-    VlanInterface, VlanProtocol, VrfConfig, VrfInterface, VxlanConfig,
-    VxlanInterface,
+    OvsBridgeOptions, OvsBridgePortConfig, OvsBridgeStpOptions, OvsDpdkConfig,
+    OvsInterface, OvsPatchConfig, SrIovConfig, SrIovVfConfig, VethConfig,
+    VlanConfig, VlanInterface, VlanProtocol, VrfConfig, VrfInterface,
+    VxlanConfig, VxlanInterface,
 };
 pub use crate::ip::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -119,7 +119,7 @@ pub(crate) fn gen_nm_ovs_br_setting(
 
     if let Some(br_conf) = &ovs_br_iface.bridge {
         if let Some(br_opts) = &br_conf.options {
-            nm_ovs_br_set.stp = br_opts.stp;
+            nm_ovs_br_set.stp = br_opts.stp.as_ref().and_then(|s| s.enabled);
             nm_ovs_br_set.rstp = br_opts.rstp;
             nm_ovs_br_set.mcast_snooping_enable = br_opts.mcast_snooping_enable;
             if let Some(fail_mode) = &br_opts.fail_mode {

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -10,8 +10,9 @@ use crate::{
     BridgePortVlanRange, Interface, InterfaceType, Interfaces, NetworkState,
     NmstateError, OvsBridgeBondConfig, OvsBridgeBondMode,
     OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
-    OvsBridgeOptions, OvsBridgePortConfig, OvsDbIfaceConfig, OvsDpdkConfig,
-    OvsInterface, OvsPatchConfig, UnknownInterface,
+    OvsBridgeOptions, OvsBridgePortConfig, OvsBridgeStpOptions,
+    OvsDbIfaceConfig, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
+    UnknownInterface,
 };
 
 use super::db::{parse_str_map, OvsDbConnection, OvsDbEntry};
@@ -114,7 +115,7 @@ fn parse_ovs_bridge_options(
         ret.fail_mode = Some(String::new());
     }
     if let Some(Value::Bool(v)) = ovsdb_opts.get("stp_enable") {
-        ret.stp = Some(*v)
+        ret.stp = Some(OvsBridgeStpOptions::new_enabled(*v))
     }
     if let Some(Value::Bool(v)) = ovsdb_opts.get("rstp_enable") {
         ret.rstp = Some(*v)

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -192,6 +192,14 @@ class Bridge:
     OPTIONS_SUBTREE = "options"
     PORT_SUBTREE = "port"
     PORTS_SUBTREE = "ports"
+    STP_SUBTREE = "stp"
+
+    class STP:
+        ENABLED = "enabled"
+        FORWARD_DELAY = "forward-delay"
+        HELLO_TIME = "hello-time"
+        MAX_AGE = "max-age"
+        PRIORITY = "priority"
 
     class Port:
         NAME = "name"
@@ -217,7 +225,6 @@ class Bridge:
 
 class LinuxBridge(Bridge):
     TYPE = "linux-bridge"
-    STP_SUBTREE = "stp"
     MULTICAST_SUBTREE = "multicast"
 
     class Options:
@@ -251,13 +258,6 @@ class LinuxBridge(Bridge):
         STP_HAIRPIN_MODE = "stp-hairpin-mode"
         STP_PATH_COST = "stp-path-cost"
         STP_PRIORITY = "stp-priority"
-
-    class STP:
-        ENABLED = "enabled"
-        FORWARD_DELAY = "forward-delay"
-        HELLO_TIME = "hello-time"
-        MAX_AGE = "max-age"
-        PRIORITY = "priority"
 
 
 class Ethernet:

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -136,7 +136,9 @@ def test_create_and_remove_ovs_bridge_options_specified():
             OVSBridge.Options.FAIL_MODE: "",
             OVSBridge.Options.MCAST_SNOOPING_ENABLED: False,
             OVSBridge.Options.RSTP: False,
-            OVSBridge.Options.STP: True,
+            OVSBridge.STP_SUBTREE: {
+                OVSBridge.STP.ENABLED: True,
+            },
         }
     )
 
@@ -1360,7 +1362,8 @@ def test_attach_linux_bond_to_ovs_bridge(
             state: up
             bridge:
               options:
-                stp: false
+                stp:
+                  enabled: false
               port:
                 - name: bond1
             """,


### PR DESCRIPTION
With this patch, both OVS bridge and Linux bridge support setting STP
like:

```yml
bridge:
  options:
    stp:
      enabled: true
```

The old format `stp: true|false` is still supported.

When querying, we are showing as structured data as Linux bridge.

Unit test cases included.