### PR TITLE
route: Allow route destination `0.0.0.0/8` when route type is specified

### DIFF
--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -71,15 +71,8 @@ impl Routes {
         // for route with route type `Blackhole`, `Unreachable`, `Prohibit`.
         if let Some(config_routes) = self.config.as_ref() {
             for route in config_routes.iter() {
-                let no_nexthop_route_type = [
-                    RouteType::Blackhole,
-                    RouteType::Unreachable,
-                    RouteType::Prohibit,
-                ];
                 if !route.is_absent() {
-                    if route.route_type.is_some()
-                        && no_nexthop_route_type
-                            .contains(&route.route_type.unwrap())
+                    if !route.is_unicast()
                         && (route.next_hop_iface.is_some()
                             && route.next_hop_iface
                                 != Some(LOOPBACK_IFACE_NAME.to_string())
@@ -94,9 +87,7 @@ impl Routes {
                             ),
                         ));
                     } else if route.next_hop_iface.is_none()
-                        && (route.route_type.is_none()
-                            || !no_nexthop_route_type
-                                .contains(&route.route_type.unwrap()))
+                        && route.is_unicast()
                     {
                         return Err(NmstateError::new(
                             ErrorKind::NotImplementedError,
@@ -107,9 +98,7 @@ impl Routes {
                         ));
                     }
                 }
-                if let Some(dst) = route.destination.as_deref() {
-                    validate_route_dst(dst)?;
-                }
+                validate_route_dst(route)?;
             }
         }
         Ok(())
@@ -216,6 +205,7 @@ impl std::fmt::Display for RouteType {
     }
 }
 
+const RTN_UNICAST: u8 = 1;
 const RTN_BLACKHOLE: u8 = 6;
 const RTN_UNREACHABLE: u8 = 7;
 const RTN_PROHIBIT: u8 = 8;
@@ -348,6 +338,11 @@ impl RouteEntry {
     pub(crate) fn is_ipv6(&self) -> bool {
         self.destination.as_ref().map(|d| is_ipv6_addr(d.as_str()))
             == Some(true)
+    }
+
+    pub(crate) fn is_unicast(&self) -> bool {
+        self.route_type.is_none()
+            || u8::from(self.route_type.unwrap()) == RTN_UNICAST
     }
 }
 
@@ -612,48 +607,51 @@ impl MergedRoutes {
 
 // Validating if the route destination network is valid,
 // 0.0.0.0/8 and its subnet cannot be used as the route destination network
-fn validate_route_dst(dst: &str) -> Result<(), NmstateError> {
-    if !is_ipv6_addr(dst) {
-        let ip_net: Vec<&str> = dst.split('/').collect();
-        let ip_addr = Ipv4Addr::from_str(ip_net[0])?;
-        if ip_addr.octets()[0] == 0 {
-            if dst.contains('/') {
-                let prefix = match ip_net[1].parse::<i32>() {
-                    Ok(p) => p,
-                    Err(_) => {
-                        return Err(NmstateError::new(
+// for unicast route
+fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
+    if let Some(dst) = route.destination.as_deref() {
+        if !is_ipv6_addr(dst) {
+            let ip_net: Vec<&str> = dst.split('/').collect();
+            let ip_addr = Ipv4Addr::from_str(ip_net[0])?;
+            if ip_addr.octets()[0] == 0 {
+                if dst.contains('/') {
+                    let prefix = match ip_net[1].parse::<i32>() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "The prefix of the route destination network \
+                                    '{dst}' is invalid"
+                                ),
+                            ));
+                        }
+                    };
+                    if prefix >= 8 && route.is_unicast() {
+                        let e = NmstateError::new(
                             ErrorKind::InvalidArgument,
-                            format!(
-                                "The prefix of the route destination network \
-                                '{dst}' is invalid"
-                            ),
-                        ));
+                            "0.0.0.0/8 and its subnet cannot be used as \
+                            the route destination for unicast route, please use \
+                            the default gateway 0.0.0.0/0 instead"
+                                .to_string(),
+                        );
+                        log::error!("{}", e);
+                        return Err(e);
                     }
-                };
-                if prefix >= 8 {
+                } else if route.is_unicast() {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         "0.0.0.0/8 and its subnet cannot be used as \
-                        the route destination, please use the default \
-                        gateway 0.0.0.0/0 instead"
+                        the route destination for unicast route, please use \
+                        the default gateway 0.0.0.0/0 instead"
                             .to_string(),
                     );
                     log::error!("{}", e);
                     return Err(e);
                 }
-            } else {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "0.0.0.0/8 and its subnet cannot be used as \
-                    the route destination, please use the default \
-                    gateway 0.0.0.0/0 instead"
-                        .to_string(),
-                );
-                log::error!("{}", e);
-                return Err(e);
             }
+            return Ok(());
         }
-        return Ok(());
     }
     Ok(())
 }

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -161,6 +161,10 @@ def test_add_static_route_with_route_type(eth1_up):
             Route.DESTINATION: "198.51.100.0/24",
             Route.ROUTETYPE: Route.ROUTETYPE_PROHIBIT,
         },
+        {
+            Route.DESTINATION: "0.0.0.0/8",
+            Route.ROUTETYPE: Route.ROUTETYPE_BLACKHOLE,
+        },
     ]
     libnmstate.apply(
         {
@@ -173,6 +177,7 @@ def test_add_static_route_with_route_type(eth1_up):
     assert IPV4_TEST_NET1 in routes_output4
     assert Route.ROUTETYPE_BLACKHOLE in routes_output4
     assert "198.51.100.0/24" in routes_output4
+    assert "0.0.0.0/8" in routes_output4
     assert Route.ROUTETYPE_PROHIBIT in routes_output4
     assert IPV6_TEST_NET1 in routes_output6
     assert Route.ROUTETYPE_UNREACHABLE in routes_output6


### PR DESCRIPTION
According to RFC6890, `0.0.0.0/8` and its subnet cannot be used as the route destination except for the route type is unreachable, blackhole or prohibit.