### PR TITLE
manpage: Fix incorrect document on `nmstatectl service`

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -118,8 +118,7 @@ displays nmstate version.
 .RS
 Apply all network state files ending with \fB.yml\fR in specified(
 default: \fB/etc/nmstate\fR) folder.
-The applied network state file will be renamed with postfix \fB.applied\fR
-to prevent repeated applied on next run.
+Please refer to manpage \fBnmstate.service(8)\fR for detail.
 .RE
 
 .PP


### PR DESCRIPTION
Instead of duplicating the explanation of `nmstatectl.service`, changed
the explanation of `nmstatectl service` to:

    Please refer to manpage `nmstate.service(8)` for detail.