### PR TITLE
service: Mark .applied with checksum

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -9,8 +9,8 @@ nmstate\&.service
 nmstate\&.service invokes \fBnmstatectl service\fR command which
 apply all network state files ending with \fB.yml\fR in
 \fB/etc/nmstate\fR folder.
-The applied network state file will be renamed with postfix \fB.applied\fR
-to prevent repeated applied on next service start.
+The applied network state file sha256 digest will be stored at \fB.applied\fR
+file to prevent repeated applied on next service start.
 .SH BUG REPORTS
 Report bugs on nmstate GitHub issues <https://github.com/nmstate/nmstate>.
 .SH COPYRIGHT

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -28,6 +28,7 @@ ctrlc = { version = "3.2.1", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
 chrono = "0.4"
 nispor = { version = "1.2", optional = true }
+ring = "0.17.7"
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]


### PR DESCRIPTION
At some envs like openshift machine-config-operator moving configuration files can break in place upgrades. This change use symlinks instead of rename to mark a .yml file as applied so the original file is preserved.

Close https://issues.redhat.com/browse/RHEL-19680