### PR TITLE
ipsec: Fix error when `ipsec-interface` set to yes or a number

### DIFF
--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -26,7 +26,9 @@ fn np_iface_type_to_nmstate(
         nispor::IfaceType::Vxlan => InterfaceType::Vxlan,
         nispor::IfaceType::Ipoib => InterfaceType::InfiniBand,
         nispor::IfaceType::Tun => InterfaceType::Tun,
-        nispor::IfaceType::Other(v) if v == "xfrm" => InterfaceType::Xfrm,
+        nispor::IfaceType::Other(v) if v.to_lowercase() == "xfrm" => {
+            InterfaceType::Xfrm
+        }
         _ => InterfaceType::Other(format!("{np_iface_type:?}")),
     }
 }


### PR DESCRIPTION
The new nispor 1.2.15 is showing xfrm interface type as `Other("Xfrm")`
as its dependent netlink-packet-route is not placing it into Other.

To fix that, we just compare the interface type after
`str::to_lowercase()`.

No test code needed, existing
`test_ipsec_ipv4_libreswan_psk_auth_with_ipsec_iface` can reproduce this
problem.