### PR TITLE
route: Normalize route table of current route when determining route removed

### DIFF
--- a/rust/src/lib/nm/query_apply/route.rs
+++ b/rust/src/lib/nm/query_apply/route.rs
@@ -2,6 +2,8 @@
 
 use super::super::nm_dbus::{NmConnection, NmIpRoute};
 
+const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
+
 pub(crate) fn is_route_removed(
     new_nm_conn: &NmConnection,
     cur_nm_conn: &NmConnection,
@@ -36,7 +38,11 @@ fn is_nm_ip_route_removed(
     cur_routes: &[NmIpRoute],
 ) -> bool {
     for cur_route in cur_routes {
-        if !new_routes.contains(cur_route) {
+        let mut cur_route_norm = cur_route.clone();
+        if cur_route_norm.table.is_none() {
+            cur_route_norm.table = Some(DEFAULT_TABLE_ID);
+        }
+        if !new_routes.contains(&cur_route_norm) {
             return true;
         }
     }


### PR DESCRIPTION
Normalizing the `None` route table ID into default table ID when
creating the merged routes will cause the routes difference in new NM
conncetion and activated NM connection when applying the same desired
state the second time, as the result, the activated connection will be
dactivated first and activated again. This is troublesome, because the
routes added by iproute2 utility will be deleted by mistake. To fix
that, normalize the route table of the current routes in the activated
NM connection before comparing the difference between current routes
and new routes.

Resolves: https://issues.redhat.com/browse/RHEL-29241