### PR TITLE
test: Remove overlapping ipsec address pool

### DIFF
--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -38,3 +38,11 @@ def is_k8s():
 
 def is_el8():
     return exec_cmd("rpm -E %{?rhel}".split())[1].strip() == "8"
+
+
+def nm_libreswan_micro_version():
+    return int(
+        exec_cmd("rpm -q NetworkManager-libreswan --qf %{VERSION}".split())[1]
+        .split(".")[-1]
+        .strip()
+    )

--- a/tests/integration/testlib/ipsec.py
+++ b/tests/integration/testlib/ipsec.py
@@ -73,7 +73,7 @@ conn hostb_conn_rsa
     leftid=@hostb-rsa.example.org
     leftrsasigkey={RSA_SIGNATURE_HOSTB}
     leftsubnet=0.0.0.0/0
-    rightaddresspool=203.0.113.102-203.0.113.200
+    rightaddresspool=203.0.113.201-203.0.113.210
     rightrsasigkey={RSA_SIGNATURE_HOSTA}
     leftmodecfgserver=yes
     rightmodecfgclient=yes
@@ -489,7 +489,6 @@ def setup_hosta_ip():
             }
         )
 
-    print("HAHA ", desired_state)
     libnmstate.apply(desired_state)
     # Need to wait 2 seconds for IPv6 duplicate address detection,
     # otherwise the `pluto` will not listen on any IPv6 address


### PR DESCRIPTION
This should fix the random failure of `test_ipsec_ipv4_libreswan_psk_auth_with_dpd`