### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,6 +198,16 @@ jobs:
     - name: Install Rust 1.66
       run: rustup install 1.66
 
+    - name: Use rust vendoring
+      run: |
+        cd rust
+        wget -qO- https://github.com/nmstate/nmstate/releases/download/v2.2.33/nmstate-vendor-2.2.33.tar.xz | tar xJ
+        mkdir .cargo
+        echo '[source.crates-io]' > .cargo/config.toml
+        echo 'replace-with = "vendored-sources"' >> .cargo/config.toml
+        echo '[source.vendored-sources]' >> .cargo/config.toml
+        echo 'directory = "vendor"' >> .cargo/config.toml
+
     - name: Build on rust 1.66
       run: cd rust && cargo +1.66 build --ignore-rust-version
 

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux"]
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.66"
 
 [[bin]]
 name = "nmstatectl"

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -5,7 +5,7 @@ version = "2.2.34"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.66"
 build = "build.rs"
 
 [lib]


### PR DESCRIPTION
* Pin minimum supported rust version to 1.66 for lib, clib and cli.
 * Use 2.2.33 vendor tarball for rust 1.66 testing.