### PR TITLE
rpm: Fix SONAME in RHEL 9 build

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -8,6 +8,13 @@
 %global debug_package %{nil}
 %endif
 
+%if 0%{?rhel}
+# RHEL does not have patchelf, hence we need to solve the SONAME problem
+# by ourselves: https://github.com/rust-lang/cargo/issues/5045
+%define _package_note_status 1
+%define _package_note_flags -Wl,-soname=libnmstate.so.2
+%endif
+
 Name:           nmstate
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
@@ -157,17 +164,6 @@ pushd rust
     %if ! %{is_snapshot}
     # Source3 is vendored dependencies
     %cargo_prep -V 3
-
-    # RHEL does not have patchelf, hence we need to solve the SONAME problem
-    # by ourselves: https://github.com/rust-lang/cargo/issues/5045
-
-    # The cargo_prep will create `.cargo/config` which take precedence over
-    # `.cargo/config.toml` shipped by upstream which fix the SONAME of cdylib.
-    # To workaround that, merge upstream rustflags into cargo_prep created one.
-    _FLAGS=`sed -ne 's/rustflags = "\(.\+\)"/\1/p' .cargo/config.toml`
-    sed -i -e "s/rustflags = \[\(.\+\), \]$/rustflags = [\1, \"$_FLAGS\"]/" \
-        .cargo/config
-    rm -f .cargo/config.toml
     %endif
 %else
     %cargo_prep


### PR DESCRIPTION
In recent release of `rust-toolset-1.75.0-1.el9.noarch`, the rpm macro
`%cargo_build` changed to use `RUSTFLAGS` which override our changes to
`.cargo/config.toml` fix for c library SONAME. This cause rpm failuer
when installing `nmstate-devel` rpm:

     error: Failed dependencies:
        libnmstate.so()(64bit) is needed by
        nmstate-devel-2.2.23-0.alpha.20240116.c606aaf.el9.x86_64

There is no document for how to append RUSTFLAGS for RHEL/Fedora rpm
build system. This patch is just hack by using `_package_note_flags`
defined by `/usr/lib/rpm/macros.d/macros.rust-toolset`.

All RHEL/CentOS 9 test need rpm been installed, hence no extra test
required for this patch.