### PR TITLE
cli: Replace `ctrlc` crate with `tokio/signal`

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -39,7 +39,6 @@ BuildRequires:  rust-packaging
 BuildRequires:  (crate(clap/cargo) >= 3.1 with crate(clap/cargo) < 4.0)
 BuildRequires:  (crate(clap/default) >= 3.1 with crate(clap/default) < 4.0)
 BuildRequires:  (crate(chrono/default) >= 0.4 with crate(chrono/default) < 0.5)
-BuildRequires:  (crate(ctrlc/default) >= 3.2 with crate(ctrlc/default) < 4.0)
 BuildRequires:  (crate(env_logger/default) >= 0.10 with crate(env_logger/default) < 0.11)
 BuildRequires:  (crate(libc/default) >= 0.2 with crate(libc/default) < 0.3)
 BuildRequires:  (crate(log/default) >= 0.4 with crate(log/default) < 0.5)
@@ -54,6 +53,10 @@ BuildRequires:  (crate(zbus/default) >= 1.9 with crate(zbus/default) < 2.0)
 BuildRequires:  (crate(zvariant/default) >= 2.10 with crate(zvariant/default) < 3.0)
 BuildRequires:  (crate(nix/default) >= 0.26 with crate(nix/default) < 0.27)
 BuildRequires:  (crate(toml/default) >= 0.8 with crate(toml/default) < 0.9)
+BuildRequires:  (crate(tokio/default) >= 1.3 with crate(tokio/default) < 2.0)
+BuildRequires:  (crate(tokio/net) >= 1.3 with crate(tokio/net) < 2.0)
+BuildRequires:  (crate(tokio/rt) >= 1.3 with crate(tokio/rt) < 2.0)
+BuildRequires:  (crate(tokio/signal) >= 1.3 with crate(tokio/signal) < 2.0)
 %endif
 
 %description
@@ -163,8 +166,6 @@ pushd rust
 %cargo_prep -V 3
 %else
 %cargo_prep
-# In Fedora, we should use latest ctrlc crates
-sed -i -e 's/^ctrlc.\+$/ctrlc = "3"/' Cargo.toml
 %endif
 
 popd

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,8 +24,6 @@ clap = { version = "3.1", features = ["cargo"] }
 chrono = "0.4"
 toml = "0.8.10"
 tokio = { version = "1.30", features = ["rt", "net"] }
-# For the seek of compiling on Rust 1.66
-ctrlc = "<=3.4.2"
 
 [workspace.metadata.vendor-filter]
 # For now we only care about tier 1+2 Linux

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
-ctrlc = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = [ "signal"] }
 uuid = { workspace = true }
 chrono = { workspace = true }
 nispor = { workspace = true, optional = true }
@@ -32,6 +32,6 @@ toml = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]
-query_apply = ["nmstate/query_apply", "ctrlc", "nispor"]
+query_apply = ["nmstate/query_apply", "dep:tokio", "dep:nispor"]
 gen_conf = ["nmstate/gen_conf"]
 gen_revert = ["nmstate/gen_revert"]

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -145,6 +145,10 @@ impl NetworkState {
         self
     }
 
+    pub fn kernel_only(&self) -> bool {
+        self.kernel_only
+    }
+
     /// By default(true), When nmstate applying the network state, after applied
     /// the network state, nmstate will verify whether the outcome network
     /// configuration matches with desired, if not, will rollback to state


### PR DESCRIPTION
The `ctrlc` latest version cannot be compiled in our minimum supported
Rust 1.66, hence replace it with `tokio/signal`.