### PR TITLE
gh,actions: Publish junit report

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,20 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']                     # runs after CI workflow
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: /nmstate-test-artifact-(.*)/  # artifact name
+        name: Integration tests                 # Name of the check run which will be created
+        path: 'junit*.xml'                      # Path to test results (inside artifact .zip)
+        reporter: junit                         # Format of test results


### PR DESCRIPTION
From the github actions notes

> Workflows triggered by pull requests from forked repositories are executed with read-only token and therefore can't create check runs. To workaround this security restriction, it's required to use two separate workflows:
> 
> CI runs in the context of the PR head branch with the read-only token. It executes the tests and uploads test results as a build artifact
> Test Report runs in the context of the repository main branch with read/write token. It will download test results and create reports
> The second workflow will only run after it has been merged into your default branch (typically main or master), it won't run in a PR unless after the workflow file is part of that branch.


So we need to merge this to see the results for the first time.