### PR TITLE
Hide secrets in Debug trait of NetworkState and its subtypes

### DIFF
--- a/rust/src/lib/ieee8021x.rs
+++ b/rust/src/lib/ieee8021x.rs
@@ -1,8 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::NetworkState;
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 /// The IEEE 802.1X authentication configuration. The example yaml output of
@@ -49,5 +51,21 @@ impl Ieee8021XConfig {
             self.private_key_password =
                 Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
         }
+    }
+}
+
+impl std::fmt::Debug for Ieee8021XConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ieee8021XConfig")
+            .field("identity", &self.identity)
+            .field("eap", &self.eap)
+            .field("private_key", &self.private_key)
+            .field("client_cert", &self.client_cert)
+            .field("ca_cert", &self.ca_cert)
+            .field(
+                "private_key_password",
+                &Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string()),
+            )
+            .finish()
     }
 }

--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -70,7 +70,7 @@ impl IpsecInterface {
                     log::info!(
                         "Treating IPv4 `dhcp: false` for IPSec interface {} \
                         as IPv4 disabled",
-                        self.base.name.as_str(),
+                        self.base.name.as_str()
                     );
                 }
                 ipv4_conf.enabled = false;
@@ -80,7 +80,7 @@ impl IpsecInterface {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LibreswanConfig {
@@ -148,6 +148,39 @@ pub struct LibreswanConfig {
 impl LibreswanConfig {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+impl std::fmt::Debug for LibreswanConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LibreswanConfig")
+            .field("right", &self.right)
+            .field("rightid", &self.rightid)
+            .field("rightrsasigkey", &self.rightrsasigkey)
+            .field("left", &self.left)
+            .field("leftid", &self.leftid)
+            .field("leftrsasigkey", &self.leftrsasigkey)
+            .field("leftcert", &self.leftcert)
+            .field("ikev2", &self.ikev2)
+            .field(
+                "psk",
+                &Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string()),
+            )
+            .field("ikelifetime", &self.ikelifetime)
+            .field("salifetime", &self.salifetime)
+            .field("ike", &self.ike)
+            .field("esp", &self.esp)
+            .field("dpddelay", &self.dpddelay)
+            .field("dpdtimeout", &self.dpdtimeout)
+            .field("dpdaction", &self.dpdaction)
+            .field("ipsec_interface", &self.ipsec_interface)
+            .field("authby", &self.authby)
+            .field("rightsubnet", &self.rightsubnet)
+            .field("leftmodecfgclient", &self.leftmodecfgclient)
+            .field("kind", &self.kind)
+            .field("hostaddrfamily", &self.hostaddrfamily)
+            .field("clientaddrfamily", &self.clientaddrfamily)
+            .finish()
     }
 }
 

--- a/rust/src/lib/ifaces/macsec.rs
+++ b/rust/src/lib/ifaces/macsec.rs
@@ -60,7 +60,7 @@ impl MacSecInterface {
                 if conf.mka_cak.is_none() ^ conf.mka_ckn.is_none() {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
-                        "The mka_cak and mka_cnk must be all missing or present.".to_string(),
+                        "The mka_cak and mka_cnk must be all missing or present.".to_string()
                     );
                     log::error!("{}", e);
                     return Err(e);
@@ -81,8 +81,10 @@ impl MacSecInterface {
                         || mka_ckn.len() < 2
                         || mka_ckn.len() % 2 == 1
                     {
-                        let e = NmstateError::new(ErrorKind::InvalidArgument,
-                        "The mka_ckn must be a string of even size between 2 and 64 characters".to_string());
+                        let e = NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            "The mka_ckn must be a string of even size between 2 and 64 characters".to_string()
+                        );
                         log::error!("{}", e);
                         return Err(e);
                     }
@@ -97,7 +99,7 @@ impl MacSecInterface {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 #[derive(Default)]
@@ -137,6 +139,24 @@ impl MacSecConfig {
             self.mka_cak =
                 Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
         }
+    }
+}
+
+impl std::fmt::Debug for MacSecConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MacSecConfig")
+            .field("encrypt", &self.encrypt)
+            .field("base_iface", &self.base_iface)
+            .field(
+                "mka_cak",
+                &Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string()),
+            )
+            .field("mka_ckn", &self.mka_ckn)
+            .field("port", &self.port)
+            .field("validation", &self.validation)
+            .field("send_sci", &self.send_sci)
+            .field("offload", &self.offload)
+            .finish()
     }
 }
 

--- a/rust/src/lib/unit_tests/debug_trait.rs
+++ b/rust/src/lib/unit_tests/debug_trait.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Interface, NetworkState};
+
+#[test]
+fn test_debug_trait() {
+    let ethernet = serde_yaml::from_str(
+        r"
+        name: eth1
+        type: ethernet
+        state: up
+        802.1x:
+            ca-cert: /etc/pki/802-1x-test/ca.crt
+            client-cert: /etc/pki/802-1x-test/client.example.org.crt
+            eap-methods:
+                - tls
+            identity: client.example.org
+            private-key: /etc/pki/802-1x-test/client.example.org.key
+            private-key-password: A1234567890
+        ",
+    )
+    .unwrap();
+
+    let des_eth = Interface::base_iface(&ethernet);
+
+    let mut net_state = NetworkState::new();
+    net_state.interfaces.push(ethernet.clone());
+
+    let debug_tr_eth = format!("{:?}", &des_eth);
+    let debug_tr_net_state = format!("{:?}", &net_state);
+
+    let password_hid_by_nmstate =
+        format!("private_key_password: Some(\"<_password_hid_by_nmstate>\")");
+
+    assert_ne!(
+        des_eth.ieee8021x.as_ref().unwrap().private_key_password,
+        Some("A123456789000".to_string())
+    );
+    assert_eq!(
+        des_eth.ieee8021x.as_ref().unwrap().private_key_password,
+        Some("A1234567890".to_string())
+    );
+    assert!(debug_tr_eth.contains(&password_hid_by_nmstate));
+    assert!(debug_tr_net_state.contains(&password_hid_by_nmstate));
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -7,6 +7,8 @@ mod bond;
 #[cfg(test)]
 mod bridge;
 #[cfg(test)]
+mod debug_trait;
+#[cfg(test)]
 mod dns;
 #[cfg(test)]
 mod ethernet;


### PR DESCRIPTION
This commit introduces changes that implement the Debug trait for `Ieee8021XConfig`,
     which holds the authentication configuration of NetworkState and its
     subtypes with IEEE 802.1X authentication interfaces.
     This ensures that sensitive information is hidden in debug output.
Test Log: https://pastebin.com/AGrnyNg0

Resolves: #2587