### PR TITLE
test: Disable the NM connectivity check in integration tests

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -210,6 +210,10 @@ function upgrade_nm_from_rpm_dir {
     find $nm_rpm_dir -name \*.rpm -exec cp -v {} "${EXPORT_DIR}/nm_rpms/" \;
     exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
     exec_cmd "dnf install -y ${CONT_EXPORT_DIR}/nm_rpms/*.rpm"
+    # It is fragile for the system to have connectivity check enabled in the
+    # integration testing, NM will add the penalty metric to the route when the
+    # machine is not connected to the Internet
+    exec_cmd "dnf remove --assumeyes NetworkManager-config-connectivity"
 }
 
 function run_customize_command {


### PR DESCRIPTION
Enabling the NM connectivity check in the integration tests will risk in making the configured routes get penalty metric because of the limited connectivity.