### PR TITLE
clib: Use build.rs to fix SONAME

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,8 +69,16 @@ jobs:
         rustup override set ${{ matrix.rust_version }}
         rustup update ${{ matrix.rust_version }}
 
+    - name: Install tools for tests
+      run: |
+        sudo apt-get update;
+        sudo apt-get -y install valgrind
+
     - name: Unit test
       run: cd rust && cargo test -- --show-output
+
+    - name: C library test
+      run: make clib_check
 
   rpm_build:
     runs-on: ubuntu-22.04
@@ -149,7 +157,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: sudo .github/workflows/run_test.sh ${{ matrix.job_type }}
-      
+
       - uses: actions/upload-artifact@v3
         with:
           name: nmstate-test-junit-artifact-${{ matrix.job_type }}

--- a/Makefile
+++ b/Makefile
@@ -187,19 +187,20 @@ clib_check: $(CLIB_SO_DEV_DEBUG) $(CLIB_HEADER)
 	cp $(CLIB_SO_DEV_DEBUG) $(TMPDIR)/$(CLIB_SO_FULL)
 	ln -sfv $(CLIB_SO_FULL) $(TMPDIR)/$(CLIB_SO_MAN)
 	ln -sfv $(CLIB_SO_FULL) $(TMPDIR)/$(CLIB_SO_DEV)
+	rust/src/clib/test/check_clib_soname.sh $(TMPDIR)/$(CLIB_SO_DEV)
 	cp $(CLIB_HEADER) $(TMPDIR)/$(shell basename $(CLIB_HEADER))
-	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
+	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) \
 		-o $(TMPDIR)/nmstate_json_test \
-		rust/src/clib/test/nmstate_json_test.c
-	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
+		rust/src/clib/test/nmstate_json_test.c -lnmstate
+	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) \
 		-o $(TMPDIR)/nmpolicy_json_test \
-		rust/src/clib/test/nmpolicy_json_test.c
-	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
+		rust/src/clib/test/nmpolicy_json_test.c -lnmstate
+	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) \
 		-o $(TMPDIR)/nmstate_yaml_test \
-		rust/src/clib/test/nmstate_yaml_test.c
-	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) -lnmstate \
+		rust/src/clib/test/nmstate_yaml_test.c -lnmstate
+	cc -g -Wall -Wextra -L$(TMPDIR) -I$(TMPDIR) \
 		-o $(TMPDIR)/nmpolicy_yaml_test \
-		rust/src/clib/test/nmpolicy_yaml_test.c
+		rust/src/clib/test/nmpolicy_yaml_test.c -lnmstate
 	LD_LIBRARY_PATH=$(TMPDIR) \
 		valgrind --trace-children=yes --leak-check=full \
 		--error-exitcode=1 \

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -8,13 +8,6 @@
 %global debug_package %{nil}
 %endif
 
-%if 0%{?rhel}
-# RHEL does not have patchelf, hence we need to solve the SONAME problem
-# by ourselves: https://github.com/rust-lang/cargo/issues/5045
-%define _package_note_status 1
-%define _package_note_flags -Wl,-soname=libnmstate.so.2
-%endif
-
 Name:           nmstate
 Version:        @VERSION@
 Release:        @RELEASE@%{?dist}
@@ -26,9 +19,6 @@ Source0:        %{url}/releases/download/v%{version}/%{srcname}-%{version}.tar.g
 Source1:        %{url}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz.asc
 Source2:        https://nmstate.io/nmstate.gpg
 Source3:        %{url}/releases/download/v%{version}/%{srcname}-vendor-%{version}.tar.xz
-%endif
-%if 0%{?fedora}
-BuildRequires:  patchelf
 %endif
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -198,11 +188,6 @@ env SKIP_PYTHON_INSTALL=1 \
     LIBDIR=%{_libdir} \
     SYSCONFDIR=%{_sysconfdir} \
     %make_install
-
-%if ! 0%{?rhel}
-patchelf --set-soname libnmstate.so.2 \
-    %{buildroot}/%{_libdir}/libnmstate.so.%{version}
-%endif
 
 pushd rust/src/python
 %py3_install

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.'cfg(target_os="linux")']
-rustflags = "-Clink-arg=-Wl,-soname=libnmstate.so.2"

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.58"
+build = "build.rs"
 
 [lib]
 name = "nmstate"

--- a/rust/src/clib/build.rs
+++ b/rust/src/clib/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-cdylib-link-arg=-Wl,-soname=libnmstate.so.2");
+}

--- a/rust/src/clib/test/check_clib_soname.sh
+++ b/rust/src/clib/test/check_clib_soname.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$(objdump -p $1 |sed -ne 's/.*SONAME \+\(libnmstate.\+\)/\1/p')" \
+    != "libnmstate.so.2" ];then
+    exit 1
+fi


### PR DESCRIPTION
Use [`cargo:rustc-cdylib-link-arg`][1] to `build.rs` to fix the SONAME issue
of cargo.

Removed workarounds in rpm spec and `.cargo/config.toml`.

Changed Makefile to place `-lnmstate` after the source file to fix
compile issue on ubuntu 20.04 old gcc.

Added test case to verify the SONAME of c library SO file.

[1]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cdylib-link-arg

