### PR TITLE
WIP: test: Mark `test_ipsec_ipv6_ipv4_subnet_tunnel` as skip in NM 1.46-

### DIFF
--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -11,10 +11,11 @@ from libnmstate.schema import InterfaceIPv6
 
 from .testlib import cmdlib
 from .testlib.env import nm_libreswan_version_int
+from .testlib.env import nm_minor_version
 from .testlib.env import version_str_to_int
+from .testlib.ipsec import IpsecTestEnv
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import show_only
-from .testlib.ipsec import IpsecTestEnv
 
 
 RETRY_COUNT = 10
@@ -108,7 +109,7 @@ def test_ipsec_ipv4_libreswan_cert_auth_add_and_remove(
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.20"),
     reason="Need NetworkManager-libreswan 1.2.20+ to support rightcert",
 )
@@ -427,7 +428,7 @@ def test_ipsec_ipv4_libreswan_authby(
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.20"),
     reason="Need NetworkManager-libreswan 1.2.20+ to support "
     "leftmodecfgclient",
@@ -466,7 +467,7 @@ def test_ipsec_ipv4_libreswan_p2p_cert_auth_add_and_remove(
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.20"),
     reason="Need NetworkManager-libreswan 1.2.20 to support leftsubnet",
 )
@@ -508,7 +509,7 @@ def test_ipsec_ipv4_libreswan_leftsubnet(
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.22"),
     reason="Need NetworkManager-libreswan 1.2.20 to support transport mode",
 )
@@ -547,7 +548,7 @@ def test_ipsec_ipv4_libreswan_transport_mode(
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.22"),
     reason="Need NetworkManager-libreswan 1.2.22+ to support IPv6",
 )
@@ -587,9 +588,11 @@ def test_ipsec_ipv6_libreswan_p2p(
     )
 
 
-@pytest.mark.xfail(
-    nm_libreswan_version_int() < version_str_to_int("1.2.22"),
-    reason="Need NetworkManager-libreswan 1.2.22+ to support IPv6",
+@pytest.mark.skipif(
+    nm_libreswan_version_int() < version_str_to_int("1.2.22")
+    or nm_minor_version() < 46,
+    reason="Need NetworkManager 1.46+ and "
+    "NetworkManager-libreswan 1.2.22+ to support IPv6 and subnet tunnel",
 )
 def test_ipsec_ipv6_host_to_subnet(
     ipsec_hosta_conn_cleanup,
@@ -633,9 +636,11 @@ def test_ipsec_ipv6_host_to_subnet(
     )
 
 
-@pytest.mark.xfail(
-    nm_libreswan_version_int() < version_str_to_int("1.2.22"),
-    reason="Need NetworkManager-libreswan 1.2.22+ to support IPv6",
+@pytest.mark.skipif(
+    nm_libreswan_version_int() < version_str_to_int("1.2.22")
+    or nm_minor_version() < 46,
+    reason="Need NetworkManager 1.46+ and "
+    "NetworkManager-libreswan 1.2.22+ to support IPv6 and subnet tunnel",
 )
 @pytest.mark.parametrize(
     "left,right,leftsubnet,rightsubnet",
@@ -841,7 +846,7 @@ def test_ipsec_dhcpv4_off_and_empty_ip_addr(
     assert not iface_state[Interface.IPV4][InterfaceIPv4.ENABLED]
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     nm_libreswan_version_int() < version_str_to_int("1.2.22"),
     reason="Need NetworkManager-libreswan 1.2.22+ to support IPv6",
 )


### PR DESCRIPTION
The IPsec host to subnet is only supported in NM 1.46+, so we mark these
tests as xfail in NM 1.46-.

Changed other ipsec xfail tests to skip to save CPU time on known
failures.