### PR TITLE
ovs: Do not skip serializing `allow-extra-patch-ports`

### DIFF
--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -246,14 +246,14 @@ impl OvsBridgeInterface {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgeConfig {
-    #[serde(skip_serializing, default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Only validate for applying, when set to `true`, extra OVS patch ports
     /// will not fail the verification. Default is false.
     /// This property will not be persisted, every time you modify
     /// ports of specified OVS bridge, you need to explicitly define this
     /// property if not using default value.
     /// Deserialize from `allow-extra-patch-ports`.
-    pub allow_extra_patch_ports: bool,
+    pub allow_extra_patch_ports: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
     #[serde(
@@ -810,7 +810,7 @@ impl MergedInterfaces {
         for merged_iface in self.iter_mut().filter(|i| {
             if let Some(Interface::OvsBridge(o)) = i.desired.as_ref() {
                 o.base.state == InterfaceState::Up
-                    && o.bridge.as_ref().map(|c| c.allow_extra_patch_ports)
+                    && o.bridge.as_ref().and_then(|c| c.allow_extra_patch_ports)
                         == Some(true)
             } else {
                 false

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -159,7 +159,7 @@ impl MergedInterfaces {
     // This function remove extra(undesired) ovs patch port from post-apply
     // current, so it will not interfere with verification
     pub(crate) fn process_allow_extra_ovs_patch_ports_for_verify(
-        &self,
+        &mut self,
         current: &mut Interfaces,
     ) {
         let mut ovs_patch_port_names: HashSet<String> = HashSet::new();
@@ -175,12 +175,20 @@ impl MergedInterfaces {
             }
         }
 
-        for des_iface in self.iter().filter_map(|i| {
-            if let Some(Interface::OvsBridge(o)) = i.desired.as_ref() {
-                if o.bridge.as_ref().map(|c| c.allow_extra_patch_ports)
+        for des_iface in self.iter_mut().filter_map(|i| {
+            if let Some(Interface::OvsBridge(o)) = i.desired.as_mut() {
+                if o.bridge.as_ref().and_then(|c| c.allow_extra_patch_ports)
                     == Some(true)
                     && o.base.state == InterfaceState::Up
                 {
+                    // Remove allow_extra_patch_ports as current state
+                    // does not have it
+                    if let Some(Interface::OvsBridge(c)) = i.for_verify.as_mut()
+                    {
+                        if let Some(c) = c.bridge.as_mut() {
+                            c.allow_extra_patch_ports = None;
+                        }
+                    }
                     Some(o)
                 } else {
                     None

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -921,3 +921,26 @@ fn test_ovs_bridge_deprecated_prop() {
 
     assert_eq!(iface.ports(), Some(vec!["eth1"]));
 }
+
+#[test]
+fn test_ovs_iface_serialize_allow_extra_patch_ports() {
+    let desired: OvsBridgeInterface = serde_yaml::from_str(
+        r#"---
+        name: br0
+        type: ovs-bridge
+        state: up
+        bridge:
+          allow-extra-patch-ports: true
+          port:
+          - name: ovs0
+          - name: eth1
+        "#,
+    )
+    .unwrap();
+
+    let new: OvsBridgeInterface =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}


### PR DESCRIPTION
The `nmstatectl fmt` will discard the `allow-extra-patch-ports` as it is
marked as skip serializing.

Normal query will hide this property as no backend provide such in
query result.

Unit test case included.