### PR TITLE
test: Two patches to tracking performance issue of NMCI

### DIFF
--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -53,7 +53,7 @@ done
 echo $NM_COPR
 echo $NM_RPM_DIR
 
-ARGS="--test-type integ_tier1"
+ARGS="--test-type integ_tier1 --nolog"
 if [[ -v NM_COPR ]];then
     ARGS="$ARGS --copr $NM_COPR"
 fi

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -22,6 +22,7 @@ CENTOS_8_STREAM_IMAGE_DEV="quay.io/nmstate/c8s-nmstate-dev"
 CENTOS_9_STREAM_IMAGE_DEV="quay.io/nmstate/c9s-nmstate-dev"
 CENTOS_10_STREAM_IMAGE_DEV="quay.io/nmstate/c10s-nmstate-dev"
 
+COLLECT_LOGS="true"
 
 PYTEST_OPTIONS="--verbose --verbose \
         --log-file-level=DEBUG \
@@ -167,7 +168,9 @@ function run_exit {
         k8s::collect_artifacts
         k8s::cleanup
     else
-        collect_artifacts
+        if [ $COLLECT_LOGS == "true" ];then
+            collect_artifacts
+        fi
         remove_container
         remove_tempdir
     fi
@@ -229,7 +232,7 @@ function run_customize_command {
 options=$(getopt --options "" \
     --long "customize:,pytest-args:,help,debug-shell,test-type:,\
     el8,el9,el10,centos-stream,fed,rawhide,copr:,artifacts-dir:,test-vdsm,\
-    machine,k8s,use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:" \
+    machine,k8s,use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:,nolog" \
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -288,6 +291,9 @@ while true; do
         ;;
     --k8s)
         RUN_K8S="true"
+        ;;
+    --nolog)
+        COLLECT_LOGS="false"
         ;;
     --use-installed-nmstate)
         INSTALL_NMSTATE="false"

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -8,7 +8,7 @@ function remove_container {
 }
 
 function container_exec {
-    ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
+    time ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
         /bin/bash -c "cd $CONTAINER_WORKSPACE && $1"
 }
 

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -357,7 +357,7 @@ pub(crate) fn get_systemd_preferred_iface_name(
         cmd.arg(root).arg("udevadm");
     }
     cmd.args(UDEVADM_CMD_OPT)
-        .arg(&format!("/sys/class/net/{iface_name}"));
+        .arg(format!("/sys/class/net/{iface_name}"));
     let output = cmd.output()?;
     if !output.status.success() {
         return Err(CliError::from(format!(


### PR DESCRIPTION
* Turn off log collecting in NMCI via `--nolog` argument in `run-test.sh`.
 * Tracking the elapsed time of each test commands.