### PR TITLE
Static routes auto ip

### DIFF
--- a/rust/src/lib/query_apply/mod.rs
+++ b/rust/src/lib/query_apply/mod.rs
@@ -26,3 +26,6 @@ mod sriov;
 mod vlan;
 mod vrf;
 mod vxlan;
+
+#[cfg(test)]
+pub(crate) use route::is_route_delayed_by_nm;

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -375,8 +375,11 @@ impl MergedNetworkState {
             .filter(|(_, t)| !t.is_userspace())
             .map(|(n, _)| n.as_str())
             .collect();
-        self.routes
-            .verify(&current.routes, ignored_kernel_ifaces.as_slice())?;
+        self.routes.verify(
+            &current.routes,
+            ignored_kernel_ifaces.as_slice(),
+            &current.interfaces,
+        )?;
         self.rules
             .verify(&current.rules, ignored_kernel_ifaces.as_slice())?;
         self.dns.verify(current.dns.clone().unwrap_or_default())?;

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -279,12 +279,17 @@ fn new_test_nic2_with_static_ip() -> Interface {
     .unwrap()
 }
 
-pub(crate) fn gen_merged_ifaces_for_route_test() -> MergedInterfaces {
+pub(crate) fn gen_merged_ifaces_for_route_test(
+) -> (MergedInterfaces, Interfaces) {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_test_nic_with_static_ip());
     ifaces.push(new_test_nic2_with_static_ip());
     let mut current = Interfaces::new();
     current.push(new_eth_iface("eth1"));
     current.push(new_eth_iface("eth2"));
-    MergedInterfaces::new(ifaces, current, false, false).unwrap()
+
+    let merged =
+        MergedInterfaces::new(ifaces, current.clone(), false, false).unwrap();
+
+    (merged, current)
 }


### PR DESCRIPTION
NetworkManager doesn't add the routes until the interface gets at least
one IP. If static routes and auto IP are configured, nmstate fails the
verification if the DHCP request hasn't completed because NM hasn't
added the route yet.

However, it's very difficult to understand the reason of the failure for a user,
let's add a warning message explaining it.

Resolves: https://issues.redhat.com/browse/RHEL-15086