### PR TITLE
ovs: Auto managed ignored OVS port

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -539,6 +539,7 @@ impl Interfaces {
         for iface in self
             .kernel_ifaces
             .values()
+            .chain(self.user_ifaces.values())
             .filter(|i| i.is_controller() && i.is_up())
         {
             let cur_iface = current.get_iface(iface.name(), iface.iface_type());


### PR DESCRIPTION
The commit 399c46b27 introduced auto manage ignored ports when all below
conditions met:
  1. Not mentioned in desire state.
  2. Been listed as port of a controller.
  3. Controller interface is new or does not contains ignored interfaces.

But we missed OVS bridge as it is user space interface and
`Interfaces::auto_managed_controller_ports()` only checks kernel
interfaces. Fixed by include user space controller into iterator also.

Unit test case and integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-23292