### PR TITLE
base_iface: Remove `prop_list`

### DIFF
--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -13,14 +13,14 @@ use crate::error::CliError;
 pub(crate) struct SortedNetworkState {
     #[serde(skip_serializing_if = "Option::is_none")]
     hostname: Option<HostNameState>,
-    #[serde(rename = "dns-resolver", default)]
-    dns: DnsState,
+    #[serde(rename = "dns-resolver", skip_serializing_if = "Option::is_none")]
+    dns: Option<DnsState>,
     #[serde(rename = "route-rules", default)]
     rules: RouteRules,
     routes: Routes,
     interfaces: Vec<Value>,
-    #[serde(rename = "ovs-db")]
-    ovsdb: OvsDbGlobalConfig,
+    #[serde(rename = "ovs-db", skip_serializing_if = "Option::is_none")]
+    ovsdb: Option<OvsDbGlobalConfig>,
     #[serde(rename = "ovn")]
     ovn: OvnConfiguration,
 }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -11,7 +11,6 @@ use crate::{
 
 const MINIMUM_IPV6_MTU: u64 = 1280;
 
-// TODO: Use prop_list to Serialize like InterfaceIpv4 did
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
@@ -26,19 +25,16 @@ pub struct BaseInterface {
     /// Interface description stored in network backend. Not available for
     /// kernel only mode.
     pub description: Option<String>,
-    #[serde(skip)]
-    /// TODO: internal use only. Hide this.
-    pub prop_list: Vec<&'static str>,
     #[serde(rename = "type", default = "default_iface_type")]
     /// Interface type. Serialize and deserialize to/from `type`
     pub iface_type: InterfaceType,
     #[serde(default = "default_state")]
     /// Interface state. Default to [InterfaceState::Up] when applying.
     pub state: InterfaceState,
-    #[serde(default, skip_serializing_if = "InterfaceIdentifier::is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Define network backend matching method on choosing network interface.
     /// Default to [InterfaceIdentifier::Name].
-    pub identifier: InterfaceIdentifier,
+    pub identifier: Option<InterfaceIdentifier>,
     /// When applying with `[InterfaceIdentifier::MacAddress]`,
     /// nmstate will store original desired interface name as `profile_name`
     /// here and store the real interface name as `name` property.

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -108,7 +108,7 @@ pub struct BaseInterface {
     /// accept all packages, also known as promiscuous mode.
     /// Serialize and deserialize to/from `accpet-all-mac-addresses`.
     pub accept_all_mac_addresses: Option<bool>,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Copy the MAC address from specified interface.
     /// Ignored during serializing.
     /// Deserialize from `copy-mac-from`.

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -367,7 +367,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for iface in self.iter().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
                 && i.base_iface().profile_name.is_none()
         }) {
             let mac_address = match iface.base_iface().mac_address.as_deref() {
@@ -446,7 +446,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for cur_iface in current.kernel_ifaces.values().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
         }) {
             if let Some(profile_name) =
                 cur_iface.base_iface().profile_name.as_ref()
@@ -470,7 +470,7 @@ impl Interfaces {
                         };
 
                     new_iface.base_iface_mut().identifier =
-                        InterfaceIdentifier::MacAddress;
+                        Some(InterfaceIdentifier::MacAddress);
                     new_iface.base_iface_mut().mac_address =
                         cur_iface.base_iface().mac_address.clone();
                     new_iface.base_iface_mut().name =

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -246,14 +246,14 @@ impl OvsBridgeInterface {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub struct OvsBridgeConfig {
-    #[serde(skip_serializing, default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Only validate for applying, when set to `true`, extra OVS patch ports
     /// will not fail the verification. Default is false.
     /// This property will not be persisted, every time you modify
     /// ports of specified OVS bridge, you need to explicitly define this
     /// property if not using default value.
     /// Deserialize from `allow-extra-patch-ports`.
-    pub allow_extra_patch_ports: bool,
+    pub allow_extra_patch_ports: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
     #[serde(
@@ -810,7 +810,7 @@ impl MergedInterfaces {
         for merged_iface in self.iter_mut().filter(|i| {
             if let Some(Interface::OvsBridge(o)) = i.desired.as_ref() {
                 o.base.state == InterfaceState::Up
-                    && o.bridge.as_ref().map(|c| c.allow_extra_patch_ports)
+                    && o.bridge.as_ref().and_then(|c| c.allow_extra_patch_ports)
                         == Some(true)
             } else {
                 false

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -86,11 +86,10 @@ struct InterfaceIp {
     #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
     pub addr_gen_mode: Option<Ipv6AddrGenMode>,
     #[serde(
-        default = "default_allow_extra_address",
-        skip_serializing,
+        skip_serializing_if = "Option::is_none",
         rename = "allow-extra-address"
     )]
-    pub allow_extra_address: bool,
+    pub allow_extra_address: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
     #[serde(
@@ -105,7 +104,7 @@ struct InterfaceIp {
     pub dhcp_custom_hostname: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 #[serde(into = "InterfaceIp")]
 #[non_exhaustive]
 /// IPv4 configuration of interface.
@@ -169,7 +168,7 @@ pub struct InterfaceIpv4 {
     /// check on IP address.
     /// Ignore when serializing.
     /// Deserialize from `allow-extra-address`
-    pub allow_extra_address: bool,
+    pub allow_extra_address: Option<bool>,
     /// Metric for routes retrieved from DHCP server.
     /// Only available for DHCPv4 enabled interface.
     /// Deserialize from `auto-route-metric`
@@ -192,28 +191,6 @@ pub struct InterfaceIpv4 {
     pub dhcp_custom_hostname: Option<String>,
     pub(crate) dns: Option<DnsClientState>,
     pub(crate) rules: Option<Vec<RouteRuleEntry>>,
-}
-
-impl Default for InterfaceIpv4 {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            prop_list: Vec::new(),
-            dhcp: None,
-            dhcp_client_id: None,
-            addresses: None,
-            dns: None,
-            rules: None,
-            auto_dns: None,
-            auto_gateway: None,
-            auto_routes: None,
-            auto_table_id: None,
-            allow_extra_address: default_allow_extra_address(),
-            auto_route_metric: None,
-            dhcp_send_hostname: None,
-            dhcp_custom_hostname: None,
-        }
-    }
 }
 
 impl InterfaceIpv4 {
@@ -488,7 +465,7 @@ impl From<InterfaceIpv4> for InterfaceIp {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 #[non_exhaustive]
 #[serde(into = "InterfaceIp")]
 /// IPv6 configurations of interface.
@@ -559,7 +536,7 @@ pub struct InterfaceIpv6 {
     /// check on IP address.
     /// Ignored when serializing.
     /// Deserialize from `allow-extra-address`.
-    pub allow_extra_address: bool,
+    pub allow_extra_address: Option<bool>,
     /// Metric for routes retrieved from DHCP server.
     /// Only available for autoconf enabled interface.
     /// Deserialize from `auto-route-metric`.
@@ -580,31 +557,6 @@ pub struct InterfaceIpv6 {
 
     pub(crate) dns: Option<DnsClientState>,
     pub(crate) rules: Option<Vec<RouteRuleEntry>>,
-}
-
-impl Default for InterfaceIpv6 {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            prop_list: Vec::new(),
-            dhcp: None,
-            dhcp_duid: None,
-            autoconf: None,
-            addr_gen_mode: None,
-            addresses: None,
-            dns: None,
-            rules: None,
-            auto_dns: None,
-            auto_gateway: None,
-            auto_routes: None,
-            auto_table_id: None,
-            allow_extra_address: default_allow_extra_address(),
-            auto_route_metric: None,
-            token: None,
-            dhcp_send_hostname: None,
-            dhcp_custom_hostname: None,
-        }
-    }
 }
 
 impl InterfaceIpv6 {
@@ -1368,11 +1320,6 @@ fn is_none_or_empty_mptcp_flags(v: &Option<Vec<MptcpAddressFlag>>) -> bool {
     } else {
         true
     }
-}
-
-// Allow extra IP by default
-fn default_allow_extra_address() -> bool {
-    true
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -128,7 +128,9 @@ pub struct InterfaceIpv4 {
     /// Whether IPv4 stack is enabled. When set to false, all IPv4 address will
     /// be removed from this interface.
     pub enabled: bool,
-    pub(crate) prop_list: Vec<&'static str>,
+    /// Indicate whether `enabled` is defined by user or learn from
+    /// default/current value.
+    pub enabled_defined: bool,
     /// Whether DHCPv4 is enabled.
     pub dhcp: Option<bool>,
     /// DHCPv4 client ID.
@@ -210,7 +212,7 @@ impl InterfaceIpv4 {
     }
 
     pub(crate) fn merge_ip(&mut self, current: &Self) {
-        if !self.prop_list.contains(&"enabled") {
+        if !self.enabled_defined {
             self.enabled = current.enabled;
         }
         if self.dhcp.is_none() && self.enabled {
@@ -238,7 +240,7 @@ impl InterfaceIpv4 {
 
     // Special action for generating merged state from desired and current.
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if !desired.prop_list.contains(&"enabled") {
+        if !desired.enabled_defined {
             self.enabled = current.enabled;
         }
         if desired.dhcp.is_none() && self.enabled {
@@ -392,20 +394,17 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
     {
         let v = serde_json::Value::deserialize(deserializer)?;
 
-        let prop_list = if let Some(v_map) = v.as_object() {
-            get_ip_prop_list(v_map)
-        } else {
-            Vec::new()
-        };
-        if prop_list.contains(&"autoconf") {
-            return Err(serde::de::Error::custom(
-                "autoconf is not allowed for IPv4",
-            ));
-        }
-        if prop_list.contains(&"dhcp_duid") {
-            return Err(serde::de::Error::custom(
-                "dhcp-duid is not allowed for IPv4",
-            ));
+        if let Some(v_map) = v.as_object() {
+            if v_map.contains_key("autoconf") {
+                return Err(serde::de::Error::custom(
+                    "autoconf is not allowed for IPv4",
+                ));
+            }
+            if v_map.contains_key("dhcp_duid") {
+                return Err(serde::de::Error::custom(
+                    "dhcp-duid is not allowed for IPv4",
+                ));
+            }
         }
 
         let ip: InterfaceIp = match serde_json::from_value(v) {
@@ -414,8 +413,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                 return Err(serde::de::Error::custom(format!("{e}")));
             }
         };
-        let mut ret = Self::from(ip);
-        ret.prop_list = prop_list;
+        let ret = Self::from(ip);
         Ok(ret)
     }
 }
@@ -424,6 +422,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
     fn from(ip: InterfaceIp) -> Self {
         Self {
             enabled: ip.enabled.unwrap_or_default(),
+            enabled_defined: ip.enabled.is_some(),
             dhcp: ip.dhcp,
             addresses: ip.addresses,
             dhcp_client_id: ip.dhcp_client_id,
@@ -442,7 +441,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
 
 impl From<InterfaceIpv4> for InterfaceIp {
     fn from(ip: InterfaceIpv4) -> Self {
-        let enabled = if ip.prop_list.contains(&"enabled") {
+        let enabled = if ip.enabled_defined {
             Some(ip.enabled)
         } else {
             None
@@ -494,7 +493,7 @@ pub struct InterfaceIpv6 {
     /// Whether IPv6 stack is enable. When set to false, the IPv6 stack is
     /// disabled with IPv6 link-local address purged also.
     pub enabled: bool,
-    pub(crate) prop_list: Vec<&'static str>,
+    pub(crate) enabled_defined: bool,
     /// Whether DHCPv6 enabled.
     pub dhcp: Option<bool>,
     /// DHCPv6 Unique Identifier
@@ -721,7 +720,7 @@ impl InterfaceIpv6 {
 
     // Special action for generating merged state from desired and current.
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if !desired.prop_list.contains(&"enabled") {
+        if !desired.enabled_defined {
             self.enabled = current.enabled;
         }
         if desired.dhcp.is_none() && self.enabled {
@@ -746,7 +745,7 @@ impl InterfaceIpv6 {
     }
 
     pub(crate) fn merge_ip(&mut self, current: &Self) {
-        if !self.prop_list.contains(&"enabled") {
+        if !self.enabled_defined {
             self.enabled = current.enabled;
         }
         if self.dhcp.is_none() && self.enabled {
@@ -783,15 +782,12 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
     {
         let v = serde_json::Value::deserialize(deserializer)?;
 
-        let prop_list = if let Some(v_map) = v.as_object() {
-            get_ip_prop_list(v_map)
-        } else {
-            Vec::new()
-        };
-        if prop_list.contains(&"dhcp_client_id") {
-            return Err(serde::de::Error::custom(
-                "dhcp-client-id is not allowed for IPv6",
-            ));
+        if let Some(v_map) = v.as_object() {
+            if v_map.contains_key("dhcp_client_id") {
+                return Err(serde::de::Error::custom(
+                    "dhcp-client-id is not allowed for IPv6",
+                ));
+            }
         }
         let ip: InterfaceIp = match serde_json::from_value(v) {
             Ok(i) => i,
@@ -799,8 +795,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                 return Err(serde::de::Error::custom(format!("{e}")));
             }
         };
-        let mut ret = Self::from(ip);
-        ret.prop_list = prop_list;
+        let ret = Self::from(ip);
         Ok(ret)
     }
 }
@@ -809,6 +804,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
     fn from(ip: InterfaceIp) -> Self {
         Self {
             enabled: ip.enabled.unwrap_or_default(),
+            enabled_defined: ip.enabled.is_some(),
             dhcp: ip.dhcp,
             autoconf: ip.autoconf,
             addresses: ip.addresses,
@@ -830,7 +826,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
 
 impl From<InterfaceIpv6> for InterfaceIp {
     fn from(ip: InterfaceIpv6) -> Self {
-        let enabled = if ip.prop_list.contains(&"enabled") {
+        let enabled = if ip.enabled_defined {
             Some(ip.enabled)
         } else {
             None
@@ -1191,53 +1187,6 @@ fn validate_wait_ip(base_iface: &BaseInterface) -> Result<(), NmstateError> {
     }
 
     Ok(())
-}
-
-fn get_ip_prop_list(
-    map: &serde_json::Map<String, serde_json::Value>,
-) -> Vec<&'static str> {
-    let mut ret = Vec::new();
-
-    if map.contains_key("enabled") {
-        ret.push("enabled")
-    }
-    if map.contains_key("dhcp") {
-        ret.push("dhcp")
-    }
-    if map.contains_key("autoconf") {
-        ret.push("autoconf")
-    }
-    if map.contains_key("dhcp-client-id") {
-        ret.push("dhcp_client_id")
-    }
-    if map.contains_key("dhcp-duid") {
-        ret.push("dhcp_duid")
-    }
-    if map.contains_key("address") {
-        ret.push("addresses")
-    }
-    if map.contains_key("auto-dns") {
-        ret.push("auto_dns")
-    }
-    if map.contains_key("auto-gateway") {
-        ret.push("auto_gateway")
-    }
-    if map.contains_key("auto-routes") {
-        ret.push("auto_routes")
-    }
-    if map.contains_key("auto-route-table-id") {
-        ret.push("auto_table_id")
-    }
-    if map.contains_key("addr-gen-mode") {
-        ret.push("addr_gen_mode")
-    }
-    if map.contains_key("dhcp-send-hostname") {
-        ret.push("dhcp_send_hostname")
-    }
-    if map.contains_key("dhcp-custom-hostname") {
-        ret.push("dhcp_custom_hostname")
-    }
-    ret
 }
 
 pub(crate) fn sanitize_ip_network(

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -101,19 +101,6 @@ pub(crate) fn np_iface_to_base_iface(
             Some(false)
         },
         ethtool: np_ethtool_to_nmstate(np_iface),
-        prop_list: vec![
-            "name",
-            "state",
-            "iface_type",
-            "ipv4",
-            "ipv6",
-            "mac_address",
-            "permanent_mac_address",
-            "controller",
-            "mtu",
-            "accept_all_mac_addresses",
-            "ethtool",
-        ],
         ..Default::default()
     };
     if !InterfaceType::SUPPORTED_LIST.contains(&base_iface.iface_type) {

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -12,19 +12,18 @@ pub(crate) fn np_ipv4_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv4> {
     if let Some(np_ip) = &np_iface.ipv4 {
-        let mut ip = InterfaceIpv4::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv4 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.dhcp = Some(true);
-                ip.prop_list.push("dhcp");
                 if running_config_only {
                     continue;
                 }
@@ -64,7 +63,7 @@ pub(crate) fn np_ipv4_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv4 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }
@@ -75,16 +74,16 @@ pub(crate) fn np_ipv6_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv6> {
     if let Some(np_ip) = &np_iface.ipv6 {
-        let mut ip = InterfaceIpv6::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv6 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         if let Some(token) = np_ip.token.as_ref() {
-            ip.prop_list.push("token");
             ip.token = Some(token.to_string());
         }
 
@@ -92,7 +91,6 @@ pub(crate) fn np_ipv6_to_nmstate(
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.autoconf = Some(true);
-                ip.prop_list.push("autoconf");
                 if running_config_only {
                     continue;
                 }
@@ -132,7 +130,7 @@ pub(crate) fn np_ipv6_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv6 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -29,7 +29,6 @@ pub(crate) fn nispor_retrieve(
 ) -> Result<NetworkState, NmstateError> {
     let mut net_state = NetworkState {
         hostname: get_hostname_state(),
-        prop_list: vec!["interfaces", "routes", "rules", "hostname"],
         ..Default::default()
     };
     let mut filter = nispor::NetStateFilter::default();

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -237,7 +237,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using profile name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().profile_name.as_deref()
                     == Some(iface.name())
             {
@@ -251,7 +251,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using interface name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().name.as_str() == iface.name()
             {
                 if let Some(mac) = cur_iface.base_iface().mac_address.as_ref() {

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -112,8 +112,8 @@ pub(crate) fn nm_apply(
         } else if merged_state
             .dns
             .desired
-            .config
             .as_ref()
+            .and_then(|d| d.config.as_ref())
             .map(|c| c.is_purge())
             == Some(true)
         {

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -44,25 +44,12 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             parse_dhcp_opts(nm_ip_setting);
         InterfaceIpv4 {
             enabled,
+            enabled_defined: true,
             dhcp,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "dhcp_client_id",
-                "dns",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "auto_route_metric",
-                "rules",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate("", nm_ip_setting)),
             rules: nm_rules_to_nmstate(false, nm_ip_setting),
             dhcp_client_id: if enabled && dhcp == Some(true) {
@@ -113,28 +100,13 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             parse_dhcp_opts(nm_ip_setting);
         let mut ret = InterfaceIpv6 {
             enabled,
+            enabled_defined: true,
             dhcp,
             autoconf,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "autoconf",
-                "dns",
-                "rules",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "dhcp_duid",
-                "addr_gen_mode",
-                "auto_route_metric",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate(iface_name, nm_ip_setting)),
             rules: nm_rules_to_nmstate(true, nm_ip_setting),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
@@ -163,7 +135,6 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
         // on nispor kernel IPv6 token, we set IPv6 token based on information
         // provided by NM connection.
         if let Some(token) = nm_ip_setting.token.as_ref() {
-            ret.prop_list.push("token");
             ret.token = Some(token.to_string());
         }
         ret

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -122,9 +122,6 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
                 iface,
             ) {
                 base_iface.iface_type = InterfaceType::OvsInterface;
-                if !base_iface.prop_list.contains(&"iface_type") {
-                    base_iface.prop_list.push("iface_type");
-                }
                 oiface.base = base_iface;
             }
         }

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -86,7 +86,7 @@ pub(crate) fn iface_to_nm_connections(
 
     let base_iface = iface.base_iface();
     let exist_nm_conn =
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             get_exist_profile_by_profile_name(
                 exist_nm_conns,
                 base_iface
@@ -428,7 +428,8 @@ pub(crate) fn gen_nm_conn_setting(
     };
 
     if iface.iface_type() != InterfaceType::Ipsec
-        && iface.base_iface().identifier == InterfaceIdentifier::Name
+        && iface.base_iface().identifier.unwrap_or_default()
+            == InterfaceIdentifier::Name
     {
         nm_conn_set.iface_name = Some(iface.name().to_string());
     } else {

--- a/rust/src/lib/nm/settings/wired.rs
+++ b/rust/src/lib/nm/settings/wired.rs
@@ -18,7 +18,7 @@ pub(crate) fn gen_nm_wired_setting(
     let base_iface = iface.base_iface();
 
     if let Some(mac) = &base_iface.mac_address {
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             nm_wired_set.mac_address = Some(mac.to_string());
         } else {
             nm_wired_set.cloned_mac_address = Some(mac.to_string());

--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -200,7 +200,7 @@ impl MergedOvnConfiguration {
 #[non_exhaustive]
 pub struct OvnBridgeMapping {
     pub localnet: String,
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// When set to `state: absent`, will delete the existing
     /// `localnet` mapping.
     pub state: Option<OvnBridgeMappingState>,

--- a/rust/src/lib/ovsdb/apply.rs
+++ b/rust/src/lib/ovsdb/apply.rs
@@ -5,7 +5,7 @@ use crate::{ovsdb::db::OvsDbConnection, MergedNetworkState, NmstateError};
 pub(crate) fn ovsdb_apply(
     merged_state: &MergedNetworkState,
 ) -> Result<(), NmstateError> {
-    if merged_state.is_global_ovsdb_changed() {
+    if merged_state.ovsdb.is_changed {
         let mut cli = OvsDbConnection::new()?;
         cli.apply_global_conf(&merged_state.ovsdb)
     } else {

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -27,8 +27,6 @@ pub(crate) fn ovsdb_is_running() -> bool {
 
 pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
-    ret.prop_list.push("interfaces");
-    ret.prop_list.push("ovsdb");
     let mut cli = OvsDbConnection::new()?;
     let ovsdb_ifaces = cli.get_ovs_ifaces()?;
     let ovsdb_brs = cli.get_ovs_bridges()?;
@@ -72,7 +70,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
         }
     }
 
-    ret.ovsdb = cli.get_ovsdb_global_conf()?;
+    ret.ovsdb = Some(cli.get_ovsdb_global_conf()?);
 
     Ok(ret)
 }

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, InterfaceType, OvsDbIfaceConfig};
+use crate::{BaseInterface, InterfaceState, InterfaceType, OvsDbIfaceConfig};
 
 impl BaseInterface {
     pub(crate) fn sanitize_current_for_verify(&mut self) {
@@ -47,64 +47,59 @@ impl BaseInterface {
     }
 
     pub(crate) fn update(&mut self, other: &BaseInterface) {
-        if other.prop_list.contains(&"name") {
-            self.name = other.name.clone();
-        }
-        if other.prop_list.contains(&"description") {
+        if other.description.is_some() {
             self.description = other.description.clone();
         }
-        if other.prop_list.contains(&"iface_type")
-            && other.iface_type != InterfaceType::Unknown
-        {
+        if other.iface_type != InterfaceType::Unknown {
             self.iface_type = other.iface_type.clone();
         }
-        if other.prop_list.contains(&"state") {
+        if other.state != InterfaceState::Unknown {
             self.state = other.state;
         }
-        if other.prop_list.contains(&"mtu") {
+        if other.mtu.is_some() {
             self.mtu = other.mtu;
         }
-        if other.prop_list.contains(&"min_mtu") {
+        if other.min_mtu.is_some() {
             self.min_mtu = other.min_mtu;
         }
-        if other.prop_list.contains(&"max_mtu") {
+        if other.max_mtu.is_some() {
             self.max_mtu = other.max_mtu;
         }
-        if other.prop_list.contains(&"mac_address") {
+        if other.mac_address.is_some() {
             self.mac_address = other.mac_address.clone();
         }
-        if other.prop_list.contains(&"permanent_mac_address") {
+        if other.permanent_mac_address.is_some() {
             self.permanent_mac_address = other.permanent_mac_address.clone();
         }
-        if other.prop_list.contains(&"controller") {
+        if other.controller.is_some() {
             self.controller = other.controller.clone();
         }
-        if other.prop_list.contains(&"controller_type") {
+        if other.controller_type.is_some() {
             self.controller_type = other.controller_type.clone();
         }
-        if other.prop_list.contains(&"accept_all_mac_addresses") {
+        if other.accept_all_mac_addresses.is_some() {
             self.accept_all_mac_addresses = other.accept_all_mac_addresses;
         }
-        if other.prop_list.contains(&"ovsdb") {
+        if other.ovsdb.is_some() {
             self.ovsdb = other.ovsdb.clone();
         }
-        if other.prop_list.contains(&"ieee8021x") {
+        if other.ieee8021x.is_some() {
             self.ieee8021x = other.ieee8021x.clone();
         }
-        if other.prop_list.contains(&"lldp") {
+        if other.lldp.is_some() {
             self.lldp = other.lldp.clone();
         }
-        if other.prop_list.contains(&"ethtool") {
+        if other.ethtool.is_some() {
             self.ethtool = other.ethtool.clone();
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"wait_ip") {
+        if other.wait_ip.is_some() {
             self.wait_ip = other.wait_ip;
         }
 
-        if other.prop_list.contains(&"ipv4") {
+        if other.ipv4.is_some() {
             if let Some(ref other_ipv4) = other.ipv4 {
                 if let Some(ref mut self_ipv4) = self.ipv4 {
                     self_ipv4.update(other_ipv4);
@@ -114,7 +109,7 @@ impl BaseInterface {
             }
         }
 
-        if other.prop_list.contains(&"ipv6") {
+        if other.ipv6.is_some() {
             if let Some(ref other_ipv6) = other.ipv6 {
                 if let Some(ref mut self_ipv6) = self.ipv6 {
                     self_ipv6.update(other_ipv6);
@@ -123,21 +118,16 @@ impl BaseInterface {
                 }
             }
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"identifier") {
+        if other.identifier.is_some() {
             self.identifier = other.identifier;
         }
-        if other.prop_list.contains(&"profile_name") {
+        if other.profile_name.is_some() {
             self.profile_name = other.profile_name.clone();
         }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name)
-            }
-        }
-        if other.prop_list.contains(&"dispatch") {
+        if other.dispatch.is_some() {
             self.dispatch = other.dispatch.clone();
         }
     }

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -3,10 +3,7 @@
 use crate::{DnsState, ErrorKind, MergedDnsState, NmstateError};
 
 impl MergedDnsState {
-    pub(crate) fn verify(
-        &self,
-        current: &DnsState,
-    ) -> Result<(), NmstateError> {
+    pub(crate) fn verify(&self, current: DnsState) -> Result<(), NmstateError> {
         if !self.is_changed() {
             return Ok(());
         }

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -25,11 +25,14 @@ impl Interface {
         }
     }
 
-    pub(crate) fn verify(&self, current: &Self) -> Result<(), NmstateError> {
+    pub(crate) fn verify(
+        &mut self,
+        current: &Self,
+    ) -> Result<(), NmstateError> {
         let mut current = current.clone();
         self.process_allow_extra_address(&mut current);
 
-        let self_value = serde_json::to_value(self)?;
+        let self_value = serde_json::to_value(&self)?;
         let current_value = serde_json::to_value(&current)?;
 
         if let Some((reference, desire, current)) = get_json_value_difference(

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -161,8 +161,8 @@ impl MergedInterfaces {
             iface.sanitize_desired_for_verify();
         }
 
-        for des_iface in merged.iter().filter(|i| i.is_desired()) {
-            let iface = if let Some(i) = des_iface.for_verify.as_ref() {
+        for des_iface in merged.iter_mut().filter(|i| i.is_desired()) {
+            let iface = if let Some(i) = des_iface.for_verify.as_mut() {
                 i
             } else {
                 continue;

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -186,29 +186,33 @@ impl InterfaceIpv6 {
 impl Interface {
     // * If `allow_extra_address: true`, remove current IP address if not found
     //   in desired.
-    pub(crate) fn process_allow_extra_address(&self, current: &mut Self) {
+    pub(crate) fn process_allow_extra_address(&mut self, current: &mut Self) {
         if let (Some(des_ip), Some(cur_ip)) = (
-            self.base_iface().ipv4.as_ref(),
+            self.base_iface_mut().ipv4.as_mut(),
             current.base_iface_mut().ipv4.as_mut(),
         ) {
             if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
-                if des_ip.allow_extra_address {
+                if des_ip.allow_extra_address != Some(false) {
                     cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
                 }
+                // Remove allow_extra_address as current does not have it
+                des_ip.allow_extra_address = None
             }
         }
         if let (Some(des_ip), Some(cur_ip)) = (
-            self.base_iface().ipv6.as_ref(),
+            self.base_iface_mut().ipv6.as_mut(),
             current.base_iface_mut().ipv6.as_mut(),
         ) {
             if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
-                if des_ip.allow_extra_address {
+                if des_ip.allow_extra_address != Some(false) {
                     cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
                 }
+                // Remove allow_extra_address as current does not have it
+                des_ip.allow_extra_address = None
             }
         }
     }

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -32,54 +32,48 @@ impl InterfaceIpv4 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
 
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_client_id") {
+        if other.dhcp_client_id.is_some() {
             self.dhcp_client_id = other.dhcp_client_id.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"allow_extra_address") {
+        if other.allow_extra_address.is_some() {
             self.allow_extra_address = other.allow_extra_address;
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }
@@ -124,61 +118,56 @@ impl InterfaceIpv6 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_duid") {
+        if other.dhcp_duid.is_some() {
             self.dhcp_duid = other.dhcp_duid.clone();
         }
-        if other.prop_list.contains(&"autoconf") {
+        if other.autoconf.is_some() {
             self.autoconf = other.autoconf;
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"token") {
+        if other.token.is_some() {
             self.token = other.token.clone();
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -5,20 +5,24 @@ use std::convert::TryInto;
 
 use crate::{
     state::get_json_value_difference, ErrorKind, Interface, InterfaceState,
-    InterfaceType, Interfaces, MergedInterfaces, MergedNetworkState,
-    MergedOvsDbGlobalConfig, NetworkState, NmstateError, OvsBridgeBondConfig,
-    OvsBridgeConfig, OvsBridgeInterface, OvsDbGlobalConfig, OvsDbIfaceConfig,
-    OvsInterface,
+    InterfaceType, Interfaces, MergedInterfaces, MergedOvsDbGlobalConfig,
+    NetworkState, NmstateError, OvsBridgeBondConfig, OvsBridgeConfig,
+    OvsBridgeInterface, OvsDbGlobalConfig, OvsDbIfaceConfig, OvsInterface,
 };
 
 impl MergedOvsDbGlobalConfig {
     pub(crate) fn verify(
         &self,
-        current: &OvsDbGlobalConfig,
+        current: OvsDbGlobalConfig,
     ) -> Result<(), NmstateError> {
+        let desired = match self.desired.as_ref() {
+            Some(d) => d,
+            None => {
+                return Ok(());
+            }
+        };
         let empty_map: HashMap<String, Option<String>> = HashMap::new();
-        let external_ids: HashMap<String, Option<String>> = self
-            .desired
+        let external_ids: HashMap<String, Option<String>> = desired
             .external_ids
             .as_ref()
             .unwrap_or(&empty_map)
@@ -31,8 +35,7 @@ impl MergedOvsDbGlobalConfig {
                 }
             })
             .collect();
-        let other_config: HashMap<String, Option<String>> = self
-            .desired
+        let other_config: HashMap<String, Option<String>> = desired
             .other_config
             .as_ref()
             .unwrap_or(&empty_map)
@@ -49,7 +52,6 @@ impl MergedOvsDbGlobalConfig {
         let desired = OvsDbGlobalConfig {
             external_ids: Some(external_ids),
             other_config: Some(other_config),
-            prop_list: vec!["external_ids", "other_config"],
         };
 
         let desired_value = serde_json::to_value(desired)?;
@@ -57,7 +59,6 @@ impl MergedOvsDbGlobalConfig {
             serde_json::to_value(OvsDbGlobalConfig {
                 external_ids: Some(HashMap::new()),
                 other_config: Some(HashMap::new()),
-                prop_list: Vec::new(),
             })?
         } else {
             serde_json::to_value(current)?
@@ -120,20 +121,6 @@ impl OvsInterface {
         }
         if other.dpdk.is_some() {
             self.dpdk = other.dpdk.clone();
-        }
-    }
-}
-
-impl MergedNetworkState {
-    // Sine desire `ovsdb: {}` means remove all, we cannot
-    // differentiate it with `ovsdb` not defined due to `serde(default)`.
-    // Hence we need to check `MergedNetworkState.prop_list`.
-    pub(crate) fn is_global_ovsdb_changed(&self) -> bool {
-        if self.prop_list.contains(&"ovsdb") || self.prop_list.contains(&"ovn")
-        {
-            self.ovsdb.is_changed
-        } else {
-            false
         }
     }
 }
@@ -217,16 +204,13 @@ impl NetworkState {
     pub(crate) fn isolate_ovn(&mut self) -> Result<(), NmstateError> {
         if let Some(ovn_maps_str) = self
             .ovsdb
-            .external_ids
             .as_mut()
+            .and_then(|o| o.external_ids.as_mut())
             .and_then(|eids| {
                 eids.remove(OvsDbGlobalConfig::OVN_BRIDGE_MAPPINGS_KEY)
             })
             .flatten()
         {
-            if !self.prop_list.contains(&"ovn") {
-                self.prop_list.push("ovn");
-            }
             self.ovn = ovn_maps_str.as_str().try_into()?;
         }
         Ok(())

--- a/rust/src/lib/revert/dns.rs
+++ b/rust/src/lib/revert/dns.rs
@@ -3,11 +3,11 @@
 use crate::{DnsState, MergedDnsState};
 
 impl MergedDnsState {
-    pub(crate) fn generate_revert(&self) -> DnsState {
+    pub(crate) fn generate_revert(&self) -> Option<DnsState> {
         if self.is_changed() {
-            self.current.clone()
+            Some(self.current.clone())
         } else {
-            DnsState::new()
+            None
         }
     }
 }

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -21,7 +21,6 @@ impl NetworkState {
             ovsdb: merged_state.ovsdb.generate_revert(),
             ovn: merged_state.ovn.generate_revert(),
             hostname: merged_state.hostname.generate_revert(),
-            prop_list: vec!["interfaces"],
             ..Default::default()
         })
     }

--- a/rust/src/lib/revert/ovsdb.rs
+++ b/rust/src/lib/revert/ovsdb.rs
@@ -5,16 +5,18 @@ use std::collections::HashMap;
 use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
 
 impl MergedOvsDbGlobalConfig {
-    pub(crate) fn generate_revert(&self) -> OvsDbGlobalConfig {
+    pub(crate) fn generate_revert(&self) -> Option<OvsDbGlobalConfig> {
+        let desired = match self.desired.as_ref() {
+            Some(d) => d,
+            None => {
+                return None;
+            }
+        };
         let mut revert_external_ids: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for eid_key in self
-            .desired
-            .external_ids
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for eid_key in
+            desired.external_ids.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_external_ids.insert(
                 eid_key.to_string(),
@@ -30,12 +32,8 @@ impl MergedOvsDbGlobalConfig {
         let mut revert_other_configs: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for cfg_key in self
-            .desired
-            .other_config
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for cfg_key in
+            desired.other_config.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_other_configs.insert(
                 cfg_key.to_string(),
@@ -49,13 +47,13 @@ impl MergedOvsDbGlobalConfig {
         }
 
         if revert_external_ids.is_empty() && revert_other_configs.is_empty() {
-            OvsDbGlobalConfig::default()
+            None
         } else {
-            OvsDbGlobalConfig {
+            Some(OvsDbGlobalConfig {
                 external_ids: Some(revert_external_ids),
                 other_config: Some(revert_other_configs),
                 ..Default::default()
-            }
+            })
         }
     }
 }

--- a/rust/src/lib/statistic/feature/dns.rs
+++ b/rust/src/lib/statistic/feature/dns.rs
@@ -5,7 +5,9 @@ use crate::{MergedDnsState, NmstateFeature};
 impl MergedDnsState {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret = Vec::new();
-        if let Some(dns_config) = self.desired.config.as_ref() {
+        if let Some(dns_config) =
+            self.desired.as_ref().and_then(|d| d.config.as_ref())
+        {
             if dns_config.server.is_some() {
                 ret.push(NmstateFeature::StaticDnsNameServer);
             }

--- a/rust/src/lib/statistic/feature/iface.rs
+++ b/rust/src/lib/statistic/feature/iface.rs
@@ -8,7 +8,10 @@ use crate::{
 impl MergedInterface {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret: Vec<NmstateFeature> = Vec::new();
-        if self.desired.as_ref().map(|i| i.base_iface().identifier)
+        if self
+            .desired
+            .as_ref()
+            .and_then(|i| i.base_iface().identifier)
             == Some(InterfaceIdentifier::MacAddress)
         {
             ret.push(NmstateFeature::MacBasedIdentifier);

--- a/rust/src/lib/statistic/feature/ovs.rs
+++ b/rust/src/lib/statistic/feature/ovs.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl MergedOvsDbGlobalConfig {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
-        if !self.desired.is_none() {
+        if self.desired.is_some() {
             vec![NmstateFeature::OvsDbGlobal]
         } else {
             Vec::new()

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -28,3 +28,22 @@ mac-address: "d4:ee:07:25:42:5a"
     iface.sanitize(true).unwrap();
     assert_eq!(iface.mac_address, Some(String::from("D4:EE:07:25:42:5A")));
 }
+
+#[test]
+fn test_base_iface_serialize_copy_mac_from() {
+    let desired: BaseInterface = serde_yaml::from_str(
+        r#"---
+          name: bond99
+          type: bond
+          state: up
+          copy-mac-from: eth2
+        "#,
+    )
+    .unwrap();
+
+    let new: BaseInterface =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -46,9 +46,9 @@ fn test_dns_verify_uncompressed_srvs() {
     )
     .unwrap();
 
-    let merged = MergedDnsState::new(desired, DnsState::new()).unwrap();
+    let merged = MergedDnsState::new(Some(desired), DnsState::new()).unwrap();
 
-    merged.verify(&current).unwrap();
+    merged.verify(current).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -541,3 +541,28 @@ fn test_auto_ip_lift_time() {
     assert_eq!(left_fmt, life_time_fmt);
     assert_eq!(iproute_fmt, life_time_fmt);
 }
+
+#[test]
+fn test_ip_serlize_allow_extra_address() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: "true"
+            dhcp: "false"
+            allow-extra-address: false
+          ipv6:
+            enabled: "true"
+            dhcp: "false"
+        "#,
+    )
+    .unwrap();
+
+    let new: Interfaces =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -265,3 +265,26 @@ fn test_ovn_map_support_state_present() {
         }]
     )
 }
+
+#[test]
+fn test_ovn_serialize_state_absent() {
+    let desired: OvnConfiguration = serde_yaml::from_str(
+        r#"---
+        bridge-mappings:
+        - localnet: blue
+          state: absent
+        - localnet: red
+          state: absent
+        - localnet: yellow
+          state: absent
+        - localnet: green
+        "#,
+    )
+    .unwrap();
+
+    let new: OvnConfiguration =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -921,3 +921,26 @@ fn test_ovs_bridge_deprecated_prop() {
 
     assert_eq!(iface.ports(), Some(vec!["eth1"]));
 }
+
+#[test]
+fn test_ovs_iface_serialize_allow_extra_patch_ports() {
+    let desired: OvsBridgeInterface = serde_yaml::from_str(
+        r#"---
+        name: br0
+        type: ovs-bridge
+        state: up
+        bridge:
+          allow-extra-patch-ports: true
+          port:
+          - name: ovs0
+          - name: eth1
+        "#,
+    )
+    .unwrap();
+
+    let new: OvsBridgeInterface =
+        serde_yaml::from_str(&serde_yaml::to_string(&desired).unwrap())
+            .unwrap();
+
+    assert_eq!(desired, new);
+}

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -38,9 +38,12 @@ other_config:
 
     let current = get_current_ovsdb_config();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r"---
@@ -79,9 +82,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -115,9 +121,12 @@ other_config:
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -151,9 +160,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -172,11 +184,11 @@ fn test_ovsdb_verify_null_current() {
     let current = desired.clone();
 
     let merged_ovsdb = MergedOvsDbGlobalConfig::new(
-        desired,
+        Some(desired),
         pre_apply_current,
         &Default::default(),
     )
     .unwrap();
 
-    merged_ovsdb.verify(&current).unwrap();
+    merged_ovsdb.verify(current).unwrap();
 }

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -206,7 +206,6 @@ fn test_policy_capture_retain_only() {
     assert_eq!(state.dns, current.dns);
 
     state.dns = empty_state.dns.clone();
-    state.prop_list = Vec::new();
     assert_eq!(state, empty_state);
 }
 

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -249,7 +249,8 @@ fn test_policy_convert_dhcp_to_static_with_dns() {
     assert_eq!(routes[0].next_hop_iface, Some("eth1".to_string()));
     assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
     assert_eq!(routes[1].next_hop_iface, Some("eth1".to_string()));
-    let dns_config = state.dns.config.as_ref().unwrap();
+    let dns_config =
+        state.dns.as_ref().and_then(|d| d.config.as_ref()).unwrap();
     assert_eq!(
         dns_config.server,
         Some(vec![

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -384,8 +384,7 @@ def test_format_command():
             f"nmstatectl format {fd.name}".split(), check=True
         )[1]
         assert (
-            """
-interfaces:
+            """interfaces:
 - name: bond99
   type: bond
   state: up


### PR DESCRIPTION
By changing `BaseInterface.identifier` to `Option<InterfaceIdentifier>`,
there is no need to track user's desired property list as they can be
replaced by `Option<T>`.