### PR TITLE
ovs: Raise invalid argument error when desired OVS bridge with MAC

### DIFF
--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -110,7 +110,7 @@ impl OvsBridgeInterface {
         }
     }
 
-    // * OVS Bridge cannot have MTU, IP
+    // * OVS Bridge cannot have MTU, IP or MAC address
     pub(crate) fn sanitize(
         &mut self,
         is_desired: bool,
@@ -122,6 +122,19 @@ impl OvsBridgeInterface {
                     as it only exists in OVS database, ignoring",
                     self.base.name.as_str()
                 );
+            }
+        }
+        if let Some(mac) = self.base.mac_address.as_ref() {
+            if !mac.is_empty() && is_desired {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "OVS Bridge {} can not hold MAC address, \
+                        please set MAC address on OVS internal interface \
+                        instead",
+                        self.base.name.as_str()
+                    ),
+                ));
             }
         }
         self.base.mtu = None;

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -924,3 +924,27 @@ fn test_ovs_iface_serialize_allow_extra_patch_ports() {
 
     assert_eq!(desired, new);
 }
+
+#[test]
+fn test_ovs_bridge_with_mac() {
+    let mut desired: OvsBridgeInterface = serde_yaml::from_str(
+        r"
+        name: br0
+        type: ovs-bridge
+        state: up
+        mac-address: 05:04:03:02:01:00
+        bridge:
+          port:
+            - name: eth1
+            - name: ovs1
+        ",
+    )
+    .unwrap();
+
+    let result = desired.sanitize(true);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}


### PR DESCRIPTION
When user desired OVS bridge with MAC address defined, they will get
Verification as OVS bridge does not have MAC address after applied.

This patch raise `InvalidArgument` error in sanitize stage with
suggestion to use OVS internal interface as error message.

Unit test case included.