### PR TITLE
ipsec: Add support of `ipsec-interface`, DPD options and `authby`

### DIFF
--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -9,6 +9,7 @@ mod ipsec;
 mod loopback;
 mod vrf;
 mod vxlan;
+mod xfrm;
 // The pub(crate) is only for unit test
 mod infiniband;
 pub(crate) mod inter_ifaces_controller;
@@ -20,6 +21,7 @@ mod ovs;
 mod sriov;
 mod vlan;
 
+pub use self::xfrm::XfrmInterface;
 pub use base::*;
 pub use bond::{
     BondAdSelect, BondAllPortsActive, BondArpAllTargets, BondArpValidate,

--- a/rust/src/lib/ifaces/xfrm.rs
+++ b/rust/src/lib/ifaces/xfrm.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::{BaseInterface, InterfaceType};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct XfrmInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+}
+
+impl Default for XfrmInterface {
+    fn default() -> Self {
+        let mut base = BaseInterface::new();
+        base.iface_type = InterfaceType::Xfrm;
+        Self { base }
+    }
+}
+
+impl XfrmInterface {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -151,6 +151,7 @@ pub use crate::ifaces::{
     OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
     SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig, VlanInterface,
     VlanProtocol, VrfConfig, VrfInterface, VxlanConfig, VxlanInterface,
+    XfrmInterface,
 };
 pub use crate::ip::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -26,6 +26,7 @@ fn np_iface_type_to_nmstate(
         nispor::IfaceType::Vxlan => InterfaceType::Vxlan,
         nispor::IfaceType::Ipoib => InterfaceType::InfiniBand,
         nispor::IfaceType::Tun => InterfaceType::Tun,
+        nispor::IfaceType::Other(v) if v == "xfrm" => InterfaceType::Xfrm,
         _ => InterfaceType::Other(format!("{np_iface_type:?}")),
     }
 }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -21,7 +21,7 @@ use crate::{
         vxlan::np_vxlan_to_nmstate,
     },
     DummyInterface, Interface, InterfaceType, Interfaces, LoopbackInterface,
