### PR TITLE
Route: add support for cwnd attribute

### DIFF
--- a/examples/eth1_add_route.yml
+++ b/examples/eth1_add_route.yml
@@ -17,5 +17,6 @@ routes:
       next-hop-address: 192.0.2.1
       next-hop-interface: eth1
       table-id: 254
+      cwnd: 20
     - destination: 198.51.200.0/24
       route-type: blackhole

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -137,6 +137,7 @@ fn np_routetype_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
             log::debug!("Got unsupported route {:?}", np_route);
         }
     }
+    route_entry.cwnd = np_route.cwnd;
     route_entry
 }
 
@@ -188,6 +189,7 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry.next_hop_addr = next_hop_addr;
     route_entry.metric = np_route.metric.map(i64::from);
     route_entry.table_id = Some(np_route.table);
+    route_entry.cwnd = np_route.cwnd;
 
     route_entry
 }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -18,6 +18,7 @@ pub struct NmIpRoute {
     pub weight: Option<u32>,
     pub route_type: Option<String>,
     pub cwnd: Option<u32>,
+    pub lock_cwnd: Option<bool>,
     _other: DbusDictionary,
 }
 
@@ -39,6 +40,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             weight,
             route_type: _from_map!(v, "type", String::try_from)?,
             cwnd: _from_map!(v, "cwnd", u32::try_from)?,
+            lock_cwnd: _from_map!(v, "lock-cwnd", bool::try_from)?,
             _other: v,
         })
     }
