### PR TITLE
Fix integration tests of routes

### DIFF
--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -546,10 +546,8 @@ def test_remove_wildcast_route_with_iface(eth1_up, get_routes_func):
         }
     )
 
-    expected_routes = []
-
     cur_state = libnmstate.show()
-    assert_routes(expected_routes, cur_state)
+    assert_routes_missing(routes, cur_state)
 
 
 @pytest.mark.tier1
@@ -580,18 +578,17 @@ def test_remove_wildcast_route_without_iface(eth1_up, get_routes_func):
         }
     )
 
-    expected_routes = []
-
     cur_state = libnmstate.show()
-    assert_routes(expected_routes, cur_state)
+    assert_routes_missing(routes, cur_state)
 
 
 # TODO: Once we can disable IPv6, we should add an IPv6 test case here
 def test_disable_ipv4_with_routes_in_current(eth1_up):
+    routes = _get_ipv4_test_routes()
     libnmstate.apply(
         {
             Interface.KEY: [ETH1_INTERFACE_STATE],
-            Route.KEY: {Route.CONFIG: _get_ipv4_test_routes()},
+            Route.KEY: {Route.CONFIG: routes},
         }
     )
 
@@ -601,15 +598,16 @@ def test_disable_ipv4_with_routes_in_current(eth1_up):
     libnmstate.apply({Interface.KEY: [eth1_state]})
 
     cur_state = libnmstate.show()
-    assert_routes([], cur_state)
+    assert_routes_missing(routes, cur_state)
 
 
 @pytest.mark.tier1
 def test_disable_ipv4_and_remove_wildcard_route(eth1_up):
+    routes = _get_ipv4_test_routes()
     libnmstate.apply(
         {
             Interface.KEY: [ETH1_INTERFACE_STATE],
-            Route.KEY: {Route.CONFIG: _get_ipv4_test_routes()},
+            Route.KEY: {Route.CONFIG: routes},
         }
     )
 
@@ -629,16 +627,17 @@ def test_disable_ipv4_and_remove_wildcard_route(eth1_up):
     )
 
     cur_state = libnmstate.show()
-    assert_routes([], cur_state)
+    assert_routes_missing(routes, cur_state)
 
 
 @pytest.mark.tier1
 @parametrize_ip_ver_routes
 def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
+    routes = get_routes_func()
     libnmstate.apply(
         {
             Interface.KEY: [ETH1_INTERFACE_STATE],
-            Route.KEY: {Route.CONFIG: get_routes_func()},
+            Route.KEY: {Route.CONFIG: routes},
         }
     )
 
@@ -655,7 +654,7 @@ def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
     )
 
     cur_state = libnmstate.show()
-    assert_routes([], cur_state)
+    assert_routes_missing(routes, cur_state)
 
 
 @pytest.mark.tier1

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -5,6 +5,9 @@ import copy
 from libnmstate.schema import Route
 
 
+KERNEL_DEFAULT_TABLE_ID = 254
+
+
 def assert_routes(routes, state, nic="eth1"):
     routes = _clone_prepare_routes(routes)
     config_routes = _clone_prepare_routes(state[Route.KEY][Route.CONFIG], nic)
@@ -14,8 +17,8 @@ def assert_routes(routes, state, nic="eth1"):
 
     # The kernel contains more route entries than desired config
     for route in routes:
-        assert any(_compare_route(route, c_r) for c_r in config_routes)
-        assert any(_compare_route(route, r_r) for r_r in running_routes)
+        assert any(route == cur_rt for cur_rt in config_routes)
+        assert any(route == run_rt for run_rt in running_routes)
 
 
 def assert_routes_missing(routes, state, nic="eth1"):
@@ -27,34 +30,27 @@ def assert_routes_missing(routes, state, nic="eth1"):
 
     # The kernel contains more route entries than desired config
     for route in routes:
-        assert all(not _compare_route(route, c_r) for c_r in config_routes)
-        assert all(not _compare_route(route, r_r) for r_r in running_routes)
+        assert all(route != cur_rt for cur_rt in config_routes)
+        assert all(route != run_rt for run_rt in running_routes)
 
 
 def _clone_prepare_routes(routes, nic=None):
     routes_out = []
     for route in routes:
         if nic is None or route.get(Route.NEXT_HOP_INTERFACE, None) == nic:
-            # The kernel routes has different metric and table id for
-            # USE_DEFAULT_ROUTE_TABLE and USE_DEFAULT_METRIC
             route = copy.deepcopy(route)
+            # Ignore metric difference like nmstate production code
             route.pop(Route.METRIC, None)
-            if Route.TABLE_ID not in route:
-                route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
+            # Compare using kernel's value for the default table_id as it's not
+            # the same than USE_DEFAULT_ROUTE_TABLE
+            table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
+            if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
+                route[Route.TABLE_ID] = KERNEL_DEFAULT_TABLE_ID
+
             routes_out.append(route)
 
     routes_out.sort(key=_route_sort_key)
     return routes_out
-
-
-def _compare_route(route, current_route):
-    # kernel uses different value for the default table id
-    table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
-    if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
-        current_route = copy.deepcopy(current_route)
-        current_route[Route.TABLE_ID] = Route.USE_DEFAULT_ROUTE_TABLE
-
-    return route == current_route
 
 
 def _route_sort_key(route):


### PR DESCRIPTION
Some checks were not done properly in the integration tests of the routes:
- Comparing routes with the default table_id could give false matches
- Some tests asserting that certain routes are missing would always pass even if the routes were not removed

I have not tried to reproduce that potential cases, but it seems pretty clear that they can happen with code inspection only.