### PR TITLE
tests: stop NM service before removing its rpms

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -203,6 +203,7 @@ function upgrade_nm_from_copr {
     exec_cmd "dnf copr enable --assumeyes ${copr_repo}"
     # centos-stream NetworkManager package is providing the alpha builds.
     # Sometimes it could be greater than the one packaged on Copr.
+    exec_cmd "systemctl stop NetworkManager"
     exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
     exec_cmd "dnf install --assumeyes NetworkManager NetworkManager-ovs  \
         --disablerepo '*' --enablerepo '${copr_repo_id}'"
@@ -213,6 +214,7 @@ function upgrade_nm_from_rpm_dir {
     local nm_rpm_dir=$1
     mkdir $EXPORT_DIR/nm_rpms || true
     find $nm_rpm_dir -name \*.rpm -exec cp -v {} "${EXPORT_DIR}/nm_rpms/" \;
+    exec_cmd "systemctl stop NetworkManager"
     exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
     exec_cmd "dnf install -y ${CONT_EXPORT_DIR}/nm_rpms/*.rpm"
     exec_cmd "rpm -q NetworkManager-libreswan || \


### PR DESCRIPTION
In EL10 we see respawn issues when removing rpms on running NM service. Stopping the service beforehand should prevent this issue.