### PR TITLE
linux bridge: Fix incorrect check on whether `vlan-default-pvid` changed

### DIFF
--- a/rust/src/lib/query_apply/linux_bridge.rs
+++ b/rust/src/lib/query_apply/linux_bridge.rs
@@ -90,6 +90,6 @@ impl MergedInterface {
             None
         };
 
-        des_default_pvid != cur_default_pvid
+        des_default_pvid.is_some() && des_default_pvid != cur_default_pvid
     }
 }

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -719,3 +719,36 @@ fn test_bridge_sanitize_group_forward_mask_and_group_fwd_mask() {
     assert_eq!(desired_old, expected);
     assert_eq!(desired_new, expected);
 }
+
+#[test]
+fn test_linux_bridge_is_default_pvid_changed() {
+    let des_iface: Interface = serde_yaml::from_str(
+        r"---
+          name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth2
+            - name: eth1",
+    )
+    .unwrap();
+    let cur_iface: Interface = serde_yaml::from_str(
+        r"---
+          name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            options:
+              vlan-default-pvid: 1",
+    )
+    .unwrap();
+
+    let merged_iface =
+        MergedInterface::new(Some(des_iface), Some(cur_iface)).unwrap();
+
+    assert!(!merged_iface.is_default_pvid_changed())
+}


### PR DESCRIPTION
When desired state have no `vlan-default-pvid` defined, nmstate treat it
as `vlan-default-pvid` changed as `None != Some(1)` when comparing
with current `vlan-default-pvid`.
This lead to full reactivation on all linux bridge ports.

Fixed by adding a `.is_some()` check first.

Unit test case included.

Resolves: https://issues.redhat.com/browse/RHEL-40683