### PR TITLE
base iface: Provide permanent-mac-address when querying

### DIFF
--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -50,11 +50,10 @@ pub struct BaseInterface {
     /// every two characters. Case insensitive when applying.
     /// Serialize and deserialize to/from `mac-address`.
     pub mac_address: Option<String>,
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// MAC address never change after reboots(normally stored in firmware of
     /// network interface). Using the same format as `mac_address` property.
     /// Ignored during apply.
-    /// TODO: expose it and we do not special merge for this.
     pub permanent_mac_address: Option<String>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -279,6 +278,11 @@ impl BaseInterface {
                     self.iface_type,
                 ),
             ));
+        }
+
+        // Remove permanent_mac_address in desired state as it is query only
+        if is_desired {
+            self.permanent_mac_address = None;
         }
 
         Ok(())

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -133,6 +133,6 @@ fn get_permanent_mac_address(iface: &nispor::Iface) -> Option<String> {
             None
         }
     } else {
-        Some(iface.permanent_mac_address.clone())
+        Some(iface.permanent_mac_address.as_str().to_uppercase())
     }
 }


### PR DESCRIPTION
No test required as this is query only property and CI(container) has no
real NIC with this property set.

Manually tested in VM `virtio_net` NIC.