### PR TITLE
Revert bad words reintroduced in the project

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -736,15 +736,6 @@ impl Interface {
             iface.change_port_name(org_port_name, new_port_name);
         }
     }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        match self {
-            Interface::OvsBridge(iface) => iface.post_deserialize_cleanup(),
-            Interface::Bond(iface) => iface.post_deserialize_cleanup(),
-            Interface::LinuxBridge(iface) => iface.post_deserialize_cleanup(),
-            _ => (),
-        }
-    }
 }
 
 // The default on enum is experimental, but clippy is suggestion we use

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -376,12 +376,6 @@ impl BondInterface {
         }
         ret
     }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if let Some(i) = self.bond.as_mut() {
-            i.post_deserialize_cleanup()
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
@@ -483,16 +477,9 @@ pub struct BondConfig {
     pub options: Option<BondOptions>,
     #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     /// Deserialize and serialize from/to `port`.
-    /// You can also use `ports` or `slaves`(deprecated) for deserializing.
+    /// You can also use `ports` for deserializing.
     /// When applying, if defined, it will override current port list.
     pub port: Option<Vec<String>>,
-    // Deprecated, please use `ports`, this is only for backwards compatibility
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        rename = "port",
-        alias = "slaves"
-    )]
-    pub(crate) slaves: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Deserialize and serialize from/to `ports-config`.
     /// When applying, if defined, it will override current ports
@@ -506,16 +493,6 @@ pub struct BondConfig {
 impl BondConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if self.slaves.as_ref().is_some() {
-            log::warn!(
-                "The `slaves` is deprecated, please replace with `ports`."
-            );
-            self.port = self.slaves.clone();
-            self.slaves = None;
-        }
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -629,14 +629,6 @@ impl MergedInterfaces {
             MergedInterface,
         > = HashMap::new();
 
-        for iface in desired
-            .kernel_ifaces
-            .values_mut()
-            .chain(desired.user_ifaces.values_mut())
-        {
-            iface.post_deserialize_cleanup();
-        }
-
         if gen_conf_mode {
             desired.set_unknown_iface_to_eth()?;
             desired.set_missing_port_to_eth();

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -339,12 +339,6 @@ impl LinuxBridgeInterface {
             }
         }
     }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if let Some(i) = self.bridge.as_mut() {
-            i.post_deserialize_cleanup()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -359,30 +353,12 @@ pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none", alias = "ports")]
     /// Linux bridge ports. When applying, desired port list will __override__
     /// current port list.
-    /// Serialize to 'port'. Deserialize from `port` or `ports`.
     pub port: Option<Vec<LinuxBridgePortConfig>>,
-    // Deprecated, please use `ports`, this is only for backwards compatibility
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        rename = "port",
-        alias = "slaves"
-    )]
-    pub(crate) slaves: Option<Vec<LinuxBridgePortConfig>>,
 }
 
 impl LinuxBridgeConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if self.slaves.as_ref().is_some() {
-            log::warn!(
-                "The `slaves` is deprecated, please replace with `ports`."
-            );
-            self.port = self.slaves.clone();
-            self.slaves = None;
-        }
     }
 }
 

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -285,13 +285,6 @@ impl OvsBridgeConfig {
             self.ports = self.slaves.clone();
             self.slaves = None;
         }
-        if let Some(ports) = self.ports.as_mut() {
-            for port in ports {
-                if let Some(bond_conf) = port.bond.as_mut() {
-                    bond_conf.post_deserialize_cleanup();
-                }
-            }
-        }
     }
 
     pub(crate) fn sanitize(
@@ -511,7 +504,6 @@ impl OvsInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
 #[non_exhaustive]
 /// The example yaml output of OVS bond:
 /// ```yml
@@ -547,13 +539,6 @@ pub struct OvsBridgeBondConfig {
     )]
     /// Serialize to 'port'. Deserialize from `port` or `ports`.
     pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
-    // Deprecated, please use `ports`, this is only for backwards compatibility
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        rename = "port",
-        alias = "slaves"
-    )]
-    pub(crate) slaves: Option<Vec<OvsBridgeBondPortConfig>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
@@ -582,16 +567,6 @@ pub struct OvsBridgeBondConfig {
 impl OvsBridgeBondConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if self.slaves.as_ref().is_some() {
-            log::warn!(
-                "The `slaves` is deprecated, please replace with `ports`."
-            );
-            self.ports = self.slaves.clone();
-            self.slaves = None;
-        }
     }
 
     pub(crate) fn ports(&self) -> Vec<&str> {

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -598,23 +598,3 @@ fn test_disable_balance_slb_valid_override_current() {
         MergedInterface::new(Some(des_iface), Some(cur_iface)).unwrap();
     merged_iface.post_inter_ifaces_process_bond().unwrap();
 }
-
-#[test]
-fn test_bond_deprecated_prop() {
-    let mut iface: BondInterface = serde_yaml::from_str(
-        r"---
-        name: bond99
-        type: bond
-        state: up
-        link-aggregation:
-          mode: balance-xor
-          slaves:
-          - eth1
-          - eth2",
-    )
-    .unwrap();
-
-    iface.post_deserialize_cleanup();
-
-    assert_eq!(iface.ports(), Some(vec!["eth1", "eth2"]));
-}

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -719,23 +719,3 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
     assert_eq!(desired_old, expected);
     assert_eq!(desired_new, expected);
 }
