### PR TITLE
CI: Auto cancel CI job on force push to PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: CI
 
+concurrency: ci-${{ github.ref }}
+
 on:
   pull_request:
    types: [opened, synchronize, reopened]


### PR DESCRIPTION
When contributor force push to existing PR, the previous CI job should
be canceled automatically.