### PR TITLE
connection: drop "controller" from the extra values

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -366,6 +366,7 @@ pub struct NmSettingConnection {
 impl TryFrom<DbusDictionary> for NmSettingConnection {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
+        v.remove("controller");
         Ok(Self {
             id: _from_map!(v, "id", String::try_from)?,
             uuid: _from_map!(v, "uuid", String::try_from)?,


### PR DESCRIPTION
NetworkManager is introducing a new alias for "master" which is
"controller". Nmstate is taking unknown DBus parameters and sending it
back unmodified. NetworkManager is prioritising "master" over
"controller" if both are present but when removing the port only
"controller" is present in Nmstate code.

In order to fix this temporarily, drop "controller" from the other
values dictionary. This is going to be dropped when using "controller"
everywhere.