### PR TITLE
test: Remove the need of nispor CLI

### DIFF
--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -11,7 +11,7 @@ RUN dnf update -y && \
         openvswitch2.17 systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk nispor python3-gobject-base libreswan \
+        libndp procps-ng dpdk python3-gobject-base libreswan \
         NetworkManager-libreswan \
         && dnf clean all
 

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -8,7 +8,7 @@ RUN dnf update -y && \
         openvswitch systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk nispor rust-packaging \
+        libndp procps-ng dpdk rust-packaging \
         python3-gobject-base NetworkManager-libreswan libreswan \
         && dnf clean all
 

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -7,7 +7,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
         openvswitch systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk nispor rust-packaging \
+        libndp procps-ng dpdk rust-packaging \
         python3-gobject-base NetworkManager-libreswan libreswan \
         && dnf clean all
 

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -135,15 +135,13 @@ def bond0(port0_up):
 
 
 def _vlan_filtering_enabled(bridge_name):
-    _, npc_output, _ = exec_cmd(
-        cmd=(
-            "npc",
-            "iface",
-            bridge_name,
-        ),
+    output = exec_cmd(
+        cmd=(f"ip -d -j link show {bridge_name}".split()),
         check=True,
+    )[1]
+    return (
+        json.loads(output)[0]["linkinfo"]["info_data"]["vlan_filtering"] == 1
     )
-    return "vlan_filtering: true" in npc_output
 
 
 def test_create_and_remove_linux_bridge_with_min_desired_state():
@@ -904,10 +902,8 @@ def test_create_linux_bridge_with_copy_mac_from(eth1_up, eth2_up):
 
 
 def _get_permanent_mac(iface_name):
-    np_iface = json.loads(
-        exec_cmd(f"npc iface {iface_name} --json".split())[1]
-    )
-    return np_iface[0].get("permanent_mac_address")
+    iface_state = show_only((iface_name,))[Interface.KEY][0]
+    return iface_state.get("permanent-mac-address")
 
 
 @pytest.fixture

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import json
+
 import pytest
 from contextlib import contextmanager
 
@@ -115,8 +117,8 @@ def test_add_new_port_to_bridge_with_unmanged_port(
         )
 
         # dummy1 should still be the bridge port
-        output = exec_cmd(f"npc iface {DUMMY1}".split(), check=True)[1]
-        assert f"controller: {BRIDGE0}" in output
+        output = exec_cmd(f"ip -j link show {DUMMY1}".split(), check=True)[1]
+        assert json.loads(output)[0]["master"] == BRIDGE0
 
 
 @pytest.fixture


### PR DESCRIPTION
In CentOS stream 10, nispor CLI is removed, hence we replace the use of
`npc` command to `ip` command in test cases.