### PR TITLE
CI: Use nm-main for Fedora test run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
           - job_type: "c9s-nm_1.42-integ_tier1"
           - job_type: "c9s-nm_1.42-integ_tier2"
           - job_type: "c9s-nm_1.42-integ_slow"
-          - job_type: "fed-nm_stable-integ_tier1"
+          - job_type: "fed-nm_main-integ_tier1"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The NM shipped in Fedora latest repo is lacking important fixes. Instead
of waiting backport, just use nm-main repo.