### PR TITLE
nm: Introduce new option to enable trace log on second try

### DIFF
--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -166,6 +166,14 @@ rebooting.
 .IP \fB--timeout\fR=<\fITIMEOUT\fR>
 the user must commit the changes within \fItimeout\fR, or they will be
 automatically rolled back. Default: 60 seconds.
+.IP \fB--verbose-when-retry
+Nmstate will retry the apply action on error of selected types.
+When this arguemnt is defined, Nmstate will temporarily enable verbose
+logging of network backend(NetworkManager) during retry of network state
+apply. The logging level of NetworkManager will be restored afterwards.
+If the apply action did not fail in first try, the log level will not
+be changed.
+By default, no log level changes to NetworkManager.
 .IP \fB--version
 displays nmstate version.
 .SH LIMITATIONS

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -97,6 +97,11 @@ where
     net_state.set_memory_only(
         matches.try_contains_id("MEMORY_ONLY").unwrap_or_default(),
     );
+    net_state.set_verbose_log_when_retry(
+        matches
+            .try_contains_id("VERBOSE_WHEN_RETRY")
+            .unwrap_or_default(),
+    );
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .build()

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -193,6 +193,13 @@ fn main() {
                         .takes_value(false)
                         .help("Do not make the state persistent"),
                 )
