### PR TITLE
WIP: nm: Persistent controller and parent connection to disk

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -338,6 +338,18 @@ impl NmConnection {
         }
         None
     }
+
+    pub fn parent(&self) -> Option<&str> {
+        self.infiniband
+            .as_ref()
+            .and_then(|i| i.parent.as_deref())
+            .or_else(|| self.macsec.as_ref().and_then(|i| i.parent.as_deref()))
+            .or_else(|| {
+                self.mac_vlan.as_ref().and_then(|i| i.parent.as_deref())
+            })
+            .or_else(|| self.vxlan.as_ref().and_then(|i| i.parent.as_deref()))
+            .or_else(|| self.vlan.as_ref().and_then(|i| i.parent.as_deref()))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -3,8 +3,8 @@
 use super::nm_dbus::{NmActiveConnection, NmConnection};
 use super::settings::{
     fix_ip_dhcp_timeout, get_exist_profile, iface_to_nm_connections,
-    remove_nm_mptcp_set, use_uuid_for_controller_reference,
-    use_uuid_for_parent_reference,
+    remove_nm_mptcp_set, save_parent_port_and_ctrl_to_disk,
+    use_uuid_for_controller_reference, use_uuid_for_parent_reference,
 };
 
 use crate::{
@@ -134,6 +134,14 @@ pub(crate) fn perpare_nm_conns(
         exist_nm_conns,
         nm_acs,
     );
+
+    if !merged_state.memory_only {
+        save_parent_port_and_ctrl_to_disk(
+            &mut nm_conns_to_update,
+            exist_nm_conns,
+            nm_acs,
+        );
+    }
 
     Ok(PerparedNmConnections {
         to_store: nm_conns_to_update,

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -565,3 +565,7 @@ fn persisten_iface_cur_conf(
         gen_conf_mode,
     )
 }
+
+pub(crate) fn is_nm_iface_type_userspace(nm_iface_type: &str) -> bool {
+    NM_SETTING_USER_SPACES.contains(&nm_iface_type)
+}

--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -40,7 +40,8 @@ pub(crate) use self::connection::{
     NM_SETTING_VXLAN_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
 };
 pub(crate) use self::inter_connections::{
-    use_uuid_for_controller_reference, use_uuid_for_parent_reference,
+    save_parent_port_and_ctrl_to_disk, use_uuid_for_controller_reference,
+    use_uuid_for_parent_reference,
 };
 pub(crate) use self::ip::fix_ip_dhcp_timeout;
 

--- a/tests/integration/nm/testlib.py
+++ b/tests/integration/nm/testlib.py
@@ -1,21 +1,5 @@
-#
-# Copyright (c) 2018-2020 Red Hat, Inc.
-#
-# This file is part of nmstate
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 2.1 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from contextlib import contextmanager
 
 from libnmstate import error
@@ -59,3 +43,14 @@ def get_proxy_port_profile_uuid_of_ovs_interface(iface_name):
         check=True,
     )
     return proxy_port_uuid
+
+
+def iface_hold_in_memory_connection(iface_name):
+    output = cmdlib.exec_cmd(
+        f"nmcli -g FILENAME,DEVICE c show  --active".split(),
+        check=True,
+    )[1].strip()
+    for line in output.split("\n"):
+        if line.endswith(f":{iface_name}"):
+            return line.startswith("/run/")
+    return False

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -12,6 +12,7 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import VLAN
 
 from ..testlib import cmdlib
+from .testlib import iface_hold_in_memory_connection
 
 TEST_VLAN = "test_vlan0"
 TEST_PROFILE_NAME = "0eth1"
@@ -80,6 +81,65 @@ def test_vlan_parent_has_two_profiles(eth1_up_with_two_profiles):
                     {
                         Interface.NAME: TEST_VLAN,
                         Interface.TYPE: InterfaceType.VLAN,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
+        )
+
+
+@pytest.fixture
+def dummy1_in_memory():
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "dummy1",
+                    Interface.TYPE: InterfaceType.DUMMY,
+                    Interface.STATE: InterfaceState.UP,
+                }
+            ]
+        },
+        save_to_disk=False,
+    )
+    assert iface_hold_in_memory_connection("dummy1")
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "dummy1",
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+def test_change_vlan_convert_parent_to_persistent(dummy1_in_memory):
+    try:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VLAN,
+                        Interface.TYPE: InterfaceType.VLAN,
+                        Interface.STATE: InterfaceState.UP,
+                        VLAN.CONFIG_SUBTREE: {
+                            VLAN.ID: 101,
+                            VLAN.BASE_IFACE: "dummy1",
+                        },
+                    }
+                ]
+            }
+        )
+        assert not iface_hold_in_memory_connection("dummy1")
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: TEST_VLAN,
                         Interface.STATE: InterfaceState.ABSENT,
                     }
                 ]


### PR DESCRIPTION
When a NM connection's parent or controller is memory only connection,
next OS reboot will cause this interface not activated due to missing
parent/controller. To fix it, we persistent its controllers and parents.

Integration test cases included.

Ref: https://issues.redhat.com/browse/OCPBUGS-15132