### PR TITLE
cargo: Fix compiling on rust 1.66

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
 
     - name: Install tools for tests
       run: |
+        # Workaround for https://github.com/actions/runner-images/issues/9733
+        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update;
         sudo apt-get -y install valgrind
 
@@ -144,6 +146,8 @@ jobs:
 
       - name: Install extra kernel modules(e.g. vrf)
         run: |
+          # Workaround for https://github.com/actions/runner-images/issues/9733
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update;
           sudo apt-get -y install "linux-modules-extra-$(uname -r)"
 
@@ -182,6 +186,17 @@ jobs:
           name: nmstate-test-artifact-${{ matrix.job_type }}
           path: test_artifacts/
           retention-days: 5
+
+  build_on_rust_1_66:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust 1.66
+      run: rustup install 1.66
+
+    - name: Build on rust 1.66
+      run: cd rust && cargo +1.66 build --ignore-rust-version
 
   macos_gen_conf_build:
     strategy:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,7 +23,8 @@ env_logger = "0.10.0"
 clap = { version = "3.1", features = ["cargo"] }
 chrono = "0.4"
 toml = "0.8.10"
-ctrlc = "3.2.1"
+# For the seek of compiling on Rust 1.66
+ctrlc = "<=3.4.2"
 
 [workspace.metadata.vendor-filter]
 # For now we only care about tier 1+2 Linux

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux-apis"]
-rust-version = "1.60"
+rust-version = "1.66"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
We need to support compiling nmstate on rust 1.66 (the version shipped
by RHEL 9.2).

Except the `--ignore-rust-version` compiling option, we need to pin the
version of `ctrlc` crate to 3.4.2 to pass the compiling as its later version use nix
0.28 which requires rust 1.69+.

Included CI test case to ensure this.