### PR TITLE
[nmstate-1.4] CI: Use vault.centos.org for CentOS Stream 8

### DIFF
--- a/packaging/Dockerfile.c8s-nmstate-build
+++ b/packaging/Dockerfile.c8s-nmstate-build
@@ -2,6 +2,11 @@ FROM quay.io/centos/centos:stream8
 
 RUN echo "2022-03-07" > /build_time
 
+# CentOS stream 8 is end of support, hence use vault.centos.org
+RUN sed -i -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/*.repo && \
+    sed -i -e 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/*.repo && \
+    sed -i -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo
+
 RUN dnf -y install --setopt=install_weak_deps=False \
        git make rust-toolset rpm-build python3 python3-devel && \
     dnf clean all

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -9,6 +9,11 @@ RUN sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
 RUN echo net.ipv6.conf.all.disable_ipv6=0 > /etc/sysctl.d/00-enable-ipv6.conf && \
     echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > /etc/sysctl.d/01-export-kernel-cores.conf
 
+# CentOS stream 8 is end of support, hence use vault.centos.org
+RUN sed -i -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/*.repo && \
+    sed -i -e 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/*.repo && \
+    sed -i -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo
+
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core epel-release && \
     dnf config-manager --set-enabled powertools && \


### PR DESCRIPTION
The c8s is end of support, we need to use vault.centos.org for dnf repo.