### PR TITLE
Create alias for nmstaetctl subcommand #2579

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -102,6 +102,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_SHOW)
                 .about("Show network state")
+                .alias("s")
                 .arg(
                     clap::Arg::new("IFNAME")
                         .index(1)
@@ -138,6 +139,7 @@ fn main() {
         .subcommand(
             clap::Command::new(SUB_CMD_APPLY)
                 .about("Apply network state or network policy")
+                .alias("a")
                 .alias("set")
                 .arg(
                     clap::Arg::new("STATE_FILE")


### PR DESCRIPTION
Add Short Aliases for nmstatectl Subcommands
This implementation uses the `clap` library's alias feature to 
create shorter aliases for commonly used subcommands

**Changes:**
- Introduced **'a'** as an alias for **'apply'** subcommand.
- Introduced **'s'** as an alias for **'show'** subcommand.

**Motivation:**
To enhance the user experience by reducing typing effort and to
streamline frequent command usage.

**Testing:**
- Compiled the project successfully with **cargo build**.
- Executed **`nmstatectl a`**  and verified it acts like  **`nmstatectl apply.`**
- Executed **`nmstatectl s`** and verified it acts like **`nmstatectl show.`**

resolves [#2579](https://github.com/nmstate/nmstate/issues/2579)
