### PR TITLE
WIP: Demo'ng use of  natural language to generate nmstate YAML for linux bridge

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [
     "src/cli",
     "src/clib",
-    "src/lib",
+    "src/lib", "src/nlp",
 ]
 
 [workspace.metadata.vendor-filter]

--- a/rust/src/nlp/Cargo.toml
+++ b/rust/src/nlp/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nlp"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust-bert = "0.5.3"

--- a/rust/src/nlp/src/main.rs
+++ b/rust/src/nlp/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust/src/nlp/src/npl.rs
+++ b/rust/src/nlp/src/npl.rs
@@ -1,0 +1,27 @@
+
+use rust_bert::pipelines::common::ModelType;
+use rust_bert::pipelines::question_answering::{QuestionAnsweringModel, QaInput};
+use std::error::Error;
+
+// process user input and extract relevant information
+pub(crate) fn process_input(input_text: &str) -> Result<String, Box<dyn Error>> {
+    //  QuestionAnsweringModel
+    let qa_model = QuestionAnsweringModel::new(ModelType::Bert);
+
+    let question = "What's the name of the bridge?";
+
+    let qa_input = QaInput {
+        question: String::from(question),
+        context: String::from(input_text),
+    };
+
+    let answers = qa_model.predict(&[qa_input], 1, 32)?;
+
+    let bridge_name = if let Some(answer) = answers.get(0) {
+        answer.answer.clone()
+    } else {
+        String::from("Bridge not found")
+    };
+
+    Ok(bridge_name)
+}


### PR DESCRIPTION
# Proposed Road map
    
- [ ] Utilize state-of-the-art NLP models such as GPT (Generative Pre-trained Transformer) and/or rust-BERT (Bidirectional Encoder Representations from Transformers) for understanding natural language prompts related to network configuration.

- [ ]  Fine-tune the pre-trained NLP model on a dataset containing examples of network configuration prompts and their corresponding NetworkManager configurations.



Example;
reproduce this as POC.

Input: Please create a linux bridge br0 using eth1 and eth2.

Output:

---
interfaces:
  - name: br0
    type: linux-bridge
    state: up
    bridge:
      ports:
        - name: eth1
        - name: eth2


 Resolves: https://github.com/nmstate/nmstate/issues/2583

