### PR TITLE
rpm spec: Fix `--ignore-rust-version` argument

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -172,10 +172,10 @@ popd
 
 %build
 pushd rust
-%if 0%{?rhel} == 9
+%if 0%{?rhel}
 # It is safe to ignore minimum rust version. The main blocker on MSRV is
 # toml which just increase their MSRV by a robot for no hard reason.
-%cargo_build --ignore-rust-version
+%{cargo_build} -- --ignore-rust-version
 %else
 %cargo_build
 %endif


### PR DESCRIPTION
As rust-toolset team suggested, we should place `--` before custom
argument to `%cargo_build`