### PR TITLE
nm ovs: Fix device reapply

### DIFF
--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -20,6 +20,8 @@ use super::{
     },
 };
 
+const NM_OVS_DEV_TYPES: [&str; 3] = ["ovs-interface", "ovs-port", "ovs-bridge"];
+
 pub struct NmApi<'a> {
     pub(crate) dbus: NmDbus<'a>,
     checkpoint: Option<String>,
@@ -221,14 +223,22 @@ impl<'a> NmApi<'a> {
     ) -> Result<(), NmError> {
         debug!("connection_reapply: {:?}", nm_conn);
         self.extend_timeout_if_required()?;
-        if let Some(iface_name) = nm_conn.iface_name() {
-            let nm_dev_obj_path = self.dbus.nm_dev_obj_path_get(iface_name)?;
-            self.dbus.nm_dev_reapply(&nm_dev_obj_path, nm_conn)
+
+        // We cannot use `org.freedesktop.NetworkManager.GetDeviceByIpIface`
+        // because OVS bridge/port/iface might hold identical device name.
+        // Need to check interface type also.
+        if let (Some(iface_name), Some(nm_iface_type)) =
+            (nm_conn.iface_name(), nm_conn.iface_type())
+        {
+            let nm_dev_obj_path =
+                self.get_disk_obj_path(iface_name, nm_iface_type)?;
+            self.dbus.nm_dev_reapply(nm_dev_obj_path.as_str(), nm_conn)
         } else {
             Err(NmError::new(
-                ErrorKind::InvalidArgument,
+                ErrorKind::Bug,
                 format!(
-                    "Failed to extract interface name from connection {nm_conn:?}"
+                    "Failed to extract interface name and type from \
+                    connection {nm_conn:?}"
                 ),
             ))
         }
@@ -399,6 +409,32 @@ impl<'a> NmApi<'a> {
     ) -> Result<(), NmError> {
         self.extend_timeout_if_required()?;
         self.dbus.set_global_dns_configuration(config.to_value()?)
+    }
+
+    // Use `org.freedesktop.NetworkManager.GetDeviceByIpIface`.
+    // Except OVS bridge/port/iface as they might hold identical device name
+    // where we search all disks.
+    fn get_disk_obj_path(
+        &mut self,
+        iface_name: &str,
+        nm_iface_type: &str,
+    ) -> Result<String, NmError> {
+        if NM_OVS_DEV_TYPES.contains(&nm_iface_type) {
+            if let Some(nm_dev) = self
+                .devices_get()?
+                .into_iter()
+                .find(|d| d.name == iface_name && d.iface_type == nm_iface_type)
+            {
+                Ok(nm_dev.obj_path)
+            } else {
+                Err(NmError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Interface {iface_name}/{nm_iface_type} not found"),
+                ))
+            }
+        } else {
+            self.dbus.nm_dev_obj_path_get(iface_name)
+        }
     }
 }
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -40,6 +40,7 @@ from .testlib.retry import retry_till_true_or_timeout
 from .testlib.servicelib import disable_service
 from .testlib.statelib import state_match
 from .testlib.vlan import vlan_interface
+from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 
 
 BOND1 = "bond1"
@@ -2196,3 +2197,10 @@ def test_raise_error_on_unknown_ovsdb_global_section():
 def remove_ovn_state_present(state):
     for ovn_map in state.get(Ovn.BRIDGE_MAPPINGS, []):
         ovn_map.pop(Ovn.BridgeMappings.STATE, None)
+
+
+@pytest.mark.tier1
+@ip_monitor_assert_stable_link_up(BRIDGE1)
+def test_ovs_link_stable(ovs_bridge1_with_internal_port_same_name):
+    desired_state = ovs_bridge1_with_internal_port_same_name
+    libnmstate.apply(desired_state)


### PR DESCRIPTION
When applying the identical YAML with OVS again, nmstate got failure
when device reapply:

    Reapply operation failed on ovs-interface ovs0
    93f1914e-67ea-4f91-a228-7ae384d285b3, reason:
    IncompatibleReapply:Can't reapply any changes to 'ovs-interface'
    setting, retry on normal activation

The root cause is OVS port and OVS interface are using the same
`connection.interface-name`, but `NmApi::connection_reapply` only search
device using interface name, which lead to nmstate asking reapply
on the wrong NmDevice.

To fix the problem, for OVS connections, we search full list of
NmDevice by matching both interface name and type.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-50556