### PR TITLE
nm: Fix incorrect device-reapply call

### DIFF
--- a/rust/src/lib/nm/active_connection.rs
+++ b/rust/src/lib/nm/active_connection.rs
@@ -2,20 +2,16 @@
 
 use std::collections::HashMap;
 
-use super::nm_dbus::NmActiveConnection;
-
-use super::settings::{
-    NM_SETTING_VETH_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
-};
+use super::nm_dbus::{NmActiveConnection, NmIfaceType};
 
 pub(crate) fn create_index_for_nm_acs_by_name_type(
     nm_acs: &[NmActiveConnection],
-) -> HashMap<(&str, &str), &NmActiveConnection> {
+) -> HashMap<(&str, NmIfaceType), &NmActiveConnection> {
     let mut ret = HashMap::new();
     for nm_ac in nm_acs {
-        let nm_iface_type = match nm_ac.iface_type.as_str() {
-            NM_SETTING_VETH_SETTING_NAME => NM_SETTING_WIRED_SETTING_NAME,
-            t => t,
+        let nm_iface_type = match &nm_ac.iface_type {
+            NmIfaceType::Veth => NmIfaceType::Ethernet,
+            t => t.clone(),
         };
         ret.insert((nm_ac.iface_name.as_str(), nm_iface_type), nm_ac);
     }

--- a/rust/src/lib/nm/device.rs
+++ b/rust/src/lib/nm/device.rs
@@ -2,15 +2,15 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::NmDevice;
+use crate::nm::nm_dbus::{NmDevice, NmIfaceType};
 
 pub(crate) fn create_index_for_nm_devs(
     nm_devs: &[NmDevice],
-) -> HashMap<(String, String), &NmDevice> {
-    let mut ret: HashMap<(String, String), &NmDevice> = HashMap::new();
+) -> HashMap<(String, NmIfaceType), &NmDevice> {
+    let mut ret: HashMap<(String, NmIfaceType), &NmDevice> = HashMap::new();
     for nm_dev in nm_devs {
         ret.insert(
-            (nm_dev.name.to_string(), nm_dev.iface_type.to_string()),
+            (nm_dev.name.to_string(), nm_dev.iface_type.clone()),
             nm_dev,
         );
     }

--- a/rust/src/lib/nm/nm_dbus/active_connection.rs
+++ b/rust/src/lib/nm/nm_dbus/active_connection.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use super::NmIfaceType;
 #[cfg(feature = "query_apply")]
 use super::{
     connection::nm_con_get_from_obj_path,
@@ -12,7 +13,7 @@ pub const NM_ACTIVATION_STATE_FLAG_EXTERNAL: u32 = 0x80;
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NmActiveConnection {
     pub uuid: String,
-    pub iface_type: String,
+    pub iface_type: NmIfaceType,
     pub iface_name: String,
     pub state_flags: u32,
 }
@@ -96,10 +97,7 @@ pub(crate) fn get_nm_ac_by_obj_path(
             Some(i) => i.to_string(),
             None => "".to_string(),
         };
-        let iface_type = match nm_conn.iface_type() {
-            Some(i) => i.to_string(),
-            None => "".to_string(),
-        };
+        let iface_type = nm_conn.iface_type().cloned().unwrap_or_default();
         Ok(Some(NmActiveConnection {
             uuid: nm_ac_obj_path_uuid_get(connection, obj_path)?,
             iface_name,

--- a/rust/src/lib/nm/nm_dbus/connection/iface_type.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/iface_type.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+
+use super::super::NmError;
+
+pub(crate) const NM_SETTING_BRIDGE_SETTING_NAME: &str = "bridge";
+pub(crate) const NM_SETTING_WIRED_SETTING_NAME: &str = "802-3-ethernet";
+pub(crate) const NM_SETTING_OVS_BRIDGE_SETTING_NAME: &str = "ovs-bridge";
+pub(crate) const NM_SETTING_OVS_PORT_SETTING_NAME: &str = "ovs-port";
+pub(crate) const NM_SETTING_OVS_IFACE_SETTING_NAME: &str = "ovs-interface";
+pub(crate) const NM_SETTING_VETH_SETTING_NAME: &str = "veth";
+pub(crate) const NM_SETTING_BOND_SETTING_NAME: &str = "bond";
+pub(crate) const NM_SETTING_DUMMY_SETTING_NAME: &str = "dummy";
+pub(crate) const NM_SETTING_MACSEC_SETTING_NAME: &str = "macsec";
+pub(crate) const NM_SETTING_MACVLAN_SETTING_NAME: &str = "macvlan";
+pub(crate) const NM_SETTING_VRF_SETTING_NAME: &str = "vrf";
+pub(crate) const NM_SETTING_VLAN_SETTING_NAME: &str = "vlan";
+pub(crate) const NM_SETTING_VXLAN_SETTING_NAME: &str = "vxlan";
+pub(crate) const NM_SETTING_INFINIBAND_SETTING_NAME: &str = "infiniband";
+pub(crate) const NM_SETTING_LOOPBACK_SETTING_NAME: &str = "loopback";
+pub(crate) const NM_SETTING_HSR_SETTING_NAME: &str = "hsr";
+pub(crate) const NM_SETTING_VPN_SETTING_NAME: &str = "vpn";
+pub(crate) const NM_SETTING_GENERIC_SETTING_NAME: &str = "generic";
+pub(crate) const NM_SETTING_WIRELESS_SETTING_NAME: &str = "802-11-wireless";
+pub(crate) const NM_SETTING_BLUETOOTH_SETTING_NAME: &str = "bluetooth";
+pub(crate) const NM_SETTING_OLPC_MESH_SETTING_NAME: &str = "802-11-olpc-mesh";
+pub(crate) const NM_SETTING_TUN_SETTING_NAME: &str = "tun";
+pub(crate) const NM_SETTING_IP_TUNNEL_SETTING_NAME: &str = "ip-tunnel";
+pub(crate) const NM_SETTING_PPP_SETTING_NAME: &str = "ppp";
+pub(crate) const NM_SETTING_WPAN_SETTING_NAME: &str = "wpan";
+pub(crate) const NM_SETTING_6LOWPAN_SETTING_NAME: &str = "6lowpan";
+pub(crate) const NM_SETTING_WIREGUARD_SETTING_NAME: &str = "wireguard";
+pub(crate) const NM_SETTING_WIFI_P2P_SETTING_NAME: &str = "wifi-p2p";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Deserialize)]
+#[non_exhaustive]
+pub enum NmIfaceType {
+    #[default]
+    Unknown,
+    Bridge,
+    Ethernet,
+    OvsBridge,
+    OvsPort,
+    OvsIface,
+    Veth,
+    Bond,
+    Dummy,
+    Macsec,
+    Macvlan,
+    Vrf,
+    Vlan,
+    Vxlan,
+    Infiniband,
+    Loopback,
+    Hsr,
+    Vpn,
+    Generic,
+    Wireless,
+    Bluetooth,
+    OlpcMesh,
+    Tun,
+    IpTunnel,
+    Ppp,
+    Wpan,
+    SixLowPan,
+    Wireguard,
+    WifiP2p,
+    Other(String),
+}
+
+impl std::fmt::Display for NmIfaceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let iface_str = match self {
+            Self::Bridge => NM_SETTING_BRIDGE_SETTING_NAME,
+            Self::Ethernet => NM_SETTING_WIRED_SETTING_NAME,
+            Self::OvsBridge => NM_SETTING_OVS_BRIDGE_SETTING_NAME,
+            Self::OvsPort => NM_SETTING_OVS_PORT_SETTING_NAME,
+            Self::OvsIface => NM_SETTING_OVS_IFACE_SETTING_NAME,
+            Self::Veth => NM_SETTING_VETH_SETTING_NAME,
+            Self::Bond => NM_SETTING_BOND_SETTING_NAME,
+            Self::Dummy => NM_SETTING_DUMMY_SETTING_NAME,
+            Self::Macsec => NM_SETTING_MACSEC_SETTING_NAME,
+            Self::Macvlan => NM_SETTING_MACVLAN_SETTING_NAME,
+            Self::Vrf => NM_SETTING_VRF_SETTING_NAME,
+            Self::Vlan => NM_SETTING_VLAN_SETTING_NAME,
+            Self::Vxlan => NM_SETTING_VXLAN_SETTING_NAME,
+            Self::Infiniband => NM_SETTING_INFINIBAND_SETTING_NAME,
+            Self::Loopback => NM_SETTING_LOOPBACK_SETTING_NAME,
+            Self::Hsr => NM_SETTING_HSR_SETTING_NAME,
+            Self::Vpn => NM_SETTING_VPN_SETTING_NAME,
+            Self::Generic => NM_SETTING_GENERIC_SETTING_NAME,
+            Self::Wireless => NM_SETTING_WIRELESS_SETTING_NAME,
+            Self::Bluetooth => NM_SETTING_BLUETOOTH_SETTING_NAME,
+            Self::OlpcMesh => NM_SETTING_OLPC_MESH_SETTING_NAME,
+            Self::Tun => NM_SETTING_TUN_SETTING_NAME,
+            Self::IpTunnel => NM_SETTING_IP_TUNNEL_SETTING_NAME,
+            Self::Ppp => NM_SETTING_PPP_SETTING_NAME,
+            Self::Wpan => NM_SETTING_WPAN_SETTING_NAME,
+            Self::SixLowPan => NM_SETTING_6LOWPAN_SETTING_NAME,
+            Self::Wireguard => NM_SETTING_WIREGUARD_SETTING_NAME,
+            Self::WifiP2p => NM_SETTING_WIFI_P2P_SETTING_NAME,
+            Self::Unknown => "unknown",
+            Self::Other(s) => s.as_str(),
+        };
+        write!(f, "{iface_str}")
+    }
+}
+
+impl From<&str> for NmIfaceType {
+    fn from(s: &str) -> Self {
+        match s {
+            NM_SETTING_BRIDGE_SETTING_NAME => Self::Bridge,
+            NM_SETTING_WIRED_SETTING_NAME => Self::Ethernet,
+            NM_SETTING_OVS_BRIDGE_SETTING_NAME => Self::OvsBridge,
+            NM_SETTING_OVS_PORT_SETTING_NAME => Self::OvsPort,
+            NM_SETTING_OVS_IFACE_SETTING_NAME => Self::OvsIface,
+            NM_SETTING_VETH_SETTING_NAME => Self::Veth,
+            NM_SETTING_BOND_SETTING_NAME => Self::Bond,
+            NM_SETTING_DUMMY_SETTING_NAME => Self::Dummy,
+            NM_SETTING_MACSEC_SETTING_NAME => Self::Macsec,
+            NM_SETTING_MACVLAN_SETTING_NAME => Self::Macvlan,
+            NM_SETTING_VRF_SETTING_NAME => Self::Vrf,
+            NM_SETTING_VLAN_SETTING_NAME => Self::Vlan,
+            NM_SETTING_VXLAN_SETTING_NAME => Self::Vxlan,
+            NM_SETTING_INFINIBAND_SETTING_NAME => Self::Infiniband,
+            NM_SETTING_LOOPBACK_SETTING_NAME => Self::Loopback,
+            NM_SETTING_HSR_SETTING_NAME => Self::Hsr,
+            NM_SETTING_VPN_SETTING_NAME => Self::Vpn,
+            NM_SETTING_GENERIC_SETTING_NAME => Self::Generic,
+            NM_SETTING_WIRELESS_SETTING_NAME => Self::Wireless,
+            NM_SETTING_BLUETOOTH_SETTING_NAME => Self::Bluetooth,
+            NM_SETTING_OLPC_MESH_SETTING_NAME => Self::OlpcMesh,
+            NM_SETTING_TUN_SETTING_NAME => Self::Tun,
+            NM_SETTING_IP_TUNNEL_SETTING_NAME => Self::IpTunnel,
+            NM_SETTING_PPP_SETTING_NAME => Self::Ppp,
+            NM_SETTING_WPAN_SETTING_NAME => Self::Wpan,
+            NM_SETTING_6LOWPAN_SETTING_NAME => Self::SixLowPan,
+            NM_SETTING_WIREGUARD_SETTING_NAME => Self::Wireguard,
+            NM_SETTING_WIFI_P2P_SETTING_NAME => Self::WifiP2p,
+            _ => {
+                log::debug!("Unknown interface type {s}");
+                Self::Other(s.to_string())
+            }
+        }
+    }
+}
+
+impl TryFrom<zvariant::OwnedValue> for NmIfaceType {
+    type Error = NmError;
+
+    fn try_from(v: zvariant::OwnedValue) -> Result<NmIfaceType, NmError> {
+        Ok(String::try_from(v).map(|v| NmIfaceType::from(v.as_str()))?)
+    }
+}
+
+#[cfg(feature = "query_apply")]
+const CONTROLLER_IFACE_TYPES: [NmIfaceType; 5] = [
+    NmIfaceType::Bond,
+    NmIfaceType::Bridge,
+    NmIfaceType::OvsBridge,
+    NmIfaceType::OvsPort,
+    NmIfaceType::Vrf,
+];
+
+#[cfg(feature = "query_apply")]
+impl NmIfaceType {
+    pub fn is_controller(&self) -> bool {
+        CONTROLLER_IFACE_TYPES.contains(self)
+    }
+}

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -23,6 +23,7 @@ mod dns;
 mod ethtool;
 mod hsr;
 mod ieee8021x;
+mod iface_type;
 mod infiniband;
 mod ip;
 mod loopback;
@@ -50,6 +51,7 @@ pub use self::conn::{
 pub use self::ethtool::NmSettingEthtool;
 pub use self::hsr::NmSettingHsr;
 pub use self::ieee8021x::NmSetting8021X;
+pub use self::iface_type::NmIfaceType;
 pub use self::infiniband::NmSettingInfiniBand;
 pub use self::ip::{NmSettingIp, NmSettingIpMethod};
 pub use self::loopback::NmSettingLoopback;

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -263,15 +263,6 @@ impl<'a> NmDbus<'a> {
         Ok(())
     }
 
-    pub(crate) fn nm_dev_obj_path_get(
-        &self,
-        iface_name: &str,
-    ) -> Result<String, NmError> {
-        Ok(obj_path_to_string(
-            self.proxy.get_device_by_ip_iface(iface_name)?,
-        ))
-    }
-
     pub(crate) fn nm_dev_obj_paths_get(&self) -> Result<Vec<String>, NmError> {
         Ok(self
             .proxy

--- a/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
@@ -60,12 +60,6 @@ trait NetworkManager {
         active_connection: &zvariant::ObjectPath,
     ) -> zbus::Result<()>;
 
-    /// GetDeviceByIpIface method
-    fn get_device_by_ip_iface(
-        &self,
-        iface: &str,
-    ) -> zbus::Result<zvariant::OwnedObjectPath>;
-
     /// GetAllDevices method
     fn get_all_devices(&self) -> zbus::Result<Vec<zvariant::OwnedObjectPath>>;
 

--- a/rust/src/lib/nm/nm_dbus/device.rs
+++ b/rust/src/lib/nm/nm_dbus/device.rs
@@ -55,7 +55,7 @@ impl From<u32> for NmDeviceState {
             NM_DEVICE_STATE_DEACTIVATING => Self::Deactivating,
             NM_DEVICE_STATE_FAILED => Self::Failed,
             _ => {
-                log::warn!("Unknown Device state reason {}", i);
+                log::debug!("Unknown Device state reason {}", i);
                 Self::Unknown
             }
         }
@@ -330,7 +330,7 @@ impl From<u32> for NmDeviceStateReason {
             }
             NM_DEVICE_STATE_REASON_PEER_NOT_FOUND => Self::PeerNotFound,
             _ => {
-                log::warn!("Unknown Device state reason {}", i);
+                log::debug!("Unknown Device state reason {}", i);
                 Self::Unknown
             }
         }

--- a/rust/src/lib/nm/nm_dbus/device.rs
+++ b/rust/src/lib/nm/nm_dbus/device.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use super::NmIfaceType;
+
 const NM_DEVICE_STATE_UNKNOWN: u32 = 0;
 const NM_DEVICE_STATE_UNMANAGED: u32 = 10;
 const NM_DEVICE_STATE_UNAVAILABLE: u32 = 20;
@@ -340,7 +342,7 @@ impl From<u32> for NmDeviceStateReason {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NmDevice {
     pub name: String,
-    pub iface_type: String,
+    pub iface_type: NmIfaceType,
     pub state: NmDeviceState,
     pub state_reason: NmDeviceStateReason,
     pub is_mac_vtap: bool,

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -25,8 +25,8 @@ pub use self::active_connection::{
     NmActiveConnection, NM_ACTIVATION_STATE_FLAG_EXTERNAL,
 };
 pub use self::connection::{
-    NmConnection, NmIpRoute, NmIpRouteRule, NmIpRouteRuleAction, NmRange,
-    NmSetting8021X, NmSettingBond, NmSettingBondPort, NmSettingBridge,
+    NmConnection, NmIfaceType, NmIpRoute, NmIpRouteRule, NmIpRouteRuleAction,
+    NmRange, NmSetting8021X, NmSettingBond, NmSettingBondPort, NmSettingBridge,
     NmSettingBridgePort, NmSettingBridgeVlanRange, NmSettingConnection,
     NmSettingEthtool, NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod,
     NmSettingLoopback, NmSettingMacSec, NmSettingMacVlan, NmSettingOvsBridge,

--- a/rust/src/lib/nm/nm_dbus/query_apply/device.rs
+++ b/rust/src/lib/nm/nm_dbus/query_apply/device.rs
@@ -7,6 +7,7 @@ use super::super::{
     dbus::{NM_DBUS_INTERFACE_DEV, NM_DBUS_INTERFACE_ROOT},
     lldp::NmLldpNeighbor,
     ErrorKind, NmDevice, NmDeviceState, NmDeviceStateReason, NmError,
+    NmIfaceType,
 };
 
 const NM_DEVICE_TYPE_UNKNOWN: u32 = 0;
@@ -16,7 +17,8 @@ const NM_DEVICE_TYPE_WIFI: u32 = 2;
 // const NM_DEVICE_TYPE_UNUSED2: u32 = 4;
 const NM_DEVICE_TYPE_BT: u32 = 5;
 const NM_DEVICE_TYPE_OLPC_MESH: u32 = 6;
-const NM_DEVICE_TYPE_WIMAX: u32 = 7;
+// WIMAX is not supported by NM
+// const NM_DEVICE_TYPE_WIMAX: u32 = 7;
 const NM_DEVICE_TYPE_MODEM: u32 = 8;
 const NM_DEVICE_TYPE_INFINIBAND: u32 = 9;
 const NM_DEVICE_TYPE_BOND: u32 = 10;
@@ -24,7 +26,8 @@ const NM_DEVICE_TYPE_VLAN: u32 = 11;
 const NM_DEVICE_TYPE_ADSL: u32 = 12;
 const NM_DEVICE_TYPE_BRIDGE: u32 = 13;
 const NM_DEVICE_TYPE_GENERIC: u32 = 14;
-const NM_DEVICE_TYPE_TEAM: u32 = 15;
+// Team is not supported by nmstate
+// const NM_DEVICE_TYPE_TEAM: u32 = 15;
 const NM_DEVICE_TYPE_TUN: u32 = 16;
 const NM_DEVICE_TYPE_IP_TUNNEL: u32 = 17;
 const NM_DEVICE_TYPE_MACVLAN: u32 = 18;
@@ -67,7 +70,7 @@ fn nm_dev_name_get(
 fn nm_dev_iface_type_get(
     dbus_conn: &zbus::Connection,
     obj_path: &str,
-) -> Result<String, NmError> {
+) -> Result<NmIfaceType, NmError> {
     let proxy = zbus::Proxy::new(
         dbus_conn,
         NM_DBUS_INTERFACE_ROOT,
@@ -77,38 +80,36 @@ fn nm_dev_iface_type_get(
     match proxy.get_property::<u32>("DeviceType") {
         Ok(i) => Ok(match i {
             // Using the NM_SETTING_*_NAME string
-            NM_DEVICE_TYPE_UNKNOWN => "unknown".to_string(),
-            NM_DEVICE_TYPE_ETHERNET => "802-3-ethernet".to_string(),
-            NM_DEVICE_TYPE_WIFI => "802-11-wireless".to_string(),
-            NM_DEVICE_TYPE_BT => "bluetooth".to_string(),
-            NM_DEVICE_TYPE_OLPC_MESH => "802-11-olpc-mesh".to_string(),
-            NM_DEVICE_TYPE_WIMAX => "wimax".to_string(),
-            NM_DEVICE_TYPE_MODEM => "modem".to_string(),
-            NM_DEVICE_TYPE_INFINIBAND => "infiniband".to_string(),
-            NM_DEVICE_TYPE_BOND => "bond".to_string(),
-            NM_DEVICE_TYPE_VLAN => "vlan".to_string(),
-            NM_DEVICE_TYPE_ADSL => "adsl".to_string(),
-            NM_DEVICE_TYPE_BRIDGE => "bridge".to_string(),
-            NM_DEVICE_TYPE_GENERIC => "generic".to_string(),
-            NM_DEVICE_TYPE_TEAM => "team".to_string(),
-            NM_DEVICE_TYPE_TUN => "tun".to_string(),
-            NM_DEVICE_TYPE_IP_TUNNEL => "ip-tunnel".to_string(),
-            NM_DEVICE_TYPE_MACVLAN => "macvlan".to_string(),
-            NM_DEVICE_TYPE_VXLAN => "vxlan".to_string(),
-            NM_DEVICE_TYPE_VETH => "veth".to_string(),
-            NM_DEVICE_TYPE_MACSEC => "macsec".to_string(),
-            NM_DEVICE_TYPE_DUMMY => "dummy".to_string(),
-            NM_DEVICE_TYPE_PPP => "ppp".to_string(),
-            NM_DEVICE_TYPE_OVS_INTERFACE => "ovs-interface".to_string(),
-            NM_DEVICE_TYPE_OVS_PORT => "ovs-port".to_string(),
-            NM_DEVICE_TYPE_OVS_BRIDGE => "ovs-bridge".to_string(),
-            NM_DEVICE_TYPE_WPAN => "wpan".to_string(),
-            NM_DEVICE_TYPE_6LOWPAN => "6lowpan".to_string(),
-            NM_DEVICE_TYPE_WIREGUARD => "wireguard".to_string(),
-            NM_DEVICE_TYPE_WIFI_P2P => "wifi-p2p".to_string(),
-            NM_DEVICE_TYPE_VRF => "vrf".to_string(),
-            NM_DEVICE_TYPE_LOOPBACK => "loopback".to_string(),
-            _ => format!("unknown({i})"),
+            NM_DEVICE_TYPE_UNKNOWN => NmIfaceType::Other("unknown".to_string()),
+            NM_DEVICE_TYPE_ETHERNET => NmIfaceType::Ethernet,
+            NM_DEVICE_TYPE_WIFI => NmIfaceType::Wireless,
+            NM_DEVICE_TYPE_BT => NmIfaceType::Bluetooth,
+            NM_DEVICE_TYPE_OLPC_MESH => NmIfaceType::OlpcMesh,
+            NM_DEVICE_TYPE_MODEM => NmIfaceType::Other("modem".to_string()),
+            NM_DEVICE_TYPE_INFINIBAND => NmIfaceType::Infiniband,
+            NM_DEVICE_TYPE_BOND => NmIfaceType::Bond,
+            NM_DEVICE_TYPE_VLAN => NmIfaceType::Vlan,
+            NM_DEVICE_TYPE_ADSL => NmIfaceType::Other("adsl".to_string()),
+            NM_DEVICE_TYPE_BRIDGE => NmIfaceType::Bridge,
+            NM_DEVICE_TYPE_GENERIC => NmIfaceType::Generic,
+            NM_DEVICE_TYPE_TUN => NmIfaceType::Tun,
+            NM_DEVICE_TYPE_IP_TUNNEL => NmIfaceType::IpTunnel,
+            NM_DEVICE_TYPE_MACVLAN => NmIfaceType::Macvlan,
+            NM_DEVICE_TYPE_VXLAN => NmIfaceType::Vxlan,
+            NM_DEVICE_TYPE_VETH => NmIfaceType::Veth,
+            NM_DEVICE_TYPE_MACSEC => NmIfaceType::Macsec,
+            NM_DEVICE_TYPE_DUMMY => NmIfaceType::Dummy,
+            NM_DEVICE_TYPE_PPP => NmIfaceType::Ppp,
+            NM_DEVICE_TYPE_OVS_INTERFACE => NmIfaceType::OvsIface,
+            NM_DEVICE_TYPE_OVS_PORT => NmIfaceType::OvsPort,
+            NM_DEVICE_TYPE_OVS_BRIDGE => NmIfaceType::OvsBridge,
+            NM_DEVICE_TYPE_WPAN => NmIfaceType::Wpan,
+            NM_DEVICE_TYPE_6LOWPAN => NmIfaceType::SixLowPan,
+            NM_DEVICE_TYPE_WIREGUARD => NmIfaceType::Wireguard,
+            NM_DEVICE_TYPE_WIFI_P2P => NmIfaceType::WifiP2p,
+            NM_DEVICE_TYPE_VRF => NmIfaceType::Vrf,
+            NM_DEVICE_TYPE_LOOPBACK => NmIfaceType::Loopback,
+            _ => NmIfaceType::Other(format!("unknown({i})")),
         }),
         Err(e) => Err(NmError::new(
             ErrorKind::Bug,
@@ -195,7 +196,7 @@ pub(crate) fn nm_dev_from_obj_path(
         real,
         mac_address: nm_dev_get_mac_address(dbus_conn, obj_path)?,
     };
-    if dev.iface_type == "macvlan" {
+    if dev.iface_type == NmIfaceType::Macvlan {
         dev.is_mac_vtap = nm_dev_is_mac_vtap_get(dbus_conn, obj_path)?;
     }
     Ok(dev)

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::{NmApi, NmConnection, NmDevice};
+use super::super::nm_dbus::{NmApi, NmConnection, NmDevice, NmIfaceType};
 use super::super::{
     query_apply::profile::{delete_profiles, is_uuid},
-    settings::{get_exist_profile, NM_SETTING_OVS_PORT_SETTING_NAME},
+    settings::get_exist_profile,
     show::nm_conn_to_base_iface,
 };
 
@@ -43,7 +43,7 @@ pub(crate) fn delete_orphan_ovs_ports(
                     .connection
                     .as_ref()
                     .and_then(|c| c.controller_type.as_ref())
-                    == Some(&NM_SETTING_OVS_PORT_SETTING_NAME.to_string())
+                    == Some(&NmIfaceType::OvsPort)
                 {
                     if let Some(ovs_port_name) = exist_profile
                         .connection
@@ -105,11 +105,11 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
 ) {
     let tun_nm_devs: Vec<&NmDevice> = nm_devs
         .iter()
-        .filter(|d| d.iface_type.as_str() == "tun")
+        .filter(|d| d.iface_type == NmIfaceType::Tun)
         .collect();
     let tun_nm_conns: Vec<&NmConnection> = nm_conns
         .iter()
-        .filter(|c| c.iface_type() == Some("tun"))
+        .filter(|c| c.iface_type() == Some(&NmIfaceType::Tun))
         .collect();
     for iface in net_state
         .interfaces

--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -2,17 +2,9 @@
 
 use std::collections::{hash_map::Entry, HashMap};
 
+use super::super::error::nm_error_to_nmstate;
 use super::super::nm_dbus::{
-    self, NmApi, NmConnection, NmSettingsConnectionFlag,
-};
-use super::super::{
-    error::nm_error_to_nmstate,
-    settings::{
-        NM_SETTING_BOND_SETTING_NAME, NM_SETTING_BRIDGE_SETTING_NAME,
-        NM_SETTING_OVS_BRIDGE_SETTING_NAME, NM_SETTING_OVS_PORT_SETTING_NAME,
-        NM_SETTING_VETH_SETTING_NAME, NM_SETTING_VPN_SETTING_NAME,
-        NM_SETTING_VRF_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
-    },
+    self, NmApi, NmConnection, NmIfaceType, NmSettingsConnectionFlag,
 };
 
 use crate::{ErrorKind, NmstateError};
@@ -20,21 +12,13 @@ use crate::{ErrorKind, NmstateError};
 const ACTIVATION_RETRY_COUNT: usize = 6;
 const ACTIVATION_RETRY_INTERVAL: u64 = 1;
 
-pub(crate) const NM_SETTING_CONTROLLERS: [&str; 5] = [
-    NM_SETTING_BOND_SETTING_NAME,
-    NM_SETTING_BRIDGE_SETTING_NAME,
-    NM_SETTING_OVS_BRIDGE_SETTING_NAME,
-    NM_SETTING_OVS_PORT_SETTING_NAME,
-    NM_SETTING_VRF_SETTING_NAME,
-];
-
 pub(crate) fn delete_exist_profiles(
     nm_api: &mut NmApi,
     exist_nm_conns: &[NmConnection],
     nm_conns: &[NmConnection],
 ) -> Result<(), NmstateError> {
     let mut excluded_uuids: Vec<&str> = Vec::new();
-    let mut changed_iface_name_types: Vec<(&str, &str)> = Vec::new();
+    let mut changed_iface_name_types: Vec<(&str, NmIfaceType)> = Vec::new();
     let mut uuids_to_delete = Vec::new();
     for nm_conn in nm_conns {
         if let Some(uuid) = nm_conn.uuid() {
@@ -42,13 +26,12 @@ pub(crate) fn delete_exist_profiles(
         }
         if let Some(name) = nm_conn.iface_name() {
             if let Some(nm_iface_type) = nm_conn.iface_type() {
-                changed_iface_name_types.push((name, nm_iface_type));
+                changed_iface_name_types.push((name, nm_iface_type.clone()));
             }
-        } else if nm_conn.iface_type() == Some(NM_SETTING_VPN_SETTING_NAME) {
+        } else if nm_conn.iface_type() == Some(&NmIfaceType::Vpn) {
             if let Some(name) = nm_conn.id() {
                 // For VPN, the we use connection id
-                changed_iface_name_types
-                    .push((name, NM_SETTING_VPN_SETTING_NAME));
+                changed_iface_name_types.push((name, NmIfaceType::Vpn));
             }
         }
     }
@@ -60,9 +43,7 @@ pub(crate) fn delete_exist_profiles(
         };
         let iface_name = if let Some(i) = exist_nm_conn.iface_name() {
             i
-        } else if exist_nm_conn.iface_type()
-            == Some(NM_SETTING_VPN_SETTING_NAME)
-        {
+        } else if exist_nm_conn.iface_type() == Some(&NmIfaceType::Vpn) {
             if let Some(i) = exist_nm_conn.id() {
                 i
             } else {
@@ -85,7 +66,8 @@ pub(crate) fn delete_exist_profiles(
             continue;
         }
         if !excluded_uuids.contains(&uuid)
-            && changed_iface_name_types.contains(&(iface_name, nm_iface_type))
+            && changed_iface_name_types
+                .contains(&(iface_name, nm_iface_type.clone()))
         {
             if let Some(uuid) = exist_nm_conn.uuid() {
                 uuids_to_delete.push(uuid);
@@ -184,12 +166,12 @@ fn _activate_nm_profiles(
     nm_ac_uuids: &[&str],
 ) -> Result<Vec<(NmConnection, NmstateError)>, NmstateError> {
     // Contain a list of `(iface_name, nm_iface_type)`.
-    let mut new_controllers: Vec<(&str, &str)> = Vec::new();
+    let mut new_controllers: Vec<(&str, NmIfaceType)> = Vec::new();
     let mut failed_nm_conns: Vec<(NmConnection, NmstateError)> = Vec::new();
-    for nm_conn in nm_conns.iter().filter(|c| {
-        c.iface_type().map(|t| NM_SETTING_CONTROLLERS.contains(&t))
-            == Some(true)
-    }) {
+    for nm_conn in nm_conns
+        .iter()
+        .filter(|c| c.iface_type().map(|t| t.is_controller()) == Some(true))
+    {
         if let Some(uuid) = nm_conn.uuid() {
             if nm_ac_uuids.contains(&uuid) {
                 if let Err(e) = reapply_or_activate(nm_api, nm_conn) {
@@ -202,7 +184,7 @@ fn _activate_nm_profiles(
             } else {
                 new_controllers.push((
                     nm_conn.iface_name().unwrap_or(""),
-                    nm_conn.iface_type().unwrap_or(""),
+                    nm_conn.iface_type().cloned().unwrap_or_default(),
                 ));
                 if let Err(e) = nm_api
                     .connection_activate(uuid)
@@ -217,17 +199,17 @@ fn _activate_nm_profiles(
             }
         }
     }
-    for nm_conn in nm_conns.iter().filter(|c| {
-        c.iface_type().map(|t| NM_SETTING_CONTROLLERS.contains(&t))
-            != Some(true)
-    }) {
+    for nm_conn in nm_conns
+        .iter()
+        .filter(|c| c.iface_type().map(|t| t.is_controller()) != Some(true))
+    {
         if let Some(uuid) = nm_conn.uuid() {
             if nm_ac_uuids.contains(&uuid) {
                 log::info!(
                     "Reapplying connection {}: {}/{}",
                     uuid,
                     nm_conn.iface_name().unwrap_or(""),
-                    nm_conn.iface_type().unwrap_or("")
+                    nm_conn.iface_type().cloned().unwrap_or_default()
                 );
                 if let Err(e) = reapply_or_activate(nm_api, nm_conn) {
                     if e.kind().can_retry() {
@@ -240,10 +222,11 @@ fn _activate_nm_profiles(
                 if let (Some(ctrller), Some(ctrller_type)) =
                     (nm_conn.controller(), nm_conn.controller_type())
                 {
-                    if nm_conn.iface_type() != Some("ovs-interface") {
+                    if nm_conn.iface_type() != Some(&NmIfaceType::OvsIface) {
                         // OVS port does not do auto port activation.
-                        if new_controllers.contains(&(ctrller, ctrller_type))
-                            && ctrller_type != "ovs-port"
+                        if new_controllers
+                            .contains(&(ctrller, ctrller_type.clone()))
+                            && ctrller_type != &NmIfaceType::OvsPort
                         {
                             log::info!(
                                 "Skip connection activation as its \
@@ -251,7 +234,10 @@ fn _activate_nm_profiles(
                                 {}: {}/{}",
                                 uuid,
                                 nm_conn.iface_name().unwrap_or(""),
-                                nm_conn.iface_type().unwrap_or("")
+                                nm_conn
+                                    .iface_type()
+                                    .cloned()
+                                    .unwrap_or_default()
                             );
                             continue;
                         }
@@ -261,7 +247,7 @@ fn _activate_nm_profiles(
                     "Activating connection {}: {}/{}",
                     uuid,
                     nm_conn.iface_name().unwrap_or(""),
-                    nm_conn.iface_type().unwrap_or("")
+                    nm_conn.iface_type().cloned().unwrap_or_default()
                 );
                 if let Err(e) = nm_api
                     .connection_activate(uuid)
@@ -289,7 +275,7 @@ pub(crate) fn deactivate_nm_profiles(
                 "Deactivating connection {}: {}/{}",
                 uuid,
                 nm_conn.iface_name().unwrap_or(""),
-                nm_conn.iface_type().unwrap_or("")
+                nm_conn.iface_type().cloned().unwrap_or_default()
             );
             if let Err(e) = nm_api.connection_deactivate(uuid) {
                 if e.kind
@@ -307,14 +293,14 @@ pub(crate) fn deactivate_nm_profiles(
 
 pub(crate) fn create_index_for_nm_conns_by_name_type(
     nm_conns: &[NmConnection],
-) -> HashMap<(&str, &str), Vec<&NmConnection>> {
-    let mut ret: HashMap<(&str, &str), Vec<&NmConnection>> = HashMap::new();
+) -> HashMap<(&str, NmIfaceType), Vec<&NmConnection>> {
+    let mut ret: HashMap<(&str, NmIfaceType), Vec<&NmConnection>> =
+        HashMap::new();
     for nm_conn in nm_conns {
         if let Some(iface_name) = nm_conn.iface_name() {
             if let Some(nm_iface_type) = nm_conn.iface_type() {
-                if nm_iface_type == NM_SETTING_VETH_SETTING_NAME {
-                    match ret.entry((iface_name, NM_SETTING_WIRED_SETTING_NAME))
-                    {
+                if nm_iface_type == &NmIfaceType::Veth {
+                    match ret.entry((iface_name, NmIfaceType::Ethernet)) {
                         Entry::Occupied(o) => {
                             o.into_mut().push(nm_conn);
                         }
@@ -323,9 +309,8 @@ pub(crate) fn create_index_for_nm_conns_by_name_type(
                         }
                     };
                 }
-                if nm_iface_type == NM_SETTING_WIRED_SETTING_NAME {
-                    match ret.entry((iface_name, NM_SETTING_VETH_SETTING_NAME))
-                    {
+                if nm_iface_type == &NmIfaceType::Ethernet {
+                    match ret.entry((iface_name, NmIfaceType::Veth)) {
                         Entry::Occupied(o) => {
                             o.into_mut().push(nm_conn);
                         }
@@ -334,7 +319,7 @@ pub(crate) fn create_index_for_nm_conns_by_name_type(
                         }
                     };
                 }
-                match ret.entry((iface_name, nm_iface_type)) {
+                match ret.entry((iface_name, nm_iface_type.clone())) {
                     Entry::Occupied(o) => {
                         o.into_mut().push(nm_conn);
                     }
@@ -380,13 +365,13 @@ fn reapply_or_activate(
         "Reapplying connection {}: {}/{}",
         uuid,
         nm_conn.iface_name().unwrap_or(""),
-        nm_conn.iface_type().unwrap_or("")
+        nm_conn.iface_type().cloned().unwrap_or_default()
     );
     if let Err(e) = nm_api.connection_reapply(nm_conn) {
         log::info!(
             "Reapply operation failed on {} {} {uuid}, \
             reason: {}, retry on normal activation",
-            nm_conn.iface_type().unwrap_or(""),
+            nm_conn.iface_type().cloned().unwrap_or_default(),
             nm_conn.iface_name().unwrap_or(""),
             e
         );

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::super::{
-    nm_dbus::{NmActiveConnection, NmConnection, NmSettingVpn},
+    nm_dbus::{NmActiveConnection, NmConnection, NmIfaceType, NmSettingVpn},
     show::nm_conn_to_base_iface,
 };
 
@@ -19,7 +19,7 @@ pub(crate) fn get_supported_vpn_ifaces(
 ) -> Result<Vec<Interface>, NmstateError> {
     let mut ret = Vec::new();
     for nm_conn in nm_acs.iter().filter_map(|nm_ac| {
-        if nm_ac.iface_type == "vpn" {
+        if nm_ac.iface_type == NmIfaceType::Vpn {
             nm_saved_conn_uuid_index.get(nm_ac.uuid.as_str())
         } else {
             None
@@ -99,7 +99,10 @@ pub(crate) fn get_match_ipsec_nm_conn<'a>(
 ) -> Vec<&'a NmConnection> {
     all_nm_conns
         .iter()
-        .filter(|c| c.iface_type() == Some("vpn") && c.id() == Some(iface_name))
+        .filter(|c| {
+            c.iface_type() == Some(&NmIfaceType::Vpn)
+                && c.id() == Some(iface_name)
+        })
         .collect()
 }
 

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::{
-    NmConnection, NmSettingConnection, NmSettingMacVlan, NmSettingVeth,
-    NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
+    NmConnection, NmIfaceType, NmSettingConnection, NmSettingMacVlan,
+    NmSettingVeth, NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
 };
 use super::{
     bond::{gen_nm_bond_port_setting, gen_nm_bond_setting},
@@ -32,41 +32,6 @@ use crate::{
     ErrorKind, Interface, InterfaceIdentifier, InterfaceType, MergedInterface,
     MergedNetworkState, NmstateError, OvsBridgePortConfig,
 };
-
-pub(crate) const NM_SETTING_BRIDGE_SETTING_NAME: &str = "bridge";
-pub(crate) const NM_SETTING_WIRED_SETTING_NAME: &str = "802-3-ethernet";
-pub(crate) const NM_SETTING_OVS_BRIDGE_SETTING_NAME: &str = "ovs-bridge";
-pub(crate) const NM_SETTING_OVS_PORT_SETTING_NAME: &str = "ovs-port";
-pub(crate) const NM_SETTING_OVS_IFACE_SETTING_NAME: &str = "ovs-interface";
-pub(crate) const NM_SETTING_VETH_SETTING_NAME: &str = "veth";
-pub(crate) const NM_SETTING_BOND_SETTING_NAME: &str = "bond";
-pub(crate) const NM_SETTING_DUMMY_SETTING_NAME: &str = "dummy";
-pub(crate) const NM_SETTING_MACSEC_SETTING_NAME: &str = "macsec";
-pub(crate) const NM_SETTING_MACVLAN_SETTING_NAME: &str = "macvlan";
-pub(crate) const NM_SETTING_VRF_SETTING_NAME: &str = "vrf";
-pub(crate) const NM_SETTING_VLAN_SETTING_NAME: &str = "vlan";
-pub(crate) const NM_SETTING_VXLAN_SETTING_NAME: &str = "vxlan";
-pub(crate) const NM_SETTING_INFINIBAND_SETTING_NAME: &str = "infiniband";
-pub(crate) const NM_SETTING_LOOPBACK_SETTING_NAME: &str = "loopback";
-pub(crate) const NM_SETTING_HSR_SETTING_NAME: &str = "hsr";
-pub(crate) const NM_SETTING_VPN_SETTING_NAME: &str = "vpn";
-
-pub(crate) const SUPPORTED_NM_KERNEL_IFACE_TYPES: [&str; 14] = [
-    NM_SETTING_WIRED_SETTING_NAME,
-    NM_SETTING_VETH_SETTING_NAME,
-    NM_SETTING_BOND_SETTING_NAME,
-    NM_SETTING_DUMMY_SETTING_NAME,
-    NM_SETTING_BRIDGE_SETTING_NAME,
-    NM_SETTING_OVS_IFACE_SETTING_NAME,
-    NM_SETTING_VRF_SETTING_NAME,
-    NM_SETTING_VLAN_SETTING_NAME,
-    NM_SETTING_VXLAN_SETTING_NAME,
-    NM_SETTING_MACVLAN_SETTING_NAME,
-    NM_SETTING_LOOPBACK_SETTING_NAME,
-    NM_SETTING_INFINIBAND_SETTING_NAME,
-    NM_SETTING_MACSEC_SETTING_NAME,
-    NM_SETTING_HSR_SETTING_NAME,
-];
 
 pub(crate) fn iface_to_nm_connections(
     merged_iface: &MergedInterface,
@@ -261,15 +226,15 @@ pub(crate) fn iface_to_nm_connections(
         _ => (),
     };
 
-    if nm_conn.controller_type() != Some(NM_SETTING_BOND_SETTING_NAME) {
+    if nm_conn.controller_type() != Some(&NmIfaceType::Bond) {
         nm_conn.bond_port = None;
     }
 
-    if nm_conn.controller_type() != Some(NM_SETTING_BRIDGE_SETTING_NAME) {
+    if nm_conn.controller_type() != Some(&NmIfaceType::Bridge) {
         nm_conn.bridge_port = None;
     }
 
-    if nm_conn.controller_type() != Some(NM_SETTING_OVS_PORT_SETTING_NAME) {
+    if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort) {
         nm_conn.ovs_iface = None;
     }
 
@@ -349,38 +314,26 @@ pub(crate) fn iface_to_nm_connections(
 
 pub(crate) fn iface_type_to_nm(
     iface_type: &InterfaceType,
-) -> Result<String, NmstateError> {
+) -> Result<NmIfaceType, NmstateError> {
     match iface_type {
-        InterfaceType::LinuxBridge => Ok(NM_SETTING_BRIDGE_SETTING_NAME.into()),
-        InterfaceType::Bond => Ok(NM_SETTING_BOND_SETTING_NAME.into()),
-        InterfaceType::Ethernet => Ok(NM_SETTING_WIRED_SETTING_NAME.into()),
-        InterfaceType::OvsBridge => {
-            Ok(NM_SETTING_OVS_BRIDGE_SETTING_NAME.into())
-        }
-        InterfaceType::OvsInterface => {
-            Ok(NM_SETTING_OVS_IFACE_SETTING_NAME.into())
-        }
-        InterfaceType::Vlan => Ok(NM_SETTING_VLAN_SETTING_NAME.to_string()),
-        InterfaceType::Vxlan => Ok(NM_SETTING_VXLAN_SETTING_NAME.to_string()),
-        InterfaceType::Dummy => Ok(NM_SETTING_DUMMY_SETTING_NAME.to_string()),
-        InterfaceType::MacVlan => {
-            Ok(NM_SETTING_MACVLAN_SETTING_NAME.to_string())
-        }
-        InterfaceType::MacVtap => {
-            Ok(NM_SETTING_MACVLAN_SETTING_NAME.to_string())
-        }
-        InterfaceType::Vrf => Ok(NM_SETTING_VRF_SETTING_NAME.to_string()),
-        InterfaceType::Veth => Ok(NM_SETTING_VETH_SETTING_NAME.to_string()),
-        InterfaceType::InfiniBand => {
-            Ok(NM_SETTING_INFINIBAND_SETTING_NAME.to_string())
-        }
-        InterfaceType::Loopback => {
-            Ok(NM_SETTING_LOOPBACK_SETTING_NAME.to_string())
-        }
-        InterfaceType::MacSec => Ok(NM_SETTING_MACSEC_SETTING_NAME.to_string()),
-        InterfaceType::Hsr => Ok(NM_SETTING_HSR_SETTING_NAME.to_string()),
-        InterfaceType::Ipsec => Ok(NM_SETTING_VPN_SETTING_NAME.to_string()),
-        InterfaceType::Other(s) => Ok(s.to_string()),
+        InterfaceType::LinuxBridge => Ok(NmIfaceType::Bridge),
+        InterfaceType::Bond => Ok(NmIfaceType::Bond),
+        InterfaceType::Ethernet => Ok(NmIfaceType::Ethernet),
+        InterfaceType::OvsBridge => Ok(NmIfaceType::OvsBridge),
+        InterfaceType::OvsInterface => Ok(NmIfaceType::OvsIface),
+        InterfaceType::Vlan => Ok(NmIfaceType::Vlan),
+        InterfaceType::Vxlan => Ok(NmIfaceType::Vxlan),
+        InterfaceType::Dummy => Ok(NmIfaceType::Dummy),
+        InterfaceType::MacVlan => Ok(NmIfaceType::Macvlan),
+        InterfaceType::MacVtap => Ok(NmIfaceType::Macvlan),
+        InterfaceType::Vrf => Ok(NmIfaceType::Vrf),
+        InterfaceType::Veth => Ok(NmIfaceType::Veth),
+        InterfaceType::InfiniBand => Ok(NmIfaceType::Infiniband),
+        InterfaceType::Loopback => Ok(NmIfaceType::Loopback),
+        InterfaceType::MacSec => Ok(NmIfaceType::Macsec),
+        InterfaceType::Hsr => Ok(NmIfaceType::Hsr),
+        InterfaceType::Ipsec => Ok(NmIfaceType::Vpn),
+        InterfaceType::Other(s) => Ok(NmIfaceType::from(s.as_str())),
         _ => Err(NmstateError::new(
             ErrorKind::NotImplementedError,
             format!("Does not support iface type: {iface_type:?} yet"),
@@ -428,8 +381,7 @@ pub(crate) fn gen_nm_conn_setting(
             Some(iface_type_to_nm(&iface.iface_type())?);
         if let Interface::Ethernet(eth_iface) = iface {
             if eth_iface.veth.is_some() {
-                new_nm_conn_set.iface_type =
-                    Some(NM_SETTING_VETH_SETTING_NAME.to_string());
+                new_nm_conn_set.iface_type = Some(NmIfaceType::Veth);
             }
         }
         new_nm_conn_set
@@ -456,7 +408,6 @@ pub(crate) fn gen_nm_conn_setting(
         .as_ref()
         .map(iface_type_to_nm)
         .transpose()?;
-    let nm_ctrl_type = nm_ctrl_type.as_deref();
     let ctrl_name = iface.base_iface().controller.as_deref();
     if let Some(ctrl_name) = ctrl_name {
         if ctrl_name.is_empty() {
@@ -464,13 +415,14 @@ pub(crate) fn gen_nm_conn_setting(
             nm_conn_set.controller_type = None;
         } else if let Some(nm_ctrl_type) = nm_ctrl_type {
             nm_conn_set.controller = Some(ctrl_name.to_string());
-            nm_conn_set.controller_type = if nm_ctrl_type == "ovs-bridge"
+            nm_conn_set.controller_type = if nm_ctrl_type
+                == NmIfaceType::OvsBridge
                 && iface.iface_type()
                     != InterfaceType::Other("ovs-port".to_string())
             {
-                Some("ovs-port".to_string())
+                Some(NmIfaceType::OvsPort)
             } else {
-                Some(nm_ctrl_type.to_string())
+                Some(nm_ctrl_type)
             };
         }
     }
@@ -506,13 +458,13 @@ pub(crate) fn get_exist_profile<'a>(
     nm_ac_uuids: &[&str],
 ) -> Option<&'a NmConnection> {
     let mut found_nm_conns: Vec<&NmConnection> = Vec::new();
+    let nm_iface_type = if let Ok(t) = iface_type_to_nm(iface_type) {
+        t
+    } else {
+        return None;
+    };
     for exist_nm_conn in exist_nm_conns {
-        let nm_iface_type = if let Ok(t) = iface_type_to_nm(iface_type) {
-            t
-        } else {
-            continue;
-        };
-        if nm_iface_type == NM_SETTING_VPN_SETTING_NAME {
+        if nm_iface_type == NmIfaceType::Vpn {
             if exist_nm_conn.id() == Some(iface_name) {
                 if let Some(uuid) = exist_nm_conn.uuid() {
                     // Prefer activated connection
@@ -524,9 +476,8 @@ pub(crate) fn get_exist_profile<'a>(
             }
         } else if exist_nm_conn.iface_name() == Some(iface_name)
             && (exist_nm_conn.iface_type() == Some(&nm_iface_type)
-                || (nm_iface_type == NM_SETTING_WIRED_SETTING_NAME
-                    && exist_nm_conn.iface_type()
-                        == Some(NM_SETTING_VETH_SETTING_NAME)))
+                || (nm_iface_type == NmIfaceType::Ethernet
+                    && exist_nm_conn.iface_type() == Some(&NmIfaceType::Veth)))
         {
             if let Some(uuid) = exist_nm_conn.uuid() {
                 // Prefer activated connection

--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -25,21 +25,9 @@ mod vrf;
 mod vxlan;
 mod wired;
 
-pub(crate) use self::connection::{
-    get_exist_profile, iface_to_nm_connections, SUPPORTED_NM_KERNEL_IFACE_TYPES,
-};
 #[cfg(feature = "query_apply")]
-pub(crate) use self::connection::{
-    iface_type_to_nm, NM_SETTING_BOND_SETTING_NAME,
-    NM_SETTING_BRIDGE_SETTING_NAME, NM_SETTING_DUMMY_SETTING_NAME,
-    NM_SETTING_HSR_SETTING_NAME, NM_SETTING_INFINIBAND_SETTING_NAME,
-    NM_SETTING_LOOPBACK_SETTING_NAME, NM_SETTING_MACSEC_SETTING_NAME,
-    NM_SETTING_MACVLAN_SETTING_NAME, NM_SETTING_OVS_BRIDGE_SETTING_NAME,
-    NM_SETTING_OVS_IFACE_SETTING_NAME, NM_SETTING_OVS_PORT_SETTING_NAME,
-    NM_SETTING_VETH_SETTING_NAME, NM_SETTING_VLAN_SETTING_NAME,
-    NM_SETTING_VPN_SETTING_NAME, NM_SETTING_VRF_SETTING_NAME,
-    NM_SETTING_VXLAN_SETTING_NAME, NM_SETTING_WIRED_SETTING_NAME,
-};
+pub(crate) use self::connection::iface_type_to_nm;
+pub(crate) use self::connection::{get_exist_profile, iface_to_nm_connections};
 pub(crate) use self::ip::fix_ip_dhcp_timeout;
 
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use super::super::nm_dbus::{
-    NmConnection, NmRange, NmSettingOvsDpdk, NmSettingOvsExtIds,
+    NmConnection, NmIfaceType, NmRange, NmSettingOvsDpdk, NmSettingOvsExtIds,
     NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
 };
 use super::super::settings::connection::gen_nm_conn_setting;
@@ -239,7 +239,7 @@ pub(crate) fn fix_ovs_iface_controller_setting(
         .unwrap_or_else(|| iface.name().to_string());
 
     if let Some(nm_conn_set) = nm_conn.connection.as_mut() {
-        nm_conn_set.controller_type = Some("ovs-port".to_string());
+        nm_conn_set.controller_type = Some(NmIfaceType::OvsPort);
         nm_conn_set.controller = Some(ovs_port_name);
     }
 }

--- a/rust/src/lib/nm/settings/veth.rs
+++ b/rust/src/lib/nm/settings/veth.rs
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::{NmConnection, NmSettingVeth};
+use super::super::nm_dbus::{NmConnection, NmIfaceType, NmSettingVeth};
 
-use super::{
-    connection::{
-        gen_nm_conn_setting, NM_SETTING_VETH_SETTING_NAME,
-        NM_SETTING_WIRED_SETTING_NAME,
-    },
-    ip::gen_nm_ip_setting,
-};
+use super::{connection::gen_nm_conn_setting, ip::gen_nm_ip_setting};
 
 use crate::{
     BaseInterface, EthernetInterface, Interface, InterfaceIpv4, InterfaceIpv6,
@@ -32,8 +26,8 @@ pub(crate) fn create_veth_peer_profile_if_not_found(
     for nm_conn in exist_nm_conns {
         if let Some(iface_type) = nm_conn.iface_type() {
             if nm_conn.iface_name() == Some(peer_name)
-                && [NM_SETTING_WIRED_SETTING_NAME, NM_SETTING_VETH_SETTING_NAME]
-                    .contains(&iface_type)
+                && [NmIfaceType::Ethernet, NmIfaceType::Veth]
+                    .contains(iface_type)
             {
                 return Ok(nm_conn.clone());
             }

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2201,6 +2201,28 @@ def remove_ovn_state_present(state):
 
 @pytest.mark.tier1
 @ip_monitor_assert_stable_link_up(BRIDGE1)
-def test_ovs_link_stable(ovs_bridge1_with_internal_port_same_name):
+def test_ovs_internal_iface_link_stable(
+    ovs_bridge1_with_internal_port_same_name,
+):
     desired_state = ovs_bridge1_with_internal_port_same_name
+    libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def ovs_bridge1_with_bond_as_system_iface(eth1_up, eth2_up):
+    with bond_interface(BOND1, ["eth1"]):
+        bridge = Bridge(BRIDGE1)
+        bridge.add_system_port(BOND1)
+        bridge.add_internal_port(
+            BRIDGE1, ipv4_state={InterfaceIPv4.ENABLED: False}
+        )
+        with bridge.create() as state:
+            yield state
+
+
+@pytest.mark.tier1
+@ip_monitor_assert_stable_link_up(BRIDGE1)
+@ip_monitor_assert_stable_link_up(BOND1)
+def test_ovs_system_iface_link_stable(ovs_bridge1_with_bond_as_system_iface):
+    desired_state = ovs_bridge1_with_bond_as_system_iface
     libnmstate.apply(desired_state)


### PR DESCRIPTION
When creating OVS port for OVS system interface, nmstate use the same name
for both OVS system interface connection and OVS port connection, the
`org.freedesktop.NetworkManager.GetDeviceByIpIface` will return unexpected
`NmDevice` when we try to do `device-reapply` call.

To fix this issue, all `NmApi::connection_reapply()` call should search all
existing `NmDevice` by both interface name and type.

To achieve that this patch unified the NmDevice.iface_type (integer) with
NmConnectionSetting.iface_type (string) into `enum NmifaceType`.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-50556