### PR TITLE
ipsec: support libreswan rightcert property

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -90,6 +90,8 @@ pub struct LibreswanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rightrsasigkey: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub rightcert: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub left: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub leftid: Option<String>,
@@ -157,6 +159,7 @@ impl std::fmt::Debug for LibreswanConfig {
             .field("right", &self.right)
             .field("rightid", &self.rightid)
             .field("rightrsasigkey", &self.rightrsasigkey)
+            .field("rightcert", &self.rightcert)
             .field("left", &self.left)
             .field("leftid", &self.leftid)
             .field("leftrsasigkey", &self.leftrsasigkey)

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -52,6 +52,7 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         }
         ret.rightid = data.get("rightid").cloned();
         ret.rightrsasigkey = data.get("rightrsasigkey").cloned();
+        ret.rightcert = data.get("rightcert").cloned();
         ret.left = data.get("left").cloned();
         ret.leftid = data.get("leftid").cloned();
         ret.leftcert = data.get("leftcert").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -18,6 +18,9 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.rightrsasigkey.as_deref() {
             vpn_data.insert("rightrsasigkey".into(), v.to_string());
         }
+        if let Some(v) = conf.rightcert.as_deref() {
+            vpn_data.insert("rightcert".into(), v.to_string());
+        }
         if let Some(v) = conf.left.as_deref() {
             vpn_data.insert("left".into(), v.to_string());
         }


### PR DESCRIPTION
This property allows to specify a locally loaded certificate to authenticate the "right" end of the IPSec connection (which is normally the remote).

Test case added.

Resolves: https://issues.redhat.com/browse/RHEL-28898