### PR TITLE
net_state: Remove `prop_list`

### DIFF
--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -13,14 +13,14 @@ use crate::error::CliError;
 pub(crate) struct SortedNetworkState {
     #[serde(skip_serializing_if = "Option::is_none")]
     hostname: Option<HostNameState>,
-    #[serde(rename = "dns-resolver", default)]
-    dns: DnsState,
+    #[serde(rename = "dns-resolver", skip_serializing_if = "Option::is_none")]
+    dns: Option<DnsState>,
     #[serde(rename = "route-rules", default)]
     rules: RouteRules,
     routes: Routes,
     interfaces: Vec<Value>,
-    #[serde(rename = "ovs-db")]
-    ovsdb: OvsDbGlobalConfig,
+    #[serde(rename = "ovs-db", skip_serializing_if = "Option::is_none")]
+    ovsdb: Option<OvsDbGlobalConfig>,
     #[serde(rename = "ovn")]
     ovn: OvnConfiguration,
 }

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -134,10 +134,17 @@ impl DnsClientState {
     //    `config: {}`
     //  * `server`, `search` and `options` are `Some<Vec::new()>`.
     pub(crate) fn is_purge(&self) -> bool {
-        self.server.is_none() && self.search.is_none() & self.options.is_none()
-            || self.server.as_deref() == Some(&[])
-                && self.search.as_deref() == Some(&[])
-                && self.options.as_deref() == Some(&[])
+        match (
+            self.server.as_ref(),
+            self.search.as_ref(),
+            self.options.as_ref(),
+        ) {
+            (None, None, None) => true,
+            (Some(srvs), Some(schs), Some(opts)) => {
+                srvs.is_empty() && schs.is_empty() && opts.is_empty()
+            }
+            _ => false,
+        }
     }
 
     pub(crate) fn is_null(&self) -> bool {
@@ -219,7 +226,7 @@ impl DnsClientState {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct MergedDnsState {
-    pub(crate) desired: DnsState,
+    pub(crate) desired: Option<DnsState>,
     pub(crate) current: DnsState,
     pub(crate) servers: Vec<String>,
     pub(crate) searches: Vec<String>,
@@ -228,10 +235,9 @@ pub(crate) struct MergedDnsState {
 
 impl MergedDnsState {
     pub(crate) fn new(
-        mut desired: DnsState,
+        desired: Option<DnsState>,
         mut current: DnsState,
     ) -> Result<Self, NmstateError> {
-        desired.sanitize()?;
         current.sanitize().ok();
         let mut servers = current
             .config
@@ -249,6 +255,21 @@ impl MergedDnsState {
             .as_ref()
             .and_then(|c| c.options.clone())
             .unwrap_or_default();
+
+        let mut desired = match desired {
+            Some(d) => d,
+            None => {
+                return Ok(Self {
+                    desired: None,
+                    current,
+                    servers,
+                    searches,
+                    options,
+                });
+            }
+        };
+
+        desired.sanitize()?;
 
         if let Some(conf) = desired.config.as_ref() {
             if conf.is_purge() {
@@ -272,7 +293,7 @@ impl MergedDnsState {
         }
 
         Ok(Self {
-            desired,
+            desired: Some(desired),
             current,
             servers,
             searches,

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -30,7 +30,6 @@ pub(crate) fn nispor_retrieve(
 ) -> Result<NetworkState, NmstateError> {
     let mut net_state = NetworkState {
         hostname: get_hostname_state(),
-        prop_list: vec!["interfaces", "routes", "rules", "hostname"],
         ..Default::default()
     };
     let mut filter = nispor::NetStateFilter::default();

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -112,8 +112,8 @@ pub(crate) fn nm_apply(
         } else if merged_state
             .dns
             .desired
-            .config
             .as_ref()
+            .and_then(|d| d.config.as_ref())
             .map(|c| c.is_purge())
             == Some(true)
         {

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{ErrorKind, MergedOvnConfiguration, NmstateError};
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct OvsDbGlobalConfig {
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -23,8 +24,6 @@ pub struct OvsDbGlobalConfig {
         serialize_with = "show_as_ordered_map"
     )]
     pub other_config: Option<HashMap<String, Option<String>>>,
-    #[serde(skip)]
-    pub(crate) prop_list: Vec<&'static str>,
 }
 
 impl OvsDbGlobalConfig {
@@ -33,7 +32,11 @@ impl OvsDbGlobalConfig {
 
     // User want to remove all settings except OVN.
     pub(crate) fn is_purge(&self) -> bool {
-        self.prop_list.is_empty()
+        match (self.external_ids.as_ref(), self.other_config.as_ref()) {
+            (None, None) => true,
+            (Some(eids), Some(oids)) => eids.is_empty() && oids.is_empty(),
+            _ => false,
+        }
     }
 
     pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
@@ -75,39 +78,6 @@ where
 impl OvsDbGlobalConfig {
     pub fn is_none(&self) -> bool {
         self.external_ids.is_none() && self.other_config.is_none()
-    }
-}
-
-impl<'de> Deserialize<'de> for OvsDbGlobalConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let mut ret = Self::default();
-        let mut v = serde_json::Value::deserialize(deserializer)?;
-        if let Some(v) = v.as_object_mut() {
-            if let Some(v) = v.remove("external_ids") {
-                ret.prop_list.push("external_ids");
-                ret.external_ids = Some(value_to_hash_map(&v));
-            }
-            if let Some(v) = v.remove("other_config") {
-                ret.prop_list.push("other_config");
-                ret.other_config = Some(value_to_hash_map(&v));
-            }
-            if !v.is_empty() {
-                let remain_keys: Vec<String> = v.keys().cloned().collect();
-                return Err(serde::de::Error::custom(format!(
-                    "Unsupported section names '{}', only supports \
-                    `external_ids` and `other_config`",
-                    remain_keys.join(", ")
-                )));
-            }
-        } else {
-            return Err(serde::de::Error::custom(format!(
-                "Expecting dict/HashMap, but got {v:?}"
-            )));
-        }
-        Ok(ret)
     }
 }
 
@@ -213,7 +183,7 @@ fn value_to_hash_map(
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct MergedOvsDbGlobalConfig {
-    pub(crate) desired: OvsDbGlobalConfig,
+    pub(crate) desired: Option<OvsDbGlobalConfig>,
     pub(crate) current: OvsDbGlobalConfig,
     pub(crate) external_ids: HashMap<String, Option<String>>,
     pub(crate) other_config: HashMap<String, Option<String>>,
@@ -226,7 +196,7 @@ impl MergedOvsDbGlobalConfig {
     //  * Use `ovsdb: {}` to remove all settings.
     //  * To remove a key from existing, use `foo: None`.
     pub(crate) fn new(
-        desired: OvsDbGlobalConfig,
+        mut desired: Option<OvsDbGlobalConfig>,
         current: OvsDbGlobalConfig,
         merged_ovn: &MergedOvnConfiguration,
     ) -> Result<Self, NmstateError> {
@@ -235,20 +205,31 @@ impl MergedOvsDbGlobalConfig {
 
         let empty_map: HashMap<String, Option<String>> = HashMap::new();
 
-        if !desired.is_purge() {
-            desired.sanitize()?;
+        let mut cur_external_ids: HashMap<String, Option<String>> =
+            current.external_ids.as_ref().unwrap_or(&empty_map).clone();
 
-            merge_ovsdb_confs(
-                desired.external_ids.as_ref(),
-                current.external_ids.as_ref().unwrap_or(&empty_map),
-                &mut external_ids,
-            );
+        let cur_other_config: HashMap<String, Option<String>> =
+            current.other_config.as_ref().unwrap_or(&empty_map).clone();
 
-            merge_ovsdb_confs(
-                desired.other_config.as_ref(),
-                current.other_config.as_ref().unwrap_or(&empty_map),
-                &mut other_config,
-            );
+        if let Some(desired) = &mut desired {
+            if !desired.is_purge() {
+                desired.sanitize()?;
+
+                merge_ovsdb_confs(
+                    desired.external_ids.as_ref(),
+                    current.external_ids.as_ref().unwrap_or(&empty_map),
+                    &mut external_ids,
+                );
+
+                merge_ovsdb_confs(
+                    desired.other_config.as_ref(),
+                    current.other_config.as_ref().unwrap_or(&empty_map),
+                    &mut other_config,
+                );
+            }
+        } else {
+            external_ids = cur_external_ids.clone();
+            other_config = cur_other_config.clone();
         }
 
         if let Some(v) = merged_ovn.to_ovsdb_external_id_value() {
@@ -258,18 +239,12 @@ impl MergedOvsDbGlobalConfig {
             );
         }
 
-        let mut cur_external_ids: HashMap<String, Option<String>> =
-            current.external_ids.as_ref().unwrap_or(&empty_map).clone();
-
         if let Some(v) = merged_ovn.current.to_ovsdb_external_id_value() {
             cur_external_ids.insert(
                 OvsDbGlobalConfig::OVN_BRIDGE_MAPPINGS_KEY.to_string(),
                 Some(v),
             );
         }
-
-        let cur_other_config: HashMap<String, Option<String>> =
-            current.other_config.as_ref().unwrap_or(&empty_map).clone();
 
         let is_changed = cur_other_config != other_config
             || cur_external_ids != external_ids;

--- a/rust/src/lib/ovsdb/apply.rs
+++ b/rust/src/lib/ovsdb/apply.rs
@@ -5,7 +5,7 @@ use crate::{ovsdb::db::OvsDbConnection, MergedNetworkState, NmstateError};
 pub(crate) fn ovsdb_apply(
     merged_state: &MergedNetworkState,
 ) -> Result<(), NmstateError> {
-    if merged_state.is_global_ovsdb_changed() {
+    if merged_state.ovsdb.is_changed {
         let mut cli = OvsDbConnection::new()?;
         cli.apply_global_conf(&merged_state.ovsdb)
     } else {

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -27,8 +27,6 @@ pub(crate) fn ovsdb_is_running() -> bool {
 
 pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
-    ret.prop_list.push("interfaces");
-    ret.prop_list.push("ovsdb");
     let mut cli = OvsDbConnection::new()?;
     let ovsdb_ifaces = cli.get_ovs_ifaces()?;
     let ovsdb_brs = cli.get_ovs_bridges()?;
@@ -72,7 +70,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
         }
     }
 
-    ret.ovsdb = cli.get_ovsdb_global_conf()?;
+    ret.ovsdb = Some(cli.get_ovsdb_global_conf()?);
 
     Ok(ret)
 }

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -3,10 +3,7 @@
 use crate::{DnsState, ErrorKind, MergedDnsState, NmstateError};
 
 impl MergedDnsState {
-    pub(crate) fn verify(
-        &self,
-        current: &DnsState,
-    ) -> Result<(), NmstateError> {
+    pub(crate) fn verify(&self, current: DnsState) -> Result<(), NmstateError> {
         if !self.is_changed() {
             return Ok(());
         }

--- a/rust/src/lib/revert/dns.rs
+++ b/rust/src/lib/revert/dns.rs
@@ -3,11 +3,11 @@
 use crate::{DnsState, MergedDnsState};
 
 impl MergedDnsState {
-    pub(crate) fn generate_revert(&self) -> DnsState {
+    pub(crate) fn generate_revert(&self) -> Option<DnsState> {
         if self.is_changed() {
-            self.current.clone()
+            Some(self.current.clone())
         } else {
-            DnsState::new()
+            None
         }
     }
 }

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -21,7 +21,6 @@ impl NetworkState {
             ovsdb: merged_state.ovsdb.generate_revert(),
             ovn: merged_state.ovn.generate_revert(),
             hostname: merged_state.hostname.generate_revert(),
-            prop_list: vec!["interfaces"],
             ..Default::default()
         })
     }

--- a/rust/src/lib/revert/ovsdb.rs
+++ b/rust/src/lib/revert/ovsdb.rs
@@ -5,16 +5,18 @@ use std::collections::HashMap;
 use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
 
 impl MergedOvsDbGlobalConfig {
-    pub(crate) fn generate_revert(&self) -> OvsDbGlobalConfig {
+    pub(crate) fn generate_revert(&self) -> Option<OvsDbGlobalConfig> {
+        let desired = match self.desired.as_ref() {
+            Some(d) => d,
+            None => {
+                return None;
+            }
+        };
         let mut revert_external_ids: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for eid_key in self
-            .desired
-            .external_ids
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for eid_key in
+            desired.external_ids.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_external_ids.insert(
                 eid_key.to_string(),
@@ -30,12 +32,8 @@ impl MergedOvsDbGlobalConfig {
         let mut revert_other_configs: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for cfg_key in self
-            .desired
-            .other_config
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for cfg_key in
+            desired.other_config.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_other_configs.insert(
                 cfg_key.to_string(),
@@ -49,13 +47,13 @@ impl MergedOvsDbGlobalConfig {
         }
 
         if revert_external_ids.is_empty() && revert_other_configs.is_empty() {
-            OvsDbGlobalConfig::default()
+            None
         } else {
-            OvsDbGlobalConfig {
+            Some(OvsDbGlobalConfig {
                 external_ids: Some(revert_external_ids),
                 other_config: Some(revert_other_configs),
                 ..Default::default()
-            }
+            })
         }
     }
 }

--- a/rust/src/lib/statistic/feature/dns.rs
+++ b/rust/src/lib/statistic/feature/dns.rs
@@ -5,7 +5,9 @@ use crate::{MergedDnsState, NmstateFeature};
 impl MergedDnsState {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret = Vec::new();
-        if let Some(dns_config) = self.desired.config.as_ref() {
+        if let Some(dns_config) =
+            self.desired.as_ref().and_then(|d| d.config.as_ref())
+        {
             if dns_config.server.is_some() {
                 ret.push(NmstateFeature::StaticDnsNameServer);
             }

--- a/rust/src/lib/statistic/feature/ovs.rs
+++ b/rust/src/lib/statistic/feature/ovs.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl MergedOvsDbGlobalConfig {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
-        if !self.desired.is_none() {
+        if self.desired.is_some() {
             vec![NmstateFeature::OvsDbGlobal]
         } else {
             Vec::new()

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -46,9 +46,9 @@ fn test_dns_verify_uncompressed_srvs() {
     )
     .unwrap();
 
-    let merged = MergedDnsState::new(desired, DnsState::new()).unwrap();
+    let merged = MergedDnsState::new(Some(desired), DnsState::new()).unwrap();
 
-    merged.verify(&current).unwrap();
+    merged.verify(current).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
+use crate::{MergedOvsDbGlobalConfig, NetworkState, OvsDbGlobalConfig};
 
 fn get_current_ovsdb_config() -> OvsDbGlobalConfig {
     serde_yaml::from_str(
@@ -38,9 +38,12 @@ other_config:
 
     let current = get_current_ovsdb_config();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r"---
@@ -79,9 +82,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -115,9 +121,12 @@ other_config:
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -151,9 +160,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -172,11 +184,37 @@ fn test_ovsdb_verify_null_current() {
     let current = desired.clone();
 
     let merged_ovsdb = MergedOvsDbGlobalConfig::new(
-        desired,
+        Some(desired),
         pre_apply_current,
         &Default::default(),
     )
     .unwrap();
 
-    merged_ovsdb.verify(&current).unwrap();
+    merged_ovsdb.verify(current).unwrap();
+}
+
+#[test]
+fn test_ovsdb_purge_by_empty_section() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        ovs-db: {}
+        ",
+    )
+    .unwrap();
+
+    assert!(desired.ovsdb.unwrap().is_purge());
+}
+
+#[test]
+fn test_ovsdb_purge_by_empty_hash() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        ovs-db:
+          external_ids: {}
+          other_config: {}
+        ",
+    )
+    .unwrap();
+
+    assert!(desired.ovsdb.unwrap().is_purge());
 }

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -206,7 +206,6 @@ fn test_policy_capture_retain_only() {
     assert_eq!(state.dns, current.dns);
 
     state.dns = empty_state.dns.clone();
-    state.prop_list = Vec::new();
     assert_eq!(state, empty_state);
 }
 

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -249,7 +249,8 @@ fn test_policy_convert_dhcp_to_static_with_dns() {
     assert_eq!(routes[0].next_hop_iface, Some("eth1".to_string()));
     assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
     assert_eq!(routes[1].next_hop_iface, Some("eth1".to_string()));
-    let dns_config = state.dns.config.as_ref().unwrap();
+    let dns_config =
+        state.dns.as_ref().and_then(|d| d.config.as_ref()).unwrap();
     assert_eq!(
         dns_config.server,
         Some(vec![

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -384,8 +384,7 @@ def test_format_command():
             f"nmstatectl format {fd.name}".split(), check=True
         )[1]
         assert (
-            """
-interfaces:
+            """interfaces:
 - name: bond99
   type: bond
   state: up


### PR DESCRIPTION
The original reason of introducing `prop_list` is to indicate which
value is defined by user instead of default value or merged value.
This is hack which require a lot of documentation and human effort on
code review.

We do not need to do this hack any more as we have MergedNetworkState
which contains 3 states now:
 * Desired state
 * Current state
 * Merged  state

For `NetworkState`, only `ovsdb`, `dns`, `hostname` do not support
partial editing, hence all of them are protected by `Option<T>` to
indicate whether user desired or not.