-
-#[test]
-fn test_linux_bridge_deprecated_prop() {
-    let mut iface: LinuxBridgeInterface = serde_yaml::from_str(
-        r"
-        name: br0
-        type: linux-bridge
-        state: up
-        bridge:
-          slaves:
-            - name: eth1
-            - name: eth2
-        ",
-    )
-    .unwrap();
-
-    iface.post_deserialize_cleanup();
-
-    assert_eq!(iface.ports(), Some(vec!["eth1", "eth2"]));
-}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -903,26 +903,6 @@ fn test_ovs_stp_option_as_bool() {
 }
 
 #[test]
-fn test_ovs_bridge_deprecated_prop() {
-    let mut iface: OvsBridgeInterface = serde_yaml::from_str(
-        r"---
-        name: br0
-        type: ovs-bridge
-        state: up
-        bridge:
-          slaves:
-          - name: eth1
-          options:
-            stp: true",
-    )
-    .unwrap();
-
-    iface.post_deserialize_cleanup();
-
-    assert_eq!(iface.ports(), Some(vec!["eth1"]));
-}
-
-#[test]
 fn test_ovs_iface_serialize_allow_extra_patch_ports() {
     let desired: OvsBridgeInterface = serde_yaml::from_str(
         r#"---

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -944,34 +944,3 @@ fn test_ovs_iface_serialize_allow_extra_patch_ports() {
 
     assert_eq!(desired, new);
 }
-
-#[test]
-fn test_ovs_bond_using_deprecated_prop() {
-    let mut iface: OvsBridgeInterface = serde_yaml::from_str(
-        r#"---
-        name: br1
-        type: ovs-bridge
-        state: up
-        bridge:
-          options:
-            stp: "true"
-            rstp: "false"
-            mcast-snooping-enable: "false"
-          slaves:
-          - name: bond1
-            link-aggregation:
-              mode: balance-slb
-              slaves:
-              - name: eth2
-              - name: eth1"#,
-    )
-    .unwrap();
-
-    iface.post_deserialize_cleanup();
-
-    let br_conf = iface.bridge.unwrap();
-    let port_conf = &br_conf.ports.as_ref().unwrap()[0];
-    let bond_conf = port_conf.bond.as_ref().unwrap();
-    assert_eq!(bond_conf.ports(), vec!["eth2", "eth1"]);
-    assert!(bond_conf.slaves.is_none());
-}

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-import copy
 import os
 import time
 
@@ -1332,19 +1331,6 @@ def test_change_bond_option_arp_missed_max(bond99_with_2_port):
     bond_options["arp_missed_max"] = 200
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
-
-
-def test_bond_deprecated_prop(eth1_up, eth2_up):
-    with bond_interface(
-        name=BOND99, port=["eth1", "eth2"], create=False
-    ) as state:
-        original_state = copy.deepcopy(state)
-        state[Interface.KEY][0][Bond.CONFIG_SUBTREE]["slaves"] = state[
-            Interface.KEY
-        ][0][Bond.CONFIG_SUBTREE].pop(Bond.PORT)
-
-        libnmstate.apply(state)
-        assertlib.assert_state_match(original_state)
 
 
 def test_change_mtu_of_bond_port(bond99_with_2_port):

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1290,17 +1290,3 @@ def test_controller_detach_from_linux_bridge(bridge0_with_port0):
         )
         == 0
     )
-
-
-def test_linux_bridge_deprecated_prop(eth1_up, eth2_up):
-    bridge_state = _create_bridge_subtree_config(("eth1", "eth2"))
-    with linux_bridge(TEST_BRIDGE0, bridge_state, create=False) as state:
-        original_state = deepcopy(state)
-
-        state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE]["slaves"] = state[
-            Interface.KEY
-        ][0][LinuxBridge.CONFIG_SUBTREE].pop(LinuxBridge.PORT_SUBTREE)
-
-        libnmstate.apply(state)
-
-        assertlib.assert_state_match(original_state)

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from contextlib import contextmanager
-from copy import deepcopy
 import os
 import pytest
 import yaml
@@ -2211,18 +2210,3 @@ def test_raise_error_on_unknown_ovsdb_global_section():
 def remove_ovn_state_present(state):
     for ovn_map in state.get(Ovn.BRIDGE_MAPPINGS, []):
         ovn_map.pop(Ovn.BridgeMappings.STATE, None)
-
-
-def test_ovs_bridge_deprecated_prop(eth1_up):
-    bridge = Bridge(BRIDGE1)
-    bridge.add_system_port("eth1")
-    bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
-    original_state = deepcopy(bridge.state)
-    bridge.bridge_iface[OVSBridge.CONFIG_SUBTREE][
-        "slaves"
-    ] = bridge.bridge_iface[OVSBridge.CONFIG_SUBTREE].pop(
-        OVSBridge.PORT_SUBTREE
-    )
-
-    with bridge.create():
-        assertlib.assert_state_match(original_state)

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -96,10 +96,6 @@ class Bridge:
     def ports_names(self):
         return [port[OVSBridge.Port.NAME] for port in self._get_ports()]
 
-    @property
-    def bridge_iface(self):
-        return self._bridge_iface
-
     def _add_port(self, name):
         self._bridge_iface[OVSBridge.CONFIG_SUBTREE].setdefault(
             OVSBridge.PORT_SUBTREE, []


### PR DESCRIPTION
Master and slave were deprecated in nmstate-0.4.1 for first time. They were supported during the whole nmstate-1 lifetime. When we branched out for nmstate-2 we decided to drop the support of these words.

Now they are back. If we must enforce our own decisions.