### PR TITLE
ip: Remove the `prop_list` property

### DIFF
--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -12,19 +12,18 @@ pub(crate) fn np_ipv4_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv4> {
     if let Some(np_ip) = &np_iface.ipv4 {
-        let mut ip = InterfaceIpv4::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv4 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.dhcp = Some(true);
-                ip.prop_list.push("dhcp");
                 if running_config_only {
                     continue;
                 }
@@ -64,7 +63,7 @@ pub(crate) fn np_ipv4_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv4 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }
@@ -75,16 +74,16 @@ pub(crate) fn np_ipv6_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv6> {
     if let Some(np_ip) = &np_iface.ipv6 {
-        let mut ip = InterfaceIpv6::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv6 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         if let Some(token) = np_ip.token.as_ref() {
-            ip.prop_list.push("token");
             ip.token = Some(token.to_string());
         }
 
@@ -92,7 +91,6 @@ pub(crate) fn np_ipv6_to_nmstate(
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.autoconf = Some(true);
-                ip.prop_list.push("autoconf");
                 if running_config_only {
                     continue;
                 }
@@ -132,7 +130,7 @@ pub(crate) fn np_ipv6_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv6 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -44,25 +44,12 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             parse_dhcp_opts(nm_ip_setting);
         InterfaceIpv4 {
             enabled,
+            enabled_defined: true,
             dhcp,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "dhcp_client_id",
-                "dns",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "auto_route_metric",
-                "rules",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate("", nm_ip_setting)),
             rules: nm_rules_to_nmstate(false, nm_ip_setting),
             dhcp_client_id: if enabled && dhcp == Some(true) {
@@ -113,28 +100,13 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             parse_dhcp_opts(nm_ip_setting);
         let mut ret = InterfaceIpv6 {
             enabled,
+            enabled_defined: true,
             dhcp,
             autoconf,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "autoconf",
-                "dns",
-                "rules",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "dhcp_duid",
-                "addr_gen_mode",
-                "auto_route_metric",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate(iface_name, nm_ip_setting)),
             rules: nm_rules_to_nmstate(true, nm_ip_setting),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
@@ -163,7 +135,6 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
         // on nispor kernel IPv6 token, we set IPv6 token based on information
         // provided by NM connection.
         if let Some(token) = nm_ip_setting.token.as_ref() {
-            ret.prop_list.push("token");
             ret.token = Some(token.to_string());
         }
         ret

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -32,54 +32,48 @@ impl InterfaceIpv4 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
 
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_client_id") {
+        if other.dhcp_client_id.is_some() {
             self.dhcp_client_id = other.dhcp_client_id.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"allow_extra_address") {
+        if other.allow_extra_address.is_some() {
             self.allow_extra_address = other.allow_extra_address;
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }
@@ -124,61 +118,56 @@ impl InterfaceIpv6 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_duid") {
+        if other.dhcp_duid.is_some() {
             self.dhcp_duid = other.dhcp_duid.clone();
         }
-        if other.prop_list.contains(&"autoconf") {
+        if other.autoconf.is_some() {
             self.autoconf = other.autoconf;
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"token") {
+        if other.token.is_some() {
             self.token = other.token.clone();
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }


### PR DESCRIPTION
We used the `prop_list` to indicate whether `enabled` is defined by user or
just set by default value. It is hack, instead of using
`enabled: Option<bool>` which makes the follow up sanitize/validation/merge
code complex, we introduce `enabled_defined: bool` property, function could
utilize that property to know whether
`enabled` is set by user/plugin.