### PR TITLE
packaging: Fix rpm build on Fedora

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -62,6 +62,10 @@ function install_nmstate {
         if [ -n "$COMPILED_RPMS_DIR" ];then
             exec_cmd "rpm -ivh ${COMPILED_RPMS_DIR}/*.rpm || exit 1"
         else
+            exec_cmd "make srpm"
+            exec_cmd "dnf install -y 'dnf-command(builddep)'"
+            exec_cmd "dnf builddep -y *.src.rpm"
+            exec_cmd "rm -f *.src.rpm"
             exec_cmd "make rpm"
             exec_cmd "rpm -ivh *.rpm"
         fi

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -28,7 +28,6 @@ BuildRequires:  systemd-rpm-macros
 BuildRequires:  rust-toolset
 %else
 BuildRequires:  rust-packaging
-%if ! %{is_snapshot}
 BuildRequires:  (crate(clap/cargo) >= 3.1 with crate(clap/cargo) < 4.0)
 BuildRequires:  (crate(clap/default) >= 3.1 with crate(clap/default) < 4.0)
 BuildRequires:  (crate(chrono/default) >= 0.4 with crate(chrono/default) < 0.5)
@@ -46,7 +45,7 @@ BuildRequires:  (crate(uuid/v5) >= 1.1 with crate(uuid/v5) < 2.0)
 BuildRequires:  (crate(zbus/default) >= 1.9 with crate(zbus/default) < 2.0)
 BuildRequires:  (crate(zvariant/default) >= 2.10 with crate(zvariant/default) < 3.0)
 BuildRequires:  (crate(nix/default) >= 0.26 with crate(nix/default) < 0.27)
-%endif
+BuildRequires:  (crate(toml/default) >= 0.8 with crate(toml/default) < 0.9)
 %endif
 
 %description
@@ -150,19 +149,11 @@ gpgv2 --keyring ./gpgkey-mantainers.gpg %{SOURCE1} %{SOURCE0}
 
 pushd rust
 
-%if 0%{?rhel}
-    %if ! %{is_snapshot}
+%if 0%{?rhel} && ! %{is_snapshot}
     # Source3 is vendored dependencies
     %cargo_prep -V 3
-    %endif
 %else
     %cargo_prep
-    rm -f .cargo/config.toml
-    %if %{is_snapshot}
-    # Remove local `source.crates-io` to use internet for snaptshot build
-    sed -ne '/\[source.crates-io\]/q;p' .cargo/config > .cargo/config.new
-    mv .cargo/config.new .cargo/config
-    %endif
 %endif
 
 popd


### PR DESCRIPTION
The `%cargo_prep` in Fedora has updated to set `offline = true` and also
override `crates.io`. Instead of hacking the `.cargo/config` file, let's
just use Fedora shipped rust crates rpms.