### PR TITLE
dns: Fix DNS option `ndots`, `timeout` and `attempts`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -54,6 +54,12 @@ const SUPPORTED_DNS_OPTS_WITH_VALUE: [&str; 3] =
 ///      - trust-ad
 ///      - rotate
 /// ```
+/// To purge all static DNS configuration:
+/// ```yml
+/// ---
+/// dns-resolver:
+///   config: {}
+/// ```
 pub struct DnsState {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The running effective state. The DNS server might be from DHCP(IPv6
@@ -120,11 +126,15 @@ impl DnsClientState {
         self.server.is_none() && self.search.is_none() && self.options.is_none()
     }
 
-    // Whether user want to purge all DNS settings
+    // Any of these conditions means purge full DNS config:
+    //  * `server`, `search` and `options` are None. Equal to desire state
+    //    `config: {}`
+    //  * `server`, `search` and `options` are `Some<Vec::new()>`.
     pub(crate) fn is_purge(&self) -> bool {
-        self.server.as_deref().unwrap_or_default().is_empty()
-            && self.search.as_deref().unwrap_or_default().is_empty()
-            && self.options.as_deref().unwrap_or_default().is_empty()
+        self.server.is_none() && self.search.is_none() & self.options.is_none()
+            || self.server.as_deref() == Some(&[])
+                && self.search.as_deref() == Some(&[])
+                && self.options.as_deref() == Some(&[])
     }
 
     pub(crate) fn is_null(&self) -> bool {

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -83,3 +83,40 @@ fn test_invalid_dns_option_with_value() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_is_purge_dns_empty_dict() {
+    let desired: DnsState = serde_yaml::from_str(
+        r"---
+        config: {}
+        ",
+    )
+    .unwrap();
+    assert!(desired.config.unwrap().is_purge());
+}
+
+#[test]
+fn test_is_purge_dns_full_empty_dict() {
+    let desired: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server: []
+          search: []
+          options: []
+        ",
+    )
+    .unwrap();
+    assert!(desired.config.unwrap().is_purge());
+}
+
+#[test]
+fn test_not_purge() {
+    let desired: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          search: []
+        ",
+    )
+    .unwrap();
+    assert!(!desired.config.unwrap().is_purge());
+}

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{DnsState, MergedDnsState};
+use crate::{DnsState, ErrorKind, MergedDnsState};
 
 #[test]
 fn test_dns_verify_uncompressed_srvs() {
@@ -49,4 +49,37 @@ fn test_dns_verify_uncompressed_srvs() {
     let merged = MergedDnsState::new(desired, DnsState::new()).unwrap();
 
     merged.verify(&current).unwrap();
+}
+
+#[test]
+fn test_dns_option_with_value() {
+    let mut desired: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          options:
+          - rotate
+          - ndots:9
+        ",
+    )
+    .unwrap();
+    desired.sanitize().unwrap();
+}
+
+#[test]
+fn test_invalid_dns_option_with_value() {
+    let mut desired: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          options:
+          - rotate
+          - ndot:9
+        ",
+    )
+    .unwrap();
+    let result = desired.sanitize();
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -540,3 +540,36 @@ def test_set_invalid_dns_options(static_dns):
     )
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+def test_set_dns_option_with_value(static_dns):
+    desired_state = yaml.load(
+        """---
+        dns-resolver:
+          config:
+            options:
+            - rotate
+            - debug
+            - ndots:9
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    current_state = libnmstate.show()
+    assert "ndots:9" in current_state[DNS.KEY][DNS.CONFIG][DNS.OPTIONS]
+
+
+def test_invalid_dns_option_with_value(static_dns):
+    desired_state = yaml.load(
+        """---
+        dns-resolver:
+          config:
+            options:
+            - rotate
+            - debug
+            - ndot:9
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(desired_state)

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -171,11 +171,7 @@ def auto_eth1(eth1_up):
         }
     )
     yield
-    libnmstate.apply(
-        {
-            DNS.KEY: {DNS.CONFIG: {DNS.SERVER: [], DNS.SEARCH: []}},
-        }
-    )
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {}}})
 
 
 def test_static_dns_search_with_auto_dns(auto_eth1):


### PR DESCRIPTION
## Patch  1
The `ndots`, `timeout` and `attempts` DNS options are allowed to
hold a integer value in the format of `<opt_name>:<int>`. Previously,
nmstate is treating them as invalid DNS option. This patch fix it.

Now this YAML is supported:

```yml
dns-resolver:
  config:
    options:
    - rotate
    - ndots:9
```



## Patch 2

When user desires:

```yml
---
dns-resolver:
  config:
    search: []
```

It means user want to remove all search but preserve servers and
options, current nmstate incorrectly treat this as purge also.

This patch only treat these two as purge.

```yml
dns-resolver:
  config: {}
```

and

```yml
dns-resolver:
  config:
    server: []
    search: []
    options: []
```