### PR TITLE
CI: Remove xfail of VxLAN on Fedora

### DIFF
--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -16,7 +16,6 @@ from .testlib.bondlib import bond_interface
 from .testlib.cmdlib import RC_SUCCESS
 from .testlib.cmdlib import exec_cmd
 from .testlib.cmdlib import format_exec_cmd_result
-from .testlib.env import is_fedora
 from .testlib.env import is_k8s
 from .testlib.env import nm_major_minor_version
 from .testlib.vxlan import VxlanState
@@ -29,11 +28,6 @@ VXLAN1_ID = 201
 VXLAN2_ID = 202
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 def test_add_and_remove_vxlan(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -45,11 +39,6 @@ def test_add_and_remove_vxlan(eth1_up):
     assertlib.assert_absent(vxlan1_ifname)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
@@ -65,11 +54,6 @@ def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     assertlib.assert_absent(vxlan_interfaces_name)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_without_base_if():
     with vxlan_interfaces(
@@ -81,11 +65,6 @@ def test_add_and_remove_vxlan_without_base_if():
     assertlib.assert_absent(vxlan1_ifname)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_nolearning():
     with vxlan_interfaces(
@@ -97,11 +76,6 @@ def test_add_and_remove_vxlan_nolearning():
     assertlib.assert_absent(vxlan1_ifname)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 @pytest.mark.xfail(
     is_k8s(),
@@ -130,11 +104,6 @@ def test_rollback_for_vxlans(eth1_up):
     assert current_state == current_state_after_apply
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 def test_set_vxlan_iface_down(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=ifname, remote="192.168.100.1")
@@ -144,11 +113,6 @@ def test_set_vxlan_iface_down(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 def test_add_new_bond_iface_with_vxlan(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     bond_name = "bond0"
@@ -167,11 +131,6 @@ def test_add_new_bond_iface_with_vxlan(eth1_up):
     assertlib.assert_absent(bond_name)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 def test_show_vxlan_with_no_remote(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=eth_name, remote="")
@@ -190,11 +149,6 @@ def test_show_vxlan_with_no_remote(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 def test_add_and_remove_vxlan_with_no_remote():
     with vxlan_interfaces(
@@ -206,11 +160,6 @@ def test_add_and_remove_vxlan_with_no_remote():
     assertlib.assert_absent(vxlan1_ifname)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 def test_add_vxlan_and_modify_vxlan_id(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
@@ -226,11 +175,6 @@ def test_add_vxlan_and_modify_vxlan_id(eth1_up):
     assertlib.assert_absent(vxlan1_ifname)
 
 
-@pytest.mark.skipif(
-    is_fedora(),
-    reason="Unknown bug of nmstate on Fedora "
-    "https://issues.redhat.com/browse/RHEL-5001",
-)
 @pytest.mark.tier1
 @pytest.mark.skipif(
     nm_major_minor_version() < 1.31,


### PR DESCRIPTION
The VxLAN issue on Fedora has been fixed by commit

efe4c20d763492c9dd3abdc60e68ca590931cee8 Use new nispor 1.2.15

Removing xfail on all VxLAN test cases.