### PR TITLE
Ignore Generated Directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ nmstate-*.tar.gz.asc
 /tags
 
 /.vscode
+
+rust/src/clib/nmstate.pc
+rust/src/python/build


### PR DESCRIPTION
This commit updates the .gitignore file to include generated directories, such as `rust/src/clib/nmstate.pc` and `rust/src/python`, which are created after running `sudo make install`.