### PR TITLE
Add sriov vlan protocol support

### DIFF
--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -92,7 +92,7 @@ impl EthernetInterface {
         if let Some(sriov_conf) =
             self.ethernet.as_mut().and_then(|e| e.sr_iov.as_mut())
         {
-            sriov_conf.sanitize();
+            sriov_conf.sanitize()?
         }
 
         Ok(())

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     ErrorKind, Interface, InterfaceType, Interfaces, MergedInterface,
-    NmstateError,
+    NmstateError, VlanProtocol,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -69,15 +69,30 @@ impl SrIovConfig {
 
     // * Convert VF MAC address to upper case
     // * Sort by VF ID
-    pub(crate) fn sanitize(&mut self) {
+    pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
         if let Some(vfs) = self.vfs.as_mut() {
             for vf in vfs.iter_mut() {
                 if let Some(address) = vf.mac_address.as_mut() {
                     address.make_ascii_uppercase()
                 }
+
+                if let Some(VlanProtocol::Ieee8021Ad) = vf.vlan_proto {
+                    if vf.vlan_id.unwrap_or_default() == 0
+                        && vf.qos.unwrap_or_default() == 0
+                    {
+                        let e = NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                "VLAN protocol 802.1ad is not allowed when both VLAN ID and VLAN QoS are zero or unset"
+                                    .to_string(),);
+                        log::error!("VF ID {}: {}", vf.id, e);
+                        return Err(e);
+                    }
+                }
             }
             vfs.sort_unstable_by(|a, b| a.id.cmp(&b.id));
         }
+
+        Ok(())
     }
 
     // * Auto fill unmentioned VF ID
@@ -174,6 +189,9 @@ pub struct SrIovVfConfig {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub qos: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_proto: Option<VlanProtocol>,
 }
 
 impl SrIovVfConfig {

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -1,6 +1,6 @@
 use crate::{
     BaseInterface, EthernetConfig, EthernetDuplex, EthernetInterface,
-    SrIovConfig, SrIovVfConfig,
+    SrIovConfig, SrIovVfConfig, VlanProtocol,
 };
 
 pub(crate) fn np_ethernet_to_nmstate(
@@ -54,6 +54,17 @@ fn gen_sriov_conf(sriov_info: &nispor::SriovInfo) -> SrIovConfig {
         vf.max_tx_rate = Some(vf_info.max_tx_rate);
         vf.vlan_id = Some(vf_info.vlan_id);
         vf.qos = Some(vf_info.qos);
+        vf.vlan_proto = match &vf_info.vlan_proto {
+            nispor::VlanProtocol::Ieee8021Q => Some(VlanProtocol::Ieee8021Q),
+            nispor::VlanProtocol::Ieee8021AD => Some(VlanProtocol::Ieee8021Ad),
+            p => {
+                log::warn!(
+                    "Got unknown VLAN protocol {p:?} on SR-IOV VF {}",
+                    vf_info.id
+                );
+                None
+            }
+        };
         vfs.push(vf);
     }
     ret.total_vfs = Some(vfs.len() as u32);

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -117,6 +117,15 @@ impl Default for NmVlanProtocol {
     }
 }
 
+impl From<crate::VlanProtocol> for NmVlanProtocol {
+    fn from(proto: crate::VlanProtocol) -> Self {
+        match proto {
+            crate::VlanProtocol::Ieee8021Q => Self::Dot1Q,
+            crate::VlanProtocol::Ieee8021Ad => Self::Dot1Ad,
+        }
+    }
+}
+
 impl TryFrom<String> for NmVlanProtocol {
     type Error = NmError;
     fn try_from(vlan_protocol: String) -> Result<Self, Self::Error> {

--- a/rust/src/lib/nm/settings/sriov.rs
+++ b/rust/src/lib/nm/settings/sriov.rs
@@ -69,6 +69,7 @@ fn gen_nm_vfs(
             let mut nm_vf_vlan = NmSettingSriovVfVlan::default();
             nm_vf_vlan.id = v;
             nm_vf_vlan.qos = vf.qos.unwrap_or_default();
+            nm_vf_vlan.protocol = vf.vlan_proto.unwrap_or_default().into();
             nm_vf.vlans = Some(vec![nm_vf_vlan]);
         }
         ret.push(nm_vf);

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -73,9 +73,11 @@ fn test_ignore_sriov_if_not_desired() {
         spoof-check: true
         vlan-id: 102
         qos: 5
+        vlan-proto: 802.1q
       - id: 1
         vlan-id: 101
         qos: 6
+        vlan-proto: 802.1ad
 ",
     )
     .unwrap();

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -841,3 +841,30 @@ fn test_get_sriov_vf_count() {
 
     assert_eq!(merged_ifaces.get_sriov_vf_count(), 32);
 }
+
+#[test]
+fn test_sriov_not_allow_802_1ad_vlan_protocol_for_vlan_0_and_qos_0() {
+    let mut desired = serde_yaml::from_str::<Interface>(
+        r"---
+        name: eth1
+        type: ethernet
+        state: up
+        ethernet:
+          sr-iov:
+            total-vfs: 1
+            vfs:
+            - id: 0
+              vlan-id: 0
+              qos: 0
+              vlan-proto: 802.1ad
+        ",
+    )
+    .unwrap();
+
+    let result = desired.sanitize(true);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -294,7 +294,7 @@ class Ethernet:
             MAX_TX_RATE = "max-tx-rate"
             VLAN_ID = "vlan-id"
             QOS = "qos"
-            PROTO = "vlan-proto"
+            VLAN_PROTO = "vlan-proto"
 
 
 class Veth:

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -294,6 +294,7 @@ class Ethernet:
             MAX_TX_RATE = "max-tx-rate"
             VLAN_ID = "vlan-id"
             QOS = "qos"
+            PROTO = "vlan-proto"
 
 
 class Veth:

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -257,7 +257,7 @@ class TestSrIov:
             ] = InterfaceState.ABSENT
             libnmstate.apply(desired_state)
 
-    def test_sriov_vf_vlan_id_and_qos(self):
+    def test_sriov_vf_vlan_id_and_qos_proto(self):
         pf_name = _test_nic_name()
         desired_state = {
             Interface.KEY: [
@@ -271,11 +271,13 @@ class TestSrIov:
                                     Ethernet.SRIOV.VFS.ID: 0,
                                     Ethernet.SRIOV.VFS.VLAN_ID: 100,
                                     Ethernet.SRIOV.VFS.QOS: 5,
+                                    Ethernet.SRIOV.VFS.PROTO: "802.1ad",
                                 },
                                 {
                                     Ethernet.SRIOV.VFS.ID: 1,
                                     Ethernet.SRIOV.VFS.VLAN_ID: 102,
                                     Ethernet.SRIOV.VFS.QOS: 6,
+                                    Ethernet.SRIOV.VFS.PROTO: "802.1q",
                                 },
                             ],
                         }

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -271,13 +271,13 @@ class TestSrIov:
                                     Ethernet.SRIOV.VFS.ID: 0,
                                     Ethernet.SRIOV.VFS.VLAN_ID: 100,
                                     Ethernet.SRIOV.VFS.QOS: 5,
-                                    Ethernet.SRIOV.VFS.PROTO: "802.1ad",
+                                    Ethernet.SRIOV.VFS.VLAN_PROTO: "802.1ad",
                                 },
                                 {
                                     Ethernet.SRIOV.VFS.ID: 1,
                                     Ethernet.SRIOV.VFS.VLAN_ID: 102,
                                     Ethernet.SRIOV.VFS.QOS: 6,
-                                    Ethernet.SRIOV.VFS.PROTO: "802.1q",
+                                    Ethernet.SRIOV.VFS.VLAN_PROTO: "802.1q",
                                 },
                             ],
                         }


### PR DESCRIPTION
These changes allow users to get and set the vlan protocol of sriov VFs.

Depends on https://github.com/nispor/nispor/pull/249
