### PR TITLE
ipsec: Treat DHCPv4 off with no static address as IPv4 disabled

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -695,6 +695,7 @@ impl Interface {
             Interface::MacVtap(iface) => iface.sanitize(is_desired)?,
             Interface::Loopback(iface) => iface.sanitize(is_desired)?,
             Interface::MacSec(iface) => iface.sanitize(is_desired)?,
+            Interface::Ipsec(iface) => iface.sanitize(is_desired),
             _ => (),
         }
         Ok(())

--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -57,6 +57,27 @@ impl IpsecInterface {
             }
         }
     }
+
+    // * IPv4 `dhcp: false` with empty static address list should be considered
+    //   as IPv4 disabled.
+    pub(crate) fn sanitize(&mut self, is_desired: bool) {
+        if let Some(ipv4_conf) = self.base.ipv4.as_mut() {
+            if ipv4_conf.dhcp == Some(false)
+                && ipv4_conf.enabled
+                && ipv4_conf.enabled_defined
+            {
+                if is_desired {
+                    log::info!(
+                        "Treating IPv4 `dhcp: false` for IPSec interface {} \
+                        as IPv4 disabled",
+                        self.base.name.as_str(),
+                    );
+                }
+                ipv4_conf.enabled = false;
+                ipv4_conf.dhcp = None;
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/unit_tests/ipsec.rs
+++ b/rust/src/lib/unit_tests/ipsec.rs
@@ -137,3 +137,29 @@ fn test_parse_ipsec_interface_from_string_bool() {
         Some("no")
     );
 }
+
+#[test]
+fn test_ipsec_treat_dhcp_off_and_empty_ip_as_disabled() {
+    let mut iface = serde_yaml::from_str::<IpsecInterface>(
+        r"---
+          name: hosta_conn
+          type: ipsec
+          state: up
+          ipv4:
+            enabled: true
+            dhcp: false
+          libreswan:
+            ipsec-interface: 'no'
+            right: 192.0.2.253
+            rightid: '@hostb-psk.example.org'
+            left: 192.0.2.250
+            leftid: '@hosta-psk.example.org'
+            ikev2: insist
+            psk: TOP_SECRET",
+    )
+    .unwrap();
+
+    iface.sanitize(false);
+
+    assert!(!iface.base.ipv4.as_ref().unwrap().enabled);
+}


### PR DESCRIPTION
When user desired `dhcp: off` with no static address for IPSec interface,
nmstate will fail as verification error.

For IPSec connection, the DHCPv4 off with empty IP address should be
treated by IP disabled as we have no intention on supporting routes on
IPSec connection yet. The route should be set by IPSec daemon or to xfrm
interface.

Unit test case and integration test cases included.