### PR TITLE
base_iface: Remove `prop_list`

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -11,7 +11,6 @@ use crate::{
 
 const MINIMUM_IPV6_MTU: u64 = 1280;
 
-// TODO: Use prop_list to Serialize like InterfaceIpv4 did
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
@@ -26,19 +25,16 @@ pub struct BaseInterface {
     /// Interface description stored in network backend. Not available for
     /// kernel only mode.
     pub description: Option<String>,
-    #[serde(skip)]
-    /// TODO: internal use only. Hide this.
-    pub prop_list: Vec<&'static str>,
     #[serde(rename = "type", default = "default_iface_type")]
     /// Interface type. Serialize and deserialize to/from `type`
     pub iface_type: InterfaceType,
     #[serde(default = "default_state")]
     /// Interface state. Default to [InterfaceState::Up] when applying.
     pub state: InterfaceState,
-    #[serde(default, skip_serializing_if = "InterfaceIdentifier::is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Define network backend matching method on choosing network interface.
     /// Default to [InterfaceIdentifier::Name].
-    pub identifier: InterfaceIdentifier,
+    pub identifier: Option<InterfaceIdentifier>,
     /// When applying with `[InterfaceIdentifier::MacAddress]`,
     /// nmstate will store original desired interface name as `profile_name`
     /// here and store the real interface name as `name` property.

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -367,7 +367,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for iface in self.iter().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
                 && i.base_iface().profile_name.is_none()
         }) {
             let mac_address = match iface.base_iface().mac_address.as_deref() {
@@ -446,7 +446,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for cur_iface in current.kernel_ifaces.values().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
         }) {
             if let Some(profile_name) =
                 cur_iface.base_iface().profile_name.as_ref()
@@ -470,7 +470,7 @@ impl Interfaces {
                         };
 
                     new_iface.base_iface_mut().identifier =
-                        InterfaceIdentifier::MacAddress;
+                        Some(InterfaceIdentifier::MacAddress);
                     new_iface.base_iface_mut().mac_address =
                         cur_iface.base_iface().mac_address.clone();
                     new_iface.base_iface_mut().name =

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -102,19 +102,6 @@ pub(crate) fn np_iface_to_base_iface(
             Some(false)
         },
         ethtool: np_ethtool_to_nmstate(np_iface),
-        prop_list: vec![
-            "name",
-            "state",
-            "iface_type",
-            "ipv4",
-            "ipv6",
-            "mac_address",
-            "permanent_mac_address",
-            "controller",
-            "mtu",
-            "accept_all_mac_addresses",
-            "ethtool",
-        ],
         ..Default::default()
     };
     if !InterfaceType::SUPPORTED_LIST.contains(&base_iface.iface_type) {

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -237,7 +237,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using profile name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().profile_name.as_deref()
                     == Some(iface.name())
             {
@@ -251,7 +251,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using interface name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().name.as_str() == iface.name()
             {
                 if let Some(mac) = cur_iface.base_iface().mac_address.as_ref() {

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -122,9 +122,6 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
                 iface,
             ) {
                 base_iface.iface_type = InterfaceType::OvsInterface;
-                if !base_iface.prop_list.contains(&"iface_type") {
-                    base_iface.prop_list.push("iface_type");
-                }
                 oiface.base = base_iface;
             }
         }

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -89,7 +89,7 @@ pub(crate) fn iface_to_nm_connections(
 
     let base_iface = iface.base_iface();
     let exist_nm_conn =
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             get_exist_profile_by_profile_name(
                 exist_nm_conns,
                 base_iface
@@ -435,7 +435,8 @@ pub(crate) fn gen_nm_conn_setting(
     };
 
     if iface.iface_type() != InterfaceType::Ipsec
-        && iface.base_iface().identifier == InterfaceIdentifier::Name
+        && iface.base_iface().identifier.unwrap_or_default()
+            == InterfaceIdentifier::Name
     {
         nm_conn_set.iface_name = Some(iface.name().to_string());
     } else {

--- a/rust/src/lib/nm/settings/wired.rs
+++ b/rust/src/lib/nm/settings/wired.rs
@@ -18,7 +18,7 @@ pub(crate) fn gen_nm_wired_setting(
     let base_iface = iface.base_iface();
 
     if let Some(mac) = &base_iface.mac_address {
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             nm_wired_set.mac_address = Some(mac.to_string());
         } else {
             nm_wired_set.cloned_mac_address = Some(mac.to_string());

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -27,11 +27,11 @@ use super::{
 use crate::{
     BaseInterface, BondConfig, BondInterface, BondOptions, DummyInterface,
     EthernetInterface, HsrInterface, InfiniBandInterface, Interface,
-    InterfaceIdentifier, InterfaceState, InterfaceType, Interfaces,
-    LinuxBridgeInterface, LoopbackInterface, MacSecConfig, MacSecInterface,
-    MacVlanInterface, MacVtapInterface, NetworkState, NmstateError,
-    OvsBridgeInterface, OvsInterface, UnknownInterface, VlanInterface,
-    VrfInterface, VxlanInterface,
+    InterfaceIdentifier, InterfaceState, InterfaceType, LinuxBridgeInterface,
+    LoopbackInterface, MacSecConfig, MacSecInterface, MacVlanInterface,
+    MacVtapInterface, NetworkState, NmstateError, OvsBridgeInterface,
+    OvsInterface, UnknownInterface, VlanInterface, VrfInterface,
+    VxlanInterface,
 };
 
 pub(crate) fn nm_retrieve(
@@ -159,7 +159,6 @@ pub(crate) fn nm_retrieve(
                     // NetworkManager, so user will not get failure when they
                     // apply the returned state.
                     if !mptcp_supported {
-                        iface.base_iface_mut().prop_list.push("mptcp");
                         iface.base_iface_mut().mptcp = None;
                     }
 
@@ -185,9 +184,6 @@ pub(crate) fn nm_retrieve(
     {
         // Do not touch interfaces nmstate does not support yet
         if !InterfaceType::SUPPORTED_LIST.contains(&iface.iface_type()) {
-            if !iface.base_iface_mut().prop_list.contains(&"state") {
-                iface.base_iface_mut().prop_list.push("state");
-            }
             iface.base_iface_mut().state = InterfaceState::Ignore;
         }
     }
@@ -213,12 +209,9 @@ pub(crate) fn nm_retrieve(
         if let Some(iface) =
             net_state.interfaces.kernel_ifaces.get_mut(&iface_name)
         {
-            iface.base_iface_mut().prop_list.push("dispatch");
             iface.base_iface_mut().dispatch = Some(conf);
         }
     }
-
-    set_ovs_iface_controller_info(&mut net_state.interfaces);
 
     merge_ovs_netdev_tun_iface(&mut net_state, &nm_devs, &nm_conns);
 
@@ -247,36 +240,18 @@ pub(crate) fn nm_conn_to_base_iface(
 
         let mut base_iface = BaseInterface::new();
         base_iface.name = iface_name.to_string();
-        base_iface.prop_list = vec![
-            "name",
-            "state",
-            "ipv4",
-            "ipv6",
-            "ieee8021x",
-            "description",
-            "lldp",
-            "wait_ip",
-            "identifier",
-            "profile_name",
-        ];
         base_iface.state = InterfaceState::Up;
         base_iface.iface_type = if let Some(nm_dev) = nm_dev {
             nm_dev_iface_type_to_nmstate(nm_dev)
         } else {
             InterfaceType::Unknown
         };
-        if base_iface.iface_type.is_userspace() {
-            // Only override iface type for user space. For other interface,
-            // we trust nispor to set the correct interface type.
-            base_iface.prop_list.push("iface_type");
-        }
         base_iface.ipv4 = ipv4;
         base_iface.ipv6 = ipv6;
         base_iface.wait_ip =
             query_nmstate_wait_ip(nm_conn.ipv4.as_ref(), nm_conn.ipv6.as_ref());
-        base_iface.controller = nm_conn.controller().map(|c| c.to_string());
         base_iface.description = get_description(nm_conn);
-        base_iface.identifier = get_identifier(nm_conn);
+        base_iface.identifier = Some(get_identifier(nm_conn));
         base_iface.profile_name = get_connection_name(nm_conn);
         if base_iface.profile_name.as_ref() == Some(&base_iface.name) {
             base_iface.profile_name = None;
@@ -458,28 +433,6 @@ fn get_nm_ac<'a>(
         .copied()
 }
 
-fn set_ovs_iface_controller_info(ifaces: &mut Interfaces) {
-    let mut pending_changes: Vec<(&str, &str)> = Vec::new();
-    for iface in ifaces.user_ifaces.values() {
-        if iface.iface_type() == InterfaceType::OvsBridge {
-            if let Some(port_names) = iface.ports() {
-                for port_name in port_names {
-                    pending_changes.push((port_name, iface.name()));
-                }
-            }
-        }
-    }
-    for (iface_name, ctrl_name) in pending_changes {
-        if let Some(ref mut iface) = ifaces.kernel_ifaces.get_mut(iface_name) {
-            iface.base_iface_mut().prop_list.push("controller");
-            iface.base_iface_mut().prop_list.push("controller_type");
-            iface.base_iface_mut().controller = Some(ctrl_name.to_string());
-            iface.base_iface_mut().controller_type =
-                Some(InterfaceType::OvsBridge);
-        }
-    }
-}
-
 fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
     let mut base_iface = BaseInterface::new();
     if nm_dev.name.is_empty() {
@@ -487,7 +440,6 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
     } else {
         base_iface.name = nm_dev.name.clone();
     }
-    base_iface.prop_list = vec!["name", "state"];
     match nm_dev.state {
         NmDeviceState::Unmanaged => {
             if !nm_dev.real {
@@ -500,7 +452,7 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
         _ => base_iface.state = InterfaceState::Up,
     }
     base_iface.iface_type = nm_dev_iface_type_to_nmstate(nm_dev);
-    let mut iface = match &base_iface.iface_type {
+    let iface = match &base_iface.iface_type {
         InterfaceType::Ethernet => Interface::Ethernet({
             let mut iface = EthernetInterface::new();
             iface.base = base_iface;
@@ -614,11 +566,6 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
             }
         }
     };
-    if iface.iface_type().is_userspace() {
-        // Only override iface type for user space. For other interface,
-        // we trust nispor to set the correct interface type.
-        iface.base_iface_mut().prop_list.push("iface_type");
-    }
     Some(iface)
 }
 

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, InterfaceType, OvsDbIfaceConfig};
+use crate::{BaseInterface, InterfaceState, InterfaceType, OvsDbIfaceConfig};
 
 impl BaseInterface {
     pub(crate) fn sanitize_current_for_verify(&mut self) {
@@ -47,64 +47,59 @@ impl BaseInterface {
     }
 
     pub(crate) fn update(&mut self, other: &BaseInterface) {
-        if other.prop_list.contains(&"name") {
-            self.name = other.name.clone();
-        }
-        if other.prop_list.contains(&"description") {
+        if other.description.is_some() {
             self.description = other.description.clone();
         }
-        if other.prop_list.contains(&"iface_type")
-            && other.iface_type != InterfaceType::Unknown
-        {
+        if other.iface_type != InterfaceType::Unknown {
             self.iface_type = other.iface_type.clone();
         }
-        if other.prop_list.contains(&"state") {
+        if other.state != InterfaceState::Unknown {
             self.state = other.state;
         }
-        if other.prop_list.contains(&"mtu") {
+        if other.mtu.is_some() {
             self.mtu = other.mtu;
         }
-        if other.prop_list.contains(&"min_mtu") {
+        if other.min_mtu.is_some() {
             self.min_mtu = other.min_mtu;
         }
-        if other.prop_list.contains(&"max_mtu") {
+        if other.max_mtu.is_some() {
             self.max_mtu = other.max_mtu;
         }
-        if other.prop_list.contains(&"mac_address") {
+        if other.mac_address.is_some() {
             self.mac_address = other.mac_address.clone();
         }
-        if other.prop_list.contains(&"permanent_mac_address") {
+        if other.permanent_mac_address.is_some() {
             self.permanent_mac_address = other.permanent_mac_address.clone();
         }
-        if other.prop_list.contains(&"controller") {
+        if other.controller.is_some() {
             self.controller = other.controller.clone();
         }
-        if other.prop_list.contains(&"controller_type") {
+        if other.controller_type.is_some() {
             self.controller_type = other.controller_type.clone();
         }
-        if other.prop_list.contains(&"accept_all_mac_addresses") {
+        if other.accept_all_mac_addresses.is_some() {
             self.accept_all_mac_addresses = other.accept_all_mac_addresses;
         }
-        if other.prop_list.contains(&"ovsdb") {
+        if other.ovsdb.is_some() {
             self.ovsdb = other.ovsdb.clone();
         }
-        if other.prop_list.contains(&"ieee8021x") {
+        if other.ieee8021x.is_some() {
             self.ieee8021x = other.ieee8021x.clone();
         }
-        if other.prop_list.contains(&"lldp") {
+        if other.lldp.is_some() {
             self.lldp = other.lldp.clone();
         }
-        if other.prop_list.contains(&"ethtool") {
+        if other.ethtool.is_some() {
             self.ethtool = other.ethtool.clone();
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"wait_ip") {
+        if other.wait_ip.is_some() {
             self.wait_ip = other.wait_ip;
         }
 
-        if other.prop_list.contains(&"ipv4") {
+        if other.ipv4.is_some() {
             if let Some(ref other_ipv4) = other.ipv4 {
                 if let Some(ref mut self_ipv4) = self.ipv4 {
                     self_ipv4.update(other_ipv4);
@@ -114,7 +109,7 @@ impl BaseInterface {
             }
         }
 
-        if other.prop_list.contains(&"ipv6") {
+        if other.ipv6.is_some() {
             if let Some(ref other_ipv6) = other.ipv6 {
                 if let Some(ref mut self_ipv6) = self.ipv6 {
                     self_ipv6.update(other_ipv6);
@@ -123,21 +118,16 @@ impl BaseInterface {
                 }
             }
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"identifier") {
+        if other.identifier.is_some() {
             self.identifier = other.identifier;
         }
-        if other.prop_list.contains(&"profile_name") {
+        if other.profile_name.is_some() {
             self.profile_name = other.profile_name.clone();
         }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name)
-            }
-        }
-        if other.prop_list.contains(&"dispatch") {
+        if other.dispatch.is_some() {
             self.dispatch = other.dispatch.clone();
         }
     }

--- a/rust/src/lib/statistic/feature/iface.rs
+++ b/rust/src/lib/statistic/feature/iface.rs
@@ -8,7 +8,10 @@ use crate::{
 impl MergedInterface {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret: Vec<NmstateFeature> = Vec::new();
-        if self.desired.as_ref().map(|i| i.base_iface().identifier)
+        if self
+            .desired
+            .as_ref()
+            .and_then(|i| i.base_iface().identifier)
             == Some(InterfaceIdentifier::MacAddress)
         {
             ret.push(NmstateFeature::MacBasedIdentifier);


### PR DESCRIPTION
By changing `BaseInterface.identifier` to `Option<InterfaceIdentifier>`,
there is no need to track user's desired property list as they can be
replaced by `Option<T>`.