### PR TITLE
Revert "ovs: Add support of deprecated `slaves` property in ovs bond"

### DIFF
--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -285,13 +285,6 @@ impl OvsBridgeConfig {
             self.ports = self.slaves.clone();
             self.slaves = None;
         }
-        if let Some(ports) = self.ports.as_mut() {
-            for port in ports {
-                if let Some(bond_conf) = port.bond.as_mut() {
-                    bond_conf.post_deserialize_cleanup();
-                }
-            }
-        }
     }
 
     pub(crate) fn sanitize(
@@ -511,7 +504,6 @@ impl OvsInterface {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
 #[non_exhaustive]
 /// The example yaml output of OVS bond:
 /// ```yml
@@ -547,13 +539,6 @@ pub struct OvsBridgeBondConfig {
     )]
     /// Serialize to 'port'. Deserialize from `port` or `ports`.
     pub ports: Option<Vec<OvsBridgeBondPortConfig>>,
-    // Deprecated, please use `ports`, this is only for backwards compatibility
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        rename = "port",
-        alias = "slaves"
-    )]
-    pub(crate) slaves: Option<Vec<OvsBridgeBondPortConfig>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
@@ -582,16 +567,6 @@ pub struct OvsBridgeBondConfig {
 impl OvsBridgeBondConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub(crate) fn post_deserialize_cleanup(&mut self) {
-        if self.slaves.as_ref().is_some() {
-            log::warn!(
-                "The `slaves` is deprecated, please replace with `ports`."
-            );
-            self.ports = self.slaves.clone();
-            self.slaves = None;
-        }
     }
 
     pub(crate) fn ports(&self) -> Vec<&str> {

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -944,34 +944,3 @@ fn test_ovs_iface_serialize_allow_extra_patch_ports() {
 
     assert_eq!(desired, new);
 }
-
-#[test]
-fn test_ovs_bond_using_deprecated_prop() {
-    let mut iface: OvsBridgeInterface = serde_yaml::from_str(
-        r#"---
-        name: br1
-        type: ovs-bridge
-        state: up
-        bridge:
-          options:
-            stp: "true"
-            rstp: "false"
-            mcast-snooping-enable: "false"
-          slaves:
-          - name: bond1
-            link-aggregation:
-              mode: balance-slb
-              slaves:
-              - name: eth2
-              - name: eth1"#,
-    )
-    .unwrap();
-
-    iface.post_deserialize_cleanup();
-
-    let br_conf = iface.bridge.unwrap();
-    let port_conf = &br_conf.ports.as_ref().unwrap()[0];
-    let bond_conf = port_conf.bond.as_ref().unwrap();
-    assert_eq!(bond_conf.ports(), vec!["eth2", "eth1"]);
-    assert!(bond_conf.slaves.is_none());
-}


### PR DESCRIPTION
This reverts commit 9565b963d74ecf5f7cfe2468d4485a020e95cb03.