+                .arg(
+                    clap::Arg::new("VERBOSE_WHEN_RETRY")
+                        .long("verbose-when-retry")
+                        .takes_value(false)
+                        .help("Enable verbose logging of network backend \
+                              when retrying the apply failure"),
+                )
         )
         .subcommand(
             clap::Command::new(SUB_CMD_GEN_CONF)

--- a/rust/src/clib/apply.rs
+++ b/rust/src/clib/apply.rs
@@ -15,6 +15,8 @@ use crate::{
     NMSTATE_FAIL, NMSTATE_PASS,
 };
 
+const NMSTATE_FLAG_VERBOSE_WHEN_RETRY: u32 = 1 << 9;
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn nmstate_net_state_apply(
@@ -73,6 +75,10 @@ pub extern "C" fn nmstate_net_state_apply(
 
     if (flags & NMSTATE_FLAG_MEMORY_ONLY) > 0 {
         net_state.set_memory_only(true);
+    }
+
+    if (flags & NMSTATE_FLAG_VERBOSE_WHEN_RETRY) > 0 {
+        net_state.set_verbose_log_when_retry(true);
     }
 
     net_state.set_timeout(rollback_timeout);

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -30,6 +30,7 @@ extern "C" {
 #define NMSTATE_FLAG_MEMORY_ONLY            1 << 6
 #define NMSTATE_FLAG_RUNNING_CONFIG_ONLY    1 << 7
 #define NMSTATE_FLAG_YAML_OUTPUT            1 << 8
+#define NMSTATE_FLAG_VERBOSE_WHEN_RETRY     1 << 9
 
 /**
  * nmstate_net_state_retrieve - Retrieve network state
@@ -53,6 +54,9 @@ extern "C" {
  *              IP addresses and routes, LLDP neighbors.
  *          * NMSTATE_FLAG_YAML_OUTPUT
  *              Show the state in YAML format
+ *          * NMSTATE_FLAG_VERBOSE_WHEN_RETRY
+ *              Enable verbose logging of network backend(NetworkManager)
+ *              during retry of network state apply.
  * @state:
  *      Output pointer of char array for network state in json format.
  *      The memory should be freed by nmstate_net_state_free().

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -20,8 +20,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             NetworkState::new(),
-            true,  // gen_conf mode
-            false, // memory only
+            true, // gen_conf mode
         )?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&merged_state)?);
         Ok(ret)

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -389,6 +389,18 @@ impl<'a> NmDbus<'a> {
     ) -> Result<(), NmError> {
         Ok(self.proxy.set_property("GlobalDnsConfiguration", value)?)
     }
+
+    pub(crate) fn get_logging(&self) -> Result<(String, String), NmError> {
+        Ok(self.proxy.get_logging()?)
+    }
+
+    pub(crate) fn set_logging(
+        &self,
+        level: &str,
+        domains: &str,
+    ) -> Result<(), NmError> {
+        Ok(self.proxy.set_logging(level, domains)?)
+    }
 }
 
 fn str_to_obj_path(obj_path: &str) -> Result<zvariant::ObjectPath, NmError> {

--- a/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
@@ -75,6 +75,12 @@ trait NetworkManager {
         checkpoint: &zvariant::ObjectPath,
         add_timeout: u32,
     ) -> zbus::Result<()>;
+
+    /// GetLogging method
+    fn get_logging(&self) -> zbus::Result<(String, String)>;
+
+    /// SetLogging method
+    fn set_logging(&self, level: &str, domains: &str) -> zbus::Result<()>;
 }
 
 #[dbus_proxy(

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -56,3 +56,6 @@ pub use self::nm_api::NmApi;
 pub(crate) use self::convert::ToDbusValue;
 #[cfg(feature = "gen_conf")]
 pub(crate) use self::gen_conf::ToKeyfile;
+
+#[cfg(feature = "query_apply")]
+pub use self::query_apply::NmLogConfig;

--- a/rust/src/lib/nm/nm_dbus/query_apply/log.rs
+++ b/rust/src/lib/nm/nm_dbus/query_apply/log.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::{NmApi, NmError};
+
+// Nmstate does not need to understand level or domains, so we do not parse
+// them into enum and Vec<String>.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NmLogConfig {
+    pub level: String,
+    pub domains: String,
+}
+
+impl NmLogConfig {
+    pub fn trace_all() -> Self {
+        NmLogConfig {
+            level: "TRACE".to_string(),
+            domains: "ALL".to_string(),
+        }
+    }
+}
+
+impl From<(String, String)> for NmLogConfig {
+    fn from(v: (String, String)) -> Self {
+        Self {
+            level: v.0,
+            domains: v.1,
+        }
+    }
+}
+
+impl std::fmt::Display for NmLogConfig {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        write!(f, "level: {} domains: {}", self.level, self.domains)
+    }
+}
+
+impl<'a> NmApi<'a> {
+    pub fn get_log_config(&mut self) -> Result<NmLogConfig, NmError> {
+        Ok(self.dbus.get_logging()?.into())
+    }
+
+    pub fn set_log_config(
+        &mut self,
+        config: &NmLogConfig,
+    ) -> Result<(), NmError> {
+        self.dbus
+            .set_logging(config.level.as_str(), config.domains.as_str())
+    }
+
+    pub fn enable_trace_log(&mut self) -> Result<(), NmError> {
+        self.set_log_config(&NmLogConfig::trace_all())
+    }
+}

--- a/rust/src/lib/nm/nm_dbus/query_apply/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/query_apply/mod.rs
@@ -1,3 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod device;
+mod log;
+
+pub use self::log::NmLogConfig;

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -177,7 +177,10 @@ impl NetworkState {
         if pf_ifaces.is_empty() {
             None
         } else {
-            let mut pf_state = NetworkState::default();
+            let mut pf_state = NetworkState {
+                option: self.option.clone(),
+                ..Default::default()
+            };
             for pf_iface in pf_ifaces {
                 pf_state.interfaces.push(pf_iface);
             }

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -7,12 +7,8 @@ impl NetworkState {
         &self,
         current: &Self,
     ) -> Result<Self, NmstateError> {
-        let merged_state = MergedNetworkState::new(
-            self.clone(),
-            current.clone(),
-            false,
-            false,
-        )?;
+        let merged_state =
+            MergedNetworkState::new(self.clone(), current.clone(), false)?;
         Ok(Self {
             interfaces: merged_state.interfaces.generate_revert()?,
             routes: merged_state.routes.generate_revert(),

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -37,7 +37,7 @@ impl NetworkState {
                 .use_pseudo_sriov_vf_name(&mut current.interfaces);
         }
         let merged_state =
-            MergedNetworkState::new(self.clone(), current, false, false)?;
+            MergedNetworkState::new(self.clone(), current, false)?;
 
         features.append(&mut merged_state.interfaces.get_features());
         features.append(&mut merged_state.dns.get_features());

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -47,7 +47,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 
@@ -85,7 +85,7 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
     )
     .unwrap();
 
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -126,7 +126,7 @@ fn test_two_dns_ipv6_link_local_iface() {
         ",
     )
     .unwrap();
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result = MergedNetworkState::new(desired, current, false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::NotImplementedError);
@@ -223,7 +223,7 @@ fn test_dns_iface_has_no_ip_stack_info() {
         })
     };
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 }
@@ -266,7 +266,7 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -325,7 +325,7 @@ fn test_dns_prefer_desired_over_current() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -371,7 +371,7 @@ fn test_copy_ip_stack_if_marked_for_dns() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -24,8 +24,7 @@ fn test_add_routes_to_new_interface() {
     des_net_state.routes = gen_test_routes_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -89,8 +88,7 @@ fn test_wildcard_absent_routes() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -125,8 +123,7 @@ fn test_absent_routes_with_iface_only() {
     des_net_state.routes.config = Some(absent_routes);
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -192,7 +189,7 @@ routes:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
     store_route_config(&mut merged_state).unwrap();
 
     let br0_iface = merged_state

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -27,8 +27,7 @@ fn test_add_rules_to_new_interface() {
     des_net_state.rules = gen_test_rules_conf();
 
     let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+        MergedNetworkState::new(des_net_state, cur_net_state, false).unwrap();
     store_route_rule_config(&mut merged_state).unwrap();
 
     let iface = merged_state
@@ -137,7 +136,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -217,7 +216,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -283,7 +282,7 @@ route-rules:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -355,7 +354,7 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, false).unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -40,6 +40,8 @@ NMSTATE_FLAG_INCLUDE_SECRETS = 1 << 4
 NMSTATE_FLAG_NO_COMMIT = 1 << 5
 NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
 NMSTATE_FLAG_RUNNING_CONFIG_ONLY = 1 << 7
+# NMSTATE_FLAG_YAML_OUTPUT = 1 << 8
+NMSTATE_FLAG_VERBOSE_WHEN_RETRY = 1 << 9
 NMSTATE_PASS = 0
 
 
@@ -92,6 +94,7 @@ def apply_net_state(
     save_to_disk=True,
     commit=True,
     rollback_timeout=60,
+    verbose_on_retry=False,
 ):
     c_err_msg = c_char_p()
     c_err_kind = c_char_p()
@@ -109,6 +112,9 @@ def apply_net_state(
 
     if not save_to_disk:
         flags |= NMSTATE_FLAG_MEMORY_ONLY
+
+    if verbose_on_retry:
+        flags = NMSTATE_FLAG_VERBOSE_WHEN_RETRY
 
     rc = lib.nmstate_net_state_apply(
         flags,

--- a/rust/src/python/libnmstate/netapplier.py
+++ b/rust/src/python/libnmstate/netapplier.py
@@ -25,6 +25,7 @@ def apply(
     save_to_disk=True,
     commit=True,
     rollback_timeout=60,
+    verbose_on_retry=False,
 ):
     return apply_net_state(
         desired_state,
@@ -33,6 +34,7 @@ def apply(
         save_to_disk=save_to_disk,
         commit=commit,
         rollback_timeout=rollback_timeout,
+        verbose_on_retry=verbose_on_retry,
     )
 
 


### PR DESCRIPTION
Introducing new API:
 * Rust: `NetworkState::set_verbose_log_when_retry(bool)`
 * C: `NMSTATE_FLAG_VERBOSE_WHEN_RETRY`
 * Python: `verbose_on_retry` argument of `libnmstate.apply()`.

When enabled, before retrying the network state apply, enable
trace log of NetworkManager and restore it after finished.

By default, this action is disabled.

The trace log of NetworkManager could be very helpful for debugging failure.

Integration test case included.