### PR TITLE
CI: Remove pylint test

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -81,7 +81,7 @@ function run_tests {
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \
        [ $TEST_TYPE == $TEST_TYPE_LINT ];then
-        exec_cmd "tox -e flake8,pylint,yamllint"
+        exec_cmd "tox -e flake8,yamllint"
     fi
 
     if [ $TEST_TYPE == $TEST_TYPE_ALL ] || \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = black, flake8, pylint, yamllint
+envlist = black, flake8, yamllint
 skip_missing_interpreters = True
 
 [testenv]
@@ -19,21 +19,6 @@ commands =
     black \
         --check \
         --diff \
-        {posargs} \
-        rust/src/python/setup.py \
-        rust/src/python/libnmstate \
-        tests/integration
-
-[testenv:pylint]
-basepython = python3
-sitepackages = true
-skip_install = true
-changedir = {toxinidir}
-deps =
-    pylint==2.13.0
-commands =
-    pylint \
-        --errors-only \
         {posargs} \
         rust/src/python/setup.py \
         rust/src/python/libnmstate \


### PR DESCRIPTION
The pylint is overlapping with flake8 and also slower than flake8.

Considering we only have very limited python code in this repo, there is
no need to waste CI resource for it.