### PR TITLE
vlan: Implement show and apply for "flags" fields

### DIFF
--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -58,6 +58,8 @@ pub use ovs::{
     OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
 };
 pub use sriov::{SrIovConfig, SrIovVfConfig};
-pub use vlan::{VlanConfig, VlanInterface, VlanProtocol};
+pub use vlan::{
+    VlanConfig, VlanInterface, VlanProtocol, VlanRegistrationProtocol,
+};
 pub use vrf::{VrfConfig, VrfInterface};
 pub use vxlan::{VxlanConfig, VxlanInterface};

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -63,6 +63,15 @@ pub struct VlanConfig {
     /// Could be `802.1q` or `802.1ad`. Default to `802.1q` if not defined.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<VlanProtocol>,
+    /// Could be `gvrp`, `mvrp` or `none`. Default to none if not defined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registration_protocol: Option<VlanRegistrationProtocol>,
+    /// reordering of output packet headers
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reorder_headers: Option<bool>,
+    /// loose binding of the interface to its master device's operating state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loose_binding: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -92,4 +101,15 @@ impl std::fmt::Display for VlanProtocol {
             }
         )
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VlanRegistrationProtocol {
+    /// GARP VLAN Registration Protocol
+    Gvrp,
+    /// Multiple VLAN Registration Protocol
+    Mvrp,
+    /// No Registration Protocol
+    None,
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -150,8 +150,8 @@ pub use crate::ifaces::{
     OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
     OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
     SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig, VlanInterface,
-    VlanProtocol, VrfConfig, VrfInterface, VxlanConfig, VxlanInterface,
-    XfrmInterface,
+    VlanProtocol, VlanRegistrationProtocol, VrfConfig, VrfInterface,
+    VxlanConfig, VxlanInterface, XfrmInterface,
 };
 pub use crate::ip::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, VlanConfig, VlanInterface, VlanProtocol};
+use crate::{
+    BaseInterface, VlanConfig, VlanInterface, VlanProtocol,
+    VlanRegistrationProtocol,
+};
 
 pub(crate) fn np_vlan_to_nmstate(
     np_iface: &nispor::Iface,
@@ -19,6 +22,17 @@ pub(crate) fn np_vlan_to_nmstate(
                 );
                 None
             }
+        },
+        reorder_headers: Some(np_vlan_info.is_reorder_hdr),
+        loose_binding: Some(np_vlan_info.is_loose_binding),
+        // They are mutually exclusive, vlan cannot be gvrp and mvrp at the
+        // same time
+        registration_protocol: if np_vlan_info.is_gvrp {
+            Some(VlanRegistrationProtocol::Gvrp)
+        } else if np_vlan_info.is_mvrp {
+            Some(VlanRegistrationProtocol::Mvrp)
+        } else {
+            Some(VlanRegistrationProtocol::None)
         },
     });
 

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -63,7 +63,7 @@ pub use self::route_rule::{NmIpRouteRule, NmIpRouteRuleAction};
 pub use self::sriov::{NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan};
 pub use self::user::NmSettingUser;
 pub use self::veth::NmSettingVeth;
-pub use self::vlan::{NmSettingVlan, NmVlanProtocol};
+pub use self::vlan::{NmSettingVlan, NmSettingVlanFlag, NmVlanProtocol};
 pub use self::vpn::NmSettingVpn;
 pub use self::vrf::NmSettingVrf;
 pub use self::vxlan::NmSettingVxlan;

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -33,8 +33,8 @@ pub use self::connection::{
     NmSettingOvsExtIds, NmSettingOvsIface, NmSettingOvsOtherConfig,
     NmSettingOvsPatch, NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf,
     NmSettingSriovVfVlan, NmSettingUser, NmSettingVeth, NmSettingVlan,
-    NmSettingVpn, NmSettingVrf, NmSettingVxlan, NmSettingWired,
-    NmSettingsConnectionFlag, NmVlanProtocol,
+    NmSettingVlanFlag, NmSettingVpn, NmSettingVrf, NmSettingVxlan,
+    NmSettingWired, NmSettingsConnectionFlag, NmVlanProtocol,
 };
 pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::NmConnection;
+use super::super::nm_dbus::{NmConnection, NmSettingVlanFlag};
 
-use crate::{VlanInterface, VlanProtocol};
+use crate::{VlanInterface, VlanProtocol, VlanRegistrationProtocol};
 
 const NM_802_1_AD: &str = "802.1ad";
 const NM_802_1_Q: &str = "802.1Q";
