### PR TITLE
CI container: Sync container with latest repos

### DIFF
--- a/packaging/Dockerfile.c9s-nmstate-build
+++ b/packaging/Dockerfile.c9s-nmstate-build
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN echo "2023-09-08" > /build_time
+RUN echo "024-04-09" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
        systemd git make rust-toolset rpm-build python3 python3-devel && \

--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-RUN echo "2023-11-06" > /build_time
+RUN echo "2024-04-09" > /build_time
 
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core epel-release \

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:latest
 
-RUN echo "2023-11-06" > /build_time
+RUN echo "2024-04-09" > /build_time
 
 RUN dnf update -y && \
     dnf -y install --setopt=install_weak_deps=False \
@@ -8,7 +8,7 @@ RUN dnf update -y && \
         openvswitch systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk nispor patchelf rust-packaging \
+        libndp procps-ng dpdk nispor rust-packaging \
         python3-gobject-base NetworkManager-libreswan libreswan \
         && dnf clean all
 

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -1,13 +1,13 @@
 FROM registry.fedoraproject.org/fedora:rawhide
 
-RUN echo "2023-11-06" > /build_time
+RUN echo "2024-04-09" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust cargo NetworkManager NetworkManager-ovs \
         openvswitch systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk nispor patchelf rust-packaging \
+        libndp procps-ng dpdk nispor rust-packaging \
         python3-gobject-base NetworkManager-libreswan libreswan \
         && dnf clean all
 


### PR DESCRIPTION
Force rebuild of CentOS stream 9 and Fedora containers to sync with
latest repos.

Removed `patchelf` from Fedora container as it is not required for
building nmstate rpm.