### PR TITLE
route: Add support for the `route-type`

### DIFF
--- a/examples/eth1_add_route.yml
+++ b/examples/eth1_add_route.yml
@@ -17,3 +17,5 @@ routes:
       next-hop-address: 192.0.2.1
       next-hop-interface: eth1
       table-id: 254
+    - destination: 198.51.200.0/24
+      route-type: blackhole

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -177,7 +177,7 @@ pub use crate::policy::{
     NetworkCaptureRules, NetworkPolicy, NetworkStateTemplate,
 };
 pub(crate) use crate::route::MergedRoutes;
-pub use crate::route::{RouteEntry, RouteState, Routes};
+pub use crate::route::{RouteEntry, RouteState, RouteType, Routes};
 pub(crate) use crate::route_rule::MergedRouteRules;
 pub use crate::route_rule::{
     RouteRuleAction, RouteRuleEntry, RouteRuleState, RouteRules,

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -56,10 +56,10 @@ pub(crate) fn get_routes(running_config_only: bool) -> Routes {
 
     if !running_config_only {
         let mut running_routes = Vec::new();
-        for np_route in np_routes.iter().filter(|np_route| {
-            SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope)
-                && np_route.oif.as_ref() != Some(&"lo".to_string())
-        }) {
+        for np_route in np_routes
+            .iter()
+            .filter(|np_route| SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope))
+        {
             if is_multipath(np_route) {
                 for route in flat_multipath_route(np_route) {
                     running_routes.push(route);
@@ -75,7 +75,6 @@ pub(crate) fn get_routes(running_config_only: bool) -> Routes {
     for np_route in np_routes.iter().filter(|np_route| {
         SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope)
             && SUPPORTED_STATIC_ROUTE_PROTOCOL.contains(&np_route.protocol)
-            && np_route.oif.as_ref() != Some(&"lo".to_string())
     }) {
         if is_multipath(np_route) {
             for route in flat_multipath_route(np_route) {

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -16,6 +16,7 @@ pub struct NmIpRoute {
     pub table: Option<u32>,
     pub metric: Option<u32>,
     pub weight: Option<u32>,
+    pub route_type: Option<String>,
     _other: DbusDictionary,
 }
 
@@ -35,6 +36,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             table: _from_map!(v, "table", u32::try_from)?,
             metric: _from_map!(v, "metric", u32::try_from)?,
             weight,
+            route_type: _from_map!(v, "type", String::try_from)?,
             _other: v,
         })
     }
@@ -82,7 +84,12 @@ impl NmIpRoute {
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }
-
+        if let Some(v) = &self.route_type {
+            ret.append(
+                zvariant::Value::new("type"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
         for (key, value) in self._other.iter() {
             ret.append(
                 zvariant::Value::new(key.as_str()),

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -26,6 +26,9 @@ impl NmIpRoute {
             if let Some(weight) = self.weight {
                 write!(opt_string, ",weight={}", weight).ok();
             }
+            if let Some(route_type) = self.route_type.as_ref() {
+                write!(opt_string, ",type={}", route_type).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -4,7 +4,9 @@ use std::convert::TryFrom;
 
 use super::super::nm_dbus::NmIpRoute;
 
-use crate::{ip::is_ipv6_addr, InterfaceIpAddr, NmstateError, RouteEntry};
+use crate::{
+    ip::is_ipv6_addr, InterfaceIpAddr, NmstateError, RouteEntry, RouteType,
+};
 
 pub(crate) fn gen_nm_ip_routes(
     routes: &[RouteEntry],
@@ -35,6 +37,12 @@ pub(crate) fn gen_nm_ip_routes(
         if let Some(weight) = route.weight {
             nm_route.weight = Some(weight as u32);
         }
+        nm_route.route_type = match route.route_type {
+            Some(RouteType::Blackhole) => Some("blackhole".to_string()),
+            Some(RouteType::Prohibit) => Some("prohibit".to_string()),
+            Some(RouteType::Unreachable) => Some("unreachable".to_string()),
+            None => None,
+        };
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -40,6 +40,10 @@ class Route:
     NEXT_HOP_ADDRESS = "next-hop-address"
     METRIC = "metric"
     WEIGHT = "weight"
+    ROUTETYPE = "route-type"
+    ROUTETYPE_BLACKHOLE = "blackhole"
+    ROUTETYPE_UNREACHABLE = "unreachable"
+    ROUTETYPE_PROHIBIT = "prohibit"
     USE_DEFAULT_METRIC = -1
     USE_DEFAULT_ROUTE_TABLE = 0
 

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -115,6 +115,11 @@ def test_dns_edit(eth1_up):
 
 
 @pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_minor_version() < 42,
+    reason="Loopback is only support on NM 1.42+, and blackhole type route "
+    "is stored in loopback",
+)
 def test_add_remove_routes(eth1_up):
     """
     Test adding a strict route and removing all routes next hop to eth1.

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -141,7 +141,7 @@ def assert_no_config_route_to_iface(iface_name):
     assert not any(
         route
         for route in current_state[Route.KEY][Route.CONFIG]
-        if route[Route.NEXT_HOP_INTERFACE] == iface_name
+        if route.get(Route.NEXT_HOP_INTERFACE, None) == iface_name
     )
 
 

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -30,7 +30,7 @@ def assert_routes(routes, state, nic="eth1"):
     routes.sort(key=_route_sort_key)
     config_routes = []
     for config_route in state[Route.KEY][Route.CONFIG]:
-        if config_route[Route.NEXT_HOP_INTERFACE] == nic:
+        if config_route.get(Route.NEXT_HOP_INTERFACE, None) == nic:
             config_routes.append(config_route)
 
     # The kernel routes contains more route entries than desired config


### PR DESCRIPTION
When users have BGP routing setups, it is common practice to blackhole some less-specific routes in order to avoid routing loops, and the BGP router might insert a more specific route dynamically afterwards.

Examples:

```
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      address:
        - ip: 192.0.2.251
          prefix-length: 24
      dhcp: false
      enabled: true

routes:
  config:
    - destination: 198.51.100.0/24
      metric: 150
      next-hop-address: 192.0.2.1
      next-hop-interface: eth1
      table-id: 254
    - destination: 198.51.200.0/24
      route-type: blackhole
```