### PR TITLE
vlan: Default `reorder-headers: true`

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -814,6 +814,7 @@ impl MergedInterface {
         self.post_inter_ifaces_process_sriov()?;
         self.post_inter_ifaces_process_vrf()?;
         self.post_inter_ifaces_process_bond()?;
+        self.post_inter_ifaces_process_vlan();
 
         if let Some(apply_iface) = self.for_apply.as_mut() {
             apply_iface.sanitize(true)?;


### PR DESCRIPTION
When `reorder-headers` is not mentioned in desire state, we should
set it to true to be consistent with default behavior of kernel and
NetworkManager.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-33362