### PR TITLE
vrf: `VrfConfig.table_id` changed from `u32` to `Option<u32>`.

### DIFF
--- a/rust/src/lib/nispor/vrf.rs
+++ b/rust/src/lib/nispor/vrf.rs
@@ -5,7 +5,7 @@ pub(crate) fn np_vrf_to_nmstate(
     base_iface: BaseInterface,
 ) -> VrfInterface {
     let vrf_conf = np_iface.vrf.as_ref().map(|np_vrf_info| VrfConfig {
-        table_id: np_vrf_info.table_id,
+        table_id: Some(np_vrf_info.table_id),
         port: {
             let mut ports = np_vrf_info.subordinates.clone();
             ports.sort_unstable();

--- a/rust/src/lib/nm/settings/vrf.rs
+++ b/rust/src/lib/nm/settings/vrf.rs
@@ -7,7 +7,7 @@ use crate::VrfConfig;
 impl From<&VrfConfig> for NmSettingVrf {
     fn from(config: &VrfConfig) -> Self {
         let mut settings = NmSettingVrf::default();
-        settings.table = Some(config.table_id);
+        settings.table = config.table_id;
         settings
     }
 }

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/current.yml
@@ -1,0 +1,19 @@
+---
+interfaces:
+- name: vrf100
+  type: vrf
+  state: up
+  vrf:
+    route-table-id: 100
+    ports:
+      - eth1
+      - eth2
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth2
+  type: ethernet
+  state: up
+- name: eth3
+  type: ethernet
+  state: up

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/desired.yml
@@ -1,0 +1,10 @@
+---
+interfaces:
+- name: vrf100
+  type: vrf
+  state: up
+  vrf:
+    route-table-id: 100
+    ports:
+      - eth3
+      - eth2

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vrf_ports/diff.yml
@@ -1,0 +1,9 @@
+---
+interfaces:
+- name: vrf100
+  type: vrf
+  state: up
+  vrf:
+    ports:
+      - eth2
+      - eth3

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -15,7 +15,7 @@ vrf:
     )
     .unwrap();
 
-    assert_eq!(iface.vrf.unwrap().table_id, 101);
+    assert_eq!(iface.vrf.unwrap().table_id, Some(101));
 }
 
 #[test]


### PR DESCRIPTION
When modifying existing VRF's port list, the `gen_diff` always include
`route-table-id: 0`.

Changing `VrfConfig.table_id` from `u32` to `Option<u32>` will fix it.

Unit test case included.