### PR TITLE
ip: Do not skip serializing allow-extra-address: false

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -86,11 +86,10 @@ struct InterfaceIp {
     #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
     pub addr_gen_mode: Option<Ipv6AddrGenMode>,
     #[serde(
-        default = "default_allow_extra_address",
-        skip_serializing,
+        skip_serializing_if = "Option::is_none",
         rename = "allow-extra-address"
     )]
-    pub allow_extra_address: bool,
+    pub allow_extra_address: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
     #[serde(
@@ -105,7 +104,7 @@ struct InterfaceIp {
     pub dhcp_custom_hostname: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 #[serde(into = "InterfaceIp")]
 #[non_exhaustive]
 /// IPv4 configuration of interface.
@@ -163,13 +162,12 @@ pub struct InterfaceIpv4 {
     /// If not defined, the main(254) will be used.
     /// Serialize and deserialize to/from `auto-table-id`.
     pub auto_table_id: Option<u32>,
-    /// By default(true), nmstate verification process allows extra IP address
-    /// found as long as desired IP address matched.
+    /// If not defined or set to true, nmstate verification process
+    /// allows extra IP address found as long as desired IP address matched.
     /// When set to false, the verification process of nmstate do exact equal
     /// check on IP address.
-    /// Ignore when serializing.
-    /// Deserialize from `allow-extra-address`
-    pub allow_extra_address: bool,
+    /// Serialize/deserialize to/from `allow-extra-address`
+    pub allow_extra_address: Option<bool>,
     /// Metric for routes retrieved from DHCP server.
     /// Only available for DHCPv4 enabled interface.
     /// Deserialize from `auto-route-metric`
@@ -192,28 +190,6 @@ pub struct InterfaceIpv4 {
     pub dhcp_custom_hostname: Option<String>,
     pub(crate) dns: Option<DnsClientState>,
     pub(crate) rules: Option<Vec<RouteRuleEntry>>,
-}
-
-impl Default for InterfaceIpv4 {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            prop_list: Vec::new(),
-            dhcp: None,
-            dhcp_client_id: None,
-            addresses: None,
-            dns: None,
-            rules: None,
-            auto_dns: None,
-            auto_gateway: None,
-            auto_routes: None,
-            auto_table_id: None,
-            allow_extra_address: default_allow_extra_address(),
-            auto_route_metric: None,
-            dhcp_send_hostname: None,
-            dhcp_custom_hostname: None,
-        }
-    }
 }
 
 impl InterfaceIpv4 {
@@ -488,7 +464,7 @@ impl From<InterfaceIpv4> for InterfaceIp {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 #[non_exhaustive]
 #[serde(into = "InterfaceIp")]
 /// IPv6 configurations of interface.
@@ -559,7 +535,7 @@ pub struct InterfaceIpv6 {
     /// check on IP address.
     /// Ignored when serializing.
     /// Deserialize from `allow-extra-address`.
-    pub allow_extra_address: bool,
+    pub allow_extra_address: Option<bool>,
     /// Metric for routes retrieved from DHCP server.
     /// Only available for autoconf enabled interface.
     /// Deserialize from `auto-route-metric`.
@@ -580,31 +556,6 @@ pub struct InterfaceIpv6 {
 
     pub(crate) dns: Option<DnsClientState>,
     pub(crate) rules: Option<Vec<RouteRuleEntry>>,
-}
-
-impl Default for InterfaceIpv6 {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            prop_list: Vec::new(),
-            dhcp: None,
-            dhcp_duid: None,
-            autoconf: None,
-            addr_gen_mode: None,
-            addresses: None,
-            dns: None,
-            rules: None,
-            auto_dns: None,
-            auto_gateway: None,
-            auto_routes: None,
-            auto_table_id: None,
-            allow_extra_address: default_allow_extra_address(),
-            auto_route_metric: None,
-            token: None,
-            dhcp_send_hostname: None,
-            dhcp_custom_hostname: None,
-        }
-    }
 }
 
 impl InterfaceIpv6 {
@@ -1344,11 +1295,6 @@ fn is_none_or_empty_mptcp_flags(v: &Option<Vec<MptcpAddressFlag>>) -> bool {
     } else {
         true
     }
-}
-
-// Allow extra IP by default
-fn default_allow_extra_address() -> bool {
-    true
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -27,11 +27,14 @@ impl Interface {
         }
     }
 
-    pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+    pub(crate) fn verify(
+        &mut self,
+        current: &Self,
+    ) -> Result<(), NmstateError> {
         let mut current = current.clone();
         self.process_allow_extra_address(&mut current);
 
-        let self_value = serde_json::to_value(self)?;
+        let self_value = serde_json::to_value(&self)?;
         let current_value = serde_json::to_value(&current)?;
 
         if let Some((reference, desire, current)) = get_json_value_difference(

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -161,8 +161,8 @@ impl MergedInterfaces {
             iface.sanitize_desired_for_verify();
         }
 
-        for des_iface in merged.iter().filter(|i| i.is_desired()) {
-            let iface = if let Some(i) = des_iface.for_verify.as_ref() {
+        for des_iface in merged.iter_mut().filter(|i| i.is_desired()) {
+            let iface = if let Some(i) = des_iface.for_verify.as_mut() {
                 i
             } else {
                 continue;

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -186,29 +186,33 @@ impl InterfaceIpv6 {
 impl Interface {
     // * If `allow_extra_address: true`, remove current IP address if not found
     //   in desired.
-    pub(crate) fn process_allow_extra_address(&self, current: &mut Self) {
+    pub(crate) fn process_allow_extra_address(&mut self, current: &mut Self) {
         if let (Some(des_ip), Some(cur_ip)) = (
-            self.base_iface().ipv4.as_ref(),
+            self.base_iface_mut().ipv4.as_mut(),
             current.base_iface_mut().ipv4.as_mut(),
         ) {
             if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
-                if des_ip.allow_extra_address {
+                if des_ip.allow_extra_address != Some(false) {
                     cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
                 }
+                // Remove allow_extra_address as current does not have it
+                des_ip.allow_extra_address = None
             }
         }
         if let (Some(des_ip), Some(cur_ip)) = (
-            self.base_iface().ipv6.as_ref(),
+            self.base_iface_mut().ipv6.as_mut(),
             current.base_iface_mut().ipv6.as_mut(),
         ) {
             if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
-                if des_ip.allow_extra_address {
+                if des_ip.allow_extra_address != Some(false) {
                     cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
                 }
+                // Remove allow_extra_address as current does not have it
+                des_ip.allow_extra_address = None
             }
         }
     }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -541,3 +541,28 @@ fn test_auto_ip_lift_time() {
     assert_eq!(left_fmt, life_time_fmt);
     assert_eq!(iproute_fmt, life_time_fmt);
 }
+
+#[test]
+fn test_ip_serlize_allow_extra_address() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: "true"
+            dhcp: "false"
+            allow-extra-address: false
+          ipv6:
+            enabled: "true"
+            dhcp: "false"
+        "#,
+    )
+    .unwrap();
+
+    let new: Interfaces =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}


### PR DESCRIPTION
The `nmstatectl fmt` will discard the `allow-extra-address` as it is
marked as skip serializing.

Normal query will hide this property as no backend provide such in
query result.

Unit test case included.