### PR TITLE
base_iface: Do not skip serializing `copy-mac-from`

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -108,7 +108,7 @@ pub struct BaseInterface {
     /// accept all packages, also known as promiscuous mode.
     /// Serialize and deserialize to/from `accpet-all-mac-addresses`.
     pub accept_all_mac_addresses: Option<bool>,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Copy the MAC address from specified interface.
     /// Ignored during serializing.
     /// Deserialize from `copy-mac-from`.

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -28,3 +28,22 @@ mac-address: "d4:ee:07:25:42:5a"
     iface.sanitize(true).unwrap();
     assert_eq!(iface.mac_address, Some(String::from("D4:EE:07:25:42:5A")));
 }
+
+#[test]
+fn test_base_iface_serialize_copy_mac_from() {
+    let desired: BaseInterface = serde_yaml::from_str(
+        r#"---
+          name: bond99
+          type: bond
+          state: up
+          copy-mac-from: eth2
+        "#,
+    )
+    .unwrap();
+
+    let new: BaseInterface =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}


### PR DESCRIPTION
The `nmstatectl fmt` will discard the `copy-mac-from` as it is
marked as skip serializing.

Normal query will hide this property as no backend provide such in
query result.

Unit test case included.