### PR TITLE
Added alias for apply and show commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -748,7 +748,7 @@ The YAML API changed: The `other_config` under OVS bond should be stored under
 ### Breaking changes
  - Deprecate specifying keyword arguments as positional arguments in the public methods.
    This will become a hard failure in Nmstate-0.3.0 and later and it affects the following functions:
-   - "libnmstate.apply()"
+   - "libnmstate.()"
    - "libnmstate.commit()"
    - "libnmstate.rollback()"
    - "libmstate.show()"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -748,7 +748,7 @@ The YAML API changed: The `other_config` under OVS bond should be stored under
 ### Breaking changes
  - Deprecate specifying keyword arguments as positional arguments in the public methods.
    This will become a hard failure in Nmstate-0.3.0 and later and it affects the following functions:
-   - "libnmstate.()"
+   - "libnmstate.apply()"
    - "libnmstate.commit()"
    - "libnmstate.rollback()"
    - "libmstate.show()"

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -93,6 +93,10 @@ fn main() {
                 .help("Disable logging")
                 .global(true),
         )
+        //setting alias a=> apply, s => show
+        .subcommand(clap::SubCommand::with_name("a").alias("apply"))
+        .subcommand(clap::SubCommand::with_name("s").alias("show"));
+        
         .subcommand(
             clap::Command::new(SUB_CMD_AUTOCONF)
                 .about(


### PR DESCRIPTION
following lines of code were added to create aliases for "apply" and "show" on cli

        //setting alias a=> apply, s => show
        .subcommand(clap::SubCommand::with_name("a").alias("apply"))
        .subcommand(clap::SubCommand::with_name("s").alias("show"));
        