### PR TITLE
Use nispor 1.2.16

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 serde_yaml = "0.9"
 
 [dependencies.nispor]
-version = "1.2.15"
+version = "1.2.16"
 optional = true
 
 [dependencies.zvariant]

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -26,10 +26,9 @@ fn np_iface_type_to_nmstate(
         nispor::IfaceType::Vxlan => InterfaceType::Vxlan,
         nispor::IfaceType::Ipoib => InterfaceType::InfiniBand,
         nispor::IfaceType::Tun => InterfaceType::Tun,
-        nispor::IfaceType::Other(v) if v.to_lowercase() == "xfrm" => {
-            InterfaceType::Xfrm
-        }
-        _ => InterfaceType::Other(format!("{np_iface_type:?}")),
+        nispor::IfaceType::Xfrm => InterfaceType::Xfrm,
+        nispor::IfaceType::Other(v) => InterfaceType::Other(v.to_lowercase()),
+        _ => InterfaceType::Other(format!("{np_iface_type:?}").to_lowercase()),
     }
 }
 


### PR DESCRIPTION
The nispor 1.2.16 has full XFRM interface support, we should use that.