### PR TITLE
rust: Add support of IEEE 802.1X peap authentication

### DIFF
--- a/examples/eth1_with_ieee_802_1x_peap.yml
+++ b/examples/eth1_with_ieee_802_1x_peap.yml
@@ -1,0 +1,11 @@
+---
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    802.1x:
+      eap-methods:
+        - peap
+      identity: client.example.org
+      password: password
+      phase2-auth: mschapv2

--- a/rust/src/lib/ieee8021x.rs
+++ b/rust/src/lib/ieee8021x.rs
@@ -43,12 +43,23 @@ pub struct Ieee8021XConfig {
     /// Deserialize and serialize from/to `private-key-password`.
     /// Replaced to `<_password_hid_by_nmstate>` when querying.
     pub private_key_password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Deserialize and serialize from/to `phase2-auth`.
+    pub phase2_auth: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Deserialize and serialize from/to `password`.
+    /// Replaced to `<_password_hid_by_nmstate>` when querying.
+    pub password: Option<String>,
 }
 
 impl Ieee8021XConfig {
     pub(crate) fn hide_secrets(&mut self) {
         if self.private_key_password.is_some() {
             self.private_key_password =
+                Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
+        }
+        if self.password.is_some() {
+            self.password =
                 Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
         }
     }
@@ -64,6 +75,11 @@ impl std::fmt::Debug for Ieee8021XConfig {
             .field("ca_cert", &self.ca_cert)
             .field(
                 "private_key_password",
+                &Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string()),
+            )
+            .field("phase2_auth", &self.phase2_auth)
+            .field(
+                "password",
                 &Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string()),
             )
             .finish()

--- a/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
@@ -19,6 +19,8 @@ pub struct NmSetting8021X {
     pub client_cert: Option<Vec<u8>>,
     pub ca_cert: Option<Vec<u8>>,
     pub private_key_password: Option<String>,
+    pub phase2_auth: Option<String>,
+    pub password: Option<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -32,6 +34,8 @@ impl TryFrom<DbusDictionary> for NmSetting8021X {
             client_cert: _from_map!(v, "client-cert", <Vec<u8>>::try_from)?,
             ca_cert: _from_map!(v, "ca-cert", <Vec<u8>>::try_from)?,
             private_key_password: None,
+            phase2_auth: _from_map!(v, "phase2-auth", String::try_from)?,
+            password: None,
             _other: v,
         })
     }
@@ -58,6 +62,12 @@ impl ToDbusValue for NmSetting8021X {
         if let Some(v) = &self.private_key_password {
             ret.insert("private-key-password", zvariant::Value::new(v));
         }
+        if let Some(v) = &self.phase2_auth {
+            ret.insert("phase2-auth", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.password {
+            ret.insert("password", zvariant::Value::new(v));
+        }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))
         }));
@@ -75,7 +85,22 @@ impl NmSetting8021X {
                 }
                 Err(e) => {
                     log::warn!(
-                        "Filed to convert private_key_password: \
+                        "Failed to convert private_key_password: \
+                        {:?} {:?}",
+                        v,
+                        e
+                    );
+                }
+            }
+        }
+        if let Some(v) = secrets.get("password") {
+            match String::try_from(v.clone()) {
+                Ok(s) => {
+                    self.password = Some(s);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to convert password: \
                         {:?} {:?}",
                         v,
                         e

--- a/rust/src/lib/nm/nm_dbus/gen_conf/ieee8021x.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ieee8021x.rs
@@ -52,6 +52,12 @@ impl ToKeyfile for NmSetting8021X {
                 zvariant::Value::new(v),
             );
         }
+        if let Some(v) = &self.phase2_auth {
+            ret.insert("phase2-auth".to_string(), zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.password {
+            ret.insert("password".to_string(), zvariant::Value::new(v));
+        }
         Ok(ret)
     }
 }

--- a/rust/src/lib/nm/query_apply/ieee8021x.rs
+++ b/rust/src/lib/nm/query_apply/ieee8021x.rs
@@ -20,6 +20,8 @@ pub(crate) fn nm_802_1x_to_nmstate(
             .and_then(vec_u8_to_file_path),
         ca_cert: nm_setting.ca_cert.as_deref().and_then(vec_u8_to_file_path),
         private_key_password: nm_setting.private_key_password.clone(),
+        phase2_auth: nm_setting.phase2_auth.clone(),
+        password: nm_setting.password.clone(),
     }
 }
 

--- a/rust/src/lib/nm/settings/ieee8021x.rs
+++ b/rust/src/lib/nm/settings/ieee8021x.rs
@@ -39,6 +39,20 @@ pub(crate) fn gen_nm_802_1x_setting(
                 .private_key_password
                 .clone_from(&conf.private_key_password);
         }
+        nm_setting.phase2_auth.clone_from(&conf.phase2_auth);
+        if conf.password.as_deref()
+            == Some(NetworkState::PASSWORD_HID_BY_NMSTATE)
+        {
+            if let Some(cur_pass) = nm_conn
+                .ieee8021x
+                .as_ref()
+                .and_then(|c| c.password.as_deref())
+            {
+                nm_setting.password = Some(cur_pass.to_string());
+            }
+        } else {
+            nm_setting.password.clone_from(&conf.password);
+        }
         nm_conn.ieee8021x = Some(nm_setting);
     }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -494,6 +494,8 @@ class Ieee8021X:
     PRIVATE_KEY_PASSWORD = "private-key-password"
     CLIENT_CERT = "client-cert"
     CA_CERT = "ca-cert"
+    PHASE2_AUTH = "phase2-auth"
+    PASSWORD = "password"
 
 
 class Ethtool:

--- a/tests/integration/test_802.1x_srv_files/hostapd.eap_user
+++ b/tests/integration/test_802.1x_srv_files/hostapd.eap_user
@@ -1,1 +1,2 @@
-* TLS
+*   PEAP,TLS
+"client.example.org"	MSCHAPV2	"password"	[2]


### PR DESCRIPTION
Added support for 802.1x PEAP authentication (e.g. using mschapv2)

Included testcase