### PR TITLE
cosmetic: dns: Move `is_iface_valid_for_dns` to top level

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -5,7 +5,10 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ip::is_ipv6_addr, ErrorKind, MergedNetworkState, NmstateError};
+use crate::{
+    ip::is_ipv6_addr, ErrorKind, MergedInterface, MergedNetworkState,
+    NmstateError,
+};
 
 const SUPPORTED_DNS_OPTS_NO_VALUE: [&str; 15] = [
     "debug",
@@ -392,4 +395,19 @@ pub(crate) fn parse_dns_ipv6_link_local_srv(
         }
     }
     Ok(None)
+}
+
+impl MergedInterface {
+    // IP stack is merged with current at this point.
+    pub(crate) fn is_iface_valid_for_dns(&self, is_ipv6: bool) -> bool {
+        if is_ipv6 {
+            self.merged.base_iface().ipv6.as_ref().map(|ip_conf| {
+                ip_conf.enabled && (ip_conf.is_static() || (ip_conf.is_auto()))
+            }) == Some(true)
+        } else {
+            self.merged.base_iface().ipv4.as_ref().map(|ip_conf| {
+                ip_conf.enabled && (ip_conf.is_static() || (ip_conf.is_auto()))
+            }) == Some(true)
+        }
+    }
 }

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -521,19 +521,6 @@ impl MergedInterface {
             false
         }
     }
-
-    // IP stack is merged with current at this point.
-    pub(crate) fn is_iface_valid_for_dns(&self, is_ipv6: bool) -> bool {
-        if is_ipv6 {
-            self.merged.base_iface().ipv6.as_ref().map(|ip_conf| {
-                ip_conf.enabled && (ip_conf.is_static() || (ip_conf.is_auto()))
-            }) == Some(true)
-        } else {
-            self.merged.base_iface().ipv4.as_ref().map(|ip_conf| {
-                ip_conf.enabled && (ip_conf.is_static() || (ip_conf.is_auto()))
-            }) == Some(true)
-        }
-    }
 }
 
 fn is_external_managed(


### PR DESCRIPTION
The `is_iface_valid_for_dns` is been used in `dns.rs`, hence it should
not be stored in `nm/dns.rs`.