### PR TITLE
nm ovs: Enable connection.autoconnect-ports for OVS port

### DIFF
--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -131,7 +131,6 @@ pub(crate) fn perpare_nm_conns(
 
 // When a new virtual interface is desired, if its controller is also newly
 // created, in NetworkManager, there is no need to activate the subordinates.
-// For OVS stuff, always return false.
 fn can_skip_activation(
     merged_iface: &MergedInterface,
     merged_ifaces: &MergedInterfaces,
@@ -175,16 +174,12 @@ fn can_skip_activation(
     if merged_iface.current.is_none()
         && merged_iface.for_apply.is_some()
         && merged_iface.merged.is_up()
-        && merged_iface.merged.iface_type() != InterfaceType::OvsInterface
     {
         if let Some(desired_iface) = merged_iface.for_apply.as_ref() {
             if let (Some(ctrl_iface), Some(ctrl_type)) = (
                 desired_iface.base_iface().controller.as_deref(),
                 desired_iface.base_iface().controller_type.as_ref(),
             ) {
-                if ctrl_type == &InterfaceType::OvsBridge {
-                    return false;
-                }
                 if let Some(merged_ctrl_iface) =
                     merged_ifaces.get_iface(ctrl_iface, ctrl_type.clone())
                 {

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -307,6 +307,9 @@ fn delete_ifaces(
 
     for uuid in &uuids_to_delete {
         nm_api
+            .connection_deactivate(uuid)
+            .map_err(nm_error_to_nmstate)?;
+        nm_api
             .connection_delete(uuid)
             .map_err(nm_error_to_nmstate)?;
     }
@@ -381,6 +384,9 @@ fn delete_orphan_ports(
         }
     }
     for uuid in &uuids_to_delete {
+        nm_api
+            .connection_deactivate(uuid)
+            .map_err(nm_error_to_nmstate)?;
         nm_api
             .connection_delete(uuid)
             .map_err(nm_error_to_nmstate)?;

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -443,7 +443,9 @@ pub(crate) fn gen_nm_conn_setting(
         nm_conn_set.iface_name = None;
     }
     nm_conn_set.autoconnect = Some(true);
-    nm_conn_set.autoconnect_ports = if iface.is_controller() {
+    nm_conn_set.autoconnect_ports = if iface.is_controller()
+        || iface.iface_type() == InterfaceType::Other("ovs-port".to_string())
+    {
         Some(true)
     } else {
         None

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import yaml
 
 import libnmstate
 from libnmstate.schema import Interface
@@ -18,6 +17,7 @@ from ..testlib import statelib
 from ..testlib.ovslib import Bridge
 from ..testlib.retry import retry_till_true_or_timeout
 from ..testlib.dummy import nm_unmanaged_dummy
+from ..testlib.yaml import load_yaml
 
 
 BRIDGE0 = "brtest0"
@@ -525,7 +525,7 @@ def test_do_not_touch_ovs_port_when_not_desired_internal_iface(
 
 
 def test_gc_on_ovs_dpdk():
-    desired_state = yaml.load(
+    desired_state = load_yaml(
         """---
         interfaces:
         - name: ovs0
@@ -544,8 +544,7 @@ def test_gc_on_ovs_dpdk():
               datapath: "netdev"
             port:
             - name: ovs0
-        """,
-        Loader=yaml.SafeLoader,
+        """
     )
     confs = libnmstate.generate_configurations(desired_state)["NetworkManager"]
     ovs_iface_conf = [conf for conf in confs if conf[0].startswith("ovs0-if")][
@@ -566,7 +565,7 @@ def unmaaged_dummy1():
 
 
 def test_ovs_bond_auto_managed_ignored_port(unmaaged_dummy1, eth1_up):
-    desired_state = yaml.load(
+    desired_state = load_yaml(
         f"""---
         interfaces:
         - name: br0
@@ -581,20 +580,55 @@ def test_ovs_bond_auto_managed_ignored_port(unmaaged_dummy1, eth1_up):
                   - name: {DUMMY1}
                   - name: eth1
         """,
-        Loader=yaml.SafeLoader,
     )
     try:
         libnmstate.apply(desired_state)
         assertlib.assert_state_match(desired_state)
     finally:
         libnmstate.apply(
-            yaml.load(
+            load_yaml(
                 """---
                 interfaces:
                 - name: br0
                   type: ovs-bridge
                   state: absent
                 """,
-                Loader=yaml.SafeLoader,
+            )
+        )
+
+
+def test_ovs_port_has_autoconnect_ports(eth1_up):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: ovs0
+          type: ovs-interface
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: ovs0
+            - name: eth1
+        """,
+    )
+    try:
+        libnmstate.apply(desired_state)
+        assert (
+            cmdlib.exec_cmd(
+                "nmcli -g connection.autoconnect-slaves "
+                "c show ovs0-port".split(),
+            )[1].strip()
+            == "1"
+        )
+    finally:
+        libnmstate.apply(
+            load_yaml(
+                """---
+                interfaces:
+                - name: br0
+                  type: ovs-bridge
+                  state: absent
+                """,
             )
         )


### PR DESCRIPTION
We forgot to enable `connection.autoconnect-ports` for OVS ports in NM
code as the `iface.is_controller()` is false for
`InterfaceType::Other("ovs-port")`

After enable `connection.autoconnect-ports` for OVS ports, we noticed
sometimes(1/10 chance) deleting OVS NM connections is not enough to
remove OVS bridge/interfaces. Hence we do deactivation explicitly before
deleting the connection.

After enable `connection.autoconnect-ports` for OVS ports, we can skip
activation of OVS interface on new OVS bridge creation now.

Fixed and added integration test case.