### PR TITLE
vlan: make 'base-iface' optional for the desired state

### DIFF
--- a/rust/src/cli/autoconf.rs
+++ b/rust/src/cli/autoconf.rs
@@ -167,7 +167,7 @@ fn gen_vlan_iface(vlan_name: &str, id: u32, parent: &str) -> Interface {
     base_iface.iface_type = InterfaceType::Vlan;
     base_iface.state = InterfaceState::Up;
     let mut vlan_conf = VlanConfig::default();
-    vlan_conf.base_iface = parent.to_string();
+    vlan_conf.base_iface = Some(parent.to_string());
     vlan_conf.id = id.try_into().unwrap();
     let mut vlan_iface = VlanInterface::new();
     vlan_iface.base = base_iface;

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -696,6 +696,7 @@ impl Interface {
             Interface::Loopback(iface) => iface.sanitize(is_desired)?,
             Interface::MacSec(iface) => iface.sanitize(is_desired)?,
             Interface::Ipsec(iface) => iface.sanitize(is_desired),
+            Interface::Vlan(iface) => iface.sanitize(is_desired)?,
             _ => (),
         }
         Ok(())

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -11,7 +11,7 @@ pub(crate) fn np_vlan_to_nmstate(
 ) -> VlanInterface {
     let vlan_conf = np_iface.vlan.as_ref().map(|np_vlan_info| VlanConfig {
         id: np_vlan_info.vlan_id,
-        base_iface: np_vlan_info.base_iface.clone(),
+        base_iface: Some(np_vlan_info.base_iface.clone()),
         protocol: match &np_vlan_info.protocol {
             nispor::VlanProtocol::Ieee8021Q => Some(VlanProtocol::Ieee8021Q),
             nispor::VlanProtocol::Ieee8021AD => Some(VlanProtocol::Ieee8021Ad),
@@ -48,9 +48,9 @@ pub(crate) fn nms_vlan_conf_to_np(
     nms_vlan_conf.map(|nms_vlan_conf| {
         let mut np_vlan_conf = nispor::VlanConf::default();
         np_vlan_conf.vlan_id = nms_vlan_conf.id;
-        np_vlan_conf
-            .base_iface
-            .clone_from(&nms_vlan_conf.base_iface);
+        if let Some(base_iface) = &nms_vlan_conf.base_iface {
+            np_vlan_conf.base_iface.clone_from(base_iface);
+        }
         np_vlan_conf
     })
 }

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -14,7 +14,7 @@ pub(crate) fn gen_nm_vlan_setting(
     if let Some(vlan_conf) = iface.vlan.as_ref() {
         let mut nm_vlan = nm_conn.vlan.as_ref().cloned().unwrap_or_default();
         nm_vlan.id = Some(vlan_conf.id.into());
-        nm_vlan.parent = Some(vlan_conf.base_iface.clone());
+        nm_vlan.parent = vlan_conf.base_iface.clone();
         if let Some(protocol) = vlan_conf.protocol {
             match protocol {
                 VlanProtocol::Ieee8021Ad => {

--- a/rust/src/lib/unit_tests/gen_diff_test_files/vlan/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/vlan/current.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    base-iface: veth0
+    id: 3
+    reorder-headers: true
+- name: veth0
+  type: veth
+  state: up
+  veth:
+    peer: veth0_p

--- a/rust/src/lib/unit_tests/gen_diff_test_files/vlan/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/vlan/desired.yml
@@ -1,0 +1,13 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    base-iface: veth0
+    id: 4
+- name: veth0
+  type: veth
+  state: up
+  veth:
+    peer: veth0_p

--- a/rust/src/lib/unit_tests/gen_diff_test_files/vlan/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/vlan/diff.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    id: 4

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -63,7 +63,7 @@ pub(crate) fn new_vlan_iface(name: &str, parent: &str, id: u16) -> Interface {
     iface.base.name = name.to_string();
     iface.base.iface_type = InterfaceType::Vlan;
     iface.vlan = Some(VlanConfig {
-        base_iface: parent.to_string(),
+        base_iface: Some(parent.to_string()),
         id,
         ..Default::default()
     });

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ErrorKind, InterfaceType, Interfaces, MergedInterfaces, VlanInterface,
-    VlanProtocol,
+    ErrorKind, Interface, InterfaceType, Interfaces, MergedInterface,
+    MergedInterfaces, VlanInterface, VlanProtocol,
 };
 
 #[test]
@@ -212,4 +212,29 @@ fn test_vlan_update() {
         iface1.vlan.as_ref().unwrap().protocol,
         Some(VlanProtocol::Ieee8021Q)
     );
+}
+
+#[test]
+fn test_vlan_base_iface_optional() {
+    let current: Interface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          base-iface: eth0
+          id: 100",
+    )
+    .unwrap();
+    let desired: Interface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          id: 101",
+    )
+    .unwrap();
+
+    let mut merged_iface =
+        MergedInterface::new(Some(desired), Some(current)).unwrap();
+    merged_iface.post_inter_ifaces_process().unwrap();
 }

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -480,3 +480,21 @@ def test_vlan_do_not_override_reorder_headers_if_not_mentioned(
     assert not current_state[Interface.KEY][0][VLAN.CONFIG_SUBTREE][
         VLAN.REORDER_HEADERS
     ]
+
+
+def test_base_iface_optional(vlan_on_eth1):
+    new_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.ID: 102,
+                },
+            }
+        ]
+    }
+
+    libnmstate.apply(new_state)
+    assertlib.assert_state_match(new_state)


### PR DESCRIPTION
When creating a VLAN interface we need to know the base interface to
which is attached. However, if the VLAN interface already exists we can
asume that, if it's not specified, base-iface remains the same.

Make 'base-iface' optional and take it from the current state if it's
missing. Emit an error if it's not already defined in the current state.

Also, there was a bug in gen_diff. If base-iface doesn't change,
creating the VlanInterface struct failed because base-iface was
mandatory and it was missing in the diff. As it is no longer
mandatory, this commit fixes the bug. The message of the bug was:
>  "missing field `base-iface`"

Added test cases.

Resolves: https://issues.redhat.com/browse/RHEL-38623