### PR TITLE
test: Use NetworkManager-libreswan-1.2.14 for NM 1.42 tests

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -19,7 +19,7 @@ NM_TYPE="${array[1]}"
 TEST_TYPE="${array[2]}"
 TEST_ARG="--test-type $TEST_TYPE"
 
-CUSTOMIZE_ARG=""
+PRETEST_EXEC="true"
 COPR_ARG=""
 
 if [ $OS_TYPE == "c8s" ];then
@@ -43,7 +43,9 @@ fi
 
 if [ $NM_TYPE == "nm_1.42" ];then
     TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-1.42"
+    PRETEST_EXEC='dnf copr enable -y nmstate/nm-libreswan-rhel9.2; dnf install -y NetworkManager-libreswan-1.2.14-4.el9'
 fi
+
 
 mkdir $TEST_ARTIFACTS_DIR || exit 1
 
@@ -64,4 +66,4 @@ env \
     $TEST_CMD \
         $TEST_ARG \
         --artifacts-dir $TEST_ARTIFACTS_DIR \
-        "$CUSTOMIZE_ARG"
+        --pretest-exec "$PRETEST_EXEC"

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -234,7 +234,8 @@ function run_customize_command {
 options=$(getopt --options "" \
     --long "customize:,pytest-args:,help,debug-shell,test-type:,\
     el8,el9,el10,centos-stream,fed,rawhide,copr:,artifacts-dir:,test-vdsm,\
-    machine,k8s,use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:,nolog" \
+    machine,k8s,use-installed-nmstate,compiled-rpms-dir:,nm-rpm-dir:,nolog,\
+    pretest-exec:" \
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -303,6 +304,10 @@ while true; do
     --compiled-rpms-dir)
         shift
         COMPILED_RPMS_DIR="$1"
+        ;;
+    --pretest-exec)
+        shift
+        PRETEST_EXEC="$1"
         ;;
     --help)
         set +x
@@ -386,4 +391,9 @@ if [ $TEST_TYPE != $TEST_TYPE_ALL ] && \
    [ $TEST_TYPE != $TEST_TYPE_FORMAT ];then
     install_nmstate
 fi
+
+if [[ -v PRETEST_EXEC ]];then
+    exec_cmd "$PRETEST_EXEC"
+fi
+
 run_tests


### PR DESCRIPTION
Introduce `--pretest-exec` to `automation/run-tests.sh` to invoke script
before tests.
And use that argument to install NetworkManager-libreswan-1.2.14 for NM
1.42 tests.