### PR TITLE
lib: Put back serde untagged to "Other" iface_type

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -81,6 +81,7 @@ pub enum InterfaceType {
     /// Unknown interface.
     Unknown,
     /// Reserved for future use.
+    #[serde(untagged)]
     Other(String),
 }
 

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -355,3 +355,16 @@ fn test_ifaces_iter_mut() {
     assert_eq!(ifaces_vec[0].base_iface().mtu, Some(1280));
     assert_eq!(ifaces_vec[1].base_iface().mtu, Some(1280));
 }
+
+#[test]
+fn test_unknown_iface_type() {
+    assert_eq!(
+        InterfaceType::Other("foo_type".to_string()).to_string(),
+        "foo_type"
+    );
+    assert_eq!(
+        serde_yaml::to_string(&InterfaceType::Other("foo_type".to_string()))
+            .unwrap(),
+        "foo_type\n"
+    );
+}


### PR DESCRIPTION
After some changes the serde "untagged" property was removed from the "Other" interface type, this change add it back and also add a little unit test for it.