### PR TITLE
[Rust API break] Use Box to wrap Interface enum entries

### DIFF
--- a/rust/src/cli/autoconf.rs
+++ b/rust/src/cli/autoconf.rs
@@ -158,7 +158,7 @@ fn gen_bond_iface(bond_name: &str, ifaces: &[&str]) -> Interface {
     let mut bond_iface = BondInterface::new();
     bond_iface.base = base_iface;
     bond_iface.bond = Some(bond_conf);
-    Interface::Bond(bond_iface)
+    Interface::Bond(Box::new(bond_iface))
 }
 
 fn gen_vlan_iface(vlan_name: &str, id: u32, parent: &str) -> Interface {
@@ -172,5 +172,5 @@ fn gen_vlan_iface(vlan_name: &str, id: u32, parent: &str) -> Interface {
     let mut vlan_iface = VlanInterface::new();
     vlan_iface.base = base_iface;
     vlan_iface.vlan = Some(vlan_conf);
-    Interface::Vlan(vlan_iface)
+    Interface::Vlan(Box::new(vlan_iface))
 }

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -243,41 +243,41 @@ impl<'de> Deserialize<'de> for UnknownInterface {
 /// Represent a kernel or user space network interface.
 pub enum Interface {
     /// [Bond interface](https://www.kernel.org/doc/Documentation/networking/bonding.txt)
-    Bond(BondInterface),
+    Bond(Box<BondInterface>),
     /// Dummy interface.
-    Dummy(DummyInterface),
+    Dummy(Box<DummyInterface>),
     /// Ethernet interface or virtual ethernet(veth) of linux kernel
-    Ethernet(EthernetInterface),
+    Ethernet(Box<EthernetInterface>),
     /// HSR interface provided by Linux kernel.
-    Hsr(HsrInterface),
+    Hsr(Box<HsrInterface>),
     /// Bridge provided by Linux kernel.
-    LinuxBridge(LinuxBridgeInterface),
+    LinuxBridge(Box<LinuxBridgeInterface>),
     /// OpenvSwitch bridge.
-    OvsBridge(OvsBridgeInterface),
+    OvsBridge(Box<OvsBridgeInterface>),
     /// OpenvSwitch system interface.
-    OvsInterface(OvsInterface),
+    OvsInterface(Box<OvsInterface>),
     /// Unknown interface.
-    Unknown(UnknownInterface),
+    Unknown(Box<UnknownInterface>),
     /// VLAN interface.
-    Vlan(VlanInterface),
+    Vlan(Box<VlanInterface>),
     /// VxLAN interface.
-    Vxlan(VxlanInterface),
+    Vxlan(Box<VxlanInterface>),
     /// MAC VLAN interface.
-    MacVlan(MacVlanInterface),
+    MacVlan(Box<MacVlanInterface>),
     /// MAC VTAP interface.
-    MacVtap(MacVtapInterface),
+    MacVtap(Box<MacVtapInterface>),
     /// [Virtual Routing and Forwarding interface](https://www.kernel.org/doc/html/latest/networking/vrf.html)
-    Vrf(VrfInterface),
+    Vrf(Box<VrfInterface>),
     /// [IP over InfiniBand interface](https://docs.kernel.org/infiniband/ipoib.html)
-    InfiniBand(InfiniBandInterface),
+    InfiniBand(Box<InfiniBandInterface>),
     /// Linux loopback interface
-    Loopback(LoopbackInterface),
+    Loopback(Box<LoopbackInterface>),
     /// MACsec interface.
-    MacSec(MacSecInterface),
+    MacSec(Box<MacSecInterface>),
     /// Ipsec connection
-    Ipsec(IpsecInterface),
+    Ipsec(Box<IpsecInterface>),
     /// Linux xfrm interface
-    Xfrm(XfrmInterface),
+    Xfrm(Box<XfrmInterface>),
 }
 
 impl<'de> Deserialize<'de> for Interface {
@@ -312,103 +312,103 @@ impl<'de> Deserialize<'de> for Interface {
             Some(InterfaceType::Ethernet) => {
                 let inner = EthernetInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Ethernet(inner))
+                Ok(Interface::Ethernet(Box::new(inner)))
             }
             Some(InterfaceType::LinuxBridge) => {
                 let inner = LinuxBridgeInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::LinuxBridge(inner))
+                Ok(Interface::LinuxBridge(Box::new(inner)))
             }
             Some(InterfaceType::Bond) => {
                 let inner = BondInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Bond(inner))
+                Ok(Interface::Bond(Box::new(inner)))
             }
             Some(InterfaceType::Veth) => {
                 let inner = EthernetInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Ethernet(inner))
+                Ok(Interface::Ethernet(Box::new(inner)))
             }
             Some(InterfaceType::Vlan) => {
                 let inner = VlanInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Vlan(inner))