@@ -28,6 +28,51 @@ pub(crate) fn gen_nm_vlan_setting(
                         nm_vlan.protocol = Some(NM_802_1_Q.to_string());
                     }
                 }
+            }
+        }
+
+        if let Some(registration_protocol) = vlan_conf.registration_protocol {
+            match registration_protocol {
+                VlanRegistrationProtocol::Gvrp => {
+                    nm_vlan
+                        .flags
+                        .retain(|x| !matches!(x, NmSettingVlanFlag::Mvrp));
+                    nm_vlan.flags.push(NmSettingVlanFlag::Gvrp);
+                }
+                VlanRegistrationProtocol::Mvrp => {
+                    nm_vlan
+                        .flags
+                        .retain(|x| !matches!(x, NmSettingVlanFlag::Gvrp));
+                    nm_vlan.flags.push(NmSettingVlanFlag::Mvrp);
+                }
+                VlanRegistrationProtocol::None => {
+                    nm_vlan.flags.retain(|x| {
+                        !matches!(
+                            x,
+                            NmSettingVlanFlag::Gvrp | NmSettingVlanFlag::Mvrp,
+                        )
+                    });
+                }
+            }
+        }
+
+        if let Some(reorder_headers) = vlan_conf.reorder_headers {
+            if reorder_headers {
+                nm_vlan.flags.push(NmSettingVlanFlag::ReorderHeaders);
+            } else {
+                nm_vlan.flags.retain(|x| {
+                    !matches!(x, NmSettingVlanFlag::ReorderHeaders)
+                });
+            }
+        }
+
+        if let Some(loose_binding) = vlan_conf.loose_binding {
+            if loose_binding {
+                nm_vlan.flags.push(NmSettingVlanFlag::LooseBinding);
+            } else {
+                nm_vlan
+                    .flags
+                    .retain(|x| !matches!(x, NmSettingVlanFlag::LooseBinding));
             }
         }
         nm_conn.vlan = Some(nm_vlan);

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -312,6 +312,12 @@ class VLAN:
     PROTOCOL = "protocol"
     PROTOCOL_802_1AD = "802.1ad"
     PROTOCOL_802_1Q = "802.1q"
+    REGISTRATION_PROTOCOL = "registration-protocol"
+    REGISTRATION_PROTOCOL_GVRP = "gvrp"
+    REGISTRATION_PROTOCOL_MVRP = "mvrp"
+    REGISTRATION_PROTOCOL_NONE = "none"
+    REORDER_HEADERS = "reorder-headers"
+    LOOSE_BINDING = "loose-binding"
 
 
 class VXLAN:

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -342,3 +342,105 @@ def test_add_qinq_vlan(eth1_up):
     ) as desired_state:
         assertlib.assert_state_match(desired_state)
     assertlib.assert_absent(VLAN_IFNAME)
+
+
+def test_configure_vlan_with_reaorder_headers(vlan_on_eth1):
+    flags_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: 102,
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.REORDER_HEADERS: True,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+    flags_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
+        VLAN.REORDER_HEADERS
+    ] = False
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+
+def test_configure_vlan_with_loose_binding(vlan_on_eth1):
+    flags_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: 102,
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.LOOSE_BINDING: True,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+    flags_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
+        VLAN.LOOSE_BINDING
+    ] = False
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+
+def test_configure_vlan_with_gvrp(vlan_on_eth1):
+    protocol = VLAN.REGISTRATION_PROTOCOL_GVRP
+    flags_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: 102,
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.REGISTRATION_PROTOCOL: protocol,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+    flags_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
+        VLAN.REGISTRATION_PROTOCOL
+    ] = VLAN.REGISTRATION_PROTOCOL_NONE
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+
+def test_configure_vlan_with_mvrp(vlan_on_eth1):
+    protocol = VLAN.REGISTRATION_PROTOCOL_MVRP
+    flags_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: 102,
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.REGISTRATION_PROTOCOL: protocol,
+                },
+            }
+        ]
+    }
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)
+
+    flags_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
+        VLAN.REGISTRATION_PROTOCOL
+    ] = VLAN.REGISTRATION_PROTOCOL_NONE
+    libnmstate.apply(flags_state)
+    assertlib.assert_state_match(flags_state)


### PR DESCRIPTION
The vlan NM field "flags" is present at nispor but it was missing at nmstate to show and apply, this change implement it as individual bool flags and as enum for registration protocols.

Closes https://issues.redhat.com/browse/RHEL-19142