### PR TITLE
route: Add support of static route in kernel mode

### DIFF
--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -3,6 +3,7 @@
 use crate::{
     nispor::{
         ip::{nmstate_ipv4_to_np, nmstate_ipv6_to_np},
+        route::gen_nispor_route_confs,
         veth::nms_veth_conf_to_np,
         vlan::nms_vlan_conf_to_np,
     },
@@ -43,6 +44,10 @@ pub(crate) async fn nispor_apply(
 
     let mut net_conf = nispor::NetConf::default();
     net_conf.ifaces = Some(np_ifaces);
+
+    if merged_state.routes.is_changed() {
+        net_conf.routes = Some(gen_nispor_route_confs(&merged_state.routes)?);
+    }
 
     if let Err(e) = net_conf.apply_async().await {
         Err(NmstateError::new(

--- a/rust/src/lib/nm/route.rs
+++ b/rust/src/lib/nm/route.rs
@@ -8,13 +8,12 @@ pub(crate) fn store_route_config(
     if merged_state.routes.is_changed() {
         let empty_rts = Vec::new();
         for iface_name in merged_state.routes.route_changed_ifaces.as_slice() {
-            let rts = if let Some(rts) =
-                merged_state.routes.indexed.get(iface_name)
-            {
-                rts
-            } else {
-                &empty_rts
-            };
+            let rts =
+                if let Some(rts) = merged_state.routes.merged.get(iface_name) {
+                    rts
+                } else {
+                    &empty_rts
+                };
             if let Some(iface) =
                 merged_state.interfaces.kernel_ifaces.get_mut(iface_name)
             {

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -353,7 +353,7 @@ fn iface_has_route_for_table_id(
     is_ipv6: bool,
     table_id: u32,
 ) -> bool {
-    if let Some(routes) = merged_state.routes.indexed.get(iface_name) {
+    if let Some(routes) = merged_state.routes.merged.get(iface_name) {
         for route in routes.as_slice().iter().filter(|r| r.is_ipv6() == is_ipv6)
         {
             if route.table_id == Some(table_id)

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -569,7 +569,7 @@ fn persisten_iface_cur_conf(
 ) -> Result<Vec<NmConnection>, NmstateError> {
     let mut iface = cur_iface.clone();
     iface.base_iface_mut().routes =
-        merged_state.routes.indexed.get(iface.name()).cloned();
+        merged_state.routes.merged.get(iface.name()).cloned();
     if let Interface::Ethernet(eth_iface) = &mut iface {
         eth_iface.veth = None;
         eth_iface.base.iface_type = InterfaceType::Ethernet;

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -18,7 +18,7 @@ impl MergedRoutes {
             }
         }
 
-        for rts in self.indexed.values() {
+        for rts in self.merged.values() {
             for rt in rts {
                 if rt.is_absent() || !current_routes.contains(rt) {
                     changed_routes.push(rt.clone());

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -146,7 +146,7 @@ config:
 
     merged_routes.remove_routes_to_ignored_ifaces(ignored_ifaces.as_slice());
 
-    let config_routes = merged_routes.indexed.get("eth2").unwrap();
+    let config_routes = merged_routes.merged.get("eth2").unwrap();
 
     assert_eq!(merged_routes.route_changed_ifaces, vec!["eth2".to_string()]);
     assert_eq!(config_routes.len(), 2);

--- a/tests/integration/testlib/assertlib.py
+++ b/tests/integration/testlib/assertlib.py
@@ -58,14 +58,14 @@ def assert_absent(*ifnames):
             time.sleep(0.5)
 
 
-def assert_state_match(desired_state_data, no_retry=False):
+def assert_state_match(desired_state_data, no_retry=False, kernel_only=False):
     """
     Given a state, assert it against the current state by treating missing
     value in desired_state as match.
     """
     for i in range(0, RETRY_COUNT):
         desired_state, current_state = _prepare_state_for_verify(
-            desired_state_data
+            desired_state_data, kernel_only=kernel_only
         )
         if desired_state.match(current_state):
             return
@@ -97,8 +97,10 @@ def _iface_macs(state):
         yield ifstate[Interface.MAC]
 
 
-def _prepare_state_for_verify(desired_state_data):
-    current_state_data = libnmstate.show(include_secrets=True)
+def _prepare_state_for_verify(desired_state_data, kernel_only=False):
+    current_state_data = libnmstate.show(
+        include_secrets=True, kernel_only=kernel_only
+    )
     # Ignore route and dns for assert check as the check are done in the test
     # case code.
     current_state_data.pop(Route.KEY, None)


### PR DESCRIPTION
Support add and remove static routes in kernel mode, these are not
supported yet:
 * route table ID bigger than 255
 * route weight
 * route type
 * route cwnd(congestion window)

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-37665