+                Ok(Interface::Vlan(Box::new(inner)))
             }
             Some(InterfaceType::Vxlan) => {
                 let inner = VxlanInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Vxlan(inner))
+                Ok(Interface::Vxlan(Box::new(inner)))
             }
             Some(InterfaceType::Dummy) => {
                 let inner = DummyInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Dummy(inner))
+                Ok(Interface::Dummy(Box::new(inner)))
             }
             Some(InterfaceType::OvsInterface) => {
                 let inner = OvsInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::OvsInterface(inner))
+                Ok(Interface::OvsInterface(Box::new(inner)))
             }
             Some(InterfaceType::OvsBridge) => {
                 let inner = OvsBridgeInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::OvsBridge(inner))
+                Ok(Interface::OvsBridge(Box::new(inner)))
             }
             Some(InterfaceType::MacVlan) => {
                 let inner = MacVlanInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::MacVlan(inner))
+                Ok(Interface::MacVlan(Box::new(inner)))
             }
             Some(InterfaceType::MacVtap) => {
                 let inner = MacVtapInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::MacVtap(inner))
+                Ok(Interface::MacVtap(Box::new(inner)))
             }
             Some(InterfaceType::Vrf) => {
                 let inner = VrfInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Vrf(inner))
+                Ok(Interface::Vrf(Box::new(inner)))
             }
             Some(InterfaceType::Hsr) => {
                 let inner = HsrInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Hsr(inner))
+                Ok(Interface::Hsr(Box::new(inner)))
             }
             Some(InterfaceType::InfiniBand) => {
                 let inner = InfiniBandInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::InfiniBand(inner))
+                Ok(Interface::InfiniBand(Box::new(inner)))
             }
             Some(InterfaceType::Loopback) => {
                 let inner = LoopbackInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Loopback(inner))
+                Ok(Interface::Loopback(Box::new(inner)))
             }
             Some(InterfaceType::MacSec) => {
                 let inner = MacSecInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::MacSec(inner))
+                Ok(Interface::MacSec(Box::new(inner)))
             }
             Some(InterfaceType::Ipsec) => {
                 let inner = IpsecInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Ipsec(inner))
+                Ok(Interface::Ipsec(Box::new(inner)))
             }
             Some(InterfaceType::Xfrm) => {
                 let inner = XfrmInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Xfrm(inner))
+                Ok(Interface::Xfrm(Box::new(inner)))
             }
             Some(iface_type) => {
                 log::warn!("Unsupported interface type {}", iface_type);
                 let inner = UnknownInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Unknown(inner))
+                Ok(Interface::Unknown(Box::new(inner)))
             }
             None => {
                 let inner = UnknownInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
-                Ok(Interface::Unknown(inner))
+                Ok(Interface::Unknown(Box::new(inner)))
             }
         }
     }
