### PR TITLE
Use Workspace Dependencies #2406

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,25 @@ members = [
     "src/lib",
 ]
 
+[workspace.dependencies]
+log = "0.4.17"
+serde_yaml = "0.9"
+serde = {version = "1.0.137", default-features = false, features = ["derive"]}
+serde_json = { version = "1.0.75", default-features = false }
+nmstate = { path = "src/lib", version = "2.2", default-features = false }
+nispor = "1.2"
+uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
+nix = { version = "0.26.2", default-features = false, features = ["feature", "hostname"] }
+zbus = { version = "1.9.2", default-features = false}
+zvariant = {version = "2.10.0", default-features = false}
+libc = "0.2.74"
+once_cell = "1.12.0"
+env_logger = "0.10.0"
+clap = { version = "3.1", features = ["cargo"] }
+chrono = "0.4"
+toml = "0.8.10"
+ctrlc = "3.2.1"
+
 [workspace.metadata.vendor-filter]
 # For now we only care about tier 1+2 Linux
 platforms = ["*-unknown-linux-gnu"]

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -17,18 +17,18 @@ name = "nmstatectl"
 path = "ncl.rs"
 
 [dependencies]
-nmstate = {path = "../lib", version = "2.2", default-features = false}
-serde_yaml = "0.9"
-clap = { version = "3.1", features = ["cargo"] }
-serde = { version = "1.0", features = ["derive"] }
-env_logger = "0.10.0"
-log = "0.4.14"
-serde_json = "1.0.75"
-ctrlc = { version = "3.2.1", optional = true }
-uuid = { version = "1.1", features = ["v4"] }
-chrono = "0.4"
-nispor = { version = "1.2", optional = true }
-toml = "0.8.10"
+nmstate = { workspace = true }
+serde_yaml = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+serde_json = { workspace = true }
+ctrlc = { workspace = true, optional = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+nispor = { workspace = true, optional = true }
+toml = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -15,13 +15,13 @@ crate-type = ["cdylib", "staticlib"]
 doc = false
 
 [dependencies]
-nmstate = { path = "../lib", default-features = false }
-libc = "0.2.74"
-serde_json = "1.0"
-serde_yaml = "0.9"
-log = "0.4.17"
-serde = { version = "1.0.137", features = ["derive"] }
-once_cell = "1.12.0"
+nmstate = { workspace = true }
+libc = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+once_cell = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf"]

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -16,48 +16,39 @@ edition = "2021"
 path = "lib.rs"
 
 [dependencies]
-serde_yaml = "0.9"
+serde_yaml = { workspace = true }
 
 [dependencies.nispor]
-version = "1.2.18"
+workspace = true 
 optional = true
 
 [dependencies.zvariant]
-version = "2.10.0"
-default-features = false
+workspace = true
 
 [dependencies.uuid]
-version = "1.1"
-default-features = false
-features = ["v4", "v5"]
+workspace = true 
+features = ["v5"]
 
 [dependencies.log]
-version = "0.4.14"
-default-features = false
+workspace = true 
 
 [dependencies.zbus]
-version = "1.9.2"
-default-features = false
+workspace = true
 optional = true
 
 [dependencies.serde_json]
-version = "1.0.68"
-default-features = false
+workspace = true 
 features = [ "preserve_order" ]
 
 [dependencies.serde]
-version = "1.0.132"
-default-features = false
-features = ["derive"]
+workspace = true 
 
 [dependencies.nix]
-version = "0.26.2"
+workspace = true
 optional = true
-default-features = false
-features = ["feature", "hostname"]
 
 [dev-dependencies]
-serde_yaml = "0.9"
+serde_yaml = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]


### PR DESCRIPTION
This PR centralizes shared dependencies to 
the workspace level, ensuring version 
consistency and simplifying dependency 
management across all crates.

Changes:
-  Introduced workspace.dependencies in the 
main Cargo.toml for shared dependencies used 
in two or more crates.
- Adjusted crate-specific Cargo.toml files to 
reference shared dependencies from the workspace.

Testing:
Ran cargo build successfully with no errors
All tests passed with cargo test

resolves [#2406](https://github.com/nmstate/nmstate/issues/2406)