### PR TITLE
packaging: Fix snapshot packaging

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,24 +1,22 @@
 ---
 specfile_path: nmstate.spec
 upstream_package_name: nmstate
-upstream_project_url: http://nmstate.io
+upstream_project_url: https://nmstate.io
 enable_net: true
 srpm_build_deps:
+  - cargo
   - make
   - git
+  - tar
+  - xz
 notifications:
   pull_request:
     successful_build: true
 actions:
   post-upstream-clone:
     - "make packaging/nmstate.spec"
-    - "sed -i -e '/^Source1/d' packaging/nmstate.spec"
-    - "sed -i -e '/^Source2/d' packaging/nmstate.spec"
-    - "sed -i -e '/^Source3/d' packaging/nmstate.spec"
-    - "mv packaging/nmstate.spec ./"
-    # packit will try to download all SOURCES even those are not ignored by
-    # rpm condiction check, so we remove it extra sources for copr build
-  create-archive:
+    - "cp packaging/nmstate.spec nmstate.spec"
+  fix-spec-file:
     - "make dist"
   get-current-version:
     - "cat VERSION"

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -17,8 +17,8 @@ COPY network_manager_enable_trace.conf \
 COPY network_manager_keyfile.conf \
      /etc/NetworkManager/conf.d/96-keyfile.conf
 
-RUN sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
-    -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
+# Fedora container has no /etc/systemd/journald.conf file in systemd rpm
+RUN  echo -e '[Journal]\nRateLimitInterval=0\nRateLimitBurst=0' > \
     /etc/systemd/journald.conf
 
 RUN echo net.ipv6.conf.all.disable_ipv6=0 > \

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -16,8 +16,8 @@ COPY network_manager_enable_trace.conf \
 COPY network_manager_keyfile.conf \
      /etc/NetworkManager/conf.d/96-keyfile.conf
 
-RUN sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
-    -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
+# Fedora container has no /etc/systemd/journald.conf file in systemd rpm
+RUN  echo -e '[Journal]\nRateLimitInterval=0\nRateLimitBurst=0' > \
     /etc/systemd/journald.conf
 
 RUN echo net.ipv6.conf.all.disable_ipv6=0 > \

--- a/packaging/make_spec.sh
+++ b/packaging/make_spec.sh
@@ -4,16 +4,24 @@ set -e
 
 SRC_DIR="$(dirname "$0")/.."
 
+SPEC_FILE_PATH="${SRC_DIR}/packaging/nmstate.spec"
+
+cp ${SPEC_FILE_PATH}.in ${SPEC_FILE_PATH}
+
 eval "$(${SRC_DIR}/packaging/get_version.sh)"
 
-# spec variable is used by COPR as well: https://docs.pagure.org/copr.copr/user_documentation.html
-if [ -z "${spec}" ]; then
-    spec="${SRC_DIR}/packaging/nmstate.spec"
+
+if [ "CHK$IS_RELEASE" == "CHK1" ];then
+    IS_SNAPSHOT=0
+    RPM_RELEASE=1
+else
+    IS_SNAPSHOT=1
 fi
 
-
-sed \
+sed -i \
+    -e "s/@IS_SNAPSHOT@/${IS_SNAPSHOT}/" \
     -e "s/@VERSION@/${RPM_VERSION}/" \
+    -e "s/@RELEASED_VERSION@/${RELEASED_VERSION}/" \
     -e "s/@RELEASE@/${RPM_RELEASE}/" \
     -e "s/@CHANGELOG@/${RPM_CHANGELOG}/" \
-    "${spec}"
+    $SPEC_FILE_PATH

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -14,11 +14,19 @@ Release:        @RELEASE@%{?dist}
 Summary:        Declarative network manager API
 License:        Apache-2.0 AND LGPL-2.1-or-later
 URL:            https://github.com/%{srcname}/%{srcname}
-Source0:        %{url}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz
 %if ! %{is_snapshot}
+Source0:        %{url}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz
 Source1:        %{url}/releases/download/v%{version}/%{srcname}-%{version}.tar.gz.asc
 Source2:        https://nmstate.io/nmstate.gpg
+%else
+Source0:        %{srcname}-%{version}-alpha-@RELEASE@.tar.gz
+%endif
+%if %{is_snapshot}
+Source3:        %{srcname}-vendor-%{version}-alpha-@RELEASE@.tar.xz
+%else
+%if 0%{?rhel}
 Source3:        %{url}/releases/download/v%{version}/%{srcname}-vendor-%{version}.tar.xz
+%endif
 %endif
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
@@ -147,13 +155,16 @@ gpg2 --import --import-options import-export,import-minimal \
 gpgv2 --keyring ./gpgkey-mantainers.gpg %{SOURCE1} %{SOURCE0}
 %endif
 
+
 pushd rust
 
-%if 0%{?rhel} && ! %{is_snapshot}
-    # Source3 is vendored dependencies
-    %cargo_prep -V 3
+%if 0%{?rhel}
+# Source3 is vendored dependencies
+%cargo_prep -V 3
 %else
-    %cargo_prep
+%cargo_prep
+# In Fedora, we should use latest ctrlc crates
+sed -i -e 's/^ctrlc.\+$/ctrlc = "3"/' Cargo.toml
 %endif
 
 popd


### PR DESCRIPTION
With rust-srpm-macros-17-4.el9, `%cargo_pre` without `-V` option will
put the crates.io registry to empty folder, hence break all snapshot rpm
builds.

The fix is use create vendor tarball for snapshot rpm build.

Also fixed Fedora compiling issue by removing the ping of ctrlc crate
version.