### PR TITLE
ipsec: add support to "leftsubnet" property

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -138,6 +138,8 @@ pub struct LibreswanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rightsubnet: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub leftsubnet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub leftmodecfgclient: Option<bool>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub kind: Option<LibreswanConnectionType>,
@@ -179,6 +181,7 @@ impl std::fmt::Debug for LibreswanConfig {
             .field("ipsec_interface", &self.ipsec_interface)
             .field("authby", &self.authby)
             .field("rightsubnet", &self.rightsubnet)
+            .field("leftsubnet", &self.leftsubnet)
             .field("leftmodecfgclient", &self.leftmodecfgclient)
             .field("kind", &self.kind)
             .field("hostaddrfamily", &self.hostaddrfamily)

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -71,6 +71,7 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.leftmodecfgclient =
             data.get("leftmodecfgclient").map(|s| s == "yes");
         ret.rightsubnet = data.get("rightsubnet").cloned();
+        ret.leftsubnet = data.get("leftsubnet").cloned();
         ret.kind = data.get("type").and_then(|s| match s.as_str() {
             "tunnel" => Some(LibreswanConnectionType::Tunnel),
             "transport" => Some(LibreswanConnectionType::Transport),

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -76,6 +76,9 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.rightsubnet.as_deref() {
             vpn_data.insert("rightsubnet".into(), v.to_string());
         }
+        if let Some(v) = conf.leftsubnet.as_deref() {
+            vpn_data.insert("leftsubnet".into(), v.to_string());
+        }
         if let Some(v) = conf.kind {
             vpn_data.insert("type".into(), v.to_string());
         }

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -32,6 +32,7 @@ HOSTA_IPV4_CRT = "192.0.2.251"
 HOSTA_IPV4_PSK = "192.0.2.250"
 HOSTA_IPV4_RSA = "192.0.2.249"
 HOSTA_IPV4_CRT_P2P = "192.0.2.248"
+HOSTA_IPV4_CRT_SUBNET = "192.0.4.0/24"
 HOSTA_IPV4_TRANSPORT = "192.0.2.247"
 HOSTA_IPSEC_CONN_NAME = "hosta_conn"
 HOSTA_IPV6_P2P = "2001:db8:f::a"
@@ -44,6 +45,7 @@ HOSTB_IPV4_CRT = "192.0.2.152"
 HOSTB_IPV4_PSK = "192.0.2.153"
 HOSTB_IPV4_RSA = "192.0.2.154"
 HOSTB_IPV4_CRT_P2P = "192.0.2.155"
+HOSTB_IPV4_CRT_SUBNET = "192.0.3.0/24"
 HOSTB_IPV4_TRANSPORT = "192.0.2.156"
 HOSTB_VPN_SUBNET_PREFIX = "203.0.113"
 HOSTB_VPN_SUBNET = f"{HOSTB_VPN_SUBNET_PREFIX}.0/24"
@@ -890,6 +892,41 @@ def test_ipsec_ipv4_libreswan_p2p_cert_auth_add_and_remove(
         _check_ipsec_policy,
         f"{HOSTA_IPV4_CRT_P2P}/32",
         f"{HOSTB_IPV4_CRT_P2P}/32",
+    )
+
+
+@pytest.mark.xfail(
+    reason="NetworkManager-libreswan might be older than 1.2.20",
+)
+def test_ipsec_ipv4_libreswan_leftsubnet(
+    ipsec_hosta_conn_cleanup,
+):
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: hosta_conn
+          type: ipsec
+          libreswan:
+            left: {HOSTA_IPV4_CRT_P2P}
+            leftid: 'hosta.example.org'
+            leftcert: hosta.example.org
+            leftsubnet: {HOSTA_IPV4_CRT_SUBNET}
+            leftmodecfgclient: no
+            right: {HOSTB_IPV4_CRT_P2P}
+            rightid: 'hostb.example.org'
+            rightsubnet: {HOSTB_IPV4_CRT_SUBNET}
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT, _check_ipsec, HOSTA_IPV4_CRT_P2P, HOSTB_IPV4_CRT_P2P
+    )
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec_policy,
+        f"{HOSTA_IPV4_CRT_SUBNET}",
+        f"{HOSTB_IPV4_CRT_SUBNET}",
     )
 
 


### PR DESCRIPTION
This property allow you to define the private subnet of the left side expressed as network/netmask.

Fixes: https://issues.redhat.com/browse/RHEL-26755