### PR TITLE
[nmstate-1.4] nm: Do not touch interface DNS if global DNS is used

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -26,12 +26,12 @@ if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
         dnf install -y python3-varlink libvarlink-util python3-jsonschema \
-            python3-nispor python3-openvswitch2.11;'
+            python3-nispor python3-openvswitch2.11 teamd NetworkManager-team;'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
         dnf install -y python3-varlink libvarlink-util python3-jsonschema \
-            python3-nispor;
+            python3-nispor teamd NetworkManager-team;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
         systemctl restart openvswitch'

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -26,14 +26,18 @@ if [ $OS_TYPE == "c8s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
         dnf install -y python3-varlink libvarlink-util python3-jsonschema \
-            python3-nispor python3-openvswitch2.11 teamd NetworkManager-team;'
+            python3-nispor python3-openvswitch2.11 \
+            NetworkManager-config-server teamd NetworkManager-team;
+        systemctl restart NetworkManager'
 elif [ $OS_TYPE == "ovs2_11" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c8s-nmstate-dev"
     CUSTOMIZE_ARG='--customize=
         dnf install -y python3-varlink libvarlink-util python3-jsonschema \
-            python3-nispor teamd NetworkManager-team;
+            python3-nispor teamd NetworkManager-team \
+            NetworkManager-config-server;
         dnf remove -y openvswitch2.11 python3-openvswitch2.11;
         dnf install -y openvswitch2.13 python3-openvswitch2.13;
+        systemctl restart NetworkManager;
         systemctl restart openvswitch'
 elif [ $OS_TYPE == "vdsm_el8" ]; then
     CONTAINER_IMAGE="quay.io/ovirt/vdsm-network-tests-functional"

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -70,10 +70,6 @@ function container_pre_test_setup {
     set -x
     ${CONTAINER_CMD} --version && cat /etc/resolv.conf
 
-    if [[ "$CI" == "true" ]];then
-        rebuild_container_images
-    fi
-
     create_container
 
     container_exec "ulimit -c unlimited"

--- a/libnmstate/net_state.py
+++ b/libnmstate/net_state.py
@@ -101,6 +101,11 @@ class NetState:
                             )
                             self.use_global_dns = True
                 elif self.dns.config_changed:
+                    logging.warning(
+                        "Storing DNS to NetworkManager via global DNS "
+                        "API, this will cause __all__ interface level "
+                        "DNS settings been ignored"
+                    )
                     self.use_global_dns = True
 
             self._ifaces.gen_route_metadata(self._route)

--- a/packaging/make_srpm.sh
+++ b/packaging/make_srpm.sh
@@ -6,6 +6,7 @@ SRC_DIR="$(dirname "$0")/.."
 TMP_DIR=$(mktemp -d)
 SPEC_FILE="$TMP_DIR/nmstate.spec"
 OLD_PWD=$(pwd)
+BASE_URL="https://github.com/nmstate/nmstate/"
 
 for candidate in python3 python
 do
@@ -40,6 +41,8 @@ TAR_FILE="${TMP_DIR}/nmstate-${VERSION}.tar"
     ./packaging/make_spec.sh > "${SPEC_FILE}"
     tar --append --file=$TAR_FILE $SPEC_FILE
     gzip "${TAR_FILE}"
+    curl -L ${BASE_URL}/releases/download/v1.4.5/nmstate-vendor-1.4.5.tar.xz \
+        --output $TMP_DIR/nmstate-vendor-1.4.5.tar.xz
 
     rpmbuild --define "_rpmdir $TMP_DIR/" --define "_srcrpmdir $TMP_DIR/" \
     -ts $TAR_FILE.gz

--- a/packaging/nmstate.spec
+++ b/packaging/nmstate.spec
@@ -12,6 +12,7 @@ Summary:        Declarative network manager API
 License:        LGPLv2+
 URL:            https://github.com/%{srcname}/%{srcname}
 Source0:        https://github.com/%{srcname}/%{srcname}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz
+Source1:        %{url}/releases/download/v1.4.5/%{srcname}-vendor-1.4.5.tar.xz
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 Requires:       python3-%{libname} = %{?epoch:%{epoch}:}%{version}-%{release}
@@ -84,6 +85,7 @@ This package contains the nmstate plugin for OVS database manipulation.
 
 %prep
 %setup -q
+%cargo_prep -V 1
 
 %preun
 %systemd_preun nmstate-varlink.service

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -819,6 +819,10 @@ def test_create_vlan_over_ovs_iface_with_use_same_name_as_bridge(
     assertlib.assert_state_match(desired_state)
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_create_vxlan_over_ovs_iface_with_use_same_name_as_bridge(
     ovs_bridge1_with_internal_port_same_name,
 ):
@@ -1093,6 +1097,10 @@ def unmanged_ovs_vxlan():
 
 
 @pytest.mark.tier1
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_ovs_vxlan_in_current_not_impact_others(unmanged_ovs_vxlan):
     with Bridge(BRIDGE1).create() as state:
         assertlib.assert_state_match(state)

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import os
 import time
 
 import pytest
@@ -45,6 +46,10 @@ VXLAN1_ID = 201
 VXLAN2_ID = 202
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_and_remove_vxlan(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -57,6 +62,10 @@ def test_add_and_remove_vxlan(eth1_up):
 
 
 @pytest.mark.tier1
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -81,6 +90,10 @@ def test_add_and_remove_two_vxlans_on_same_iface(eth1_up):
     raises=AssertionError,
     strict=False,
 )
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_rollback_for_vxlans(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     current_state = libnmstate.show()
@@ -99,6 +112,10 @@ def test_rollback_for_vxlans(eth1_up):
     assert current_state == current_state_after_apply
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_set_vxlan_iface_down(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=ifname, remote="192.168.100.1")
@@ -108,6 +125,10 @@ def test_set_vxlan_iface_down(eth1_up):
         assertlib.assert_absent(vxlan.name)
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_new_bond_iface_with_vxlan(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     bond_name = "bond0"
@@ -126,6 +147,10 @@ def test_add_new_bond_iface_with_vxlan(eth1_up):
     assertlib.assert_absent(bond_name)
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_show_vxlan_with_no_remote(eth1_up):
     eth_name = eth1_up[Interface.KEY][0][Interface.NAME]
     vxlan = VxlanState(id=VXLAN1_ID, base_if=eth_name, remote="")
@@ -145,6 +170,10 @@ def test_show_vxlan_with_no_remote(eth1_up):
 
 
 @pytest.mark.tier1
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
+)
 def test_add_vxlan_and_modify_vxlan_id(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]
     with vxlan_interfaces(
@@ -163,6 +192,10 @@ def test_add_vxlan_and_modify_vxlan_id(eth1_up):
 @pytest.mark.skipif(
     nm_major_minor_version() < 1.31,
     reason="Modifying accept-all-mac-addresses is not supported on NM.",
+)
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="https://issues.redhat.com/browse/RHEL-5001",
 )
 def test_vxlan_enable_and_disable_accept_all_mac_addresses(eth1_up):
     ifname = eth1_up[Interface.KEY][0][Interface.NAME]


### PR DESCRIPTION
When desire state only contains DNS configurations, we noticed nmstate
also purging interface DNS even global DNS is chose, this lead to
unnecessary modification of existing interfaces.

This patch skip the interface DNS modification if global DNS is used.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-32218