### PR TITLE
gh, actions: Rename "Integration tests" report

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: dorny/test-reporter@v1
       with:
         artifact: /nmstate-test-junit-artifact-(.*)/  # artifact name
-        name: Integration tests $1                    # Name of the check run which will be created
+        name: Test Results $1                         # Name of the check run which will be created
         path: 'junit*.xml'                            # Path to test results (inside artifact .zip)
         reporter: java-junit                          # Format of test results


### PR DESCRIPTION
Now some extra lines appear at each PR with the name "CI / Integration tests XYZ" but they are just a clear view of the junit reports. This PR change that to "CI / Test report XYZ".