### PR TITLE
base_iface: Add driver

### DIFF
--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -19,7 +19,7 @@ path = "lib.rs"
 serde_yaml = "0.9"
 
 [dependencies.nispor]
-version = "1.2.16"
+version = "1.2.18"
 optional = true
 
 [dependencies.zvariant]

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -28,6 +28,9 @@ pub struct BaseInterface {
     #[serde(rename = "type", default = "default_iface_type")]
     /// Interface type. Serialize and deserialize to/from `type`
     pub iface_type: InterfaceType,
+    #[serde(skip_serializing_if = "crate::serializer::is_option_string_empty")]
+    /// The driver of the specified network device.
+    pub driver: Option<String>,
     #[serde(default = "default_state")]
     /// Interface state. Default to [InterfaceState::Up] when applying.
     pub state: InterfaceState,
@@ -232,6 +235,7 @@ impl BaseInterface {
         self.max_mtu = None;
         self.min_mtu = None;
         self.copy_mac_from = None;
+        self.driver = None;
 
         if let Some(ipv4_conf) = self.ipv4.as_mut() {
             ipv4_conf.sanitize(is_desired)?;

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -55,6 +55,7 @@ pub(crate) fn np_iface_to_base_iface(
 ) -> BaseInterface {
     let mut base_iface = BaseInterface {
         name: np_iface.name.to_string(),
+        driver: np_iface.driver.clone(),
         state: (&np_iface.state, np_iface.flags.as_slice()).into(),
         iface_type: np_iface_type_to_nmstate(&np_iface.iface_type),
         ipv4: np_ipv4_to_nmstate(np_iface, running_config_only),


### PR DESCRIPTION
This commits adds a `driver` field to the base interface. It is meant to
provide an information about the driver used by the specific interface
if available. As some interfaces do not have any driver assigned (e.g.
loopback), this field will not be always present.

Example output:

```yml
interfaces:
- name: ens3
  type: ethernet
  driver: virtio_net
  state: up
```

Since our CI has not physical NIC, we cannot have this new property
tested in CI. Only manually tested.