### PR TITLE
statistic: Allowing input multiple desire states

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -21,6 +21,9 @@ nmstatectl \- A nmstate command line tool
 .br
 .B nmstatectl service \fR[\fI-c, --config <CONFIG_FOLDER>\fR]
 .br
+.B nmstatectl statistic \fISTATE_FILE_PATH\fR [\fI-c, --current
+<CURRENT_STATE_FILE>\fR]
+.br
 .B nmstatectl version
 .br
 .SH DESCRIPTION
@@ -119,6 +122,15 @@ displays nmstate version.
 Apply all network state files ending with \fB.yml\fR in specified(
 default: \fB/etc/nmstate\fR) folder.
 Please refer to manpage \fBnmstate.service(8)\fR for detail.
+.RE
+
+.B statistic
+.RS
+Generate statistic for specified network state files.
+Multiple desire states files are supported.
+The \fB--current <CURRENT_STATE_FILE>\fR argument could instruct nmstate to
+read current network state from specified file instead of querying current
+host.
 .RE
 
 .PP

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -355,12 +355,13 @@ fn main() {
    .subcommand(
             clap::Command::new(SUB_CMD_STATISTIC)
                 .alias("st")
-                .about("Generate statistic of specified desire state")
+                .about("Generate statistic of specified desire states")
                 .arg(
                     clap::Arg::new("STATE_FILE")
                         .required(true)
+                        .multiple_occurrences(true)
                         .index(1)
-                        .help("Network state file"),
+                        .help("Network state file (repeatable)"),
                 )
                 .arg(
                     clap::Arg::new("CURRENT_STATE")

--- a/rust/src/cli/statistic.rs
+++ b/rust/src/cli/statistic.rs
@@ -9,12 +9,15 @@ use crate::error::CliError;
 pub(crate) fn statistic(
     matches: &clap::ArgMatches,
 ) -> Result<String, crate::error::CliError> {
-    let desired_state = if let Some(file_path) = matches.value_of("STATE_FILE")
-    {
-        state_from_file(file_path)?
+    let mut desired_state = NetworkState::default();
+    if let Some(file_paths) = matches.values_of("STATE_FILE") {
+        let file_paths: Vec<&str> = file_paths.collect();
+        for file_path in file_paths {
+            desired_state.merge_desire(&state_from_file(file_path)?)
+        }
     } else {
-        state_from_file("-")?
-    };
+        desired_state = state_from_file("-")?;
+    }
     let current_state =
         if let Some(cur_state_file) = matches.value_of("CURRENT_STATE") {
             state_from_file(cur_state_file)?

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -116,7 +116,7 @@ impl Interfaces {
         }
     }
 
-    fn remove_iface(
+    pub fn remove_iface(
         &mut self,
         iface_name: &str,
         iface_type: InterfaceType,

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -12,6 +12,13 @@ pub struct NmstateStatistic {
 }
 
 impl NetworkState {
+    /// Only used for statistics by merging multiple desire states
+    /// to generate the final statistics.
+    pub fn merge_desire(&mut self, new_desire: &Self) {
+        self.update_state(new_desire);
+        self.interfaces.merge_desire(&new_desire.interfaces);
+    }
+
     pub fn statistic(
         &self,
         current: &Self,


### PR DESCRIPTION
Introducing `NetworkState::merge_desire()`, use could merge multiple
desire states and generate the statistic of the final outcome.

The `nmstatectl statistic` subcommand now support multiple desired
state files.

Manpage of `nmstatectl` updated to include this change.

Unit test case included.

Resolves: https://issues.redhat.com/browse/RHEL-21048