### PR TITLE
ip: Support assigning static routes to interface without addresses

### DIFF
--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -878,7 +878,6 @@ def test_remove_all_ip_address(setup_eth1_static_ip):
         ]
     }
     libnmstate.apply(desired_state)
-    # Nmstate should auto convert empty IPv4 address to disabled IPv4.
     desired_state[Interface.KEY][0][Interface.IPV4][
         InterfaceIPv4.ENABLED
     ] = False


### PR DESCRIPTION
OpenShift MetalLB team requests to configure additional routes whenever the nodes does not have a configured IP address or route for the subnet in which MetalLB issues addresses.

Note in linux network stack, it does not matter what interface you add the address on a node (for example, loopback), the kernel is always processing arp-requests and sending arp-replies to any of them, this behavior is considered correct and, moreover, it is widely used in the a dynamic environment as Kubernetes.

https://issues.redhat.com/browse/RHEL-4908