### PR TITLE
gen_diff: Include context information for `gen_diff()`

### DIFF
--- a/examples/policy/change-gateway-iface-to-mac-identifier/current.yml
+++ b/examples/policy/change-gateway-iface-to-mac-identifier/current.yml
@@ -1,0 +1,18 @@
+---
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.0.2.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:00:51:00:00:0A
+    ipv4:
+      enabled: true
+      address:
+        - ip: 192.0.2.9
+          prefix-length: 16
+      dhcp: false

--- a/examples/policy/change-gateway-iface-to-mac-identifier/expected.yml
+++ b/examples/policy/change-gateway-iface-to-mac-identifier/expected.yml
@@ -1,0 +1,8 @@
+---
+interfaces:
+  - name: eth1
+    profile-name: eth1
+    type: ethernet
+    state: up
+    identifier: mac-address
+    mac-address: 00:00:51:00:00:0A

--- a/examples/policy/change-gateway-iface-to-mac-identifier/policy.yml
+++ b/examples/policy/change-gateway-iface-to-mac-identifier/policy.yml
@@ -1,0 +1,9 @@
+---
+capture:
+  gw: routes.running.destination=="0.0.0.0/0"
+  gw-iface: interfaces.name==capture.gw.routes.running.0.next-hop-interface
+desiredState:
+  interfaces:
+    - name: "{{ capture.gw-iface.interfaces.0.name }}"
+      identifier: mac-address
+      mac-address: "{{ capture.gw-iface.interfaces.0.mac-address }}"

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -1,8 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, InterfaceState, InterfaceType, OvsDbIfaceConfig};
+use crate::{
+    BaseInterface, InterfaceIdentifier, InterfaceState, InterfaceType,
+    OvsDbIfaceConfig,
+};
 
 impl BaseInterface {
+    pub(crate) fn include_diff_context(&mut self, current: &Self) {
+        if self.identifier == Some(InterfaceIdentifier::MacAddress)
+            && self.mac_address.is_none()
+        {
+            self.mac_address.clone_from(&current.mac_address)
+        }
+    }
+
     pub(crate) fn sanitize_current_for_verify(&mut self) {
         if self.controller.is_none() {
             self.controller = Some(String::new());

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -247,6 +247,11 @@ impl Interface {
             _ => (),
         }
     }
+
+    pub(crate) fn include_diff_context(&mut self, current: &Self) {
+        self.base_iface_mut()
+            .include_diff_context(current.base_iface());
+    }
 }
 
 impl InterfaceType {

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -178,8 +178,9 @@ impl MergedInterfaces {
                 new_iface.base_iface_mut().state = des_iface.base_iface().state;
                 let mut new_iface_value = serde_json::to_value(&new_iface)?;
                 merge_json_value(&mut new_iface_value, &diff_value);
-                let new_iface =
+                let mut new_iface =
                     serde_json::from_value::<Interface>(new_iface_value)?;
+                new_iface.include_diff_context(&cur_iface);
                 ret.push(new_iface);
             }
         }


### PR DESCRIPTION
When user applying below policy file:

```yml
---
capture:
  gw: routes.running.destination=="0.0.0.0/0"
  gw-iface: interfaces.name==capture.gw.routes.running.0.next-hop-interface
desiredState:
  interfaces:
    - name: "{{ capture.gw-iface.interfaces.0.name }}"
      identifier: mac-address
      mac-address: "{{ capture.gw-iface.interfaces.0.mac-address }}"
```

Nmstate generate a `NetworkState` without mac address defined because it
is not changed.

To fix the issue, we should treat `mac-address` as context of
`interface.identifier: mac-address` which should be included in
`gen_diff()` output.

Unit test case included.

Resolves: https://issues.redhat.com/browse/RHEL-54292