### PR TITLE
Add check for nmstate C library on pip install

### DIFF
--- a/rust/src/python/setup.py
+++ b/rust/src/python/setup.py
@@ -1,16 +1,33 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
-
+import ctypes
+import sys
 import setuptools
 
 
 def requirements():
     req = []
-    with open("requirements.txt") as fd:
+    with open("requirements.txt", encoding="utf-8") as fd:
         for line in fd:
             line.strip()
             if not line.startswith("#"):
                 req.append(line)
     return req
+
+
+def check_nmstate_c_library():
+    if "bdist_rpm" not in sys.argv:
+        try:
+            ctypes.cdll.LoadLibrary("libnmstate.so.2")
+        except OSError as exc:
+            raise RuntimeError(
+                "Error: nmstate C library not found. "
+                "Please install nmstate C library separately "
+                "before installing the Python package."
+                "See: https://nmstate.io/user/install.html"
+            ) from exc
+
+
+check_nmstate_c_library()
 
 
 setuptools.setup(

--- a/rust/src/python/setup.py
+++ b/rust/src/python/setup.py
@@ -2,6 +2,7 @@
 import ctypes
 import sys
 import setuptools
+import subprocess
 
 
 def requirements():
@@ -17,6 +18,22 @@ def requirements():
 def check_nmstate_c_library():
     if "bdist_rpm" not in sys.argv:
         try:
+            # Run the find command
+            result = subprocess.run(
+                ["find", "/", "-name", "libnmstate.so.2"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+
+            # Check if the command was successful
+            if result.returncode == 0:
+                # Print the result
+                print("-----Found files:\n", result.stdout)
+            else:
+                # Print the error if the command failed
+                print("----The Error is:\n", result.stderr)
             ctypes.cdll.LoadLibrary("libnmstate.so.2")
         except OSError as exc:
             raise RuntimeError(


### PR DESCRIPTION
Added check for the presence of the nmstate C library in the setup.py script.

This commit modifies the setup.py script to check for the presence of the nmstate C library using ctypes.cdll.LoadLibrary("libnmstate.so.2"). If the library is not found, a `RuntimeError` is raised, guiding the user to install the nmstate C library separately before installing the Python package. This enhancement ensures that users are informed about the dependency on the nmstate C library before proceeding with the installation.


Resolves: https://github.com/nmstate/nmstate/issues/2575
