### PR TITLE
controller: Fix incorrect ports name matching when validating ports

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -68,7 +68,7 @@ impl MergedInterfaces {
                         continue;
                     }
                     if let Some(ports) = ctrl_iface.merged.ports() {
-                        if !ports.contains(&des_ctrl_name.as_str()) {
+                        if !ports.contains(&merged_iface.merged.name()) {
                             return Err(NmstateError::new(
                                 ErrorKind::InvalidArgument,
                                 format!(

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -453,6 +453,31 @@ fn test_overbook_swap_port_of_bond() {
 }
 
 #[test]
+fn test_iface_controller_not_conflict_with_bond_ports() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+- name: bond0
+  type: bond
+  state: up
+  link-aggregation:
+    mode: balance-rr
+  controller: br0
+- name: br0
+  type: ovs-bridge
+  state: up
+  bridge:
+    port:
+      - name: bond0
+",
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, Interfaces::new(), false, false);
+    assert!(result.is_ok());
+}
+
+#[test]
 fn test_iface_controller_conflict_with_bond_ports() {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_eth_iface("eth0"));


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/RHEL-1414