### PR TITLE
veth: Alway show veth interface with type veth

### DIFF
--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -50,7 +50,13 @@ impl BaseInterface {
         if other.description.is_some() {
             self.description.clone_from(&other.description);
         }
-        if other.iface_type != InterfaceType::Unknown {
+
+        // Do not allow unknown interface type overriding existing
+        // Do not allow ethernet interface type overriding veth
+        if other.iface_type != InterfaceType::Unknown
+            && !(other.iface_type == InterfaceType::Ethernet
+                && self.iface_type == InterfaceType::Veth)
+        {
             self.iface_type = other.iface_type.clone();
         }
         if other.state != InterfaceState::Unknown {

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -381,3 +381,11 @@ def veth_interface_both_up(ifname, peer):
 def veth1_up():
     with veth_interface(VETH1, VETH1PEER):
         yield
+
+
+# https://issues.redhat.com/browse/RHEL-32698
+@pytest.mark.tier1
+def test_show_veth_as_veth_iface_type(veth1_up):
+    state = statelib.show_only((VETH1,))
+    assert state[Interface.KEY][0][Interface.NAME] == VETH1
+    assert state[Interface.KEY][0][Interface.TYPE] == InterfaceType.VETH


### PR DESCRIPTION
We should not allow nm plugin to override ethernet interface type to
veth interface type queried by nispor.

Integration test case included and marked as tier1 test.

Resolves: https://issues.redhat.com/browse/RHEL-32698