### PR TITLE
Skip activation of port as its controller desired to be down/absent

### DIFF
--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -4,7 +4,6 @@ import pytest
 from contextlib import contextmanager
 
 import libnmstate
-from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -482,10 +481,6 @@ def test_activate_nmcli_down_linux_bridge(br0_down):
     assertlib.assert_state_match(br0_up_state)
 
 
-@pytest.mark.xfail(
-    raises=NmstateVerificationError,
-    reason="https://issues.redhat.com/browse/RHEL-14144",
-)
 def test_create_down_linux_bridge(br0_down):
     state = br0_down
     state[Interface.KEY][0][Interface.STATE] = InterfaceState.DOWN


### PR DESCRIPTION
The test `test_create_down_linux_bridge` fails randomly, the root cause is that when the controller desires to be down or absent, we should not activate the port connection again, because the activation of the port will risk making its controller activate again.