### PR TITLE
service: Use content instead of checksum

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -9,8 +9,8 @@ nmstate\&.service
 nmstate\&.service invokes \fBnmstatectl service\fR command which
 apply all network state files ending with \fB.yml\fR in
 \fB/etc/nmstate\fR folder.
-The applied network state file sha256 digest will be stored at \fB.applied\fR
-file to prevent repeated applied on next service start.
+The applied network state file will be copied to new file with \fB.applied\fR
+postfix to prevent repeated applied on next service start.
 .SH BUG REPORTS
 Report bugs on nmstate GitHub issues <https://github.com/nmstate/nmstate>.
 .SH COPYRIGHT

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -28,7 +28,6 @@ ctrlc = { version = "3.2.1", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
 chrono = "0.4"
 nispor = { version = "1.2", optional = true }
-ring = "0.17.7"
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import hashlib
 from pathlib import Path
 
 import yaml
@@ -75,13 +74,6 @@ TEST_CONFIG3_APPLIED_FILE_PATH = f"{CONFIG_DIR}/03-nmstate-policy-test.applied"
 DUMMY1 = "dummy1"
 
 
-def sha256sum(filename):
-    with open(filename, "rb", buffering=0) as f:
-        digest = hashlib.sha256()
-        digest.update(f.read())
-        return digest.hexdigest()
-
-
 @pytest.fixture
 def nmstate_etc_config():
     if not os.path.isdir(CONFIG_DIR):
@@ -123,12 +115,14 @@ def test_nmstate_service_apply(nmstate_etc_config):
     assert_state_match(desire_state)
 
     assert os.path.isfile(TEST_CONFIG1_FILE_PATH)
-    assert Path(TEST_CONFIG1_APPLIED_FILE_PATH).read_text() == sha256sum(
-        TEST_CONFIG1_FILE_PATH
+    assert (
+        Path(TEST_CONFIG1_APPLIED_FILE_PATH).read_text()
+        == Path(TEST_CONFIG1_FILE_PATH).read_text()
     )
     assert os.path.isfile(TEST_CONFIG2_FILE_PATH)
-    assert Path(TEST_CONFIG2_APPLIED_FILE_PATH).read_text() == sha256sum(
-        TEST_CONFIG2_FILE_PATH
+    assert (
+        Path(TEST_CONFIG2_APPLIED_FILE_PATH).read_text()
+        == Path(TEST_CONFIG2_FILE_PATH).read_text()
     )
 
 
@@ -169,8 +163,9 @@ def test_nmstate_service_apply_nmpolicy(dummy1_up):
         exec_cmd("systemctl restart nmstate".split(), check=True)
         assert_absent(DUMMY1)
         assert os.path.isfile(TEST_CONFIG3_FILE_PATH)
-        assert Path(TEST_CONFIG3_APPLIED_FILE_PATH).read_text() == sha256sum(
-            TEST_CONFIG3_FILE_PATH
+        assert (
+            Path(TEST_CONFIG3_APPLIED_FILE_PATH).read_text()
+            == Path(TEST_CONFIG3_FILE_PATH).read_text()
         )
     finally:
         os.remove(TEST_CONFIG3_APPLIED_FILE_PATH)


### PR DESCRIPTION
Using checksum for the .applied file breaks backward compatibility and introduce at new crypto library with possible CVEs.

This changes replace that by copying the content instead of calculating the checksum.

Closes https://github.com/nmstate/nmstate/issues/2539