### PR TITLE
automation: install dnf5 copr module for Rawhide

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -194,7 +194,10 @@ function upgrade_nm_from_copr {
     local copr_repo=$1
     # The repoid for a Copr repo is the name with the slash replaces by a colon
     local copr_repo_id="copr:copr.fedorainfracloud.org:${copr_repo/\//:}"
-    exec_cmd "command -v dnf && plugin='dnf-command(copr)' || plugin='yum-plugin-copr'; yum install --assumeyes \$plugin;"
+    exec_cmd "command -v dnf && plugin='dnf-command(copr)' || \
+                command -v dnf5 && plugin='dnf5-command(copr)' || \
+                plugin='yum-plugin-copr'; \
+                yum install --assumeyes \$plugin;"
     exec_cmd "yum copr enable --assumeyes ${copr_repo}"
     # centos-stream NetworkManager package is providing the alpha builds.
     # Sometimes it could be greater than the one packaged on Copr.


### PR DESCRIPTION
We need to have dnf5 copr plugin installed in Rawhide as dnf5 is the default there.