### PR TITLE
route rule: Append rule instead of overriding when iface defined

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -260,7 +260,7 @@ impl InterfaceIpv4 {
         }
 
         // The rules is `pub(crate)`, it will not merged by `merge_json_value()`
-        self.rules = current.rules.clone();
+        self.rules.clone_from(&current.rules);
 
         self.sanitize(false).ok();
     }
@@ -746,7 +746,7 @@ impl InterfaceIpv6 {
         }
 
         // The rules is `pub(crate)`, it will not merged by `merge_json_value()`
-        self.rules = current.rules.clone();
+        self.rules.clone_from(&current.rules);
 
         self.sanitize(false).ok();
     }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -258,6 +258,10 @@ impl InterfaceIpv4 {
         {
             self.addresses.clone_from(&current.addresses);
         }
+
+        // The rules is `pub(crate)`, it will not merged by `merge_json_value()`
+        self.rules = current.rules.clone();
+
         self.sanitize(false).ok();
     }
 
@@ -740,6 +744,10 @@ impl InterfaceIpv6 {
         {
             self.addresses.clone_from(&current.addresses);
         }
+
+        // The rules is `pub(crate)`, it will not merged by `merge_json_value()`
+        self.rules = current.rules.clone();
+
         self.sanitize(false).ok();
     }
 

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -180,6 +180,16 @@ fn append_route_rule(
                 if let Some(ip_conf) =
                     apply_iface.base_iface_mut().ipv6.as_mut()
                 {
+                    // When desired state has no rules defined, we should
+                    // copy current rules first, then append.
+                    if ip_conf.rules.is_none() {
+                        ip_conf.rules = iface
+                            .merged
+                            .base_iface()
+                            .ipv6
+                            .as_ref()
+                            .and_then(|i| i.rules.clone());
+                    }
                     if let Some(rules) = ip_conf.rules.as_mut() {
                         rules.push(rule.clone());
                     } else {
@@ -196,6 +206,16 @@ fn append_route_rule(
                 if let Some(ip_conf) =
                     apply_iface.base_iface_mut().ipv4.as_mut()
                 {
+                    // When desired state has no rules defined, we should
+                    // copy current rules first, then append.
+                    if ip_conf.rules.is_none() {
+                        ip_conf.rules = iface
+                            .merged
+                            .base_iface()
+                            .ipv4
+                            .as_ref()
+                            .and_then(|i| i.rules.clone());
+                    }
                     if let Some(rules) = ip_conf.rules.as_mut() {
                         rules.push(rule.clone());
                     } else {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1884,3 +1884,44 @@ def test_route_rule_suppress_prefix_length(route_rule_test_env):
     }
     libnmstate.apply(desired_state)
     _check_ip_rules(desired_state[RouteRule.KEY][RouteRule.CONFIG])
+
+
+def test_append_route_rule(route_rule_test_env):
+    desired_state = {
+        RouteRule.KEY: {
+            RouteRule.CONFIG: [
+                {
+                    RouteRule.IP_FROM: "2001:db8:f::/64",
+                    RouteRule.ROUTE_TABLE: IPV6_ROUTE_TABLE_ID1,
+                },
+                {
+                    RouteRule.IP_FROM: "192.0.2.1/32",
+                    RouteRule.ROUTE_TABLE: IPV4_ROUTE_TABLE_ID1,
+                },
+            ]
+        }
+    }
+    libnmstate.apply(desired_state)
+    _check_ip_rules(desired_state[RouteRule.KEY][RouteRule.CONFIG])
+
+    new_desired_state = {
+        RouteRule.KEY: {
+            RouteRule.CONFIG: [
+                {
+                    RouteRule.IP_FROM: "2001:db8:e::/64",
+                    RouteRule.ROUTE_TABLE: IPV6_ROUTE_TABLE_ID1,
+                },
+                {
+                    RouteRule.IP_FROM: "192.0.2.2/32",
+                    RouteRule.ROUTE_TABLE: IPV4_ROUTE_TABLE_ID1,
+                },
+            ]
+        },
+        Interface.KEY: [ETH1_INTERFACE_STATE],
+    }
+
+    libnmstate.apply(new_desired_state)
+    _check_ip_rules(
+        desired_state[RouteRule.KEY][RouteRule.CONFIG]
+        + new_desired_state[RouteRule.KEY][RouteRule.CONFIG]
+    )


### PR DESCRIPTION
When desire state contains both route rule and the interface which will
hold the desire routes, nmstate will override existing route rules
instead appending desire ones to current.

This is caused by `nm/route_rule.rs`, `append_route_rule()` is not
preserving current route rule when interface is already desired.

Integration test case included.