### PR TITLE
go: Configure GOPROXY and GOSUMDB

### DIFF
--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -14,6 +14,8 @@ RUN dnf update -y && \
         tcpreplay wpa_supplicant hostapd libndp procps-ng dpdk nispor \
         python3-gobject-base && dnf clean all
 
+RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"
+
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
 COPY network_manager_keyfile.conf \

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -33,9 +33,7 @@ pub(crate) fn gen_nm_ip_routes(
         };
         nm_route.next_hop = route.next_hop_addr.as_ref().cloned();
         if let Some(weight) = route.weight {
-            if let Ok(w) = u32::try_from(weight) {
-                nm_route.weight = Some(w);
-            }
+            nm_route.weight = Some(weight as u32);
         }
         ret.push(nm_route);
     }


### PR DESCRIPTION
Latest go 1.21 installed at dev c9s image need a pair of go env to be set. This change configure them with default values.

https://github.com/golang/go/issues/62274
https://github.com/golang/go/issues/31964