### PR TITLE
WIP: Support backend specific option

### DIFF
--- a/rust/src/cli/config.rs
+++ b/rust/src/cli/config.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+
+use serde::Deserialize;
+
+use crate::error::CliError;
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct Config {
+    #[serde(default)]
+    pub(crate) service: ServiceConfig,
+    #[serde(default)]
+    pub(crate) apply: ApplyConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ServiceConfig {
+    #[serde(default)]
+    pub(crate) keep_state_file_after_apply: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ApplyConfig {
+    #[serde(default)]
+    pub(crate) backend_options: Vec<String>,
+}
+
+impl Config {
+    pub(crate) const DEFAULT_CONFIG_FILE_NAME: &'static str = "nmstate.conf";
+    pub(crate) const DEFAULT_CONFIG_PATH: &'static str =
+        "/etc/nmstate/nmstate.conf";
+
+    pub(crate) fn load(path: &str) -> Result<Self, CliError> {
+        let path = std::path::Path::new(path);
+        if !path.exists() {
+            return Ok(Config::default());
+        }
+        let mut fd = std::fs::File::open(path)?;
+        let mut content = String::new();
+        fd.read_to_string(&mut content)?;
+        match toml::from_str::<Config>(&content) {
+            Ok(c) => {
+                log::info!("Configuration loaded:\n{content}");
+                Ok(c)
+            }
+            Err(e) => Err(CliError::from(format!(
+                "Failed to read configuration from {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+}

--- a/rust/src/cli/gen_conf.rs
+++ b/rust/src/cli/gen_conf.rs
@@ -1,10 +1,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::CliError, state::state_from_file};
+use crate::{config::Config, error::CliError, state::state_from_file};
 
-pub(crate) fn gen_conf(file_path: &str) -> Result<String, CliError> {
-    let net_state = state_from_file(file_path)?;
-    let confs = net_state.gen_conf()?;
-    let escaped_string = serde_yaml::to_string(&confs)?;
-    Ok(escaped_string.replace("\\n", "\n\n"))
+pub(crate) fn gen_conf(matches: &clap::ArgMatches) -> Result<String, CliError> {
+    if let Some(file_path) = matches.value_of("STATE_FILE") {
+        let mut net_state = state_from_file(file_path)?;
+        let backend_opts: Vec<String> =
+            match matches.try_get_one::<String>("BACKEND_OPTIONS") {
+                Ok(Some(t)) => t.split(',').map(|s| s.to_string()).collect(),
+                Ok(None) => {
+                    let config_path = if let Ok(Some(p)) =
+                        matches.try_get_one::<String>("CONFIG")
+                    {
+                        p.as_str()
+                    } else {
+                        Config::DEFAULT_CONFIG_PATH
+                    };
+
+                    let config = Config::load(config_path)?;
+                    config.apply.backend_options
+                }
+                Err(e) => {
+                    return Err(CliError {
+                        code: crate::error::EX_DATAERR,
+                        error_msg: e.to_string(),
+                    });
+                }
+            };
+        if !backend_opts.is_empty() {
+            net_state.set_backend_options(backend_opts);
+        }
+
+        let confs = net_state.gen_conf()?;
+        let escaped_string = serde_yaml::to_string(&confs)?;
+        Ok(escaped_string.replace("\\n", "\n\n"))
+    } else {
+        Err("Please define at least one STATE_FILE".into())
+    }
 }

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -20,8 +20,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             NetworkState::new(),
-            true,  // gen_conf mode
-            false, // memory only
+            true, // gen_conf mode
         )?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&merged_state)?);
         Ok(ret)

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -192,6 +192,15 @@ impl NetworkState {
         self
     }
 
+    /// Passing backend specific options. Currently only support:
+    ///  * `nm:refer_controller_parent_by_name`:  Instruct NetworkManager to use
+    ///    interface name instead of connection UUID when referring controller
+    ///    or parent.
+    pub fn set_backend_options(&mut self, value: Vec<String>) -> &mut Self {
+        self.apply_options.backend_options = value;
+        self
+    }
+
     /// Create empty [NetworkState]
     pub fn new() -> Self {
         Default::default()
@@ -351,6 +360,7 @@ pub struct NetworkStateApplyOption {
     pub(crate) no_commit: bool,
     pub(crate) timeout: Option<u32>,
     pub(crate) memory_only: bool,
+    pub(crate) backend_options: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/rust/src/lib/nm/backend_opt.rs
+++ b/rust/src/lib/nm/backend_opt.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const BACKEND_OPT_REF_BY_NAME: &str = "nm:refer_controller_parent_by_name";
+
+pub(crate) fn backend_opt_has_ref_by_name(backend_opts: &[String]) -> bool {
+    backend_opts.contains(&BACKEND_OPT_REF_BY_NAME.to_string())
+}

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -3,6 +3,7 @@
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
 use super::{
+    backend_opt::backend_opt_has_ref_by_name,
     dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
     profile::perpare_nm_conns,
     route::store_route_config,
@@ -39,6 +40,9 @@ pub(crate) fn nm_gen_conf(
         &Vec::new(),
         &Vec::new(),
         true, // gen_conf mode
+        backend_opt_has_ref_by_name(
+            merged_state.apply_options.backend_options.as_slice(),
+        ),
     )?
     .to_store;
 

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "query_apply")]
 mod active_connection;
+mod backend_opt;
 #[cfg(feature = "query_apply")]
 mod checkpoint;
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -23,6 +23,7 @@ pub(crate) fn perpare_nm_conns(
     exist_nm_conns: &[NmConnection],
     nm_acs: &[NmActiveConnection],
     gen_conf_mode: bool,
+    ref_by_name: bool,
 ) -> Result<PerparedNmConnections, NmstateError> {
     let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
@@ -108,19 +109,21 @@ pub(crate) fn perpare_nm_conns(
 
     fix_ip_dhcp_timeout(&mut nm_conns_to_update);
 
-    use_uuid_for_controller_reference(
-        &mut nm_conns_to_update,
-        &merged_state.interfaces,
-        exist_nm_conns,
-        nm_acs,
-    )?;
+    if !ref_by_name {
+        use_uuid_for_controller_reference(
+            &mut nm_conns_to_update,
+            &merged_state.interfaces,
+            exist_nm_conns,
+            nm_acs,
+        )?;
 
-    use_uuid_for_parent_reference(
-        &mut nm_conns_to_update,
-        &merged_state.interfaces,
-        exist_nm_conns,
-        nm_acs,
-    );
+        use_uuid_for_parent_reference(
+            &mut nm_conns_to_update,
+            &merged_state.interfaces,
+            exist_nm_conns,
+            nm_acs,
+        );
+    }
 
     Ok(PerparedNmConnections {
         to_store: nm_conns_to_update,

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use super::super::{
+    backend_opt::backend_opt_has_ref_by_name,
     device::create_index_for_nm_devs,
     dns::{
         cur_dns_ifaces_still_valid_for_dns, store_dns_config_to_iface,
@@ -142,6 +143,9 @@ pub(crate) fn nm_apply(
         exist_nm_conns.as_slice(),
         nm_acs.as_slice(),
         false,
+        backend_opt_has_ref_by_name(
+            merged_state.apply_options.backend_options.as_slice(),
+        ),
     )?;
 
     let nm_ac_uuids: Vec<&str> =

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -51,7 +51,7 @@ pub(crate) fn nm_apply(
     nm_api.set_checkpoint(checkpoint, timeout);
     nm_api.set_checkpoint_auto_refresh(true);
 
-    if !merged_state.memory_only {
+    if !merged_state.apply_options.memory_only {
         delete_ifaces(&mut nm_api, merged_state)?;
     }
 
@@ -61,7 +61,7 @@ pub(crate) fn nm_apply(
         .as_ref()
         .and_then(|c| c.config.as_ref())
     {
-        if merged_state.memory_only {
+        if merged_state.apply_options.memory_only {
             log::debug!(
                 "NM: Cannot change configure hostname in memory only mode, \
                 ignoring"
@@ -168,9 +168,9 @@ pub(crate) fn nm_apply(
     save_nm_profiles(
         &mut nm_api,
         nm_conns_to_store.as_slice(),
-        merged_state.memory_only,
+        merged_state.apply_options.memory_only,
     )?;
-    if !merged_state.memory_only {
+    if !merged_state.apply_options.memory_only {
         delete_exist_profiles(
             &mut nm_api,
             &exist_nm_conns,

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -7,12 +7,8 @@ impl NetworkState {
         &self,
         current: &Self,
     ) -> Result<Self, NmstateError> {
-        let merged_state = MergedNetworkState::new(
-            self.clone(),
-            current.clone(),
-            false,
-            false,
-        )?;
+        let merged_state =
+            MergedNetworkState::new(self.clone(), current.clone(), false)?;
         Ok(Self {
             interfaces: merged_state.interfaces.generate_revert()?,
             routes: merged_state.routes.generate_revert(),

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -30,7 +30,7 @@ impl NetworkState {
                 .use_pseudo_sriov_vf_name(&mut current.interfaces);
         }
         let merged_state =
-            MergedNetworkState::new(self.clone(), current, false, false)?;
+            MergedNetworkState::new(self.clone(), current, false)?;
 
         features.append(&mut merged_state.interfaces.get_features());
         features.append(&mut merged_state.dns.get_features());

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -47,7 +47,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 
@@ -85,7 +85,7 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
     )
     .unwrap();
 
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -126,7 +126,7 @@ fn test_two_dns_ipv6_link_local_iface() {
         ",
     )
     .unwrap();
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::NotImplementedError);
@@ -223,7 +223,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
         })
     };
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 }
@@ -266,7 +266,7 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -325,7 +325,7 @@ fn test_dns_prefer_desired_over_current() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -371,7 +371,7 @@ fn test_copy_ip_stack_if_marked_for_dns() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -24,8 +24,7 @@ fn test_add_routes_to_new_interface() {
     des_net_state.routes = gen_test_routes_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -89,8 +88,7 @@ fn test_wildcard_absent_routes() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -125,8 +123,7 @@ fn test_absent_routes_with_iface_only() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -192,7 +189,7 @@ routes:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
     store_route_config(&mut merged_state).unwrap();
 
     let br0_iface = merged_state

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -27,8 +27,7 @@ fn test_add_rules_to_new_interface() {
     des_net_state.rules = gen_test_rules_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
     store_route_rule_config(&mut merged_state).unwrap();
 
     let iface = merged_state
@@ -137,7 +136,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -217,7 +216,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -283,7 +282,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -355,7 +354,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 


### PR DESCRIPTION
Introducing `NetworkState::set_backend_options(Vec<String>)` allowing
user to pass arbitrary string to network backend when applying and
generate config. Currently, only support option is:

 * `nm:refer_controller_parent_by_name`:  Instruct NetworkManager to use
   interface name instead of connection UUID when referring controller
   or parent.

For CLI,
 * Both `apply` and `gc` command takes `--backend-options`.
 * If `--backend-options` not defined, will read config from
   `--config <config_path>` (default to `/etc/nmstate/nmstate.conf`)

Example config file:

```toml
[apply]
backend_options = ["nm:refer_controller_parent_by_name"]
```

TODO:
 * Need test to confirm whether refer by name still works on all use
   cases.