### PR TITLE
package: Ignore minimum rust version

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -28,3 +28,4 @@ jobs:
     metadata:
       targets:
         - centos-stream-9-x86_64
+        - epel-9-x86_64

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -183,7 +183,13 @@ popd
 
 %build
 pushd rust
+%if 0%{?rhel}
+# It is safe to ignore minimum rust version. The main blocker on MSRV is
+# toml which just increase their MSRV by a robot for no hard reason.
+%cargo_build --ignore-rust-version
+%else
 %cargo_build
+%endif
 popd
 
 pushd rust/src/python


### PR DESCRIPTION
When compiling on rust 1.66 (the rust version shipping by RHEL 9.2), we
got failure:

    package `toml_datetime v0.6.5` cannot be built because it requires
    rustc 1.67 or newer

The `toml_datetime` just change their MSRV(minimum safe rust version) by
a auto robot for no hardware reason.

Added `--ignore-rust-version` to cargo build in rpm SPEC fil, re-enabled
EPEL-9 build root for packit.