### PR TITLE
Use SPDX-License-Identifier to all rust and python API code

### DIFF
--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -9,8 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
-    - uses: apache/skywalking-eyes/dependency@main
+
+    - uses: apache/skywalking-eyes@main
 
 #  macos-x64:
 #    runs-on: macos-latest

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -9,21 +9,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    
+    - name: Install License Eye
+        run: |
+          curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
+
     - uses: apache/skywalking-eyes/dependency@main
 
-  macos-x64:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    
-    - uses: apache/skywalking-eyes/dependency@main
-    
-  macos-aarch64:
-    runs-on: macos-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    
-    - uses: apache/skywalking-eyes/dependency@main
+#  macos-x64:
+#    runs-on: macos-latest
+#
+#    steps:
+#    - uses: actions/checkout@v3
+#    - name: Install License Eye
+#        run: |
+#          curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
+#
+#    - uses: apache/skywalking-eyes/dependency@main
+#    
+#  macos-aarch64:
+#    runs-on: macos-latest
+#
+#    steps:
+#    - uses: actions/checkout@v3
+#    - name: Install License Eye
+#        run: |
+#          curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
+#
+#    - uses: apache/skywalking-eyes/dependency@main

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install License Eye
-        run: |
-          curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
+      run: |
+        curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
 
     - uses: apache/skywalking-eyes/dependency@main
 

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -9,10 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install License Eye
-      run: |
-        curl -sfL https://raw.githubusercontent.com/apache/skywalking-eyes/v2.8.1/install.sh | sh -s -- -b /usr/local/bin
-
+    
     - uses: apache/skywalking-eyes/dependency@main
 
 #  macos-x64:

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -1,0 +1,29 @@
+name: Check Dependencies' License
+
+on:
+  push:
+
+jobs:
+  linux-x64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - uses: apache/skywalking-eyes/dependency@main
+
+  macos-x64:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - uses: apache/skywalking-eyes/dependency@main
+    
+  macos-aarch64:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - uses: apache/skywalking-eyes/dependency@main

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -11,26 +11,26 @@ header:
       - 'LICENSE'
       - 'NOTICE'
       
-  - path: "rust/src/python"
-    license:
-      spdx-id: LGPL-2.1-or-later
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
-      
-  - path: "tests"
-    license:
-      spdx-id: LGPL-2.1-or-later
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
+#  - path: "rust/src/python"
+#    license:
+#      spdx-id: LGPL-2.1-or-later
+#    paths-ignore:
+#      - 'rust/target'
+#      - 'licenses'
+#      - '**/*.md'
+#      - '**/*.toml'
+#      - '**/*.yml'
+#      - 'LICENSE'
+#      - 'NOTICE'
+#      
+#  - path: "tests"
+#    license:
+#      spdx-id: LGPL-2.1-or-later
+#    paths-ignore:
+#      - 'rust/target'
+#      - 'licenses'
+#      - '**/*.md'
+#      - '**/*.toml'
+#      - '**/*.yml'
+#      - 'LICENSE'
+#      - 'NOTICE'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,21 +23,21 @@ header:
   paths:
     - 'rust/src/*'
 
-  paths-ignore:
-    - '**/*.md'
-    - '**/*.json'
-    - '**/*.txt'
-    - '.gitignore'
-    - '.gitmodules'
-    - 'LICENSE'
-    - 'NOTICE'
-    - 'go.mod'
-    - 'go.sum'
-    - 'rust/target'
-    - 'licenses'
-    - '**/*.md'
-    - '**/*.toml'
-    - '**/*.yml'
+#  paths-ignore:
+#    - '**/*.md'
+#    - '**/*.json'
+#    - '**/*.txt'
+#    - '.gitignore'
+#    - '.gitmodules'
+#    - 'LICENSE'
+#    - 'NOTICE'
+#    - 'go.mod'
+#    - 'go.sum'
+#    - 'rust/target'
+#    - 'licenses'
+#    - '**/*.md'
+#    - '**/*.toml'
+#    - '**/*.yml'
 
   comment: on-failure
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -18,10 +18,9 @@
 header:
   license:
     spdx-id: Apache-2.0
-    copyright-owner: Apache Software Foundation
 
   paths:
-    - 'rust/src/*'
+    - 'rust/src'
 
 #  paths-ignore:
 #    - '**/*.md'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -41,8 +41,8 @@ header:
 
   comment: on-failure
 
-  language:
-    Rust:
-      extensions:
-        - ".rs"
-      comment_style_id: DoubleSlash
+#  language:
+#    Rust:
+#      extensions:
+#        - ".rs"
+#      comment_style_id: DoubleSlash

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -20,7 +20,7 @@ header:
     spdx-id: Apache-2.0
 
   pattern: |
-    ^(?:\s*//|\/\*) Apache-2.0
+    ^(?:\s*//|\/\*) SPDX-License-Identifier: Apache-2.0
 
   paths:
     - 'rust/src'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -20,8 +20,9 @@ header:
     spdx-id: Apache-2.0
     copyright-owner: Apache Software Foundation
 
-  path: "rust/src"
-  
+  paths:
+    - 'rust/src/*'
+
   paths-ignore:
     - '**/*.md'
     - '**/*.json'
@@ -38,6 +39,10 @@ header:
     - '**/*.toml'
     - '**/*.yml'
 
-  extension: ".rs"
-
   comment: on-failure
+
+  language:
+    Rust:
+      extensions:
+        - ".rs"
+      comment_style_id: DoubleSlash

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -19,8 +19,8 @@ header:
   license:
     spdx-id: Apache-2.0
 
-  #pattern: |
-  #  SPDX-License-Identifier: Apache-2.0
+  pattern: |
+    SPDX-License-Identifier: Apache-2.0
 
   paths:
     - 'rust/src'
@@ -44,7 +44,7 @@ header:
   comment: on-failure
 
   language:
-    Python:
+    Rust:
       extensions:
-        - ".py"
+        - ".rs"
       comment_style_id: DoubleSlash

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,15 +1,7 @@
 header:
-  - path: "rust/src/**"
+  - path: "rust/src/*"
     license:
       spdx-id: Apache-2.0
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
       
 #  - path: "rust/src/python"
 #    license:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,31 +1,16 @@
 header:
-  license:
-    spdx-id: Apache-2.0
-  path: "rust/src/*"
-  paths-ignore:
-    - 'rust/target'
-    - 'licenses'
-    - '**/*.md'
-    - '**/*.toml'
-    - '**/*.yml'
-    - 'LICENSE'
-    - 'NOTICE'
-    
-  license:
-    spdx-id: LGPL-2.1-or-later
-  path: "rust/src/python/*"
-  paths-ignore:
-    - 'rust/target'
-    - 'licenses'
-    - '**/*.md'
-    - '**/*.toml'
-    - '**/*.yml'
-    - 'LICENSE'
-    - 'NOTICE'
-    
-  license:
-    spdx-id: LGPL-2.1-or-later
-  path: "tests/*"
+  - path: "rust/src"
+    license:
+      spdx-id: Apache-2.0
+
+  - path: "rust/src/python"
+    license:
+      spdx-id: LGPL-2.1-or-later
+
+  - path: "tests"
+    license:
+      spdx-id: LGPL-2.1-or-later
+
   paths-ignore:
     - 'rust/target'
     - 'licenses'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -20,7 +20,7 @@ header:
     spdx-id: Apache-2.0
 
   pattern: |
-    SPDX-License-Identifier: Apache-2.0
+    ^(?:\s*//|\/\*) SPDX-License-Identifier: Apache-2.0
 
   paths:
     - 'rust/src'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,36 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 header:
-  - path: "rust/src"
-    license:
-      spdx-id: Apache-2.0
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
-      
-  - path: "rust/src/python"
-    license:
-      spdx-id: LGPL-2.1-or-later
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
-      
-  - path: "tests"
-    license:
-      spdx-id: LGPL-2.1-or-later
-    paths-ignore:
-      - 'rust/target'
-      - 'licenses'
-      - '**/*.md'
-      - '**/*.toml'
-      - '**/*.yml'
-      - 'LICENSE'
-      - 'NOTICE'
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  path: "rust/src"
+  
+  paths-ignore:
+    - '**/*.md'
+    - '**/*.json'
+    - '**/*.txt'
+    - '.gitignore'
+    - '.gitmodules'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'go.mod'
+    - 'go.sum'
+    - 'rust/target'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.toml'
+    - '**/*.yml'
+
+  extension: ".rs"
+
+  comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -22,21 +22,21 @@ header:
   paths:
     - 'rust/src'
 
-#  paths-ignore:
-#    - '**/*.md'
-#    - '**/*.json'
-#    - '**/*.txt'
-#    - '.gitignore'
-#    - '.gitmodules'
-#    - 'LICENSE'
-#    - 'NOTICE'
-#    - 'go.mod'
-#    - 'go.sum'
-#    - 'rust/target'
-#    - 'licenses'
-#    - '**/*.md'
-#    - '**/*.toml'
-#    - '**/*.yml'
+  paths-ignore:
+    - '**/*.md'
+    - '**/*.json'
+    - '**/*.txt'
+    - '.gitignore'
+    - '.gitmodules'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'go.mod'
+    - 'go.sum'
+    - 'rust/target'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.toml'
+    - '**/*.yml'
 
   comment: on-failure
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,36 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+  path: "rust/src/*"
+  paths-ignore:
+    - 'rust/target'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.toml'
+    - '**/*.yml'
+    - 'LICENSE'
+    - 'NOTICE'
+    
+  license:
+    spdx-id: LGPL-2.1-or-later
+  path: "rust/src/python/*"
+  paths-ignore:
+    - 'rust/target'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.toml'
+    - '**/*.yml'
+    - 'LICENSE'
+    - 'NOTICE'
+    
+  license:
+    spdx-id: LGPL-2.1-or-later
+  path: "tests/*"
+  paths-ignore:
+    - 'rust/target'
+    - 'licenses'
+    - '**/*.md'
+    - '**/*.toml'
+    - '**/*.yml'
+    - 'LICENSE'
+    - 'NOTICE'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,8 +16,8 @@
 # under the License.
 
 header:
-  license:
-    spdx-id: Apache-2.0
+  #license:
+  #  spdx-id: Apache-2.0
 
   pattern: |
     ^(?:\s*//|\/\*) SPDX-License-Identifier: Apache-2.0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -40,8 +40,8 @@ header:
 
   comment: on-failure
 
-#  language:
-#    Rust:
-#      extensions:
-#        - ".rs"
-#      comment_style_id: DoubleSlash
+  language:
+    Rust:
+      extensions:
+        - ".rs"
+      comment_style_id: DoubleSlash

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,17 +16,16 @@
 # under the License.
 
 header:
-  #license:
-  #  spdx-id: Apache-2.0
+  license:
+    spdx-id: Apache-2.0
 
   pattern: |
-    ^(?:\s*//|\/\*) SPDX-License-Identifier: Apache-2.0
+    ^(?:\s*//|\/\*) Apache-2.0
 
   paths:
     - 'rust/src'
 
   paths-ignore:
-    - '**/*.md'
     - '**/*.json'
     - '**/*.txt'
     - '.gitignore'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -2,20 +2,35 @@ header:
   - path: "rust/src"
     license:
       spdx-id: Apache-2.0
-
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'
+      
   - path: "rust/src/python"
     license:
       spdx-id: LGPL-2.1-or-later
-
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'
+      
   - path: "tests"
     license:
       spdx-id: LGPL-2.1-or-later
-
-  paths-ignore:
-    - 'rust/target'
-    - 'licenses'
-    - '**/*.md'
-    - '**/*.toml'
-    - '**/*.yml'
-    - 'LICENSE'
-    - 'NOTICE'
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 header:
-  - path: "rust/src"
+  - path: "rust/src/**"
     license:
       spdx-id: Apache-2.0
     paths-ignore:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -19,6 +19,9 @@ header:
   license:
     spdx-id: Apache-2.0
 
+  #pattern: |
+  #  SPDX-License-Identifier: Apache-2.0
+
   paths:
     - 'rust/src'
 
@@ -41,7 +44,7 @@ header:
   comment: on-failure
 
   language:
-    Rust:
+    Python:
       extensions:
-        - ".rs"
+        - ".py"
       comment_style_id: DoubleSlash

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,28 +1,36 @@
 header:
-  - path: "rust/src/*"
+  - path: "rust/src"
     license:
       spdx-id: Apache-2.0
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'
       
-#  - path: "rust/src/python"
-#    license:
-#      spdx-id: LGPL-2.1-or-later
-#    paths-ignore:
-#      - 'rust/target'
-#      - 'licenses'
-#      - '**/*.md'
-#      - '**/*.toml'
-#      - '**/*.yml'
-#      - 'LICENSE'
-#      - 'NOTICE'
-#      
-#  - path: "tests"
-#    license:
-#      spdx-id: LGPL-2.1-or-later
-#    paths-ignore:
-#      - 'rust/target'
-#      - 'licenses'
-#      - '**/*.md'
-#      - '**/*.toml'
-#      - '**/*.yml'
-#      - 'LICENSE'
-#      - 'NOTICE'
+  - path: "rust/src/python"
+    license:
+      spdx-id: LGPL-2.1-or-later
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'
+      
+  - path: "tests"
+    license:
+      spdx-id: LGPL-2.1-or-later
+    paths-ignore:
+      - 'rust/target'
+      - 'licenses'
+      - '**/*.md'
+      - '**/*.toml'
+      - '**/*.yml'
+      - 'LICENSE'
+      - 'NOTICE'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,29 @@ serving the tests of Nmstate.
 
 - `./examples/` - Contains YAML examples for different configurations.
 
+- `./logo` Logos used for publication.
+
+- `./k8s` k8s folder holds the scripts for kubernetes-nmstate CI
+
+- `./rust/src/clib` C binding of nmstate written in rust
+
+- `./rust/src/go/nmstate` Contains the classes including the attributes of the 
+interfaces.
+ 
+- `./rust/src/python/libnmstate`, `./rust/src/python` Python library of nmstate written in python wrapping the C binding of nmstate
+
+ - `./rust/src/lib/ifaces/` Contains the classes including the attributes of the 
+interfaces.
+ 
+- `./rust/src/lib/nispor/` Contains the nmstate nispor plugin, currently for 
+querying kernel network status. 
+
+- `./rust/src/lib/nm/` Contains the code related to applying the settings via NetworkManager backend.
+
+- `./rust/src/lib/ovsdb/` Contains the code related to ovsdb communication and structures. 
+
+- `./rust/src/cli/` - Contains command lines tools.
+
 - `./packaging/` - Contains packaging utilities.
 
 - `./tests/` - Contains tests for unit and integration tests.
@@ -164,3 +187,39 @@ Do your best to follow the clean code guidelines.
 - Don’t return an error code, throw an exception instead.
 
 Ref: Book: Clean Code by Robert C. Martin (Uncle Bob)
+
+## Compilation and Installation
+This guide is helpful to compile and install Nmstate from source, for installing stable release or other installation methods, pleaser refer to [Nmstate installation guide](https://nmstate.io/user/install.md)
+
+### Dependencies
+Nmstate requires NetworkManager 1.26 or later version installed and started.
+
+In order to support specific capabilities, additional packages are required:
+
+OpenVSwitch support through the NM provider requires NetworkManager-ovs.
+
+Extended ovsdb support requires openvswitch-2.11 and python3-openvswitch2.11 or greater.
+
+Team interface support through the NM provider requires NetworkManager-team
+
+### Clone the source
+```
+git clone https://github.com/nmstate/nmstate.git
+cd nmstate
+```
+
+### Compilation 
+```
+#Check that the system installed the official compiler for the rust programming language
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+make
+```
+
+### Installation
+```
+python rust/src/python/setup.py install
+```
+
+__Note__: In order to report current state, installing Nmstate as a non-root user should be enough. For change support, install the package as root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,21 +24,6 @@ serving the tests of Nmstate.
 
 - `./examples/` - Contains YAML examples for different configurations.
 
-- `./libnmstate/ifaces/` Contains the classes including the attributes of the 
-interfaces.
- 
-- `./libnmstate/nispor/` Contains the nmstate nispor plugin, currently for 
-querying kernel network status. 
-
-- `./libnmstate/nm/` Contains the nmstate NetworkManager plugin, currently for 
-querying network status and applying network states. 
-
-- `./libnmstate/plugins/` Contains the plugins supported by default (e.g. ovsdb). 
-
-- `./libnmstate/schemas/` Contains the API schema file.
-
-- `./nmstatectl/` - Contains command lines tools.
-
 - `./packaging/` - Contains packaging utilities.
 
 - `./tests/` - Contains tests for unit and integration tests.

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
 use std::io::{stdin, stdout, Read, Write};

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
 use std::io::{stdin, stdout, Read, Write};

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -386,7 +386,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new(SUB_CMD_VERSION)
-            .alias("h")
+            .alias("v")
             .about("Show version")
        );
     if cfg!(feature = "query_apply") {

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -95,6 +95,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new(SUB_CMD_AUTOCONF)
+                .alias("ac")
                 .about(
                     "Automatically configure network based on LLDP \
                     information (experimental)")
@@ -102,6 +103,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_SHOW)
                 .about("Show network state")
+                .alias("s")
                 .arg(
                     clap::Arg::new("IFNAME")
                         .index(1)
@@ -139,6 +141,7 @@ fn main() {
             clap::Command::new(SUB_CMD_APPLY)
                 .about("Apply network state or network policy")
                 .alias("set")
+                .alias("a")
                 .arg(
                     clap::Arg::new("STATE_FILE")
                         .required(false)
@@ -205,6 +208,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_COMMIT)
                 .about("Commit a change")
+                .alias("c")
                 .arg(
                     clap::Arg::new("CHECKPOINT")
                         .required(false)
@@ -215,6 +219,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_ROLLBACK)
                 .about("Rollback a change")
+                .alias("r")
                 .arg(
                     clap::Arg::new("CHECKPOINT")
                         .required(false)
@@ -225,6 +230,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_EDIT)
                 .about("Edit network state in EDITOR")
+                .alias("e")
                 .arg(
                     clap::Arg::new("IFNAME")
                         .required(false)
@@ -265,6 +271,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_SERVICE)
                 .about("Service mode: apply files from service folder")
+                .alias("S")
                 .arg(
                     clap::Arg::new(CONFIG_FOLDER_KEY)
                         .long("config")
@@ -379,6 +386,7 @@ fn main() {
         )
         .subcommand(
             clap::Command::new(SUB_CMD_VERSION)
+            .alias("h")
             .about("Show version")
        );
     if cfg!(feature = "query_apply") {

--- a/rust/src/clib/logger.rs
+++ b/rust/src/clib/logger.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // This is based on the work of https://github.com/gahag/memory_logger
 // which is MIT licensed.
 

--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package nmstate
 
 // #cgo CFLAGS: -g -Wall

--- a/rust/src/go/nmstate/nmstate_test.go
+++ b/rust/src/go/nmstate/nmstate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package nmstate
 
 import (

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::error::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/src/lib/ieee8021x.rs
+++ b/rust/src/lib/ieee8021x.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::NetworkState;

--- a/rust/src/lib/ifaces/dummy.rs
+++ b/rust/src/lib/ifaces/dummy.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::{BaseInterface, InterfaceType};

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 mod base;
 mod bond;
 mod bridge_vlan;

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::{BaseInterface, InterfaceType};

--- a/rust/src/lib/nispor/bond.rs
+++ b/rust/src/lib/nispor/bond.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use log::warn;
 
 use crate::{

--- a/rust/src/lib/nispor/error.rs
+++ b/rust/src/lib/nispor/error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{ErrorKind, NmstateError};
 
 pub(crate) fn np_error_to_nmstate(

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     BaseInterface, EthernetConfig, EthernetDuplex, EthernetInterface,
     SrIovConfig, SrIovVfConfig, VlanProtocol,

--- a/rust/src/lib/nispor/ethtool.rs
+++ b/rust/src/lib/nispor/ethtool.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     EthtoolCoalesceConfig, EthtoolConfig, EthtoolPauseConfig, EthtoolRingConfig,
 };

--- a/rust/src/lib/nispor/infiniband.rs
+++ b/rust/src/lib/nispor/infiniband.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     BaseInterface, InfiniBandConfig, InfiniBandInterface, InfiniBandMode,
 };

--- a/rust/src/lib/nispor/linux_bridge_port_vlan.rs
+++ b/rust/src/lib/nispor/linux_bridge_port_vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange,

--- a/rust/src/lib/nispor/mac_vlan.rs
+++ b/rust/src/lib/nispor/mac_vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     BaseInterface, MacVlanConfig, MacVlanInterface, MacVlanMode, MacVtapConfig,
     MacVtapInterface, MacVtapMode,

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 mod apply;
 mod base_iface;
 mod bond;

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use log::warn;
 
 use crate::{RouteEntry, RouteType, Routes};

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{BaseInterface, EthernetInterface, VethConfig};
 
 pub(crate) fn np_veth_to_nmstate(

--- a/rust/src/lib/nispor/vrf.rs
+++ b/rust/src/lib/nispor/vrf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{BaseInterface, VrfConfig, VrfInterface};
 
 pub(crate) fn np_vrf_to_nmstate(

--- a/rust/src/lib/nm/checkpoint.rs
+++ b/rust/src/lib/nm/checkpoint.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::NmApi;
 use log::warn;
 

--- a/rust/src/lib/nm/nm_dbus/connection/bond.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/bond.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/hsr.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/hsr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/infiniband.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/infiniband.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/loopback.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/loopback.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/mac_vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mac_vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/macros.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/macros.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 macro_rules! _connection_inner_string_member {
     ($self_struct: ident, $member: ident) => {
         $self_struct

--- a/rust/src/lib/nm/nm_dbus/connection/macsec.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/macsec.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/veth.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/veth.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/vrf.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vrf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 

--- a/rust/src/lib/nm/nm_dbus/gen_conf/keyfile.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/keyfile.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::fmt::Write;
 

--- a/rust/src/lib/nm/nm_dbus/lldp.rs
+++ b/rust/src/lib/nm/nm_dbus/lldp.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::convert::TryFrom;
 
 use serde::Deserialize;

--- a/rust/src/lib/nm/settings/ethtool.rs
+++ b/rust/src/lib/nm/settings/ethtool.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::nm::nm_dbus::{NmConnection, NmSettingEthtool};

--- a/rust/src/lib/nm/settings/hsr.rs
+++ b/rust/src/lib/nm/settings/hsr.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::NmConnection;
 
 use crate::{HsrInterface, HsrProtocol};

--- a/rust/src/lib/nm/settings/infiniband.rs
+++ b/rust/src/lib/nm/settings/infiniband.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::NmConnection;
 
 use crate::InfiniBandInterface;

--- a/rust/src/lib/nm/settings/mac_vlan.rs
+++ b/rust/src/lib/nm/settings/mac_vlan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::NmSettingMacVlan;
 
 use crate::{MacVlanConfig, MacVtapConfig};

--- a/rust/src/lib/nm/settings/sriov.rs
+++ b/rust/src/lib/nm/settings/sriov.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::nm::nm_dbus::{
     NmConnection, NmSettingSriovVf, NmSettingSriovVfVlan,
 };

--- a/rust/src/lib/nm/settings/user.rs
+++ b/rust/src/lib/nm/settings/user.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use crate::nm::nm_dbus::{NmConnection, NmSettingUser};

--- a/rust/src/lib/nm/unit_tests/mod.rs
+++ b/rust/src/lib/nm/unit_tests/mod.rs
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod profiles;

--- a/rust/src/lib/ovsdb/global_conf.rs
+++ b/rust/src/lib/ovsdb/global_conf.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use serde_json::{Map, Value};

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use std::io::{Read, Write};
 use std::os::unix::net::UnixStream;
 use std::time::SystemTime;

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 mod apply;
 mod db;
 mod global_conf;

--- a/rust/src/lib/serializer.rs
+++ b/rust/src/lib/serializer.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::Serializer;
 
 pub(crate) fn is_option_string_empty(data: &Option<String>) -> bool {

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod base;
 #[cfg(test)]

--- a/rust/src/python/libnmstate/__init__.py
+++ b/rust/src/python/libnmstate/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from .clib_wrapper import NmstateError
 from .gen_conf import generate_configurations
 from .netapplier import apply


### PR DESCRIPTION
All rust code have // SPDX-License-Identifier: Apache-2.0 as first line.

All python code have # SPDX-License-Identifier: LGPL-2.1-or-later as first line.

Introduce a CI task, using `license-eye` from https://github.com/apache/skywalking-eyes for github action.