### PR TITLE
dns: Fix error when purging DNS with empty server

### DIFF
--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -398,23 +398,27 @@ fn set_iface_dns_conf(
     priority: Option<i32>,
 ) -> Result<(), NmstateError> {
     let dns_conf = DnsClientState {
-        server: Some(servers),
-        search: Some(searches),
-        options: Some(options),
+        server: Some(servers.clone()),
+        search: Some(searches.clone()),
+        options: Some(options.clone()),
         priority,
     };
     if is_ipv6 {
         if let Some(ip_conf) = iface.base_iface_mut().ipv6.as_mut() {
             ip_conf.dns = Some(dns_conf);
-        } else if !dns_conf.is_purge() {
+        } else if !(servers.is_empty()
+            && searches.is_empty()
+            && options.is_empty())
+        {
             return Err(NmstateError::new(
                 ErrorKind::Bug,
-                format!("BUG: The dns interface is hold None IP {iface:?}"),
+                format!("BUG: The dns interface is hold None IPv6 {iface:?}"),
             ));
         }
     } else if let Some(ip_conf) = iface.base_iface_mut().ipv4.as_mut() {
         ip_conf.dns = Some(dns_conf);
-    } else if !dns_conf.is_purge() {
+    } else if !(servers.is_empty() && searches.is_empty() && options.is_empty())
+    {
         return Err(NmstateError::new(
             ErrorKind::Bug,
             format!("BUG: The dns interface is hold None IP {iface:?}"),

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -116,14 +116,7 @@ pub(crate) fn nm_apply(
                     merged_state.dns.options.as_slice(),
                 )?;
             }
-        } else if merged_state
-            .dns
-            .desired
-            .as_ref()
-            .and_then(|d| d.config.as_ref())
-            .map(|c| c.is_purge())
-            == Some(true)
-        {
+        } else if merged_state.dns.is_purge() {
             // Also need to purge interface level DNS
             store_dns_config_to_iface(&mut merged_state, &nm_acs, &nm_devs)
                 .ok();

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -3,6 +3,13 @@
 use crate::{DnsState, ErrorKind, MergedDnsState, NmstateError};
 
 impl MergedDnsState {
+    pub(crate) fn is_purge(&self) -> bool {
+        self.desired.is_some()
+            && self.servers.is_empty()
+            && self.searches.is_empty()
+            && self.options.is_empty()
+    }
+
     pub(crate) fn verify(&self, current: DnsState) -> Result<(), NmstateError> {
         if !self.is_changed() {
             return Ok(());

--- a/rust/src/lib/unit_tests/dns.rs
+++ b/rust/src/lib/unit_tests/dns.rs
@@ -92,7 +92,20 @@ fn test_is_purge_dns_empty_dict() {
         ",
     )
     .unwrap();
-    assert!(desired.config.unwrap().is_purge());
+    let current: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server:
+          - 192.0.2.251
+          search:
+          - example.org
+          options:
+          - rotate
+        ",
+    )
+    .unwrap();
+    let merged = MergedDnsState::new(Some(desired), current).unwrap();
+    assert!(merged.is_purge());
 }
 
 #[test]
@@ -106,7 +119,20 @@ fn test_is_purge_dns_full_empty_dict() {
         ",
     )
     .unwrap();
-    assert!(desired.config.unwrap().is_purge());
+    let current: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server:
+          - 192.0.2.251
+          search:
+          - example.org
+          options:
+          - rotate
+        ",
+    )
+    .unwrap();
+    let merged = MergedDnsState::new(Some(desired), current).unwrap();
+    assert!(merged.is_purge());
 }
 
 #[test]
@@ -118,5 +144,41 @@ fn test_not_purge() {
         ",
     )
     .unwrap();
-    assert!(!desired.config.unwrap().is_purge());
+    let current: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server:
+          - 192.0.2.251
+          search:
+          - example.org
+        ",
+    )
+    .unwrap();
+    let merged = MergedDnsState::new(Some(desired), current).unwrap();
+    assert!(!merged.is_purge());
+}
+
+#[test]
+fn test_purge_with_empty_server_and_search() {
+    let desired: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server: []
+          search: []
+        ",
+    )
+    .unwrap();
+    let current: DnsState = serde_yaml::from_str(
+        r"---
+        config:
+          server:
+          - 192.0.2.251
+          search:
+          - example.org
+          options: []
+        ",
+    )
+    .unwrap();
+    let merged = MergedDnsState::new(Some(desired), current).unwrap();
+    assert!(merged.is_purge());
 }

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -617,3 +617,11 @@ def test_purge_dns_full_config(static_dns_with_options):
 
     current_state = libnmstate.show()
     assert not current_state[DNS.KEY][DNS.CONFIG]
+
+
+def test_purge_dns_with_empty_server_and_search(static_dns):
+    desired_state = {DNS.KEY: {DNS.CONFIG: {DNS.SERVER: [], DNS.SEARCH: []}}}
+    libnmstate.apply(desired_state)
+
+    current_state = libnmstate.show()
+    assert not current_state[DNS.KEY][DNS.CONFIG]


### PR DESCRIPTION
When desired state holds empty nameserver and empty searches, with
current state holding empty DNS options, we should treat desire state as
purging all static DNS config.

The fix is move `is_purge()` function to `MergedDnsState`, so we can
determine whether we are purging DNS after merged desire state and
current state.

Both unit test cases and integration test case are included.