### PR TITLE
Implement std::fmt::Debug for NetworkState and its subtypes

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -74,7 +74,7 @@ use crate::{
 ///     system-id: 176866c7-6dc8-400f-98ac-c658509ec09f
 ///   other_config: {}
 /// ```
-#[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[derive(Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct NetworkState {
@@ -119,6 +119,26 @@ pub struct NetworkState {
     pub(crate) running_config_only: bool,
     #[serde(skip)]
     pub(crate) memory_only: bool,
+}
+
+impl std::fmt::Debug for NetworkState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("NetworkState");
+        debug_struct.field("hostname", &self.hostname);
+        debug_struct.field("dns", &self.dns);
+        debug_struct.field("rules", &self.rules);
+        debug_struct.field("routes", &self.routes);
+        debug_struct.field("interfaces", &self.interfaces);
+        debug_struct.field("ovsdb", &self.ovsdb);
+        debug_struct.field("timeout", &"<_password_hid_by_nmstate>");
+        debug_struct.field("no_verify", &"<_password_hid_by_nmstate>");
+        debug_struct.field("no_commit", &"<_password_hid_by_nmstate>");
+        debug_struct.field("include_secrets", &self.include_secrets);
+        debug_struct.field("include_status_data", &self.include_status_data);
+        debug_struct.field("running_config_only", &self.running_config_only);
+        debug_struct.field("memory_only", &self.memory_only);
+        debug_struct.finish()
+    }
 }
 
 impl NetworkState {

--- a/rust/src/lib/unit_tests/net_state.rs
+++ b/rust/src/lib/unit_tests/net_state.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::HostNameState;
+use crate::Interfaces;
 use crate::NetworkState;
+use crate::OvnConfiguration;
+use crate::RouteRules;
+use crate::Routes;
 
 #[test]
 fn test_invalid_top_key() {
@@ -22,4 +27,44 @@ fn test_invalid_top_type() {
     );
 
     assert!(result.is_err());
+}
+
+#[test]
+fn test_network_state_debug() {
+    let network_state = NetworkState {
+        hostname: Some(HostNameState::default()), // Use Option<HostNameState>
+        dns: None,
+        rules: RouteRules::default(),
+        routes: Routes::default(),
+        interfaces: Interfaces::default(),
+        ovsdb: None,
+        timeout: Some(60),
+        no_verify: true,
+        no_commit: false,
+        include_secrets: true,
+        include_status_data: false,
+        kernel_only: true,
+        memory_only: true,
+        running_config_only: false,
+        ovn: OvnConfiguration::default(),
+    };
+
+    let debug_output = format!("{:?}", network_state);
+
+    // Assert that the debug output contains the expected fields
+    assert!(debug_output.contains("hostname"));
+    assert!(debug_output.contains("dns"));
+    assert!(debug_output.contains("rules"));
+    assert!(debug_output.contains("routes"));
+    assert!(debug_output.contains("interfaces"));
+    assert!(debug_output.contains("ovsdb"));
+    assert!(debug_output.contains("timeout"));
+    assert!(debug_output.contains("no_verify"));
+    assert!(debug_output.contains("no_commit"));
+    assert!(debug_output.contains("include_secrets"));
+    assert!(debug_output.contains("include_status_data"));
+    assert!(debug_output.contains("running_config_only"));
+    assert!(debug_output.contains("memory_only"));
+    // Assert that the debug output contains the hidden password
+    assert!(debug_output.contains("<_password_hid_by_nmstate>"))
 }


### PR DESCRIPTION
Implemented the fmt::Debug trait for the NetworkState struct,
Created a new impl fmt::Debug block for the NetworkState struct.
Defined the fmt function within the impl block std::fmt::Formatter and returns a std::fmt::Result.
Constructed a debug representation of the NetworkState using the debug_struct method from std::fmt::Formatter.
Created Tests to verify the debug output of the NetworkState struct includes the expected fields and that the sensitive information is appropriately hidden.
