### PR TITLE
SRIOV: Fix VerificationError on switchdev mode SRIOV

### DIFF
--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -14,6 +14,7 @@ pub enum ErrorKind {
     DependencyError,
     PolicyError,
     PermissionError,
+    SrIovVfNotFound,
 }
 
 #[cfg(feature = "query_apply")]
@@ -24,7 +25,15 @@ impl ErrorKind {
             ErrorKind::PluginFailure
                 | ErrorKind::Bug
                 | ErrorKind::VerificationError
+                | ErrorKind::SrIovVfNotFound
         )
+    }
+
+    // Indicate this error can be ignore at the final retry. This group of
+    // errors is only used for verification retry. For example waiting
+    // SR-IOV configure all the VFs
+    pub(crate) fn can_ignore(&self) -> bool {
+        matches!(self, ErrorKind::SrIovVfNotFound)
     }
 }
 

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -40,12 +40,10 @@ impl SrIovConfig {
             match cur_ifaces.get_iface(pf_name, InterfaceType::Ethernet) {
                 Some(Interface::Ethernet(i)) => i,
                 _ => {
-                    let e = NmstateError::new(
-                        ErrorKind::VerificationError,
+                    return Err(NmstateError::new(
+                        ErrorKind::SrIovVfNotFound,
                         format!("Failed to find PF interface {pf_name}"),
-                    );
-                    log::error!("{}", e);
-                    return Err(e);
+                    ));
                 }
             };
 
@@ -61,29 +59,25 @@ impl SrIovConfig {
         };
         for vf in vfs {
             if vf.iface_name.is_empty() {
-                let e = NmstateError::new(
-                    ErrorKind::VerificationError,
+                return Err(NmstateError::new(
+                    ErrorKind::SrIovVfNotFound,
                     format!(
                         "Failed to find VF {} interface name of PF {pf_name}",
                         vf.id
                     ),
-                );
-                log::error!("{}", e);
-                return Err(e);
+                ));
             } else if cur_ifaces
                 .get_iface(vf.iface_name.as_str(), InterfaceType::Ethernet)
                 .is_none()
             {
-                let e = NmstateError::new(
-                    ErrorKind::VerificationError,
+                return Err(NmstateError::new(
+                    ErrorKind::SrIovVfNotFound,
                     format!(
                         "Find VF {} interface name {} of PF {pf_name} \
                         is not exist yet",
                         vf.id, &vf.iface_name
                     ),
-                );
-                log::error!("{}", e);
-                return Err(e);
+                ));
             }
         }
         Ok(())

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -791,14 +791,15 @@ fn test_sriov_vf_revert_to_default() {
 }
 
 #[test]
-fn test_has_sriov_with_unknown_iface_type() {
+fn test_get_sriov_vf_count() {
     let desired = serde_yaml::from_str::<Interfaces>(
         r"---
         - name: eth1
           state: up
           ethernet:
             sr-iov:
-              total-vfs: 2
+              total-vfs: 16
+        - name: eth2
         ",
     )
     .unwrap();
@@ -810,7 +811,19 @@ fn test_has_sriov_with_unknown_iface_type() {
           state: up
           ethernet:
             sr-iov:
-              total-vfs: 1
+              total-vfs: 2
+        - name: eth2
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 16
+        - name: eth3
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 16
         ",
     )
     .unwrap();
@@ -818,5 +831,5 @@ fn test_has_sriov_with_unknown_iface_type() {
     let merged_ifaces =
         MergedInterfaces::new(desired, current, false, false).unwrap();
 
-    assert!(merged_ifaces.has_sriov());
+    assert_eq!(merged_ifaces.get_sriov_vf_count(), 32);
 }


### PR DESCRIPTION
With switchdev mode SRIOV PF card, its VF interface name is unknown to
nispor as kernel does not store VF interface name in folder for
switchdev mode:

    /sys/class/net/<pf_name>/device/virtfn<sriov_id>/net/

In that case, only devlink protocol can query out PF/VF relationship.

Meanwhile, with `sriov_drivers_autoprobe` set to 0, kernel will not load
VF driver which means no VF NIC will be created.

Hence nmstate should not treat VF missing as VerificationError.

To still allows nmstate verification retry to wait VF show up in other
use cases, this patch introduce new error kind `SrIovVfNotFound`.

This error will never raise to user as it will be silently ignored at
the final verification retry.

Unit test case included and manually tested in reproduced system.