### PR TITLE
[nmstate-1.4] dns: Fix DNS option `ndots`, `timeout` and `attempts`

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -19,4 +19,3 @@ jobs:
     metadata:
       targets:
         - centos-stream-8-x86_64
-        - epel-8-x86_64

--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -19,14 +19,12 @@ EMPTY_DNS = {
 REMOVE_DNS_CONFIG = {DNS.CONFIG: EMPTY_DNS}
 
 
-SUPPORTED_DNS_OPTIONS = [
-    "attempts",
+SUPPORTED_DNS_OPTS_NO_VALUE = [
     "debug",
     "edns0",
     "inet6",
     "ip6-bytestring",
     "ip6-dotint",
-    "ndots",
     "no-aaaa",
     "no-check-names",
     "no-ip6-dotint",
@@ -35,9 +33,14 @@ SUPPORTED_DNS_OPTIONS = [
     "rotate",
     "single-request",
     "single-request-reopen",
-    "timeout",
     "trust-ad",
     "use-vc",
+]
+
+SUPPORTED_DNS_OPTS_WITH_VALUE = [
+    "ndots",
+    "timeout",
+    "attempts",
 ]
 
 
@@ -73,10 +76,24 @@ class DnsState:
 
     def _canonicalize_dns_options(self):
         for opt in self.config_options:
-            if opt not in SUPPORTED_DNS_OPTIONS:
+            if opt.find(":") > 0:
+                opt = opt[: opt.find(":")]
+                if opt not in SUPPORTED_DNS_OPTS_WITH_VALUE:
+                    raise NmstateValueError(
+                        "Option '{}' is not supported to hold "
+                        "a value, only support these without "
+                        "value: {} and these with values: {}:n",
+                        opt,
+                        ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
+                        ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
+                    )
+            elif opt not in SUPPORTED_DNS_OPTS_NO_VALUE:
                 raise NmstateValueError(
-                    f"Unsupported DNS option {opt}, only support: "
-                    f"{', '.join(SUPPORTED_DNS_OPTIONS)}",
+                    "Option '{}' is not supported, only support these "
+                    "without value: {} and these with values: {}:n",
+                    opt,
+                    ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
+                    ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
                 )
 
     @property

--- a/libnmstate/nm/dns.py
+++ b/libnmstate/nm/dns.py
@@ -158,7 +158,11 @@ def get_dns_config_iface_names(acs_and_ipv4_profiles, acs_and_ipv6_profiles):
     for nm_ac, ip_profile in chain(
         acs_and_ipv6_profiles, acs_and_ipv4_profiles
     ):
-        if ip_profile.props.dns or ip_profile.props.dns_search:
+        if (
+            ip_profile.props.dns
+            or ip_profile.props.dns_search
+            or ip_profile.props.dns_options
+        ):
             try:
                 iface_name = nm_ac.get_devices()[0].get_iface()
                 iface_names.append(iface_name)

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -498,3 +498,36 @@ def test_set_invalid_dns_options(static_dns):
     )
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+def test_set_dns_option_with_value(static_dns):
+    desired_state = yaml.load(
+        """---
+        dns-resolver:
+          config:
+            options:
+            - rotate
+            - debug
+            - ndots:9
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    current_state = libnmstate.show()
+    assert "ndots:9" in current_state[DNS.KEY][DNS.CONFIG][DNS.OPTIONS]
+
+
+def test_invalid_dns_option_with_value(static_dns):
+    desired_state = yaml.load(
+        """---
+        dns-resolver:
+          config:
+            options:
+            - rotate
+            - debug
+            - ndot:9
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(desired_state)

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -531,3 +531,47 @@ def test_invalid_dns_option_with_value(static_dns):
     )
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def static_dns_with_options(static_dns):
+    desired_state = {
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.OPTIONS: ["debug", "rotate"],
+            }
+        },
+    }
+    libnmstate.apply(desired_state)
+
+
+def test_remove_all_dns_options(static_dns_with_options):
+    pre_apply_state = libnmstate.show()
+
+    desired_state = {
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.OPTIONS: [],
+            }
+        },
+    }
+    libnmstate.apply(desired_state)
+
+    current_state = libnmstate.show()
+    assert DNS.OPTIONS not in current_state[DNS.KEY][DNS.CONFIG]
+    assert (
+        current_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]
+        == pre_apply_state[DNS.KEY][DNS.CONFIG][DNS.SERVER]
+    )
+    assert (
+        current_state[DNS.KEY][DNS.CONFIG][DNS.SEARCH]
+        == pre_apply_state[DNS.KEY][DNS.CONFIG][DNS.SEARCH]
+    )
+
+
+def test_purge_dns_full_config(static_dns_with_options):
+    desired_state = {DNS.KEY: {DNS.CONFIG: {}}}
+    libnmstate.apply(desired_state)
+
+    current_state = libnmstate.show()
+    assert not current_state[DNS.KEY][DNS.CONFIG]


### PR DESCRIPTION
## Patch  1
The `ndots`, `timeout` and `attempts` DNS options are allowed to
hold a integer value in the format of `<opt_name>:<int>`. Previously,
nmstate is treating them as invalid DNS option. This patch fix it.

Now this YAML is supported:

```yml
dns-resolver:
  config:
    options:
    - rotate
    - ndots:9
```



## Patch 2

When user desires:

```yml
---
dns-resolver:
  config:
    search: []
```

It means user want to remove all search but preserve servers and
options, current nmstate incorrectly treat this as purge also.

This patch only treat these two as purge.

```yml
dns-resolver:
  config: {}
```

and

```yml
dns-resolver:
  config:
    server: []
    search: []
    options: []
```