@@ -438,96 +438,96 @@ impl Interface {
             Self::LinuxBridge(iface) => {
                 let mut new_iface = LinuxBridgeInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::LinuxBridge(new_iface)
+                Self::LinuxBridge(Box::new(new_iface))
             }
             Self::Ethernet(iface) => {
                 let mut new_iface = EthernetInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
                 // Do not use veth interface type when clone internally
                 new_iface.base.iface_type = InterfaceType::Ethernet;
-                Self::Ethernet(new_iface)
+                Self::Ethernet(Box::new(new_iface))
             }
             Self::Vlan(iface) => {
                 let mut new_iface = VlanInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Vlan(new_iface)
+                Self::Vlan(Box::new(new_iface))
             }
             Self::Vxlan(iface) => {
                 let mut new_iface = VxlanInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Vxlan(new_iface)
+                Self::Vxlan(Box::new(new_iface))
             }
             Self::Dummy(iface) => {
                 let mut new_iface = DummyInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Dummy(new_iface)
+                Self::Dummy(Box::new(new_iface))
             }
             Self::OvsInterface(iface) => {
                 let mut new_iface = OvsInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::OvsInterface(new_iface)
+                Self::OvsInterface(Box::new(new_iface))
             }
             Self::OvsBridge(iface) => {
                 let mut new_iface = OvsBridgeInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::OvsBridge(new_iface)
+                Self::OvsBridge(Box::new(new_iface))
             }
             Self::Bond(iface) => {
                 let mut new_iface = BondInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Bond(new_iface)
+                Self::Bond(Box::new(new_iface))
             }
             Self::MacVlan(iface) => {
                 let mut new_iface = MacVlanInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::MacVlan(new_iface)
+                Self::MacVlan(Box::new(new_iface))
             }
             Self::MacVtap(iface) => {
                 let mut new_iface = MacVtapInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::MacVtap(new_iface)
+                Self::MacVtap(Box::new(new_iface))
             }
             Self::Vrf(iface) => {
                 let mut new_iface = VrfInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Vrf(new_iface)
+                Self::Vrf(Box::new(new_iface))
             }
             Self::Hsr(iface) => {
                 let mut new_iface = HsrInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Hsr(new_iface)
+                Self::Hsr(Box::new(new_iface))
             }
             Self::InfiniBand(iface) => {
                 let new_iface = InfiniBandInterface {
                     base: iface.base.clone_name_type_only(),
                     ..Default::default()
                 };
-                Self::InfiniBand(new_iface)
+                Self::InfiniBand(Box::new(new_iface))
             }
             Self::Loopback(iface) => {
                 let mut new_iface = LoopbackInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Loopback(new_iface)
+                Self::Loopback(Box::new(new_iface))
             }
             Self::MacSec(iface) => {
                 let mut new_iface = MacSecInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::MacSec(new_iface)
+                Self::MacSec(Box::new(new_iface))
             }
             Self::Ipsec(iface) => {
                 let mut new_iface = IpsecInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Ipsec(new_iface)
+                Self::Ipsec(Box::new(new_iface))
             }
             Self::Xfrm(iface) => {
                 let mut new_iface = XfrmInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Xfrm(new_iface)
+                Self::Xfrm(Box::new(new_iface))
             }
             Self::Unknown(iface) => {
                 let mut new_iface = UnknownInterface::new();
                 new_iface.base = iface.base.clone_name_type_only();
-                Self::Unknown(new_iface)
+                Self::Unknown(Box::new(new_iface))
             }
         }
     }