@@ -95,6 +97,12 @@ impl NmIpRoute {
         if let Some(v) = &self.cwnd {
             ret.append(
                 zvariant::Value::new("cwnd"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.lock_cwnd {
+            ret.append(
+                zvariant::Value::new("lock-cwnd"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -17,6 +17,7 @@ pub struct NmIpRoute {
     pub metric: Option<u32>,
     pub weight: Option<u32>,
     pub route_type: Option<String>,
+    pub cwnd: Option<u32>,
     _other: DbusDictionary,
 }
 
@@ -37,6 +38,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             metric: _from_map!(v, "metric", u32::try_from)?,
             weight,
             route_type: _from_map!(v, "type", String::try_from)?,
+            cwnd: _from_map!(v, "cwnd", u32::try_from)?,
             _other: v,
         })
     }
@@ -87,6 +89,12 @@ impl NmIpRoute {
         if let Some(v) = &self.route_type {
             ret.append(
                 zvariant::Value::new("type"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.cwnd {
+            ret.append(
+                zvariant::Value::new("cwnd"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -29,6 +29,9 @@ impl NmIpRoute {
             if let Some(route_type) = self.route_type.as_ref() {
                 write!(opt_string, ",type={}", route_type).ok();
             }
+            if let Some(cwnd) = self.cwnd {
+                write!(opt_string, ",cwnd={}", cwnd).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -32,6 +32,9 @@ impl NmIpRoute {
             if let Some(cwnd) = self.cwnd {
                 write!(opt_string, ",cwnd={}", cwnd).ok();
             }
+            if let Some(lock_cwnd) = self.lock_cwnd {
+                write!(opt_string, ",lock-cwnd={}", lock_cwnd).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -42,6 +42,7 @@ pub(crate) fn gen_nm_ip_routes(
             None => None,
         };
         nm_route.cwnd = route.cwnd;
+        nm_route.lock_cwnd = route.cwnd.map(|_| true);
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -41,6 +41,7 @@ pub(crate) fn gen_nm_ip_routes(
             Some(RouteType::Unreachable) => Some("unreachable".to_string()),
             None => None,
         };
+        nm_route.cwnd = route.cwnd;
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -233,6 +233,7 @@ impl RouteEntry {
         matches!(self.state, Some(RouteState::Absent))
     }
 
+    /// Whether the desired route (self) matches with another
     pub(crate) fn is_match(&self, other: &Self) -> bool {
         if self.destination.as_ref().is_some()
             && self.destination.as_deref() != Some("")

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -580,3 +580,35 @@ fn test_route_cwnd_is_match() {
     assert!(!desired_route.is_match(&not_match_route_2));
     assert!(desired_route.is_match(&match_route));
 }
+
+#[test]
+fn test_route_without_options_is_match_with_any() {
+    let desired_route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "192.0.2.1"
+        "#,
+    )
+    .unwrap();
+
+    let not_match_route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "192.0.2.100"
+        metric: 1
+        table-id: 2
+        cwnd: 3
+        "#,
+    )
+    .unwrap();
+    let match_route: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "192.0.2.1"
+        metric: 1
+        table-id: 2
+        cwnd: 3
+        "#,
+    )
+    .unwrap();
+
+    assert!(!desired_route.is_match(&not_match_route));
+    assert!(desired_route.is_match(&match_route));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -46,6 +46,7 @@ class Route:
     ROUTETYPE_PROHIBIT = "prohibit"
     USE_DEFAULT_METRIC = -1
     USE_DEFAULT_ROUTE_TABLE = 0
+    CWND = "cwnd"
 
 
 class RouteRule:

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -5,43 +5,56 @@ import copy
 from libnmstate.schema import Route
 
 
-def _assert_in_current_route(route, current_routes):
-    route_in_current_routes = False
-    for current_route in current_routes:
-        current_route.pop(Route.METRIC, None)
-        table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
-        if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
-            current_route = copy.deepcopy(current_route)
-            current_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
-
-        if route == current_route:
-            route_in_current_routes = True
-            break
-    assert route_in_current_routes
-
-
 def assert_routes(routes, state, nic="eth1"):
-    routes = copy.deepcopy(routes)
-    for route in routes:
-        # Ignore metric difference like nmstate production code
-        route.pop(Route.METRIC, None)
-        if Route.TABLE_ID not in route:
-            route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
-    routes.sort(key=_route_sort_key)
-    config_routes = []
-    for config_route in state[Route.KEY][Route.CONFIG]:
-        if config_route.get(Route.NEXT_HOP_INTERFACE, None) == nic:
-            config_routes.append(config_route)
+    routes = _clone_prepare_routes(routes)
+    config_routes = _clone_prepare_routes(state[Route.KEY][Route.CONFIG], nic)
+    running_routes = _clone_prepare_routes(
+        state[Route.KEY][Route.RUNNING], nic
+    )
 
-    # The kernel routes contains more route entries than desired config
-    # The kernel routes also has different metric and table id for
-    # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
-    config_routes.sort(key=_route_sort_key)
+    # The kernel contains more route entries than desired config
     for route in routes:
-        _assert_in_current_route(route, config_routes)
-    running_routes = state[Route.KEY][Route.RUNNING]
+        assert any(_compare_route(route, c_r) for c_r in config_routes)
+        assert any(_compare_route(route, r_r) for r_r in running_routes)
+
+
+def assert_routes_missing(routes, state, nic="eth1"):
+    routes = _clone_prepare_routes(routes)
+    config_routes = _clone_prepare_routes(state[Route.KEY][Route.CONFIG], nic)
+    running_routes = _clone_prepare_routes(
+        state[Route.KEY][Route.RUNNING], nic
+    )
+
+    # The kernel contains more route entries than desired config
     for route in routes:
-        _assert_in_current_route(route, running_routes)
+        assert all(not _compare_route(route, c_r) for c_r in config_routes)
+        assert all(not _compare_route(route, r_r) for r_r in running_routes)
+
+
+def _clone_prepare_routes(routes, nic=None):
+    routes_out = []
+    for route in routes:
+        if nic is None or route.get(Route.NEXT_HOP_INTERFACE, None) == nic:
+            # The kernel routes has different metric and table id for
+            # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
+            route = copy.deepcopy(route)
+            route.pop(Route.METRIC, None)
+            if Route.TABLE_ID not in route:
+                route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+            routes_out.append(route)
+
+    routes_out.sort(key=_route_sort_key)
+    return routes_out
+
+
+def _compare_route(route, current_route):
+    # kernel uses different value for the default table id
+    table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
+    if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
+        current_route = copy.deepcopy(current_route)
+        current_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+
+    return route == current_route
 
 
 def _route_sort_key(route):


### PR DESCRIPTION
Add support to define the route's clamp for the TCP congestion window (route's attribute name: cwnd).

According to `man ip-route`: It is ignored if the lock flag is not used. We have checked in the kernel that, indeed, setting cwnd without the lock flag is useless. Because of this, nmstate will set the lock flag automatically because the user's intention is clear enough just defining 'cwnd'.

Resolves: https://issues.redhat.com/browse/RHEL-19409