### PR TITLE
CI: Install NM-libreswan if not found

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -210,6 +210,8 @@ function upgrade_nm_from_rpm_dir {
     find $nm_rpm_dir -name \*.rpm -exec cp -v {} "${EXPORT_DIR}/nm_rpms/" \;
     exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
     exec_cmd "dnf install -y ${CONT_EXPORT_DIR}/nm_rpms/*.rpm"
+    exec_cmd "rpm -q NetworkManager-libreswan || \
+        dnf install -y NetworkManager-libreswan"
     # It is fragile for the system to have connectivity check enabled in the
     # integration testing, NM will add the penalty metric to the route when the
     # machine is not connected to the Internet


### PR DESCRIPTION
In `upgrade_nm_from_rpm_dir()` we removed all NetworkManager related
rpms including NetworkManager-libreswan, when rpm_dir does not contain
that NM-libreswan RPM, all ipsec rpms will fails due to missing it.

To fix that, we use dnf to install NetworkManager-libreswan if not
found.