### PR TITLE
nm bond-port: Fix error on NetworkManager does not support bond-port

### DIFF
--- a/rust/src/lib/nm/settings/bond.rs
+++ b/rust/src/lib/nm/settings/bond.rs
@@ -232,8 +232,22 @@ pub(crate) fn gen_nm_bond_port_setting(
         return;
     };
 
+    // NetworkManager 1.34- does not support bond_port yet, we skip creating
+    // this NmSettingBondPort on default value unless it pre-exist.
+    if (bond_port_conf.priority.is_none() || bond_port_conf.priority == Some(0))
+        && (bond_port_conf.queue_id.is_none()
+            || bond_port_conf.queue_id == Some(0))
+        && nm_conn.bond_port.is_none()
+    {
+        return;
+    }
+
+    // NetworkManager 1.42.8- does not support priority, hence we do not touch
+    // it unless non-default defined or pre-exist.
     if let Some(v) = bond_port_conf.priority {
-        nm_set.priority = Some(v);
+        if nm_set.priority.is_some() || v != 0 {
+            nm_set.priority = Some(v);
+        }
     }
 
     if let Some(v) = bond_port_conf.queue_id {

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1362,3 +1362,17 @@ def test_bond_deprecated_prop(eth1_up, eth2_up):
 
         libnmstate.apply(state)
         assertlib.assert_state_match(original_state)
+
+
+def test_change_mtu_of_bond_port(bond99_with_2_port):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.MTU: 1280,
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
With NetworkManager not supporting bond-port, changing MTU of a bond
port will cause error:

    libnmstate.error.NmstateValueError:
    Connection(InvalidProperty):bond-port.prio: unknown property

To fix it, we do not create bond port setting for default value unless
pre-exists.

Integration test case included.