### PR TITLE
cli: Remove cargo slug `os::linux`

### DIFF
--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://nmstate.io"
 documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
-categories = ["network-programming", "os::linux"]
+categories = ["network-programming"]
 edition = "2021"
 rust-version = "1.66"
 


### PR DESCRIPTION
The `os::linux` slug is removed from crates.io. The `os` is for OS
specific binding which does not align with nmstatectl CLI tool. Hence
remove `os::linux` cargo slug.