### PR TITLE
c10s: create new podman files for c10s

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,7 @@ jobs:
           - job_type: "c9s-nm_1.42-integ_tier2"
           - job_type: "c9s-nm_1.42-integ_slow"
           - job_type: "fed-nm_main-integ_tier1"
+          - job_type: "c10s-nm_stable-integ_tier1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -30,6 +30,8 @@ elif [ $OS_TYPE == "fed" ];then
 elif [ $OS_TYPE == "c9s" ];then
     CONTAINER_IMAGE="quay.io/nmstate/c9s-nmstate-dev"
     TEST_ARG="$TEST_ARG --compiled-rpms-dir rpms/el9"
+elif [ $OS_TYPE == "c10s" ];then
+    CONTAINER_IMAGE="quay.io/nmstate/c10s-nmstate-dev"
 else
     echo "Invalid OS type ${OS_TYPE}"
     exit 1

--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -5,7 +5,7 @@ PROJECT_DIR="$(dirname $EXEC_DIR)"
 TEST_CMD="${EXEC_DIR}/run-tests.sh"
 
 options=$(getopt --options "" \
-    --long "copr:,rpm-dir:,help,debug-shell,el8,el9,fed,rawhide" \
+    --long "copr:,rpm-dir:,help,debug-shell,el8,el9,el10,fed,rawhide" \
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -14,6 +14,9 @@ while true; do
         use_el8="1"
         ;;
     --el9)
+        ;;
+    --el10)
+        use_el10="1"
         ;;
     --fed)
         use_fed="1"
@@ -35,7 +38,7 @@ while true; do
     --help)
         set +x
         echo -n "$0 [--copr=...] [--rpm-dir=...] [--debug-shell] "
-        echo -n "[--el8] [--el9] [--fed] [--rawhide]"
+        echo -n "[--el8] [--el9] [--el10] [--fed] [--rawhide]"
         echo
         exit
         ;;
@@ -65,6 +68,8 @@ fi
 
 if [[ -v use_el8 ]];then
     ARGS="$ARGS --el8"
+elif [[ -v use_el10 ]];then
+    ARGS="$ARGS --el10"
 elif [[ -v use_fed ]];then
     ARGS="$ARGS --fed"
 elif [[ -v use_rawhide ]];then

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -20,6 +20,7 @@ FEDORA_IMAGE_DEV="quay.io/nmstate/fed-nmstate-dev:latest"
 RAWHIDE_IMAGE_DEV="quay.io/nmstate/fed-nmstate-dev:rawhide"
 CENTOS_8_STREAM_IMAGE_DEV="quay.io/nmstate/c8s-nmstate-dev"
 CENTOS_9_STREAM_IMAGE_DEV="quay.io/nmstate/c9s-nmstate-dev"
+CENTOS_10_STREAM_IMAGE_DEV="quay.io/nmstate/c10s-nmstate-dev"
 
 
 PYTEST_OPTIONS="--verbose --verbose \
@@ -227,7 +228,7 @@ function run_customize_command {
 
 options=$(getopt --options "" \
     --long "customize:,pytest-args:,help,debug-shell,test-type:,\
-    el8,el9,centos-stream,fed,rawhide,copr:,artifacts-dir:,test-vdsm,\
+    el8,el9,el10,centos-stream,fed,rawhide,copr:,artifacts-dir:,test-vdsm,\
     machine,k8s,use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:" \
     -- "${@}")
 eval set -- "$options"
@@ -264,6 +265,9 @@ while true; do
         ;;
     --el9)
         CONTAINER_IMAGE=$CENTOS_9_STREAM_IMAGE_DEV
+        ;;
+    --el10)
+        CONTAINER_IMAGE=$CENTOS_10_STREAM_IMAGE_DEV
         ;;
     --fed)
         CONTAINER_IMAGE=$FEDORA_IMAGE_DEV

