### PR TITLE
fix(github-actions): fix macOS x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,17 +30,17 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust Stable
-      run: rustup update
+      run: rustup update && rustup target add x86_64-apple-darwin
 
     - name: Build release
       run: |
-        cd rust && cargo build --release \
+        cd rust && cargo build --release --target=x86_64-apple-darwin \
             --no-default-features --features gen_conf
 
     - uses: actions/upload-artifact@v4
       with:
         name: nmstatectl-macos-x64
-        path: rust/target/release/nmstatectl
+        path: rust/target/x86_64-apple-darwin/release/nmstatectl
         retention-days: 30
 
   macos-aarch64:


### PR DESCRIPTION
## Description

The `macos-latest` GitHub actions runners now default to macOS 14 on Apple Silicon, thus any actions that build Intel binaries need to explicitly define the architecture they are building for. See [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

## Issues Fixed

Fixes #2702

