### PR TITLE
rust: Provide async API

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.10.0"
 clap = { version = "3.1", features = ["cargo"] }
 chrono = "0.4"
 toml = "0.8.10"
+tokio = { version = "1.30", features = ["rt", "net"] }
 # For the seek of compiling on Rust 1.66
 ctrlc = "<=3.4.2"
 

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -19,31 +19,35 @@ path = "lib.rs"
 serde_yaml = { workspace = true }
 
 [dependencies.nispor]
-workspace = true 
+workspace = true
 optional = true
 
 [dependencies.zvariant]
 workspace = true
 
 [dependencies.uuid]
-workspace = true 
+workspace = true
 features = ["v5"]
 
 [dependencies.log]
-workspace = true 
+workspace = true
 
 [dependencies.zbus]
 workspace = true
 optional = true
 
 [dependencies.serde_json]
-workspace = true 
+workspace = true
 features = [ "preserve_order" ]
 
 [dependencies.serde]
-workspace = true 
+workspace = true
 
 [dependencies.nix]
+workspace = true
+optional = true
+
+[dependencies.tokio]
 workspace = true
 optional = true
 
@@ -52,6 +56,6 @@ serde_yaml = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]
-query_apply = ["dep:nispor", "dep:nix", "dep:zbus"]
+query_apply = ["dep:nispor", "dep:nix", "dep:zbus", "dep:tokio"]
 gen_conf = []
 gen_revert = []

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -246,6 +246,15 @@ impl NetworkState {
         ))
     }
 
+    #[cfg(not(feature = "query_apply"))]
+    pub async fn retrieve_async(&mut self) -> Result<&mut Self, NmstateError> {
+        Err(NmstateError::new(
+            ErrorKind::DependencyError,
+            "NetworkState::retrieve_async() need `query_apply` feature enabled"
+                .into(),
+        ))
+    }
+
     /// Replace secret string with `<_password_hid_by_nmstate>`
     pub fn hide_secrets(&mut self) {
         self.interfaces.hide_secrets();
@@ -253,6 +262,14 @@ impl NetworkState {
 
     #[cfg(not(feature = "query_apply"))]
     pub fn apply(&mut self) -> Result<(), NmstateError> {
+        Err(NmstateError::new(
+            ErrorKind::DependencyError,
+            "NetworkState::apply() need `query_apply` feature enabled".into(),
+        ))
+    }
+
+    #[cfg(not(feature = "query_apply"))]
+    pub async fn apply_async(&mut self) -> Result<(), NmstateError> {
         Err(NmstateError::new(
             ErrorKind::DependencyError,
             "NetworkState::apply() need `query_apply` feature enabled".into(),

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -26,7 +26,7 @@ const IPV6_EMPTY_NEXT_HOP_ADDRESS: &str = "::";
 // kernel values
 const RTAX_CWND: u32 = 7;
 
-pub(crate) fn get_routes(running_config_only: bool) -> Routes {
+pub(crate) async fn get_routes(running_config_only: bool) -> Routes {
     let mut ret = Routes::new();
     let mut np_routes: Vec<nispor::Route> = Vec::new();
     let route_type = [
@@ -45,7 +45,7 @@ pub(crate) fn get_routes(running_config_only: bool) -> Routes {
         rt_filter.protocol = Some(*protocol);
         let mut filter = nispor::NetStateFilter::minimum();
         filter.route = Some(rt_filter);
-        match nispor::NetState::retrieve_with_filter(&filter) {
+        match nispor::NetState::retrieve_with_filter_async(&filter).await {
             Ok(np_state) => {
                 for np_rt in np_state.routes {
                     np_routes.push(np_rt);


### PR DESCRIPTION
Introducing rust ASYNC API:

 * `NetworkState::retrieve_async()`
 * `NetworkState::apply_async()`

Changed nispor plugin code to use async API.

Existing test cases is enough to test this patch.

Considering nispor need tokio, we are not introducing new dependency.

Benefits:
 * Allowing nmstate rust crate user to use their own async runtime
   instead of tokio.
 * Replace ctrlc with `tokio` signal feature which is ASYNC only.
 * Upgrade zbus 1.x to zbus 4.x which is ASYNC only.