@@ -745,7 +745,7 @@ impl Interface {
 #[allow(clippy::derivable_impls)]
 impl Default for Interface {
     fn default() -> Self {
-        Interface::Unknown(UnknownInterface::default())
+        Interface::Unknown(Box::default())
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -547,7 +547,7 @@ impl Interfaces {
             iface.base.name.clone_from(&iface_name);
             log::warn!("Assuming undefined port {} as ethernet", iface_name);
             self.kernel_ifaces
-                .insert(iface_name, Interface::Ethernet(iface));
+                .insert(iface_name, Interface::Ethernet(Box::new(iface)));
         }
     }
 
@@ -599,7 +599,7 @@ impl Interfaces {
         for iface in new_ifaces {
             self.kernel_ifaces.insert(
                 iface.base.name.to_string(),
-                Interface::Ethernet(iface),
+                Interface::Ethernet(Box::new(iface)),
             );
         }
         Ok(())

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -218,12 +218,12 @@ impl MergedInterfaces {
                     self.kernel_ifaces.insert(
                         iface_name.to_string(),
                         MergedInterface::new(
-                            Some(Interface::OvsInterface(
+                            Some(Interface::OvsInterface(Box::new(
                                 OvsInterface::new_with_name_and_ctrl(
                                     &iface_name,
                                     &ctrl_name,
                                 ),
-                            )),
+                            ))),
                             None,
                         )?,
                     );

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -95,14 +95,12 @@ impl VrfInterface {
         current: Option<&Interface>,
     ) -> Result<(), NmstateError> {
         if self.vrf.as_ref().map(|v| v.table_id) == Some(0) {
-            if let Some(&Interface::Vrf(VrfInterface {
-                vrf:
-                    Some(VrfConfig {
-                        table_id: cur_table_id,
-                        ..
-                    }),
-                ..
-            })) = current
+            if let Some(cur_table_id) =
+                if let Some(Interface::Vrf(vrf_iface)) = current {
+                    vrf_iface.vrf.as_ref().map(|v| v.table_id)
+                } else {
+                    None
+                }
             {
                 if let Some(vrf_conf) = self.vrf.as_mut() {
                     vrf_conf.table_id = cur_table_id;

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -72,7 +72,7 @@ pub(crate) async fn nispor_retrieve(
                     np_iface,
                     port_np_ifaces,
                 );
-                Interface::LinuxBridge(br_iface)
+                Interface::LinuxBridge(Box::new(br_iface))
             }
             InterfaceType::Bond => {
                 let mut bond_iface = np_bond_to_nmstate(np_iface, base_iface);
@@ -83,42 +83,42 @@ pub(crate) async fn nispor_retrieve(
                     }
                 }
                 append_bond_port_config(&mut bond_iface, port_np_ifaces);
-                Interface::Bond(bond_iface)
+                Interface::Bond(Box::new(bond_iface))
             }
-            InterfaceType::Ethernet => Interface::Ethernet(
+            InterfaceType::Ethernet => Interface::Ethernet(Box::new(
                 np_ethernet_to_nmstate(np_iface, base_iface),
-            ),
-            InterfaceType::Hsr => {
-                Interface::Hsr(np_hsr_to_nmstate(np_iface, base_iface))
-            }
-            InterfaceType::Veth => {
-                Interface::Ethernet(np_veth_to_nmstate(np_iface, base_iface))
-            }
-            InterfaceType::Vlan => {
-                Interface::Vlan(np_vlan_to_nmstate(np_iface, base_iface))
-            }
-            InterfaceType::Vxlan => {
-                Interface::Vxlan(np_vxlan_to_nmstate(np_iface, base_iface))
-            }
+            )),
+            InterfaceType::Hsr => Interface::Hsr(Box::new(np_hsr_to_nmstate(
+                np_iface, base_iface,
+            ))),
+            InterfaceType::Veth => Interface::Ethernet(Box::new(
+                np_veth_to_nmstate(np_iface, base_iface),
+            )),
+            InterfaceType::Vlan => Interface::Vlan(Box::new(
+                np_vlan_to_nmstate(np_iface, base_iface),
+            )),
+            InterfaceType::Vxlan => Interface::Vxlan(Box::new(
+                np_vxlan_to_nmstate(np_iface, base_iface),
+            )),
             InterfaceType::Dummy => Interface::Dummy({
                 let mut iface = DummyInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::OvsInterface => Interface::OvsInterface({
                 let mut iface = OvsInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
-            InterfaceType::MacVlan => {
-                Interface::MacVlan(np_mac_vlan_to_nmstate(np_iface, base_iface))
-            }
-            InterfaceType::MacVtap => {
-                Interface::MacVtap(np_mac_vtap_to_nmstate(np_iface, base_iface))
-            }
-            InterfaceType::Vrf => {
-                Interface::Vrf(np_vrf_to_nmstate(np_iface, base_iface))
-            }
+            InterfaceType::MacVlan => Interface::MacVlan(Box::new(
+                np_mac_vlan_to_nmstate(np_iface, base_iface),
+            )),
+            InterfaceType::MacVtap => Interface::MacVtap(Box::new(
+                np_mac_vtap_to_nmstate(np_iface, base_iface),
+            )),
+            InterfaceType::Vrf => Interface::Vrf(Box::new(np_vrf_to_nmstate(
+                np_iface, base_iface,
+            ))),
             InterfaceType::InfiniBand => {
                 // We don't support HFI interface which contains PKEY but no
                 // parent.
@@ -129,18 +129,22 @@ pub(crate) async fn nispor_retrieve(
                     );
                     continue;
                 }
-                Interface::InfiniBand(np_ib_to_nmstate(np_iface, base_iface))
+                Interface::InfiniBand(Box::new(np_ib_to_nmstate(
+                    np_iface, base_iface,
+                )))
             }
             InterfaceType::Loopback => {
-                Interface::Loopback(LoopbackInterface { base: base_iface })
+                Interface::Loopback(Box::new(LoopbackInterface {
+                    base: base_iface,
+                }))
             }
-            InterfaceType::MacSec => {
-                Interface::MacSec(np_macsec_to_nmstate(np_iface, base_iface))
-            }
+            InterfaceType::MacSec => Interface::MacSec(Box::new(
+                np_macsec_to_nmstate(np_iface, base_iface),
+            )),
             InterfaceType::Xfrm => {
                 let mut iface = XfrmInterface::new();
                 iface.base = base_iface;
-                Interface::Xfrm(iface)
+                Interface::Xfrm(Box::new(iface))
             }
             _ => {
                 log::info!(
@@ -151,7 +155,7 @@ pub(crate) async fn nispor_retrieve(
                 Interface::Unknown({
                     let mut iface = UnknownInterface::new();
                     iface.base = base_iface;
-                    iface
+                    Box::new(iface)
                 })
             }
         };

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -36,7 +36,7 @@ pub(crate) fn get_supported_vpn_ifaces(
                     base_iface.iface_type = InterfaceType::Ipsec;
                     iface.base = base_iface;
                     iface.libreswan = Some(get_libreswan_conf(nm_set_vpn));
-                    ret.push(Interface::Ipsec(iface));
+                    ret.push(Interface::Ipsec(Box::new(iface)));
                 }
             }
         }

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -28,7 +28,11 @@ pub(crate) fn create_ovs_port_nm_conn(
     base_iface.controller_type = Some(InterfaceType::OvsBridge);
     let mut iface = UnknownInterface::new();
     iface.base = base_iface;
-    gen_nm_conn_setting(&Interface::Unknown(iface), &mut nm_conn, stable_uuid)?;
+    gen_nm_conn_setting(
+        &Interface::Unknown(Box::new(iface)),
+        &mut nm_conn,
+        stable_uuid,
+    )?;
 
     let mut nm_ovs_port_set =
         nm_conn.ovs_port.as_ref().cloned().unwrap_or_default();

--- a/rust/src/lib/nm/settings/veth.rs
+++ b/rust/src/lib/nm/settings/veth.rs
@@ -49,7 +49,7 @@ pub(crate) fn create_veth_peer_profile_if_not_found(
         ipv6: Some(InterfaceIpv6::new()),
         ..Default::default()
     };
-    let iface = Interface::Ethernet(eth_iface);
+    let iface = Interface::Ethernet(Box::new(eth_iface));
     let mut nm_conn = NmConnection::default();
     gen_nm_conn_setting(&iface, &mut nm_conn, stable_uuid)?;
     gen_nm_ip_setting(&iface, None, &mut nm_conn)?;

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -278,12 +278,12 @@ fn iface_get(
             InterfaceType::LinuxBridge => Interface::LinuxBridge({
                 let mut iface = LinuxBridgeInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Ethernet => Interface::Ethernet({
                 let mut iface = EthernetInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Bond => Interface::Bond({
                 let mut iface = BondInterface::new();
@@ -296,52 +296,52 @@ fn iface_get(
                     ..Default::default()
                 };
                 iface.bond = Some(bond_config);
-                iface
+                Box::new(iface)
             }),
             InterfaceType::OvsInterface => Interface::OvsInterface({
                 let mut iface = OvsInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Dummy => Interface::Dummy({
                 let mut iface = DummyInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Vlan => Interface::Vlan({
                 let mut iface = VlanInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Vxlan => Interface::Vxlan({
                 let mut iface = VxlanInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::MacVlan => Interface::MacVlan({
                 let mut iface = MacVlanInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::MacVtap => Interface::MacVtap({
                 let mut iface = MacVtapInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Vrf => Interface::Vrf({
                 let mut iface = VrfInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::OvsBridge => Interface::OvsBridge({
                 let mut iface = OvsBridgeInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Loopback => Interface::Loopback({
                 let mut iface = LoopbackInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             InterfaceType::MacSec => Interface::MacSec({
                 let mut iface = MacSecInterface::new();
@@ -361,12 +361,12 @@ fn iface_get(
                     }
                     iface.macsec = Some(macsec_config);
                 }
-                iface
+                Box::new(iface)
             }),
             InterfaceType::Hsr => Interface::Hsr({
                 let mut iface = HsrInterface::new();
                 iface.base = base_iface;
-                iface
+                Box::new(iface)
             }),
             _ => {
                 log::debug!("Skip unsupported interface {:?}", base_iface);
@@ -448,79 +448,79 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
         InterfaceType::Ethernet => Interface::Ethernet({
             let mut iface = EthernetInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Dummy => Interface::Dummy({
             let mut iface = DummyInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::LinuxBridge => Interface::LinuxBridge({
             let mut iface = LinuxBridgeInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::OvsInterface => Interface::OvsInterface({
             let mut iface = OvsInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::OvsBridge => Interface::OvsBridge({
             let mut iface = OvsBridgeInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Bond => Interface::Bond({
             let mut iface = BondInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Vlan => Interface::Vlan({
             let mut iface = VlanInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Vxlan => Interface::Vxlan({
             let mut iface = VxlanInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::MacVlan => Interface::MacVlan({
             let mut iface = MacVlanInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::MacVtap => Interface::MacVtap({
             let mut iface = MacVtapInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Vrf => Interface::Vrf({
             let mut iface = VrfInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Loopback => Interface::Loopback({
             let mut iface = LoopbackInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::MacSec => Interface::MacSec({
             let mut iface = MacSecInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
         InterfaceType::Hsr => Interface::Hsr({
             let mut iface = HsrInterface::new();
             iface.base = base_iface;
-            iface
+            Box::new(iface)
         }),
-        InterfaceType::InfiniBand => Interface::InfiniBand({
+        InterfaceType::InfiniBand => Interface::InfiniBand(Box::new({
             InfiniBandInterface {
                 base: base_iface,
                 ..Default::default()
             }
-        }),
+        })),
         iface_type
             if iface_type == &InterfaceType::Other("ovs-port".to_string()) =>
         {
@@ -543,7 +543,7 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
                 let mut iface = LoopbackInterface::new();
                 base_iface.iface_type = InterfaceType::Loopback;
                 iface.base = base_iface;
-                Interface::Loopback(iface)
+                Interface::Loopback(Box::new(iface))
             } else {
                 // For unknown/unsupported interface,
                 // if it has MAC address, we treat it as UnknownInterface which
@@ -554,7 +554,7 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
                 }
                 let mut iface = UnknownInterface::new();
                 iface.base = base_iface;
-                Interface::Unknown(iface)
+                Interface::Unknown(Box::new(iface))
             }
         }
     };

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -54,7 +54,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
         });
         iface.bridge =
             Some(parse_ovs_bridge_conf(ovsdb_br, &ovsdb_ports, &ovsdb_ifaces));
-        ret.append_interface_data(Interface::OvsBridge(iface));
+        ret.append_interface_data(Interface::OvsBridge(Box::new(iface)));
     }
 
     for ovsdb_iface in ovsdb_ifaces.values() {
@@ -346,12 +346,12 @@ fn ovsdb_iface_to_nmstate(
     }
 
     let mut iface = match ovsdb_iface.iface_type.as_str() {
-        "system" => Interface::Unknown(UnknownInterface::new()),
-        "internal" => Interface::OvsInterface(OvsInterface::new()),
+        "system" => Interface::Unknown(Box::new(UnknownInterface::new())),
+        "internal" => Interface::OvsInterface(Box::new(OvsInterface::new())),
         "patch" => {
             let mut ovs_iface = OvsInterface::new();
             ovs_iface.patch = parse_ovs_patch_conf(ovsdb_iface);
-            Interface::OvsInterface(ovs_iface)
+            Interface::OvsInterface(Box::new(ovs_iface))
         }
         "dpdk" => {
             let mut ovs_iface = OvsInterface::new();
@@ -359,7 +359,7 @@ fn ovsdb_iface_to_nmstate(
             // DPDK interface does not have kernel representative, the MTU is
             // set in ovsdb.
             ovs_iface.base.mtu = get_dpdk_mtu(ovsdb_iface);
-            Interface::OvsInterface(ovs_iface)
+            Interface::OvsInterface(Box::new(ovs_iface))
         }
         i => {
             log::warn!("Unknown OVS interface type {i}");

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -163,11 +163,13 @@ impl NetworkState {
                 iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
             {
                 if let Some(eth_conf) = iface.ethernet.as_ref() {
-                    pf_ifaces.push(Interface::Ethernet(EthernetInterface {
-                        base: iface.base.clone_name_type_only(),
-                        ethernet: Some(eth_conf.clone()),
-                        ..Default::default()
-                    }));
+                    pf_ifaces.push(Interface::Ethernet(Box::new(
+                        EthernetInterface {
+                            base: iface.base.clone_name_type_only(),
+                            ethernet: Some(eth_conf.clone()),
+                            ..Default::default()
+                        },
+                    )));
                 }
             }
         }

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -205,14 +205,14 @@ impl Interfaces {
             }
         }
         for psudo_vf_name in new_vf_names {
-            current.push(Interface::Ethernet(EthernetInterface {
+            current.push(Interface::Ethernet(Box::new(EthernetInterface {
                 base: BaseInterface {
                     name: psudo_vf_name,
                     iface_type: InterfaceType::Ethernet,
                     ..Default::default()
                 },
                 ..Default::default()
-            }));
+            })));
         }
     }
 }

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -301,7 +301,7 @@ fn test_auto_absent_ovs_interface() {
     absent_br0.base.name = "br0".to_string();
     absent_br0.base.state = InterfaceState::Absent;
     let mut ifaces = Interfaces::new();
-    ifaces.push(Interface::OvsBridge(absent_br0));
+    ifaces.push(Interface::OvsBridge(Box::new(absent_br0)));
 
     let merged_ifaces =
         MergedInterfaces::new(ifaces, cur_ifaces, false, false).unwrap();

--- a/rust/src/lib/unit_tests/statistic.rs
+++ b/rust/src/lib/unit_tests/statistic.rs
@@ -422,13 +422,14 @@ fn gen_dummy_ifaces(iface_count: usize) -> NetworkState {
     let mut ret = NetworkState::default();
 
     for i in 0..iface_count {
-        ret.interfaces.push(Interface::Dummy(DummyInterface {
-            base: BaseInterface {
-                name: format!("dummy{i}"),
-                iface_type: InterfaceType::Dummy,
-                ..Default::default()
-            },
-        }));
+        ret.interfaces
+            .push(Interface::Dummy(Box::new(DummyInterface {
+                base: BaseInterface {
+                    name: format!("dummy{i}"),
+                    iface_type: InterfaceType::Dummy,
+                    ..Default::default()
+                },
+            })));
     }
     ret
 }

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -12,25 +12,25 @@ use crate::{
 pub(crate) fn new_eth_iface(name: &str) -> Interface {
     let mut iface = EthernetInterface::new();
     iface.base.name = name.to_string();
-    Interface::Ethernet(iface)
+    Interface::Ethernet(Box::new(iface))
 }
 
 pub(crate) fn new_unknown_iface(name: &str) -> Interface {
     let mut iface = UnknownInterface::new();
     iface.base.name = name.to_string();
-    Interface::Unknown(iface)
+    Interface::Unknown(Box::new(iface))
 }
 
 pub(crate) fn new_br_iface(name: &str) -> Interface {
     let mut iface = LinuxBridgeInterface::new();
     iface.base.name = name.to_string();
-    Interface::LinuxBridge(iface)
+    Interface::LinuxBridge(Box::new(iface))
 }
 
 fn new_bond_iface(name: &str) -> Interface {
     let mut iface = BondInterface::new();
     iface.base.name = name.to_string();
-    Interface::Bond(iface)
+    Interface::Bond(Box::new(iface))
 }
 
 pub(crate) fn new_ovs_br_iface(name: &str, port_names: &[&str]) -> Interface {
@@ -46,7 +46,7 @@ pub(crate) fn new_ovs_br_iface(name: &str, port_names: &[&str]) -> Interface {
     }
     br_conf.ports = Some(br_port_confs);
     br0.bridge = Some(br_conf);
-    Interface::OvsBridge(br0)
+    Interface::OvsBridge(Box::new(br0))
 }
 
 pub(crate) fn new_ovs_iface(name: &str, ctrl_name: &str) -> Interface {
@@ -55,7 +55,7 @@ pub(crate) fn new_ovs_iface(name: &str, ctrl_name: &str) -> Interface {
     iface.base.name = name.to_string();
     iface.base.controller = Some(ctrl_name.to_string());
     iface.base.controller_type = Some(InterfaceType::OvsBridge);
-    Interface::OvsInterface(iface)
+    Interface::OvsInterface(Box::new(iface))
 }
 
 pub(crate) fn new_vlan_iface(name: &str, parent: &str, id: u16) -> Interface {
@@ -67,7 +67,7 @@ pub(crate) fn new_vlan_iface(name: &str, parent: &str, id: u16) -> Interface {
         id,
         ..Default::default()
     });
-    Interface::Vlan(iface)
+    Interface::Vlan(Box::new(iface))
 }
 
 pub(crate) fn new_nested_4_ifaces() -> [Interface; 6] {


### PR DESCRIPTION
The cargo clippy suggest us to use Box<> to wrap enum entries when enum
entries are holding different size data types, hence changed the
`enum Interface` to use Box<> for enum entires.

This break rust API, but has has no impact on YAML/JSON API.