### PR TITLE
ovs: Warn user when cannot connect OVS daemon but desired

### DIFF
--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -14,7 +14,7 @@ const OVS_DB_NAME: &str = "Open_vSwitch";
 pub(crate) const GLOBAL_CONFIG_TABLE: &str = "Open_vSwitch";
 const NM_RESERVED_EXTERNAL_ID: &str = "NM.connection.uuid";
 
-const DEFAULT_OVS_DB_SOCKET_PATH: &str = "/run/openvswitch/db.sock";
+pub(crate) const DEFAULT_OVS_DB_SOCKET_PATH: &str = "/run/openvswitch/db.sock";
 
 #[derive(Debug)]
 pub(crate) struct OvsDbConnection {

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -1,9 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
 mod apply;
 mod db;
 mod global_conf;
 mod json_rpc;
 mod show;
 
+pub(crate) use self::db::DEFAULT_OVS_DB_SOCKET_PATH;
 pub(crate) use apply::ovsdb_apply;
 pub(crate) use show::ovsdb_is_running;
 pub(crate) use show::ovsdb_retrieve;

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -7,6 +7,13 @@ use crate::{
 };
 
 impl Interfaces {
+    pub(crate) fn has_up_ovs_iface(&self) -> bool {
+        self.iter().any(|i| {
+            i.iface_type() == InterfaceType::OvsBridge
+                || i.iface_type() == InterfaceType::OvsInterface
+        })
+    }
+
     pub fn update(&mut self, other: &Self) {
         let mut new_ifaces: Vec<Interface> = Vec::new();
         let other_ifaces = other.to_vec();

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -6,7 +6,10 @@ use crate::{
         nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
         nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_retrieve,
     },
-    ovsdb::{ovsdb_apply, ovsdb_is_running, ovsdb_retrieve},
+    ovsdb::{
+        ovsdb_apply, ovsdb_is_running, ovsdb_retrieve,
+        DEFAULT_OVS_DB_SOCKET_PATH,
+    },
     ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
     NmstateError,
 };
@@ -86,6 +89,14 @@ impl NetworkState {
                 MAX_SUPPORTED_INTERFACES,
             );
         }
+        if self.interfaces.has_up_ovs_iface() && !ovsdb_is_running() {
+            log::warn!(
+                "Desired state contains OVS interfaces, but not able \
+                to connect OVS daemon at socket {}",
+                DEFAULT_OVS_DB_SOCKET_PATH
+            );
+        }
+
         if !self.kernel_only {
             self.apply_with_nm_backend()
         } else {


### PR DESCRIPTION
When desire state has OVS interface/bridge, we should warn user on
not able to connect OVS daemon socket. If not the verification error
will confuse people on desired OVS interface/bridge not found.

A warning message will emit in this case, for example:

```
[2024-03-26T10:07:22Z WARN  nmstate::query_apply::net_state] Desired
state contains OVS interfaces, but not able to connection OVS daemon at
socket /run/openvswitch/db.sock
```

Since log cannot checked in auto integration test, manually tested with
OVS daemon stopped.