### PR TITLE
net_state: Add description to top level YAML/JSON API

### DIFF
--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -23,6 +23,8 @@ pub(crate) struct SortedNetworkState {
     ovsdb: Option<OvsDbGlobalConfig>,
     #[serde(rename = "ovn")]
     ovn: OvnConfiguration,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    description: String,
 }
 
 const IFACE_TOP_PRIORTIES: [&str; 2] = ["name", "type"];
@@ -94,6 +96,7 @@ pub(crate) fn sort_netstate(
             dns: net_state.dns,
             ovsdb: net_state.ovsdb,
             ovn: net_state.ovn,
+            description: net_state.description,
         });
     }
 
@@ -105,6 +108,7 @@ pub(crate) fn sort_netstate(
         dns: net_state.dns,
         ovsdb: net_state.ovsdb,
         ovn: net_state.ovn,
+        description: net_state.description,
     })
 }
 

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -78,6 +78,11 @@ use crate::{
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct NetworkState {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    /// Description for the whole desire state. Currently it will not be
+    /// persisted by network backend and will be ignored during applying or
+    /// querying.
+    pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Hostname of current host.
     pub hostname: Option<HostNameState>,

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -371,6 +371,9 @@ impl NetworkState {
 
         ret.routes = merged_state.routes.gen_diff();
         ret.rules = merged_state.rules.gen_diff();
+        if self.description != current.description {
+            ret.description.clone_from(&self.description);
+        }
 
         if merged_state.ovsdb.is_changed() {
             ret.ovsdb.clone_from(&self.ovsdb);

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -552,3 +552,7 @@ class Mptcp:
     FLAG_SUBFLOW = "subflow"
     FLAG_BACKUP = "backup"
     FLAG_FULLMESH = "fullmesh"
+
+
+class Description:
+    KEY = "description"

--- a/tests/integration/testlib/apply.py
+++ b/tests/integration/testlib/apply.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import libnmstate
+
+from libnmstate.schema import Description
+
+
+def apply_with_description(description, desired_state, *args, **kwargs):
+    desired_state[Description.KEY] = description
+    libnmstate.apply(desired_state, *args, **kwargs)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -9,6 +9,7 @@ from operator import itemgetter
 
 import libnmstate
 from libnmstate.schema import Bond
+from libnmstate.schema import Description
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIP
 from libnmstate.schema import InterfaceIPv4
@@ -111,6 +112,7 @@ class State:
         self._sort_ovs_lag_ports()
         self._sort_mptcp_flags()
         self._remove_mptcp_flags_of_ip_addr()
+        self._remove_top_descriptions()
 
     def match(self, other):
         return state_match(self.state, other.state)
@@ -293,6 +295,9 @@ class State:
                 InterfaceIPv6.ADDRESS, []
             ):
                 addr.pop(InterfaceIPv6.MPTCP_FLAGS, None)
+
+    def _remove_top_descriptions(self):
+        self._state.pop(Description.KEY, None)
 
 
 def _lookup_iface_state_by_name(interfaces_state, ifname):


### PR DESCRIPTION
Introducing `description` as top level key of YAML/JSON API holding a
String. For example:

```yml
description: test-description: "Abc"
```

Currently, this property will be ignored when applying or querying, no
backend will persist this property. It is designed for user to store
description for the whole YAML only for now.

By using `testlib.apply.apply_with_description()`, we could store:
`test_description: <string>` into `.descriptions`. The
`pytest ----dump-ai-train-yaml` will store the YAML file into `.states`
folder for training AI.

The `--dump-ai-train-yaml` will only store YAML files with top level
description and the output will only contains the difference between
desired state and current state.

