### PR TITLE
Cargo: Use optional dependency instead of internal feature

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux-apis"]
-rust-version = "1.58"
+rust-version = "1.60"
 edition = "2021"
 
 [lib]
@@ -61,6 +61,6 @@ serde_yaml = "0.9"
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]
-query_apply = ["nispor", "nix", "zbus"]
+query_apply = ["dep:nispor", "dep:nix", "dep:zbus"]
 gen_conf = []
 gen_revert = []

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -414,8 +414,8 @@ def test_linux_bridge_store_stp_setting_even_disabled(
 
 @pytest.fixture
 def unmangaed_dummy1_dummy2():
-    exec_cmd("ip link add dummy1 type dummy".split(), check=True)
-    exec_cmd("ip link add dummy2 type dummy".split(), check=True)
+    exec_cmd("ip link add dummy1 type dummy".split(), check=False)
+    exec_cmd("ip link add dummy2 type dummy".split(), check=False)
     exec_cmd("ip link set dummy1 up".split(), check=True)
     exec_cmd("ip link set dummy2 up".split(), check=True)
     exec_cmd("nmcli dev set dummy1 managed false".split(), check=True)


### PR DESCRIPTION
Since Rust 1.60, we can use `dep:<opt_dep_name>` to prevent cargo from
creating internal feature.

Reference document in rust:
https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies