### PR TITLE
(Fix)Deprecate PrettyState in python API

### DIFF
--- a/rust/src/python/libnmstate/prettystate.py
+++ b/rust/src/python/libnmstate/prettystate.py
@@ -22,6 +22,7 @@ from collections.abc import Sequence
 from copy import deepcopy
 import difflib
 import json
+import warnings
 
 import yaml
 
@@ -72,6 +73,11 @@ def format_desired_current_state_diff(desired_state, current_state):
 class PrettyState:
     def __init__(self, state):
         yaml.add_representer(dict, represent_dict)
+        warnings.warn(
+            "PrettyState class is deprecated;to be removed in future release."
+            "The output of libnmstate.show() is already sorted.",
+            DeprecationWarning,
+        )
         self.state = _sort_with_priority(state)
 
     @property

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -13,7 +13,6 @@ import libnmstate
 from libnmstate.error import NmstateKernelIntegerRoundedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
-from libnmstate.prettystate import PrettyState
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
@@ -609,13 +608,6 @@ class TestVlanFiltering:
 
         with linux_bridge(TEST_BRIDGE0, bridge_config_subtree):
             assert _vlan_filtering_enabled(TEST_BRIDGE0)
-
-    def test_pretty_state_port_name_first(
-        self, bridge_with_trunk_port_and_native_config
-    ):
-        current_state = show_only((TEST_BRIDGE0,))
-        pretty_state = PrettyState(current_state)
-        assert VLAN_FILTER_PORT_YAML in pretty_state.yaml
 
     def test_move_bridge_port_to_bond(self, bridge_with_access_port_config):
         with bond_interface(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -6,7 +6,6 @@ import pytest
 import yaml
 
 import libnmstate
-from libnmstate.prettystate import PrettyState
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
@@ -347,19 +346,6 @@ class TestOvsLinkAggregation:
 
         assertlib.assert_absent(BRIDGE1)
         assertlib.assert_absent(BOND1)
-
-    def test_pretty_state_ovs_lag_name_first(self, eth1_up, eth2_up):
-        bridge = Bridge(BRIDGE1)
-        bridge.add_link_aggregation_port(
-            BOND1,
-            (ETH1, ETH2),
-            mode=OVSBridge.Port.LinkAggregation.Mode.ACTIVE_BACKUP,
-        )
-
-        with bridge.create():
-            current_state = statelib.show_only((BRIDGE1,))
-            pretty_state = PrettyState(current_state)
-            assert OVS_BOND_YAML_STATE in pretty_state.yaml
 
     @pytest.mark.tier1
     def test_add_ovs_lag_to_existing_ovs_bridge(self, port0_up, port1_up):


### PR DESCRIPTION
Issue: https://github.com/nmstate/nmstate/issues/2588

Description;

The PrettyState is only used for test codes.
    

- [x] Mark PrettyState as deprecated in Python API, providing message indicate libnmstate.show() output is already sorted.
- [x] Remove test cases regarding PrettyState


