### PR TITLE
ovn: Do not skip serializing state: absent

### DIFF
--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -200,7 +200,7 @@ impl MergedOvnConfiguration {
 #[non_exhaustive]
 pub struct OvnBridgeMapping {
     pub localnet: String,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// When set to `state: absent`, will delete the existing
     /// `localnet` mapping.
     pub state: Option<OvnBridgeMappingState>,

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -265,3 +265,26 @@ fn test_ovn_map_support_state_present() {
         }]
     )
 }
+
+#[test]
+fn test_ovn_serialize_state_absent() {
+    let desired: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+        bridge-mappings:
+        - localnet: blue
+          state: absent
+        - localnet: red
+          state: absent
+        - localnet: yellow
+          state: absent
+        - localnet: green
+        "#,
+    )
+    .unwrap();
+
+    let new: OvnConfiguration =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}


### PR DESCRIPTION
The nmstatectl fmt will discard the OVN `state: absent` as it is
marked as skip serializing.

Normal query will hide this property as no backend provide such in
query result.

Unit test case included.