### PR TITLE
ipsec: Add support of P2P IPSec tunnel

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -112,6 +112,10 @@ pub struct LibreswanConfig {
     pub ipsec_interface: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authby: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rightsubnet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leftmodecfgclient: Option<bool>,
 }
 
 impl LibreswanConfig {

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -66,6 +66,9 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.dpdaction = data.get("dpdaction").cloned();
         ret.ipsec_interface = data.get("ipsec-interface").cloned();
         ret.authby = data.get("authby").cloned();
+        ret.leftmodecfgclient =
+            data.get("leftmodecfgclient").map(|s| s == "yes");
+        ret.rightsubnet = data.get("rightsubnet").cloned();
     }
     if let Some(secrets) = nm_set_vpn.secrets.as_ref() {
         ret.psk = secrets.get("pskvalue").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -60,6 +60,19 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.authby.as_deref() {
             vpn_data.insert("authby".into(), v.to_string());
         }
+        if let Some(v) = conf.leftmodecfgclient {
+            vpn_data.insert(
+                "leftmodecfgclient".into(),
+                if v {
+                    "yes".to_string()
+                } else {
+                    "no".to_string()
+                },
+            );
+        }
+        if let Some(v) = conf.rightsubnet.as_deref() {
+            vpn_data.insert("rightsubnet".into(), v.to_string());
+        }
 
         let mut nm_vpn_set = NmSettingVpn::default();
         nm_vpn_set.data = Some(vpn_data);


### PR DESCRIPTION
Add support of these libreswan options in order to support P2P IPSec
tunnel:
 * `rightsubnet`
 * `leftmodecfgclient`

In P2P IPSec tunnel setup, please explicitly set `rightsubnet` and
`leftmodecfgclient=no`.

Integration test case included and marked as xfail as NM-libreswan rpm is not shipped yet.