### PR TITLE
ovs bond: Deny unknown fields in ovs bond section

### DIFF
--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -485,8 +485,6 @@ impl OvsInterface {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[non_exhaustive]
 /// The example yaml output of OVS bond:
 /// ```yml
 /// ---
@@ -511,6 +509,9 @@ impl OvsInterface {
 ///           - name: eth2
 ///           - name: eth1
 /// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
 pub struct OvsBridgeBondConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<OvsBridgeBondMode>,

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -948,3 +948,28 @@ fn test_ovs_bridge_with_mac() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_deny_unknown_field_in_ovs_bond() {
+    let result = serde_yaml::from_str::<OvsBridgeInterface>(
+        r"
+        name: br0
+        type: ovs-bridge
+        state: up
+        mac-address: 05:04:03:02:01:00
+        bridge:
+          port:
+          - name: bond1
+            link-aggregation:
+              mode: active-backup
+              bond-downdelay: 100
+              bond-updelay: 101
+              invalid: foo
+              ports:
+              - name: eth1
+              - name: eth2
+        ",
+    );
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
The `link-aggregation` of ovs bond should deny unknown fields like
other sections.

Unit test case included.