### PR TITLE
policy: Fix resolving token in array items

### DIFF
--- a/examples/policy/bridge_ref_port_by_mac/current.yml
+++ b/examples/policy/bridge_ref_port_by_mac/current.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: eth1
+    mac-address: 52:54:00:F6:80:01
+    state: up
+  - name: eth2
+    mac-address: 52:54:00:F6:80:02
+    state: up

--- a/examples/policy/bridge_ref_port_by_mac/expected.yml
+++ b/examples/policy/bridge_ref_port_by_mac/expected.yml
@@ -1,0 +1,17 @@
+---
+interfaces:
+  - name: bondcnv
+    type: bond
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: true
+    copy-mac-from: eth1
+    link-aggregation:
+      mode: balance-xor
+      options:
+        xmit_hash_policy: vlan+srcmac
+        balance_slb: true
+      port:
+        - eth1
+        - eth2

--- a/examples/policy/bridge_ref_port_by_mac/policy.yml
+++ b/examples/policy/bridge_ref_port_by_mac/policy.yml
@@ -1,0 +1,21 @@
+---
+capture:
+  primary-nic: interfaces.mac-address == "52:54:00:F6:80:01"
+  secondary-nic: interfaces.mac-address == "52:54:00:F6:80:02"
+desiredState:
+  interfaces:
+    - name: bondcnv
+      type: bond
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: true
+      copy-mac-from: "{{ capture.primary-nic.interfaces.0.name }}"
+      link-aggregation:
+        mode: balance-xor
+        options:
+          xmit_hash_policy: vlan+srcmac
+          balance-slb: 1
+        port:
+          - "{{ capture.primary-nic.interfaces.0.name }}"
+          - "{{ capture.secondary-nic.interfaces.0.name }}"


### PR DESCRIPTION
When policy has reference token in array, nmstate will failed to replace
it. The policy in question is:

```yml
capture:
  primary-nic: interfaces.mac-address == "52:54:00:F6:80:01"
desiredState:
  interfaces:
  - name: bondcnv
    type: bond
    state: up
    link-aggregation:
      port:
      - "{{ capture.primary-nic.interfaces.0.name }}"
```

The root cause is the code forgot to update the array after get the
resolved data in the match branch of array.

Unit test case included.