### PR TITLE
cli service: Allow user to opt-in on not deleting applied file

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -9,8 +9,20 @@ nmstate\&.service
 nmstate\&.service invokes \fBnmstatectl service\fR command which
 apply all network state files ending with \fB.yml\fR in
 \fB/etc/nmstate\fR folder.
-The applied network state file will be copied to new file with \fB.applied\fR
-postfix to prevent repeated applied on next service start.
+By default, the network state file will be renamed with the suffix
+\fB.applied\fR after applying it. This is to prevent it being applied again
+when the service runs next.
+
+With \fB/etc/nmstate/nmstate.conf\fR holding below content:
+
+\fB
+[service]
+keep_state_file_after_apply = true
+\fR
+
+The nmstate.service will not remove network state file, just copy applied
+network stata to file with the suffix \fB.applied\fR after applying it.
+
 .SH BUG REPORTS
 Report bugs on nmstate GitHub issues <https://github.com/nmstate/nmstate>.
 .SH COPYRIGHT

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -28,6 +28,7 @@ ctrlc = { version = "3.2.1", optional = true }
 uuid = { version = "1.1", features = ["v4"] }
 chrono = "0.4"
 nispor = { version = "1.2", optional = true }
+toml = "0.8.10"
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -451,6 +451,8 @@ fn main() {
         log_builder.init();
     }
 
+    log::info!("Nmstate version: {}", clap::crate_version!());
+
     if let Some(matches) = matches.subcommand_matches(SUB_CMD_GEN_CONF) {
         if let Some(file_path) = matches.value_of("STATE_FILE") {
             print_result_and_exit(gen_conf(file_path));


### PR DESCRIPTION
Previously, we introduced new method on finding un-applied state YAML
files. It was a changed behaviour which break API.

This patch change `nmstatectl service` to original behaviour which just
rename applied YAML file with `.applied` postfix.

If you don't want the applied state been deleted, please place
`/etc/nmstate/nmstate.conf` (folder can be defined by `--config`
argument) with content of:

```toml
[service]
delete_applied = false
```

Manpage updated.

Integration test case included.