### PR TITLE
lldp: Simplify rust structs and serde

### DIFF
--- a/rust/src/cli/autoconf.rs
+++ b/rust/src/cli/autoconf.rs
@@ -98,7 +98,7 @@ fn get_lldp_vlans(net_state: &NetworkState) -> HashMap<(u32, &str), Vec<&str>> {
                 for lldp_tlv in lldp_tlvs {
                     if let LldpNeighborTlv::Ieee8021Vlans(lldp_vlans) = lldp_tlv
                     {
-                        for lldp_vlan in &lldp_vlans.0 {
+                        for lldp_vlan in &lldp_vlans.ieee_802_1_vlans {
                             match ret
                                 .entry((lldp_vlan.vid, lldp_vlan.name.as_str()))
                             {

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -159,10 +159,10 @@ pub use crate::ip::{
 };
 pub use crate::lldp::{
     LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
-    LldpMacPhyConf, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs,
-    LldpNeighborTlv, LldpPortId, LldpPortIdType, LldpPpvids,
-    LldpSystemCapabilities, LldpSystemCapability, LldpSystemDescription,
-    LldpSystemName, LldpVlan, LldpVlans,
+    LldpMacPhy, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs, LldpNeighborTlv,
+    LldpPortId, LldpPortIdType, LldpPpvids, LldpSystemCapabilities,
+    LldpSystemCapability, LldpSystemDescription, LldpSystemName, LldpVlan,
+    LldpVlans,
 };
 pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
 pub(crate) use crate::net_state::MergedNetworkState;


### PR DESCRIPTION
Currently the serialization/deserialization of LLDP attributes is done
using serialization and deserialization functions. This change move that
to a more declarative way using some structs.

This effort make easier to parse and understand the rust nmstate AST
tree of the interface.