--- a/packaging/Dockerfile.c10s-nmstate-build
+++ b/packaging/Dockerfile.c10s-nmstate-build
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream10-development
 
-RUN echo "2024-24-06" > /build_time
+RUN echo "2024-26-06" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
        systemd git make rust-toolset rpm-build python3 python3-devel && \

--- a/packaging/Dockerfile.c10s-nmstate-build
+++ b/packaging/Dockerfile.c10s-nmstate-build
@@ -1,0 +1,7 @@
+FROM quay.io/centos/centos:stream10-development
+
+RUN echo "2024-24-06" > /build_time
+
+RUN dnf -y install --setopt=install_weak_deps=False \
+       systemd git make rust-toolset rpm-build python3 python3-devel && \
+    dnf clean all

--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -1,0 +1,35 @@
+FROM quay.io/centos/centos:stream10-development
+
+RUN echo "2024-06-24" > /build_time
+
+RUN dnf update -y && \
+    dnf -y install dnf-plugins-core  && \
+    dnf -y copr enable nmstate/ovs-el10 centos-stream-10-x86_64 && \ 
+    dnf config-manager --set-enabled crb && \
+    dnf -y install --setopt=install_weak_deps=False \
+        systemd make go rust-toolset NetworkManager NetworkManager-ovs \
+        systemd-udev python3-devel python3-pyyaml python3-setuptools dnsmasq \
+        git iproute rpm-build python3-pytest wpa_supplicant hostapd libndp python3-pip \
+        procps-ng dpdk python3-gobject-base libreswan NetworkManager-libreswan \
+        openvswitch3.3 python3-openvswitch3.3 && \
+    dnf clean all
+
+RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"
+
+COPY network_manager_enable_trace.conf \
+     /etc/NetworkManager/conf.d/97-trace-logging.conf
+COPY network_manager_keyfile.conf \
+     /etc/NetworkManager/conf.d/96-keyfile.conf
+
+# Fedora container has no /etc/systemd/journald.conf file in systemd rpm
+RUN  echo -e '[Journal]\nRateLimitInterval=0\nRateLimitBurst=0' > \
+    /etc/systemd/journald.conf
+
+RUN echo net.ipv6.conf.all.disable_ipv6=0 > \
+        /etc/sysctl.d/00-enable-ipv6.conf && \
+    echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > \
+    /etc/sysctl.d/01-export-kernel-cores.conf
+
+RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec
+
+CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream10-development
 
-RUN echo "2024-06-24" > /build_time
+RUN echo "2024-06-26" > /build_time
 
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core  && \
@@ -16,12 +16,14 @@ RUN dnf update -y && \
 
 RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"
 
+RUN mkdir -p /etc/NetworkManager/conf.d/
+
 COPY network_manager_enable_trace.conf \
      /etc/NetworkManager/conf.d/97-trace-logging.conf
 COPY network_manager_keyfile.conf \
      /etc/NetworkManager/conf.d/96-keyfile.conf
 
-# Fedora container has no /etc/systemd/journald.conf file in systemd rpm
+# RHEL/CentOS stream 10 container has no /etc/systemd/journald.conf file in systemd rpm
 RUN  echo -e '[Journal]\nRateLimitInterval=0\nRateLimitBurst=0' > \
     /etc/systemd/journald.conf
 

--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -172,7 +172,7 @@ popd
 
 %build
 pushd rust
-%if 0%{?rhel}
+%if 0%{?rhel} == 9
 # It is safe to ignore minimum rust version. The main blocker on MSRV is
 # toml which just increase their MSRV by a robot for no hard reason.
 %cargo_build --ignore-rust-version


### PR DESCRIPTION
* We don't have epel repo so using files from Fedora40 where needed.
* For tox and virtualenv we need to use pip to be compatible for the same lack of epel reasons.
* It seems /etc/systemd/journald.conf is not present either so RateLimits added directly (not sure here if not too invasive)
* We don't need nispor as it should be part of nmstate now.