### PR TITLE
sriov: add support for drivers-autoprobe

### DIFF
--- a/examples/eth1_with_sriov.yml
+++ b/examples/eth1_with_sriov.yml
@@ -5,6 +5,7 @@ interfaces:
     state: up
     ethernet:
       sr-iov:
+        drivers-autoprobe: false
         total-vfs: 1
         vfs:
           - id: 0

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -23,6 +23,7 @@ use crate::{
 ///   max-mtu: 9702
 ///   ethernet:
 ///     sr-iov:
+///       drivers-autoprobe: false
 ///       total-vfs: 2
 ///       vfs:
 ///       - id: 0
@@ -43,6 +44,16 @@ use crate::{
 ///         qos: 0
 /// ```
 pub struct SrIovConfig {
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    /// Bind created VFs to their default kernel driver.
+    /// This relates to sriov_drivers_autoprobe.
+    /// More info here https://docs.kernel.org/PCI/pci-iov-howto.html#sr-iov-api
+    /// Deserialize and serialize from/to `drivers-autoprobe`.
+    pub drivers_autoprobe: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,

--- a/rust/src/lib/nm/settings/sriov.rs
+++ b/rust/src/lib/nm/settings/sriov.rs
@@ -27,6 +27,10 @@ pub(crate) fn gen_nm_sriov_setting(
         nm_sriov_set.total_vfs = Some(v);
     }
 
+    if let Some(autoprobe) = sriov_conf.drivers_autoprobe {
+        nm_sriov_set.autoprobe_drivers = Some(autoprobe);
+    }
+
     if let Some(vfs) = &sriov_conf.vfs {
         nm_sriov_set.vfs = Some(gen_nm_vfs(
             vfs,

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -23,6 +23,9 @@ impl SrIovConfig {
 
     pub(crate) fn update(&mut self, other: Option<&SrIovConfig>) {
         if let Some(other) = other {
+            if let Some(autoprobe) = other.drivers_autoprobe {
+                self.drivers_autoprobe = Some(autoprobe);
+            }
             if let Some(total_vfs) = other.total_vfs {
                 self.total_vfs = Some(total_vfs);
             }
@@ -53,6 +56,23 @@ impl SrIovConfig {
                     ));
                 }
             };
+
+        if let Some(desired_autoprobe) = self.drivers_autoprobe {
+            if !desired_autoprobe {
+                return Ok(());
+            }
+        }
+
+        if let Some(cur_autoprobe) = cur_pf_iface
+            .ethernet
+            .as_ref()
+            .and_then(|eth_conf| eth_conf.sr_iov.as_ref())
+            .and_then(|sriov_conf| sriov_conf.drivers_autoprobe.as_ref())
+        {
+            if !cur_autoprobe {
+                return Ok(());
+            }
+        }
 
         let vfs = if let Some(vfs) = cur_pf_iface
             .ethernet

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -15,6 +15,7 @@ ethernet:
   auto-negotiation: "false"
   speed: "1000"
   sr-iov:
+    drivers-autoprobe: "false"
     total-vfs: "64"
     vfs:
       - id: "0"
@@ -33,6 +34,7 @@ ethernet:
     let vf_conf = sriov_conf.vfs.as_ref().unwrap().first().unwrap();
 
     assert_eq!(eth_conf.speed, Some(1000));
+    assert_eq!(sriov_conf.drivers_autoprobe, Some(false));
     assert_eq!(sriov_conf.total_vfs, Some(64));
     assert_eq!(vf_conf.id, 0);
     assert_eq!(vf_conf.spoof_check, Some(true));

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -629,6 +629,7 @@ fn test_sriov_enable_and_use_in_single_yaml() {
         assert_eq!(eth_conf.speed, Some(10000));
         assert_eq!(eth_conf.duplex, Some(EthernetDuplex::Full));
         let sr_iov_conf = eth_conf.sr_iov.as_ref().unwrap();
+        assert_eq!(sr_iov_conf.drivers_autoprobe, None);
         assert_eq!(sr_iov_conf.total_vfs, Some(2));
     } else {
         panic!("Expecting Ethernet interface, got {:?}", pf_state);

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -285,6 +285,7 @@ class Ethernet:
     SRIOV_SUBTREE = "sr-iov"
 
     class SRIOV:
+        DRIVERS_AUTOPROBE = "drivers-autoprobe"
         TOTAL_VFS = "total-vfs"
         VFS_SUBTREE = "vfs"
 

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -526,3 +526,38 @@ class TestSrIov:
         libnmstate.apply(desired_state)
         vf_ifaces = get_sriov_vf_names(pf_name)
         assert len(vf_ifaces) == 62
+
+    def test_drivers_autoprobe_false(self):
+        pf_name = _test_nic_name()
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Ethernet.CONFIG_SUBTREE: {
+                        Ethernet.SRIOV_SUBTREE: {
+                            Ethernet.SRIOV.DRIVERS_AUTOPROBE: False,
+                            Ethernet.SRIOV.TOTAL_VFS: 32,
+                        },
+                    },
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        vf_ifaces = get_sriov_vf_names(pf_name)
+        assert len(vf_ifaces) == 0
+
+    def test_drivers_autoprobe_restore_default(self):
+        pf_name = _test_nic_name()
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Ethernet.CONFIG_SUBTREE: {
+                        Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+                    },
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        vf_ifaces = get_sriov_vf_names(pf_name)
+        assert len(vf_ifaces) == 2


### PR DESCRIPTION
NetworkManager already supports setting sriov_drivers_autoprobe, add it in the nmstate schema.

I am not sure if what I am doing is enough here. I'd like some guidance.

Thanks!