### PR TITLE
networking: Sort route rules retrieved from nispor 

### DIFF
--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -83,6 +83,8 @@ pub(crate) fn get_route_rules(
         };
         rules.push(rule);
     }
+
+    rules.sort_unstable_by_key(|rule| rule.priority.unwrap_or(0));
     ret.config = Some(rules);
 
     ret

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -320,3 +320,27 @@ fn test_route_rule_auto_priority_increasing_from_empty() {
     );
     assert_eq!(rules[2].priority, Some(30002));
 }
+
+#[test]
+fn test_route_rule_sorting() {
+    let mut rules = vec![
+        RouteRuleEntry {
+            priority: Some(200),
+            ..Default::default()
+        },
+        RouteRuleEntry {
+            priority: Some(100),
+            ..Default::default()
+        },
+        RouteRuleEntry {
+            priority: Some(300),
+            ..Default::default()
+        },
+    ];
+
+    rules.sort_unstable();
+
+    assert_eq!(rules[0].priority, Some(100));
+    assert_eq!(rules[1].priority, Some(200));
+    assert_eq!(rules[2].priority, Some(300));
+}


### PR DESCRIPTION
The` Ord` trait implementation of `RouteRuleEntry` already includes a sorting function. However, the order provided by nispor_retrieve() does not guarantee the desired sorting based on priority, which can lead to inconsistencies, particularly when the kernel prioritizes certain rules over others.

This commit addresses the task by adding explicit sorting of route rules returned by `nispor_retrieve()`. The `sort_unstable_by_key() `function is used to ensure stable sorting, with priority taking precedence.

Unit test cases have been added to verify that the sorting function works as expected. These tests validate the ordering of route rules based on priority, ensuring that the sorting implementation meets the requirements specified in the task.

Resolves: https://github.com/nmstate/nmstate/issues/1416