### PR TITLE
ip: Fix routes on empty address

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -297,14 +297,6 @@ impl InterfaceIpv4 {
                     }
                 }
             }
-        } else if self.addresses.as_ref().map_or(false, Vec::is_empty)
-            && self.enabled
-        {
-            // Empty address should equal to disabled IPv4 stack
-            if is_desired {
-                log::info!("Empty IPv4 address is considered as IPv4 disabled");
-            }
-            self.enabled = false;
         }
 
         if let Some(addrs) = self.addresses.as_mut() {

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -14,12 +14,12 @@ impl InterfaceIpv4 {
         }
 
         // No IP address means empty.
-        if self.enabled && self.addresses.is_none() {
+        if self.addresses.is_none() {
             self.addresses = Some(Vec::new());
         }
 
         // No DHCP means off
-        if self.enabled && self.dhcp.is_none() {
+        if self.dhcp.is_none() {
             self.dhcp = Some(false);
         }
     }
@@ -27,8 +27,14 @@ impl InterfaceIpv4 {
     // Sort addresses and dedup
     pub(crate) fn sanitize_desired_for_verify(&mut self) {
         if let Some(addrs) = self.addresses.as_mut() {
-            addrs.sort_unstable();
-            addrs.dedup();
+            if addrs.is_empty() {
+                // For empty address, we do not care about ip stack enabled or
+                // false as it might varied depend on whether have route on it
+                self.enabled_defined = false;
+            } else {
+                addrs.sort_unstable();
+                addrs.dedup();
+            }
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -668,10 +668,12 @@ def test_static_route_with_empty_ip(eth1_up):
     eth1_state[Interface.IPV4] = {
         InterfaceIPv4.DHCP: False,
         InterfaceIPv4.ENABLED: True,
+        InterfaceIPv4.ADDRESS: [],
     }
     eth1_state[Interface.IPV6] = {
         InterfaceIPv6.DHCP: False,
         InterfaceIPv6.ENABLED: True,
+        InterfaceIPv4.ADDRESS: [],
     }
     routes = [
         {


### PR DESCRIPTION
Nmstate fails when applying below state:

```yml
---
routes:
  config:
  - destination: 198.51.100.0/24
    metric: 150
    next-hop-interface: eth1
    table-id: 254
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      enabled: true
      address: []
```

The error message is:

    NmstateError: InvalidArgument: The next hop interface of desired Route
    'destination: 198.51.100.0/24 next-hop-interface: eth1 metric: 150
    table-id: 254' has been marked as IPv4 disabled

The root cause is nmstate try to set `ipv4.enabled` to false when got
empty address, this then lead to incorrect validation.

To fix this issue, removed the sanitize on setting `ipv4.enabled` to
false on empty address, but ignore `ipvX.enabled` in validation stage
when got empty IP address list.

Integration test case updated.