### PR TITLE
Validate interface in desired port list of controller

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -66,7 +66,11 @@ impl MergedInterfaces {
                     if !ctrl_iface.is_desired() {
                         continue;
                     }
-                    if let Some(ports) = ctrl_iface.merged.ports() {
+                    if let Some(ports) = ctrl_iface
+                        .desired
+                        .as_ref()
+                        .and_then(|desire| desire.ports())
+                    {
                         if !ports.contains(&merged_iface.merged.name()) {
                             return Err(NmstateError::new(
                                 ErrorKind::InvalidArgument,

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -612,6 +612,35 @@ fn test_iface_detach_controller_been_list_in_other_port_list() {
 }
 
 #[test]
+fn test_iface_controller_conflict_with_empty_br_ports() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+- name: br0
+  type: linux-bridge
+  bridge:
+    ports: []
+- name: bond99
+  type: bond
+  state: up
+  controller: br0
+  link-aggregation:
+    mode: balance-rr
+    port:
+    - eth2
+    - eth1
+",
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(des_ifaces, Interfaces::new(), false, false);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
 fn test_auto_manage_ports() {
     let des_ifaces: Interfaces = serde_yaml::from_str(
         r"---

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1282,3 +1282,18 @@ def test_controller_detach_from_linux_bridge(bridge0_with_port0):
         )
         == 0
     )
+
+
+@pytest.fixture
+def empty_bridge():
+    bridge_config = {}
+    with linux_bridge(TEST_BRIDGE0, bridge_config) as state:
+        yield state
+
+
+def test_attach_bond_to_empty_bridge(empty_bridge, bond0):
+    bond0[Interface.KEY][0][Interface.CONTROLLER] = TEST_BRIDGE0
+    desired_state = bond0
+    desired_state[Interface.KEY].append(empty_bridge[Interface.KEY][0])
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
When the last port of the controller is absent, the port list of the controller becomes empty, in the situaiton of applying the controller and port settings again, before generating the port config, we should not validate if interface is in the port list of controller when port is empty.

Resolves: https://issues.redhat.com/browse/RHEL-31977