### PR TITLE
WIP: Add new apply option `allow_overlap_ext_sriov`.

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -42,6 +42,9 @@ where
     let kernel_only = matches.try_contains_id("KERNEL").unwrap_or_default();
     let no_verify = matches.try_contains_id("NO_VERIFY").unwrap_or_default();
     let no_commit = matches.try_contains_id("NO_COMMIT").unwrap_or_default();
+    let allow_overlap = matches
+        .try_contains_id("ALLOW_SRIOV_OVERLAP")
+        .unwrap_or_default();
     let timeout = if matches.try_contains_id("TIMEOUT").unwrap_or_default() {
         match matches.try_get_one::<String>("TIMEOUT") {
             Ok(Some(t)) => match u32::from_str(t) {
@@ -101,6 +104,7 @@ where
     net_state.set_memory_only(
         matches.try_contains_id("MEMORY_ONLY").unwrap_or_default(),
     );
+    net_state.set_allow_overlap_ext_sriov(allow_overlap);
 
     net_state.apply()?;
     if !matches.try_contains_id("SHOW_SECRETS").unwrap_or_default() {
@@ -161,6 +165,8 @@ pub(crate) fn state_edit(
     desire_state.set_verify_change(!matches.is_present("NO_VERIFY"));
     desire_state.set_commit(!matches.is_present("NO_COMMIT"));
     desire_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
+    desire_state
+        .set_allow_overlap_ext_sriov(matches.is_present("ALLOW_SRIOV_OVERLAP"));
     desire_state.apply()?;
     Ok(serde_yaml::to_string(&desire_state)?)
 }

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -191,6 +191,13 @@ fn main() {
                         .takes_value(false)
                         .help("Do not make the state persistent"),
                 )
+                .arg(
+                    clap::Arg::new("ALLOW_SRIOV_OVERLAP")
+                        .long("allow-sriov-overlap")
+                        .takes_value(false)
+                        .help("Do not fail when found desired state \
+                               overlapping with external SRIOV tool"),
+                )
         )
         .subcommand(
             clap::Command::new(SUB_CMD_GEN_CONF)

--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -13,14 +13,14 @@ use crate::error::CliError;
 pub(crate) struct SortedNetworkState {
     #[serde(skip_serializing_if = "Option::is_none")]
     hostname: Option<HostNameState>,
-    #[serde(rename = "dns-resolver", default)]
-    dns: DnsState,
+    #[serde(rename = "dns-resolver", skip_serializing_if = "Option::is_none")]
+    dns: Option<DnsState>,
     #[serde(rename = "route-rules", default)]
     rules: RouteRules,
     routes: Routes,
     interfaces: Vec<Value>,
-    #[serde(rename = "ovs-db")]
-    ovsdb: OvsDbGlobalConfig,
+    #[serde(rename = "ovs-db", skip_serializing_if = "Option::is_none")]
+    ovsdb: Option<OvsDbGlobalConfig>,
     #[serde(rename = "ovn")]
     ovn: OvnConfiguration,
 }

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -15,6 +15,7 @@ pub enum ErrorKind {
     PolicyError,
     PermissionError,
     SrIovVfNotFound,
+    SrIovOperatorOverlap,
 }
 
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -20,8 +20,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             NetworkState::new(),
-            true,  // gen_conf mode
-            false, // memory only
+            true, // gen_conf mode
         )?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&merged_state)?);
         Ok(ret)

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -11,7 +11,6 @@ use crate::{
 
 const MINIMUM_IPV6_MTU: u64 = 1280;
 
-// TODO: Use prop_list to Serialize like InterfaceIpv4 did
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
@@ -26,19 +25,16 @@ pub struct BaseInterface {
     /// Interface description stored in network backend. Not available for
     /// kernel only mode.
     pub description: Option<String>,
-    #[serde(skip)]
-    /// TODO: internal use only. Hide this.
-    pub prop_list: Vec<&'static str>,
     #[serde(rename = "type", default = "default_iface_type")]
     /// Interface type. Serialize and deserialize to/from `type`
     pub iface_type: InterfaceType,
     #[serde(default = "default_state")]
     /// Interface state. Default to [InterfaceState::Up] when applying.
     pub state: InterfaceState,
-    #[serde(default, skip_serializing_if = "InterfaceIdentifier::is_default")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Define network backend matching method on choosing network interface.
     /// Default to [InterfaceIdentifier::Name].
-    pub identifier: InterfaceIdentifier,
+    pub identifier: Option<InterfaceIdentifier>,
     /// When applying with `[InterfaceIdentifier::MacAddress]`,
     /// nmstate will store original desired interface name as `profile_name`
     /// here and store the real interface name as `name` property.

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -367,7 +367,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for iface in self.iter().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
                 && i.base_iface().profile_name.is_none()
         }) {
             let mac_address = match iface.base_iface().mac_address.as_deref() {
@@ -446,7 +446,7 @@ impl Interfaces {
     ) -> Result<(), NmstateError> {
         let mut changed_ifaces: Vec<Interface> = Vec::new();
         for cur_iface in current.kernel_ifaces.values().filter(|i| {
-            i.base_iface().identifier == InterfaceIdentifier::MacAddress
+            i.base_iface().identifier == Some(InterfaceIdentifier::MacAddress)
         }) {
             if let Some(profile_name) =
                 cur_iface.base_iface().profile_name.as_ref()
@@ -470,7 +470,7 @@ impl Interfaces {
                         };
 
                     new_iface.base_iface_mut().identifier =
-                        InterfaceIdentifier::MacAddress;
+                        Some(InterfaceIdentifier::MacAddress);
                     new_iface.base_iface_mut().mac_address =
                         cur_iface.base_iface().mac_address.clone();
                     new_iface.base_iface_mut().name =

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -128,7 +128,9 @@ pub struct InterfaceIpv4 {
     /// Whether IPv4 stack is enabled. When set to false, all IPv4 address will
     /// be removed from this interface.
     pub enabled: bool,
-    pub(crate) prop_list: Vec<&'static str>,
+    /// Indicate whether `enabled` is defined by user or learn from
+    /// default/current value.
+    pub enabled_defined: bool,
     /// Whether DHCPv4 is enabled.
     pub dhcp: Option<bool>,
     /// DHCPv4 client ID.
@@ -209,7 +211,7 @@ impl InterfaceIpv4 {
     }
 
     pub(crate) fn merge_ip(&mut self, current: &Self) {
-        if !self.prop_list.contains(&"enabled") {
+        if !self.enabled_defined {
             self.enabled = current.enabled;
         }
         if self.dhcp.is_none() && self.enabled {
@@ -237,7 +239,7 @@ impl InterfaceIpv4 {
 
     // Special action for generating merged state from desired and current.
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if !desired.prop_list.contains(&"enabled") {
+        if !desired.enabled_defined {
             self.enabled = current.enabled;
         }
         if desired.dhcp.is_none() && self.enabled {
@@ -391,20 +393,17 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
     {
         let v = serde_json::Value::deserialize(deserializer)?;
 
-        let prop_list = if let Some(v_map) = v.as_object() {
-            get_ip_prop_list(v_map)
-        } else {
-            Vec::new()
-        };
-        if prop_list.contains(&"autoconf") {
-            return Err(serde::de::Error::custom(
-                "autoconf is not allowed for IPv4",
-            ));
-        }
-        if prop_list.contains(&"dhcp_duid") {
-            return Err(serde::de::Error::custom(
-                "dhcp-duid is not allowed for IPv4",
-            ));
+        if let Some(v_map) = v.as_object() {
+            if v_map.contains_key("autoconf") {
+                return Err(serde::de::Error::custom(
+                    "autoconf is not allowed for IPv4",
+                ));
+            }
+            if v_map.contains_key("dhcp_duid") {
+                return Err(serde::de::Error::custom(
+                    "dhcp-duid is not allowed for IPv4",
+                ));
+            }
         }
 
         let ip: InterfaceIp = match serde_json::from_value(v) {
@@ -413,8 +412,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv4 {
                 return Err(serde::de::Error::custom(format!("{e}")));
             }
         };
-        let mut ret = Self::from(ip);
-        ret.prop_list = prop_list;
+        let ret = Self::from(ip);
         Ok(ret)
     }
 }
@@ -423,6 +421,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
     fn from(ip: InterfaceIp) -> Self {
         Self {
             enabled: ip.enabled.unwrap_or_default(),
+            enabled_defined: ip.enabled.is_some(),
             dhcp: ip.dhcp,
             addresses: ip.addresses,
             dhcp_client_id: ip.dhcp_client_id,
@@ -441,7 +440,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
 
 impl From<InterfaceIpv4> for InterfaceIp {
     fn from(ip: InterfaceIpv4) -> Self {
-        let enabled = if ip.prop_list.contains(&"enabled") {
+        let enabled = if ip.enabled_defined {
             Some(ip.enabled)
         } else {
             None
@@ -493,7 +492,7 @@ pub struct InterfaceIpv6 {
     /// Whether IPv6 stack is enable. When set to false, the IPv6 stack is
     /// disabled with IPv6 link-local address purged also.
     pub enabled: bool,
-    pub(crate) prop_list: Vec<&'static str>,
+    pub(crate) enabled_defined: bool,
     /// Whether DHCPv6 enabled.
     pub dhcp: Option<bool>,
     /// DHCPv6 Unique Identifier
@@ -720,7 +719,7 @@ impl InterfaceIpv6 {
 
     // Special action for generating merged state from desired and current.
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if !desired.prop_list.contains(&"enabled") {
+        if !desired.enabled_defined {
             self.enabled = current.enabled;
         }
         if desired.dhcp.is_none() && self.enabled {
@@ -745,7 +744,7 @@ impl InterfaceIpv6 {
     }
 
     pub(crate) fn merge_ip(&mut self, current: &Self) {
-        if !self.prop_list.contains(&"enabled") {
+        if !self.enabled_defined {
             self.enabled = current.enabled;
         }
         if self.dhcp.is_none() && self.enabled {
@@ -782,15 +781,12 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
     {
         let v = serde_json::Value::deserialize(deserializer)?;
 
-        let prop_list = if let Some(v_map) = v.as_object() {
-            get_ip_prop_list(v_map)
-        } else {
-            Vec::new()
-        };
-        if prop_list.contains(&"dhcp_client_id") {
-            return Err(serde::de::Error::custom(
-                "dhcp-client-id is not allowed for IPv6",
-            ));
+        if let Some(v_map) = v.as_object() {
+            if v_map.contains_key("dhcp_client_id") {
+                return Err(serde::de::Error::custom(
+                    "dhcp-client-id is not allowed for IPv6",
+                ));
+            }
         }
         let ip: InterfaceIp = match serde_json::from_value(v) {
             Ok(i) => i,
@@ -798,8 +794,7 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                 return Err(serde::de::Error::custom(format!("{e}")));
             }
         };
-        let mut ret = Self::from(ip);
-        ret.prop_list = prop_list;
+        let ret = Self::from(ip);
         Ok(ret)
     }
 }
@@ -808,6 +803,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
     fn from(ip: InterfaceIp) -> Self {
         Self {
             enabled: ip.enabled.unwrap_or_default(),
+            enabled_defined: ip.enabled.is_some(),
             dhcp: ip.dhcp,
             autoconf: ip.autoconf,
             addresses: ip.addresses,
@@ -829,7 +825,7 @@ impl From<InterfaceIp> for InterfaceIpv6 {
 
 impl From<InterfaceIpv6> for InterfaceIp {
     fn from(ip: InterfaceIpv6) -> Self {
-        let enabled = if ip.prop_list.contains(&"enabled") {
+        let enabled = if ip.enabled_defined {
             Some(ip.enabled)
         } else {
             None
@@ -1166,53 +1162,6 @@ fn validate_wait_ip(base_iface: &BaseInterface) -> Result<(), NmstateError> {
     }
 
     Ok(())
-}
-
-fn get_ip_prop_list(
-    map: &serde_json::Map<String, serde_json::Value>,
-) -> Vec<&'static str> {
-    let mut ret = Vec::new();
-
-    if map.contains_key("enabled") {
-        ret.push("enabled")
-    }
-    if map.contains_key("dhcp") {
-        ret.push("dhcp")
-    }
-    if map.contains_key("autoconf") {
-        ret.push("autoconf")
-    }
-    if map.contains_key("dhcp-client-id") {
-        ret.push("dhcp_client_id")
-    }
-    if map.contains_key("dhcp-duid") {
-        ret.push("dhcp_duid")
-    }
-    if map.contains_key("address") {
-        ret.push("addresses")
-    }
-    if map.contains_key("auto-dns") {
-        ret.push("auto_dns")
-    }
-    if map.contains_key("auto-gateway") {
-        ret.push("auto_gateway")
-    }
-    if map.contains_key("auto-routes") {
-        ret.push("auto_routes")
-    }
-    if map.contains_key("auto-route-table-id") {
-        ret.push("auto_table_id")
-    }
-    if map.contains_key("addr-gen-mode") {
-        ret.push("addr_gen_mode")
-    }
-    if map.contains_key("dhcp-send-hostname") {
-        ret.push("dhcp_send_hostname")
-    }
-    if map.contains_key("dhcp-custom-hostname") {
-        ret.push("dhcp_custom_hostname")
-    }
-    ret
 }
 
 pub(crate) fn sanitize_ip_network(

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -192,6 +192,16 @@ impl NetworkState {
         self
     }
 
+    /// Only available when [NetworkState::apply()].
+    /// When set to false, nmstate will refused to apply desired state if
+    /// non-nmstate tool is controlling the desired SR-IOV PF.
+    /// When set to true, nmstate will only warn user on this overlap.
+    /// Default is false.
+    pub fn set_allow_overlap_ext_sriov(&mut self, value: bool) -> &mut Self {
+        self.apply_options.allow_overlap_ext_sriov = value;
+        self
+    }
+
     /// Create empty [NetworkState]
     pub fn new() -> Self {
         Default::default()
@@ -351,6 +361,7 @@ pub struct NetworkStateApplyOption {
     pub(crate) no_commit: bool,
     pub(crate) timeout: Option<u32>,
     pub(crate) memory_only: bool,
+    pub(crate) allow_overlap_ext_sriov: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -102,19 +102,6 @@ pub(crate) fn np_iface_to_base_iface(
             Some(false)
         },
         ethtool: np_ethtool_to_nmstate(np_iface),
-        prop_list: vec![
-            "name",
-            "state",
-            "iface_type",
-            "ipv4",
-            "ipv6",
-            "mac_address",
-            "permanent_mac_address",
-            "controller",
-            "mtu",
-            "accept_all_mac_addresses",
-            "ethtool",
-        ],
         ..Default::default()
     };
     if !InterfaceType::SUPPORTED_LIST.contains(&base_iface.iface_type) {

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -12,19 +12,18 @@ pub(crate) fn np_ipv4_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv4> {
     if let Some(np_ip) = &np_iface.ipv4 {
-        let mut ip = InterfaceIpv4::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv4 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         let mut addresses = Vec::new();
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.dhcp = Some(true);
-                ip.prop_list.push("dhcp");
                 if running_config_only {
                     continue;
                 }
@@ -64,7 +63,7 @@ pub(crate) fn np_ipv4_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv4 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }
@@ -75,16 +74,16 @@ pub(crate) fn np_ipv6_to_nmstate(
     running_config_only: bool,
 ) -> Option<InterfaceIpv6> {
     if let Some(np_ip) = &np_iface.ipv6 {
-        let mut ip = InterfaceIpv6::default();
-        ip.prop_list.push("enabled");
-        ip.prop_list.push("addresses");
-        if np_ip.addresses.is_empty() {
-            ip.enabled = false;
+        let mut ip = InterfaceIpv6 {
+            enabled: !np_ip.addresses.is_empty(),
+            enabled_defined: true,
+            ..Default::default()
+        };
+
+        if !ip.enabled {
             return Some(ip);
         }
-        ip.enabled = true;
         if let Some(token) = np_ip.token.as_ref() {
-            ip.prop_list.push("token");
             ip.token = Some(token.to_string());
         }
 
@@ -92,7 +91,6 @@ pub(crate) fn np_ipv6_to_nmstate(
         for np_addr in &np_ip.addresses {
             if np_addr.valid_lft != "forever" {
                 ip.autoconf = Some(true);
-                ip.prop_list.push("autoconf");
                 if running_config_only {
                     continue;
                 }
@@ -132,7 +130,7 @@ pub(crate) fn np_ipv6_to_nmstate(
         // IP might just disabled
         Some(InterfaceIpv6 {
             enabled: false,
-            prop_list: vec!["enabled"],
+            enabled_defined: true,
             ..Default::default()
         })
     }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -30,7 +30,6 @@ pub(crate) fn nispor_retrieve(
 ) -> Result<NetworkState, NmstateError> {
     let mut net_state = NetworkState {
         hostname: get_hostname_state(),
-        prop_list: vec!["interfaces", "routes", "rules", "hostname"],
         ..Default::default()
     };
     let mut filter = nispor::NetStateFilter::default();

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -12,8 +12,9 @@ use super::super::{
     nm_dbus::{NmApi, NmConnection},
     profile::{perpare_nm_conns, PerparedNmConnections},
     query_apply::{
-        activate_nm_profiles, create_index_for_nm_conns_by_name_type,
-        deactivate_nm_profiles, delete_exist_profiles, delete_orphan_ovs_ports,
+        activate_nm_profiles, check_sriov_operator_overlap,
+        create_index_for_nm_conns_by_name_type, deactivate_nm_profiles,
+        delete_exist_profiles, delete_orphan_ovs_ports,
         dispatch::apply_dispatch_script,
         dns::{
             is_iface_dns_desired, purge_global_dns_config,
@@ -48,6 +49,8 @@ pub(crate) fn nm_apply(
     if !merged_state.apply_options.memory_only {
         delete_ifaces(&mut nm_api, merged_state)?;
     }
+
+    check_sriov_operator_overlap(merged_state)?;
 
     if let Some(hostname) = merged_state
         .hostname

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -237,7 +237,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using profile name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().profile_name.as_deref()
                     == Some(iface.name())
             {
@@ -251,7 +251,7 @@ fn delete_ifaces(
         // User might want to delete mac based interface using interface name
         if let Some(cur_iface) = &merged_iface.current {
             if cur_iface.base_iface().identifier
-                == InterfaceIdentifier::MacAddress
+                == Some(InterfaceIdentifier::MacAddress)
                 && cur_iface.base_iface().name.as_str() == iface.name()
             {
                 if let Some(mac) = cur_iface.base_iface().mac_address.as_ref() {

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -45,7 +45,7 @@ pub(crate) fn nm_apply(
     nm_api.set_checkpoint(checkpoint, timeout);
     nm_api.set_checkpoint_auto_refresh(true);
 
-    if !merged_state.memory_only {
+    if !merged_state.apply_options.memory_only {
         delete_ifaces(&mut nm_api, merged_state)?;
     }
 
@@ -55,7 +55,7 @@ pub(crate) fn nm_apply(
         .as_ref()
         .and_then(|c| c.config.as_ref())
     {
-        if merged_state.memory_only {
+        if merged_state.apply_options.memory_only {
             log::debug!(
                 "NM: Cannot change configure hostname in memory only mode, \
                 ignoring"
@@ -166,9 +166,9 @@ pub(crate) fn nm_apply(
     save_nm_profiles(
         &mut nm_api,
         nm_conns_to_store.as_slice(),
-        merged_state.memory_only,
+        merged_state.apply_options.memory_only,
     )?;
-    if !merged_state.memory_only {
+    if !merged_state.apply_options.memory_only {
         delete_exist_profiles(
             &mut nm_api,
             &exist_nm_conns,

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -112,8 +112,8 @@ pub(crate) fn nm_apply(
         } else if merged_state
             .dns
             .desired
-            .config
             .as_ref()
+            .and_then(|d| d.config.as_ref())
             .map(|c| c.is_purge())
             == Some(true)
         {

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -44,25 +44,12 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             parse_dhcp_opts(nm_ip_setting);
         InterfaceIpv4 {
             enabled,
+            enabled_defined: true,
             dhcp,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "dhcp_client_id",
-                "dns",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "auto_route_metric",
-                "rules",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate("", nm_ip_setting)),
             rules: nm_rules_to_nmstate(false, nm_ip_setting),
             dhcp_client_id: if enabled && dhcp == Some(true) {
@@ -113,28 +100,13 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             parse_dhcp_opts(nm_ip_setting);
         let mut ret = InterfaceIpv6 {
             enabled,
+            enabled_defined: true,
             dhcp,
             autoconf,
             auto_dns,
             auto_routes,
             auto_gateway,
             auto_table_id,
-            prop_list: vec![
-                "enabled",
-                "dhcp",
-                "autoconf",
-                "dns",
-                "rules",
-                "auto_dns",
-                "auto_routes",
-                "auto_gateway",
-                "auto_table_id",
-                "dhcp_duid",
-                "addr_gen_mode",
-                "auto_route_metric",
-                "dhcp_send_hostname",
-                "dhcp_custom_hostname",
-            ],
             dns: Some(nm_dns_to_nmstate(iface_name, nm_ip_setting)),
             rules: nm_rules_to_nmstate(true, nm_ip_setting),
             dhcp_duid: nm_dhcp_duid_to_nmstate(nm_ip_setting),
@@ -163,7 +135,6 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
         // on nispor kernel IPv6 token, we set IPv6 token based on information
         // provided by NM connection.
         if let Some(token) = nm_ip_setting.token.as_ref() {
-            ret.prop_list.push("token");
             ret.token = Some(token.to_string());
         }
         ret

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -11,6 +11,7 @@ mod mptcp;
 pub(crate) mod ovs;
 mod profile;
 mod route;
+mod sriov;
 mod user;
 mod veth;
 mod vlan;
@@ -32,6 +33,7 @@ pub(crate) use self::profile::{
     deactivate_nm_profiles, delete_exist_profiles, save_nm_profiles,
 };
 pub(crate) use self::route::is_route_removed;
+pub(crate) use self::sriov::check_sriov_operator_overlap;
 pub(crate) use self::user::get_description;
 pub(crate) use self::veth::is_veth_peer_changed;
 pub(crate) use self::vlan::is_vlan_changed;

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -122,9 +122,6 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
                 iface,
             ) {
                 base_iface.iface_type = InterfaceType::OvsInterface;
-                if !base_iface.prop_list.contains(&"iface_type") {
-                    base_iface.prop_list.push("iface_type");
-                }
                 oiface.base = base_iface;
             }
         }

--- a/rust/src/lib/nm/query_apply/sriov.rs
+++ b/rust/src/lib/nm/query_apply/sriov.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use serde::Deserialize;
+
+use crate::{ErrorKind, Interface, MergedNetworkState, NmstateError};
+
+const OCP_SRIOV_OPERATOR_CFG_DIR: &str = "/etc/sriov-operator/pci";
+
+pub(crate) fn check_sriov_operator_overlap(
+    state: &MergedNetworkState,
+) -> Result<(), NmstateError> {
+    let mut pf_list: HashSet<String> = HashSet::new();
+    for iface in state.interfaces.kernel_ifaces.values().filter_map(|i| {
+        if let Some(Interface::Ethernet(eth_iface)) = i.for_apply.as_ref() {
+            Some(eth_iface)
+        } else {
+            None
+        }
+    }) {
+        if iface
+            .ethernet
+            .as_ref()
+            .and_then(|e| e.sr_iov.as_ref())
+            .is_some()
+        {
+            pf_list.insert(iface.base.name.to_string());
+        }
+    }
+
+    let ex_pf_list = get_ocp_sriov_provider_pf_list();
+
+    let overlap_pfs: Vec<&str> = pf_list
+        .intersection(&ex_pf_list)
+        .map(String::as_str)
+        .collect();
+
+    if !overlap_pfs.is_empty() {
+        if state.apply_options.allow_overlap_ext_sriov {
+            log::warn!(
+                "Found OpenShift SRIOV-network operator also \
+                controlling PF interfaces in desired state: {}",
+                overlap_pfs.join(",")
+            );
+        } else {
+            return Err(NmstateError::new(
+                ErrorKind::SrIovOperatorOverlap,
+                format!(
+                    "Found OpenShift SRIOV-network operator also \
+                    controlling PF interfaces in desired state: {}, \
+                    you may pass `--allow-sriov-overlap` to nmstatectl or \
+                    call `NetworkState.set_allow_overlap_ext_sriov()`",
+                    overlap_pfs.join(",")
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn get_ocp_sriov_provider_pf_list() -> HashSet<String> {
+    let mut ret: HashSet<String> = HashSet::new();
+
+    if let Ok(fd) = std::fs::read_dir(OCP_SRIOV_OPERATOR_CFG_DIR) {
+        for dir in fd {
+            if let Some(pf) = dir.ok().and_then(|d| get_ocp_pf_name(&d)) {
+                ret.insert(pf);
+            }
+        }
+    }
+    ret
+}
+
+#[derive(Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+struct OcpSriovConf {
+    #[serde(rename = "numVfs")]
+    num_vfs: u32,
+    name: String,
+}
+
+fn get_ocp_pf_name(dir: &std::fs::DirEntry) -> Option<String> {
+    let file_path =
+        std::path::Path::new(OCP_SRIOV_OPERATOR_CFG_DIR).join(dir.path());
+
+    std::fs::File::open(file_path)
+        .ok()
+        .and_then(|fd| {
+            serde_json::from_reader::<std::fs::File, OcpSriovConf>(fd).ok()
+        })
+        .map(|c| c.name)
+}

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -89,7 +89,7 @@ pub(crate) fn iface_to_nm_connections(
 
     let base_iface = iface.base_iface();
     let exist_nm_conn =
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             get_exist_profile_by_profile_name(
                 exist_nm_conns,
                 base_iface
@@ -435,7 +435,8 @@ pub(crate) fn gen_nm_conn_setting(
     };
 
     if iface.iface_type() != InterfaceType::Ipsec
-        && iface.base_iface().identifier == InterfaceIdentifier::Name
+        && iface.base_iface().identifier.unwrap_or_default()
+            == InterfaceIdentifier::Name
     {
         nm_conn_set.iface_name = Some(iface.name().to_string());
     } else {

--- a/rust/src/lib/nm/settings/wired.rs
+++ b/rust/src/lib/nm/settings/wired.rs
@@ -18,7 +18,7 @@ pub(crate) fn gen_nm_wired_setting(
     let base_iface = iface.base_iface();
 
     if let Some(mac) = &base_iface.mac_address {
-        if base_iface.identifier == InterfaceIdentifier::MacAddress {
+        if base_iface.identifier == Some(InterfaceIdentifier::MacAddress) {
             nm_wired_set.mac_address = Some(mac.to_string());
         } else {
             nm_wired_set.cloned_mac_address = Some(mac.to_string());

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -26,11 +26,12 @@ use super::{
 };
 use crate::{
     BaseInterface, BondConfig, BondInterface, BondOptions, DummyInterface,
-    EthernetInterface, InfiniBandInterface, Interface, InterfaceIdentifier,
-    InterfaceState, InterfaceType, LinuxBridgeInterface, LoopbackInterface,
-    MacSecConfig, MacSecInterface, MacVlanInterface, MacVtapInterface,
-    NetworkState, NmstateError, OvsBridgeInterface, OvsInterface,
-    UnknownInterface, VlanInterface, VrfInterface, VxlanInterface,
+    EthernetInterface, HsrInterface, InfiniBandInterface, Interface,
+    InterfaceIdentifier, InterfaceState, InterfaceType, LinuxBridgeInterface,
+    LoopbackInterface, MacSecConfig, MacSecInterface, MacVlanInterface,
+    MacVtapInterface, NetworkState, NmstateError, OvsBridgeInterface,
+    OvsInterface, UnknownInterface, VlanInterface, VrfInterface,
+    VxlanInterface,
 };
 
 pub(crate) fn nm_retrieve(

--- a/rust/src/lib/ovsdb/apply.rs
+++ b/rust/src/lib/ovsdb/apply.rs
@@ -5,7 +5,7 @@ use crate::{ovsdb::db::OvsDbConnection, MergedNetworkState, NmstateError};
 pub(crate) fn ovsdb_apply(
     merged_state: &MergedNetworkState,
 ) -> Result<(), NmstateError> {
-    if merged_state.is_global_ovsdb_changed() {
+    if merged_state.ovsdb.is_changed {
         let mut cli = OvsDbConnection::new()?;
         cli.apply_global_conf(&merged_state.ovsdb)
     } else {

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -27,8 +27,6 @@ pub(crate) fn ovsdb_is_running() -> bool {
 
 pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
-    ret.prop_list.push("interfaces");
-    ret.prop_list.push("ovsdb");
     let mut cli = OvsDbConnection::new()?;
     let ovsdb_ifaces = cli.get_ovs_ifaces()?;
     let ovsdb_brs = cli.get_ovs_bridges()?;
@@ -72,7 +70,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
         }
     }
 
-    ret.ovsdb = cli.get_ovsdb_global_conf()?;
+    ret.ovsdb = Some(cli.get_ovsdb_global_conf()?);
 
     Ok(ret)
 }

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, InterfaceType, OvsDbIfaceConfig};
+use crate::{BaseInterface, InterfaceState, InterfaceType, OvsDbIfaceConfig};
 
 impl BaseInterface {
     pub(crate) fn sanitize_current_for_verify(&mut self) {
@@ -47,64 +47,59 @@ impl BaseInterface {
     }
 
     pub(crate) fn update(&mut self, other: &BaseInterface) {
-        if other.prop_list.contains(&"name") {
-            self.name = other.name.clone();
-        }
-        if other.prop_list.contains(&"description") {
+        if other.description.is_some() {
             self.description = other.description.clone();
         }
-        if other.prop_list.contains(&"iface_type")
-            && other.iface_type != InterfaceType::Unknown
-        {
+        if other.iface_type != InterfaceType::Unknown {
             self.iface_type = other.iface_type.clone();
         }
-        if other.prop_list.contains(&"state") {
+        if other.state != InterfaceState::Unknown {
             self.state = other.state;
         }
-        if other.prop_list.contains(&"mtu") {
+        if other.mtu.is_some() {
             self.mtu = other.mtu;
         }
-        if other.prop_list.contains(&"min_mtu") {
+        if other.min_mtu.is_some() {
             self.min_mtu = other.min_mtu;
         }
-        if other.prop_list.contains(&"max_mtu") {
+        if other.max_mtu.is_some() {
             self.max_mtu = other.max_mtu;
         }
-        if other.prop_list.contains(&"mac_address") {
+        if other.mac_address.is_some() {
             self.mac_address = other.mac_address.clone();
         }
-        if other.prop_list.contains(&"permanent_mac_address") {
+        if other.permanent_mac_address.is_some() {
             self.permanent_mac_address = other.permanent_mac_address.clone();
         }
-        if other.prop_list.contains(&"controller") {
+        if other.controller.is_some() {
             self.controller = other.controller.clone();
         }
-        if other.prop_list.contains(&"controller_type") {
+        if other.controller_type.is_some() {
             self.controller_type = other.controller_type.clone();
         }
-        if other.prop_list.contains(&"accept_all_mac_addresses") {
+        if other.accept_all_mac_addresses.is_some() {
             self.accept_all_mac_addresses = other.accept_all_mac_addresses;
         }
-        if other.prop_list.contains(&"ovsdb") {
+        if other.ovsdb.is_some() {
             self.ovsdb = other.ovsdb.clone();
         }
-        if other.prop_list.contains(&"ieee8021x") {
+        if other.ieee8021x.is_some() {
             self.ieee8021x = other.ieee8021x.clone();
         }
-        if other.prop_list.contains(&"lldp") {
+        if other.lldp.is_some() {
             self.lldp = other.lldp.clone();
         }
-        if other.prop_list.contains(&"ethtool") {
+        if other.ethtool.is_some() {
             self.ethtool = other.ethtool.clone();
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"wait_ip") {
+        if other.wait_ip.is_some() {
             self.wait_ip = other.wait_ip;
         }
 
-        if other.prop_list.contains(&"ipv4") {
+        if other.ipv4.is_some() {
             if let Some(ref other_ipv4) = other.ipv4 {
                 if let Some(ref mut self_ipv4) = self.ipv4 {
                     self_ipv4.update(other_ipv4);
@@ -114,7 +109,7 @@ impl BaseInterface {
             }
         }
 
-        if other.prop_list.contains(&"ipv6") {
+        if other.ipv6.is_some() {
             if let Some(ref other_ipv6) = other.ipv6 {
                 if let Some(ref mut self_ipv6) = self.ipv6 {
                     self_ipv6.update(other_ipv6);
@@ -123,21 +118,16 @@ impl BaseInterface {
                 }
             }
         }
-        if other.prop_list.contains(&"mptcp") {
+        if other.mptcp.is_some() {
             self.mptcp = other.mptcp.clone();
         }
-        if other.prop_list.contains(&"identifier") {
+        if other.identifier.is_some() {
             self.identifier = other.identifier;
         }
-        if other.prop_list.contains(&"profile_name") {
+        if other.profile_name.is_some() {
             self.profile_name = other.profile_name.clone();
         }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name)
-            }
-        }
-        if other.prop_list.contains(&"dispatch") {
+        if other.dispatch.is_some() {
             self.dispatch = other.dispatch.clone();
         }
     }

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -3,10 +3,7 @@
 use crate::{DnsState, ErrorKind, MergedDnsState, NmstateError};
 
 impl MergedDnsState {
-    pub(crate) fn verify(
-        &self,
-        current: &DnsState,
-    ) -> Result<(), NmstateError> {
+    pub(crate) fn verify(&self, current: DnsState) -> Result<(), NmstateError> {
         if !self.is_changed() {
             return Ok(());
         }

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -32,54 +32,48 @@ impl InterfaceIpv4 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
 
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_client_id") {
+        if other.dhcp_client_id.is_some() {
             self.dhcp_client_id = other.dhcp_client_id.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"allow_extra_address") {
+        if other.allow_extra_address.is_some() {
             self.allow_extra_address = other.allow_extra_address;
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }
@@ -124,61 +118,56 @@ impl InterfaceIpv6 {
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
-        if other.prop_list.contains(&"enabled") {
+        if other.enabled_defined {
             self.enabled = other.enabled;
         }
-        if other.prop_list.contains(&"dhcp") {
+        if other.dhcp.is_some() {
             self.dhcp = other.dhcp;
         }
-        if other.prop_list.contains(&"dhcp_duid") {
+        if other.dhcp_duid.is_some() {
             self.dhcp_duid = other.dhcp_duid.clone();
         }
-        if other.prop_list.contains(&"autoconf") {
+        if other.autoconf.is_some() {
             self.autoconf = other.autoconf;
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"addresses") {
+        if other.addresses.is_some() {
             self.addresses = other.addresses.clone();
         }
-        if other.prop_list.contains(&"auto_dns") {
+        if other.auto_dns.is_some() {
             self.auto_dns = other.auto_dns;
         }
-        if other.prop_list.contains(&"auto_gateway") {
+        if other.auto_gateway.is_some() {
             self.auto_gateway = other.auto_gateway;
         }
-        if other.prop_list.contains(&"auto_routes") {
+        if other.auto_routes.is_some() {
             self.auto_routes = other.auto_routes;
         }
-        if other.prop_list.contains(&"auto_table_id") {
+        if other.auto_table_id.is_some() {
             self.auto_table_id = other.auto_table_id;
         }
-        if other.prop_list.contains(&"dns") {
+        if other.dns.is_some() {
             self.dns = other.dns.clone();
         }
-        if other.prop_list.contains(&"rules") {
+        if other.rules.is_some() {
             self.rules = other.rules.clone();
         }
-        if other.prop_list.contains(&"addr_gen_mode") {
+        if other.addr_gen_mode.is_some() {
             self.addr_gen_mode = other.addr_gen_mode.clone();
         }
-        if other.prop_list.contains(&"auto_route_metric") {
+        if other.auto_route_metric.is_some() {
             self.auto_route_metric = other.auto_route_metric;
         }
-        if other.prop_list.contains(&"token") {
+        if other.token.is_some() {
             self.token = other.token.clone();
         }
-        if other.prop_list.contains(&"dhcp_send_hostname") {
+        if other.dhcp_send_hostname.is_some() {
             self.dhcp_send_hostname = other.dhcp_send_hostname;
         }
-        if other.prop_list.contains(&"dhcp_custom_hostname") {
+        if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname = other.dhcp_custom_hostname.clone();
-        }
-        for other_prop_name in &other.prop_list {
-            if !self.prop_list.contains(other_prop_name) {
-                self.prop_list.push(other_prop_name);
-            }
         }
     }
 }

--- a/rust/src/lib/revert/dns.rs
+++ b/rust/src/lib/revert/dns.rs
@@ -3,11 +3,11 @@
 use crate::{DnsState, MergedDnsState};
 
 impl MergedDnsState {
-    pub(crate) fn generate_revert(&self) -> DnsState {
+    pub(crate) fn generate_revert(&self) -> Option<DnsState> {
         if self.is_changed() {
-            self.current.clone()
+            Some(self.current.clone())
         } else {
-            DnsState::new()
+            None
         }
     }
 }

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -21,7 +21,6 @@ impl NetworkState {
             ovsdb: merged_state.ovsdb.generate_revert(),
             ovn: merged_state.ovn.generate_revert(),
             hostname: merged_state.hostname.generate_revert(),
-            prop_list: vec!["interfaces"],
             ..Default::default()
         })
     }

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -7,12 +7,8 @@ impl NetworkState {
         &self,
         current: &Self,
     ) -> Result<Self, NmstateError> {
-        let merged_state = MergedNetworkState::new(
-            self.clone(),
-            current.clone(),
-            false,
-            false,
-        )?;
+        let merged_state =
+            MergedNetworkState::new(self.clone(), current.clone(), false)?;
         Ok(Self {
             interfaces: merged_state.interfaces.generate_revert()?,
             routes: merged_state.routes.generate_revert(),

--- a/rust/src/lib/revert/ovsdb.rs
+++ b/rust/src/lib/revert/ovsdb.rs
@@ -5,16 +5,18 @@ use std::collections::HashMap;
 use crate::{MergedOvsDbGlobalConfig, OvsDbGlobalConfig};
 
 impl MergedOvsDbGlobalConfig {
-    pub(crate) fn generate_revert(&self) -> OvsDbGlobalConfig {
+    pub(crate) fn generate_revert(&self) -> Option<OvsDbGlobalConfig> {
+        let desired = match self.desired.as_ref() {
+            Some(d) => d,
+            None => {
+                return None;
+            }
+        };
         let mut revert_external_ids: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for eid_key in self
-            .desired
-            .external_ids
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for eid_key in
+            desired.external_ids.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_external_ids.insert(
                 eid_key.to_string(),
@@ -30,12 +32,8 @@ impl MergedOvsDbGlobalConfig {
         let mut revert_other_configs: HashMap<String, Option<String>> =
             HashMap::new();
         let empty_hash: HashMap<String, Option<String>> = HashMap::new();
-        for cfg_key in self
-            .desired
-            .other_config
-            .as_ref()
-            .unwrap_or(&empty_hash)
-            .keys()
+        for cfg_key in
+            desired.other_config.as_ref().unwrap_or(&empty_hash).keys()
         {
             revert_other_configs.insert(
                 cfg_key.to_string(),
@@ -49,13 +47,13 @@ impl MergedOvsDbGlobalConfig {
         }
 
         if revert_external_ids.is_empty() && revert_other_configs.is_empty() {
-            OvsDbGlobalConfig::default()
+            None
         } else {
-            OvsDbGlobalConfig {
+            Some(OvsDbGlobalConfig {
                 external_ids: Some(revert_external_ids),
                 other_config: Some(revert_other_configs),
                 ..Default::default()
-            }
+            })
         }
     }
 }

--- a/rust/src/lib/statistic/feature/dns.rs
+++ b/rust/src/lib/statistic/feature/dns.rs
@@ -5,7 +5,9 @@ use crate::{MergedDnsState, NmstateFeature};
 impl MergedDnsState {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret = Vec::new();
-        if let Some(dns_config) = self.desired.config.as_ref() {
+        if let Some(dns_config) =
+            self.desired.as_ref().and_then(|d| d.config.as_ref())
+        {
             if dns_config.server.is_some() {
                 ret.push(NmstateFeature::StaticDnsNameServer);
             }

--- a/rust/src/lib/statistic/feature/iface.rs
+++ b/rust/src/lib/statistic/feature/iface.rs
@@ -8,7 +8,10 @@ use crate::{
 impl MergedInterface {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
         let mut ret: Vec<NmstateFeature> = Vec::new();
-        if self.desired.as_ref().map(|i| i.base_iface().identifier)
+        if self
+            .desired
+            .as_ref()
+            .and_then(|i| i.base_iface().identifier)
             == Some(InterfaceIdentifier::MacAddress)
         {
             ret.push(NmstateFeature::MacBasedIdentifier);

--- a/rust/src/lib/statistic/feature/ovs.rs
+++ b/rust/src/lib/statistic/feature/ovs.rs
@@ -7,7 +7,7 @@ use crate::{
 
 impl MergedOvsDbGlobalConfig {
     pub(crate) fn get_features(&self) -> Vec<NmstateFeature> {
-        if !self.desired.is_none() {
+        if self.desired.is_some() {
             vec![NmstateFeature::OvsDbGlobal]
         } else {
             Vec::new()

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -30,7 +30,7 @@ impl NetworkState {
                 .use_pseudo_sriov_vf_name(&mut current.interfaces);
         }
         let merged_state =
-            MergedNetworkState::new(self.clone(), current, false, false)?;
+            MergedNetworkState::new(self.clone(), current, false)?;
 
         features.append(&mut merged_state.interfaces.get_features());
         features.append(&mut merged_state.dns.get_features());

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -46,9 +46,9 @@ fn test_dns_verify_uncompressed_srvs() {
     )
     .unwrap();
 
-    let merged = MergedDnsState::new(desired, DnsState::new()).unwrap();
+    let merged = MergedDnsState::new(Some(desired), DnsState::new()).unwrap();
 
-    merged.verify(&current).unwrap();
+    merged.verify(current).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -47,7 +47,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 
@@ -85,7 +85,7 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
     )
     .unwrap();
 
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -126,7 +126,7 @@ fn test_two_dns_ipv6_link_local_iface() {
         ",
     )
     .unwrap();
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::NotImplementedError);
@@ -223,7 +223,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
         })
     };
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 }
@@ -266,7 +266,7 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -325,7 +325,7 @@ fn test_dns_prefer_desired_over_current() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -371,7 +371,7 @@ fn test_copy_ip_stack_if_marked_for_dns() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -24,8 +24,7 @@ fn test_add_routes_to_new_interface() {
     des_net_state.routes = gen_test_routes_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -89,8 +88,7 @@ fn test_wildcard_absent_routes() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -125,8 +123,7 @@ fn test_absent_routes_with_iface_only() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -192,7 +189,7 @@ routes:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
     store_route_config(&mut merged_state).unwrap();
 
     let br0_iface = merged_state

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -27,8 +27,7 @@ fn test_add_rules_to_new_interface() {
     des_net_state.rules = gen_test_rules_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
     store_route_rule_config(&mut merged_state).unwrap();
 
     let iface = merged_state
@@ -137,7 +136,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -217,7 +216,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -283,7 +282,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -355,7 +354,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 

--- a/rust/src/lib/unit_tests/ovsdb.rs
+++ b/rust/src/lib/unit_tests/ovsdb.rs
@@ -38,9 +38,12 @@ other_config:
 
     let current = get_current_ovsdb_config();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     let expect: OvsDbGlobalConfig = serde_yaml::from_str(
         r"---
@@ -79,9 +82,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -115,9 +121,12 @@ other_config:
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -151,9 +160,12 @@ other_config: {}
     )
     .unwrap();
 
-    let merged_ovsdb =
-        MergedOvsDbGlobalConfig::new(desired, current, &Default::default())
-            .unwrap();
+    let merged_ovsdb = MergedOvsDbGlobalConfig::new(
+        Some(desired),
+        current,
+        &Default::default(),
+    )
+    .unwrap();
 
     assert_eq!(
         &merged_ovsdb.external_ids,
@@ -172,11 +184,11 @@ fn test_ovsdb_verify_null_current() {
     let current = desired.clone();
 
     let merged_ovsdb = MergedOvsDbGlobalConfig::new(
-        desired,
+        Some(desired),
         pre_apply_current,
         &Default::default(),
     )
     .unwrap();
 
-    merged_ovsdb.verify(&current).unwrap();
+    merged_ovsdb.verify(current).unwrap();
 }

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -206,7 +206,6 @@ fn test_policy_capture_retain_only() {
     assert_eq!(state.dns, current.dns);
 
     state.dns = empty_state.dns.clone();
-    state.prop_list = Vec::new();
     assert_eq!(state, empty_state);
 }
 

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -249,7 +249,8 @@ fn test_policy_convert_dhcp_to_static_with_dns() {
     assert_eq!(routes[0].next_hop_iface, Some("eth1".to_string()));
     assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
     assert_eq!(routes[1].next_hop_iface, Some("eth1".to_string()));
-    let dns_config = state.dns.config.as_ref().unwrap();
+    let dns_config =
+        state.dns.as_ref().and_then(|d| d.config.as_ref()).unwrap();
     assert_eq!(
         dns_config.server,
         Some(vec![

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -91,6 +91,7 @@ def apply_net_state(
     save_to_disk=True,
     commit=True,
     rollback_timeout=60,
+    allow_overlap_ext_sriov=False,
 ):
     c_err_msg = c_char_p()
     c_err_kind = c_char_p()

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -384,8 +384,7 @@ def test_format_command():
             f"nmstatectl format {fd.name}".split(), check=True
         )[1]
         assert (
-            """
-interfaces:
+            """interfaces:
 - name: bond99
   type: bond
   state: up


### PR DESCRIPTION
When nmstate found desired state contains PF SRIOV setting which is already
controlled by OpenShift SRIOV network operator[1], nmstate will refuse to
apply the state.

This can be bypassed by `NetworkState.set_allow_overlap_ext_sriov()` or
`nmstatectl apply --allow-sriov-overlap`.

[1]: By checking /etc//etc/sriov-operator/pci folder