### PR TITLE
(fix)Use @warnings.deprecated()

### DIFF
--- a/rust/src/python/libnmstate/prettystate.py
+++ b/rust/src/python/libnmstate/prettystate.py
@@ -70,6 +70,11 @@ def format_desired_current_state_diff(desired_state, current_state):
     )
 
 
+# pylint: disable=E1101
+@warnings.deprecated(
+    message="PrettyState class is deprecated; libnmstate.show() is sorted.",
+    category=DeprecationWarning,
+)
 class PrettyState:
     def __init__(self, state):
         yaml.add_representer(dict, represent_dict)


### PR DESCRIPTION
Issue: https://github.com/nmstate/nmstate/issues/2588

Description;

The PrettyState is only used for test codes.

Mark PrettyState as deprecated in Python API, providing message indicate libnmstate.show() output is already sorted.




According to https://peps.python.org/pep-0702/ we should use @warnings.deprecated()