### PR TITLE
test: Remove the need of python3-gobject-base

### DIFF
--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -4,14 +4,14 @@ RUN echo "2024-06-26" > /build_time
 
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core  && \
-    dnf -y copr enable nmstate/ovs-el10 centos-stream-10-x86_64 && \ 
+    dnf -y copr enable nmstate/ovs-el10 centos-stream-10-x86_64 && \
     dnf config-manager --set-enabled crb && \
     dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust-toolset NetworkManager NetworkManager-ovs \
         systemd-udev python3-devel python3-pyyaml python3-setuptools dnsmasq \
-        git iproute rpm-build python3-pytest wpa_supplicant hostapd libndp python3-pip \
-        procps-ng dpdk python3-gobject-base libreswan NetworkManager-libreswan \
-        openvswitch3.3 python3-openvswitch3.3 && \
+        git iproute rpm-build python3-pytest wpa_supplicant hostapd libndp \
+        python3-pip procps-ng dpdk libreswan NetworkManager-libreswan \
+        openvswitch3.3 && \
     dnf clean all
 
 RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"

--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -11,8 +11,7 @@ RUN dnf update -y && \
         openvswitch2.17 systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
-        libndp procps-ng dpdk python3-gobject-base libreswan \
-        NetworkManager-libreswan \
+        libndp procps-ng dpdk libreswan NetworkManager-libreswan \
         && dnf clean all
 
 RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -9,7 +9,7 @@ RUN dnf update -y && \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
         libndp procps-ng dpdk rust-packaging \
-        python3-gobject-base NetworkManager-libreswan libreswan \
+        NetworkManager-libreswan libreswan \
         && dnf clean all
 
 COPY network_manager_enable_trace.conf \

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -8,7 +8,7 @@ RUN dnf -y install --setopt=install_weak_deps=False \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
         libndp procps-ng dpdk rust-packaging \
-        python3-gobject-base NetworkManager-libreswan libreswan \
+        NetworkManager-libreswan libreswan \
         && dnf clean all
 
 COPY network_manager_enable_trace.conf \

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -2,18 +2,7 @@
 
 import os
 
-import gi
-
 from .cmdlib import exec_cmd
-
-gi.require_version("NM", "1.0")
-# It is required to state the NM version before importing it
-# But this break the flak8 rule: https://www.flake8rules.com/rules/E402.html
-# Use NOQA: E402 to suppress it.
-# pylint: disable=no-name-in-module
-from gi.repository import NM  # NOQA: E402
-
-# pylint: enable=no-name-in-module
 
 
 def is_fedora():
@@ -24,12 +13,12 @@ def is_ubuntu_kernel():
     return "Ubuntu" in os.uname().version
 
 
-def nm_major_minor_version():
-    return float(f"{NM.MAJOR_VERSION}.{NM.MINOR_VERSION}")
-
-
 def nm_minor_version():
-    return int(f"{NM.MINOR_VERSION}")
+    version_str = exec_cmd(
+        "rpm -q NetworkManager --qf %{VERSION}".split(),
+        check=True,
+    )[1]
+    return int(version_str.split(".")[1])
 
 
 def is_k8s():


### PR DESCRIPTION
The python3-gobject-base is too big for test container.
Change the test code to use rpm instead to query NetworkManager version.