### PR TITLE
ipsec: Support more options

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -81,6 +81,14 @@ pub struct LibreswanConfig {
     /// PSK authentication, if not defined, will use X.509 PKI authentication
     #[serde(skip_serializing_if = "Option::is_none")]
     pub psk: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ikelifetime: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salifetime: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ike: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub esp: Option<String>,
 }
 
 impl LibreswanConfig {

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -54,6 +54,10 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.leftid = data.get("leftid").cloned();
         ret.leftcert = data.get("leftcert").cloned();
         ret.ikev2 = data.get("ikev2").cloned();
+        ret.ikelifetime = data.get("ikelifetime").cloned();
+        ret.salifetime = data.get("salifetime").cloned();
+        ret.ike = data.get("ike").cloned();
+        ret.esp = data.get("esp").cloned();
     }
     if let Some(secrets) = nm_set_vpn.secrets.as_ref() {
         ret.psk = secrets.get("pskvalue").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -33,6 +33,18 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.ikev2.as_deref() {
             vpn_data.insert("ikev2".into(), v.to_string());
         }
+        if let Some(v) = conf.ikelifetime.as_deref() {
+            vpn_data.insert("ikelifetime".into(), v.to_string());
+        }
+        if let Some(v) = conf.salifetime.as_deref() {
+            vpn_data.insert("salifetime".into(), v.to_string());
+        }
+        if let Some(v) = conf.ike.as_deref() {
+            vpn_data.insert("ike".into(), v.to_string());
+        }
+        if let Some(v) = conf.esp.as_deref() {
+            vpn_data.insert("esp".into(), v.to_string());
+        }
 
         let mut nm_vpn_set = NmSettingVpn::default();
         nm_vpn_set.data = Some(vpn_data);

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -366,7 +366,9 @@ def test_ipsec_ipv4_libreswan_cert_auth_add_and_remove(
             leftcert: hosta.example.org
             right: 192.0.2.252
             rightid: 'hostb.example.org'
-            ikev2: insist""",
+            ikev2: insist
+            ikelifetime: 24h
+            salifetime: 24h""",
         Loader=yaml.SafeLoader,
     )
     libnmstate.apply(desired_state)


### PR DESCRIPTION
Add support of these options:
 * `ikelifetime`
 * `salifetime`
 * `ike`
 * `esp`

Please refer to libreswan document for definition of them.

Integration test case included for `ikelifetime` and `salifetime`.

For `ike` and `esp`, hard coding them require effort on syncing it with
OS encryption method of OS and ipsec. So we are trusting user know how
to set these options correct, no integration test case for it.