### PR TITLE
base_iface: Add driver

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -135,6 +135,9 @@ pub struct BaseInterface {
     pub(crate) up_priority: u32,
     #[serde(skip)]
     pub(crate) routes: Option<Vec<RouteEntry>>,
+    #[serde(skip_serializing_if = "crate::serializer::is_option_string_empty")]
+    /// The driver of the specified network device.
+    pub driver: Option<String>,
     #[serde(flatten)]
     pub _other: serde_json::Map<String, serde_json::Value>,
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -25,6 +25,7 @@ class Interface:
     IDENTIFIER = "identifier"
     IDENTIFIER_NAME = "name"
     IDENTIFIER_MAC = "mac-address"
+    DRIVER = "driver"
 
 
 class Route:


### PR DESCRIPTION
This commits adds a `driver` field to the base interface. It is meant to provide an information about the driver used by the specific interface if available. As some interfaces do not have any driver assigned (e.g. loopback), this field will not be always present.

As per https://docs.kernel.org/admin-guide/sysfs-rules.html, we are using sysfs and read the "driver"-link to get what's needed.