### PR TITLE
Create alias for nmstaetctl subcommand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,29 @@ serving the tests of Nmstate.
 
 - `./examples/` - Contains YAML examples for different configurations.
 
+- `./logo` Logos used for publication.
+
+- `./k8s` k8s folder holds the scripts for kubernetes-nmstate CI
+
+- `./rust/src/clib` C binding of nmstate written in rust
+
+- `./rust/src/go/nmstate` Contains the classes including the attributes of the 
+interfaces.
+ 
+- `./rust/src/python/libnmstate`, `./rust/src/python` Python library of nmstate written in python wrapping the C binding of nmstate
+
+ - `./rust/src/lib/ifaces/` Contains the classes including the attributes of the 
+interfaces.
+ 
+- `./rust/src/lib/nispor/` Contains the nmstate nispor plugin, currently for 
+querying kernel network status. 
+
+- `./rust/src/lib/nm/` Contains the code related to applying the settings via NetworkManager backend.
+
+- `./rust/src/lib/ovsdb/` Contains the code related to ovsdb communication and structures. 
+
+- `./rust/src/cli/` - Contains command lines tools.
+
 - `./packaging/` - Contains packaging utilities.
 
 - `./tests/` - Contains tests for unit and integration tests.
@@ -164,3 +187,39 @@ Do your best to follow the clean code guidelines.
 - Don’t return an error code, throw an exception instead.
 
 Ref: Book: Clean Code by Robert C. Martin (Uncle Bob)
+
+## Compilation and Installation
+This guide is helpful to compile and install Nmstate from source, for installing stable release or other installation methods, pleaser refer to [Nmstate installation guide](https://nmstate.io/user/install.md)
+
+### Dependencies
+Nmstate requires NetworkManager 1.26 or later version installed and started.
+
+In order to support specific capabilities, additional packages are required:
+
+OpenVSwitch support through the NM provider requires NetworkManager-ovs.
+
+Extended ovsdb support requires openvswitch-2.11 and python3-openvswitch2.11 or greater.
+
+Team interface support through the NM provider requires NetworkManager-team
+
+### Clone the source
+```
+git clone https://github.com/nmstate/nmstate.git
+cd nmstate
+```
+
+### Compilation 
+```
+#Check that the system installed the official compiler for the rust programming language
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+make
+```
+
+### Installation
+```
+python rust/src/python/setup.py install
+```
+
+__Note__: In order to report current state, installing Nmstate as a non-root user should be enough. For change support, install the package as root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,21 +24,6 @@ serving the tests of Nmstate.
 
 - `./examples/` - Contains YAML examples for different configurations.
 
-- `./libnmstate/ifaces/` Contains the classes including the attributes of the 
-interfaces.
- 
-- `./libnmstate/nispor/` Contains the nmstate nispor plugin, currently for 
-querying kernel network status. 
-
-- `./libnmstate/nm/` Contains the nmstate NetworkManager plugin, currently for 
-querying network status and applying network states. 
-
-- `./libnmstate/plugins/` Contains the plugins supported by default (e.g. ovsdb). 
-
-- `./libnmstate/schemas/` Contains the API schema file.
-
-- `./nmstatectl/` - Contains command lines tools.
-
 - `./packaging/` - Contains packaging utilities.
 
 - `./tests/` - Contains tests for unit and integration tests.

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -102,6 +102,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_SHOW)
                 .about("Show network state")
+                .alias("s")
                 .arg(
                     clap::Arg::new("IFNAME")
                         .index(1)
@@ -139,6 +140,7 @@ fn main() {
             clap::Command::new(SUB_CMD_APPLY)
                 .about("Apply network state or network policy")
                 .alias("set")
+                .alias("a")
                 .arg(
                     clap::Arg::new("STATE_FILE")
                         .required(false)


### PR DESCRIPTION
This commit introduces aliases for the `apply` and `show` subcommands
in the `nmstate` cli tools. These aliases allow users to use shorter and more
intuitive commands for common actions, enhancing the usability and user
experience of the CLI interface. With this enhancement, users can now
use the `nmstatectl a` and `nmstatectl s` commands interchangeably with the
original `nmstatectl apply` and `nmstatectl show` commands, respectively.
This change simplifies command usage and reduces the cognitive load
on users, especially those who frequently interact with the `nmstate` cli
tools.