-    NetworkState, NmstateError, OvsInterface, UnknownInterface,
+    NetworkState, NmstateError, OvsInterface, UnknownInterface, XfrmInterface,
 };
 
 pub(crate) fn nispor_retrieve(
@@ -129,6 +129,11 @@ pub(crate) fn nispor_retrieve(
             }
             InterfaceType::MacSec => {
                 Interface::MacSec(np_macsec_to_nmstate(np_iface, base_iface))
+            }
+            InterfaceType::Xfrm => {
+                let mut iface = XfrmInterface::new();
+                iface.base = base_iface;
+                Interface::Xfrm(iface)
             }
             _ => {
                 log::info!(

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use crate::{
     Interface, InterfaceType, IpsecInterface, LibreswanConfig, NmstateError,
@@ -59,6 +60,12 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.salifetime = data.get("salifetime").cloned();
         ret.ike = data.get("ike").cloned();
         ret.esp = data.get("esp").cloned();
+        ret.dpddelay = data.get("dpddelay").and_then(|d| u64::from_str(d).ok());
+        ret.dpdtimeout =
+            data.get("dpdtimeout").and_then(|d| u64::from_str(d).ok());
+        ret.dpdaction = data.get("dpdaction").cloned();
+        ret.ipsec_interface = data.get("ipsec-interface").cloned();
+        ret.authby = data.get("authby").cloned();
     }
     if let Some(secrets) = nm_set_vpn.secrets.as_ref() {
         ret.psk = secrets.get("pskvalue").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -45,6 +45,21 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.esp.as_deref() {
             vpn_data.insert("esp".into(), v.to_string());
         }
+        if let Some(v) = conf.dpddelay {
+            vpn_data.insert("dpddelay".into(), v.to_string());
+        }
+        if let Some(v) = conf.dpdtimeout {
+            vpn_data.insert("dpdtimeout".into(), v.to_string());
+        }
+        if let Some(v) = conf.dpdaction.as_deref() {
+            vpn_data.insert("dpdaction".into(), v.to_string());
+        }
+        if let Some(v) = conf.ipsec_interface.as_deref() {
+            vpn_data.insert("ipsec-interface".into(), v.to_string());
+        }
+        if let Some(v) = conf.authby.as_deref() {
+            vpn_data.insert("authby".into(), v.to_string());
+        }
 
         let mut nm_vpn_set = NmSettingVpn::default();
         nm_vpn_set.data = Some(vpn_data);

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -234,7 +234,7 @@ impl Interface {
 }
 
 impl InterfaceType {
-    pub(crate) const SUPPORTED_LIST: [InterfaceType; 16] = [
+    pub(crate) const SUPPORTED_LIST: [InterfaceType; 17] = [
         InterfaceType::Bond,
         InterfaceType::LinuxBridge,
         InterfaceType::Dummy,
@@ -251,5 +251,6 @@ impl InterfaceType {
         InterfaceType::MacSec,
         InterfaceType::Vrf,
         InterfaceType::Ipsec,
+        InterfaceType::Xfrm,
     ];
 }

--- a/rust/src/lib/unit_tests/ipsec.rs
+++ b/rust/src/lib/unit_tests/ipsec.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NetworkState;
+use crate::{IpsecInterface, NetworkState};
 
 #[test]
 fn test_ipsec_hide_psk() {
@@ -40,4 +40,100 @@ fn test_ipsec_hide_psk() {
     assert!(!serde_yaml::to_string(&state)
         .unwrap()
         .contains("TOP_SECRET"));
+}
+
+#[test]
+fn test_invalid_ipsec_interface_value() {
+    let result = serde_yaml::from_str::<NetworkState>(
+        r"---
+        interfaces:
+        - name: hosta_conn
+          type: ipsec
+          state: up
+          libreswan:
+            ipsec-interface: true
+            right: 192.0.2.253
+            rightid: '@hostb-psk.example.org'
+            left: 192.0.2.250
+            leftid: '@hosta-psk.example.org'
+            ikev2: insist
+            psk: TOP_SECRET",
+    );
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert!(e.to_string().contains("Invalid ipsec-interface value"))
+    }
+}
+
+#[test]
+fn test_parse_ipsec_interface_from_string_interger() {
+    let iface = serde_yaml::from_str::<IpsecInterface>(
+        r"---
+          name: hosta_conn
+          type: ipsec
+          state: up
+          libreswan:
+            ipsec-interface: '99'
+            right: 192.0.2.253
+            rightid: '@hostb-psk.example.org'
+            left: 192.0.2.250
+            leftid: '@hosta-psk.example.org'
+            ikev2: insist
+            psk: TOP_SECRET",
+    )
+    .unwrap();
+
+    assert_eq!(
+        iface.libreswan.as_ref().unwrap().ipsec_interface.as_deref(),
+        Some("99")
+    );
+}
+
+#[test]
+fn test_parse_ipsec_interface_from_interger() {
+    let iface = serde_yaml::from_str::<IpsecInterface>(
+        r"---
+          name: hosta_conn
+          type: ipsec
+          state: up
+          libreswan:
+            ipsec-interface: 99
+            right: 192.0.2.253
+            rightid: '@hostb-psk.example.org'
+            left: 192.0.2.250
+            leftid: '@hosta-psk.example.org'
+            ikev2: insist
+            psk: TOP_SECRET",
+    )
+    .unwrap();
+
+    assert_eq!(
+        iface.libreswan.as_ref().unwrap().ipsec_interface.as_deref(),
+        Some("99")
+    );
+}
+
+#[test]
+fn test_parse_ipsec_interface_from_string_bool() {
+    let iface = serde_yaml::from_str::<IpsecInterface>(
+        r"---
+          name: hosta_conn
+          type: ipsec
+          state: up
+          libreswan:
+            ipsec-interface: 'no'
+            right: 192.0.2.253
+            rightid: '@hostb-psk.example.org'
+            left: 192.0.2.250
+            leftid: '@hosta-psk.example.org'
+            ikev2: insist
+            psk: TOP_SECRET",
+    )
+    .unwrap();
+
+    assert_eq!(
+        iface.libreswan.as_ref().unwrap().ipsec_interface.as_deref(),
+        Some("no")
+    );
 }


### PR DESCRIPTION
Add support of these libreswan Ipsec options:
 * `ipsec-interface: 'yes'|'no'|u32`
 * `dpddelay: u64`
 * `dpdtimeout: u64`
 * `dpdaction: String`
 * `authby: String`

Integration test case included but marked as OK to fail as
NetworkManager-libreswan supporting these options is not released yet.