### PR TITLE
nm ip: fix `ipv4.dhcp-timeout` even when ip not desired

### DIFF
--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -2,8 +2,9 @@
 
 use super::nm_dbus::{NmActiveConnection, NmConnection};
 use super::settings::{
-    get_exist_profile, iface_to_nm_connections, remove_nm_mptcp_set,
-    use_uuid_for_controller_reference, use_uuid_for_parent_reference,
+    fix_ip_dhcp_timeout, get_exist_profile, iface_to_nm_connections,
+    remove_nm_mptcp_set, use_uuid_for_controller_reference,
+    use_uuid_for_parent_reference,
 };
 
 use crate::{
@@ -117,6 +118,8 @@ pub(crate) fn perpare_nm_conns(
             nm_conns_to_update.push(nm_conn);
         }
     }
+
+    fix_ip_dhcp_timeout(&mut nm_conns_to_update);
 
     use_uuid_for_controller_reference(
         &mut nm_conns_to_update,

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -343,3 +343,17 @@ fn apply_nmstate_wait_ip(
         None => (),
     }
 }
+
+// Even user not desired IP section changes, we should set ipv4.dhcp_timeout
+// and ipv6.dhcp_timeout to i32::MAX to make sure NetworkManager never
+// deactivate a desired interface
+pub(crate) fn fix_ip_dhcp_timeout(nm_conns: &mut [NmConnection]) {
+    for nm_conn in nm_conns {
+        if let Some(nm_ip_set) = nm_conn.ipv4.as_mut() {
+            nm_ip_set.dhcp_timeout = Some(i32::MAX);
+        }
+        if let Some(nm_ip_set) = nm_conn.ipv6.as_mut() {
+            nm_ip_set.dhcp_timeout = Some(i32::MAX);
+        }
+    }
+}

--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -42,6 +42,7 @@ pub(crate) use self::connection::{
 pub(crate) use self::inter_connections::{
     use_uuid_for_controller_reference, use_uuid_for_parent_reference,
 };
+pub(crate) use self::ip::fix_ip_dhcp_timeout;
 
 #[cfg(feature = "query_apply")]
 pub(crate) use self::bond::get_bond_balance_slb;


### PR DESCRIPTION
When a NM connection holding non-infinity `ipv4.dhcp-timeout`, the
connection will be deactivated on DHCP timeout, when nmstate modifying
this NM connection, it should also fix `ipv4.dhcp-timeout` to make sure
it never been deactivated due to timeout even when ipv4 not mentioned in
desired state.

This patch will always set `ipv4.dhcp-timeout` and `ipv6.dhcp-timeout`
to `i32::MAX` for NM connections we are about to modify.

Integration test case include.

Resolves: https://issues.redhat.com/browse/RHEL-16865