### PR TITLE
nm ovs: Enable connection.autoconnect-ports for OVS port

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -340,7 +340,9 @@ fn delete_remain_virtual_interface_as_desired(
         .kernel_ifaces
         .values()
         .filter(|i| {
-            i.is_changed() && (i.merged.is_absent() || i.merged.is_down())
+            i.merged.iface_type() != InterfaceType::OvsInterface
+                && i.is_changed()
+                && (i.merged.is_absent() || i.merged.is_down())
         })
         .map(|i| &i.merged)
     {

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -418,7 +418,9 @@ pub(crate) fn gen_nm_conn_setting(
         nm_conn_set.iface_name = None;
     }
     nm_conn_set.autoconnect = Some(true);
-    nm_conn_set.autoconnect_ports = if iface.is_controller() {
+    nm_conn_set.autoconnect_ports = if iface.is_controller()
+        || iface.iface_type() == InterfaceType::Other("ovs-port".to_string())
+    {
         Some(true)
     } else {
         None

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -19,6 +19,7 @@ use crate::{
 const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;
 const VERIFY_RETRY_INTERVAL_MILLISECONDS: u64 = 1000;
 const VERIFY_RETRY_COUNT_DEFAULT: usize = 5;
+const VERIFY_RETRY_COUNT_OVS: usize = 10;
 const VERIFY_RETRY_COUNT_SRIOV_MIN: usize = 30;
 const VERIFY_RETRY_COUNT_SRIOV_MAX: usize = 300;
 const VERIFY_RETRY_COUNT_KERNEL_MODE: usize = 5;
@@ -486,7 +487,13 @@ impl MergedNetworkState {
 
 fn get_proper_verify_retry_count(merged_ifaces: &MergedInterfaces) -> usize {
     match merged_ifaces.get_sriov_vf_count() {
-        0 => VERIFY_RETRY_COUNT_DEFAULT,
+        0 => {
+            if merged_ifaces.has_ovs() {
+                VERIFY_RETRY_COUNT_OVS
+            } else {
+                VERIFY_RETRY_COUNT_DEFAULT
+            }
+        }
         v if v >= 64 => VERIFY_RETRY_COUNT_SRIOV_MAX,
         v if v <= 16 => VERIFY_RETRY_COUNT_SRIOV_MIN,
         v => v as usize / 64 * VERIFY_RETRY_COUNT_SRIOV_MAX,

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -146,6 +146,18 @@ impl OvsBridgeBondConfig {
     }
 }
 impl MergedInterfaces {
+    pub(crate) fn has_ovs(&self) -> bool {
+        self.kernel_ifaces
+            .values()
+            .chain(self.user_ifaces.values())
+            .any(|i| {
+                i.for_apply.as_ref().map(|i| {
+                    i.iface_type() == InterfaceType::OvsBridge
+                        || i.iface_type() == InterfaceType::OvsInterface
+                }) == Some(true)
+            })
+    }
+
     // This function remove extra(undesired) ovs patch port from post-apply
     // current, so it will not interfere with verification
     pub(crate) fn process_allow_extra_ovs_patch_ports_for_verify(


### PR DESCRIPTION
We forgot to enable `connection.autoconnect-ports` for OVS ports in NM
code as the `iface.is_controller()` is false for
`InterfaceType::Other("ovs-port")`

Extend verify retry to 30 seconds, as NM takes longer time after enabled
`connection.autoconnect-ports` due to extra reactivations in NM internal.

With this change, we can also skip activation on OVS interface as OVS
port will activate its subordinates.

Fixed and added integration test case.