### PR TITLE
vrf: Skip serializing if port is undefined

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -14,7 +14,9 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-/// Bond interface. When serializing or deserializing, the [BaseInterface] will
+/// Bond interface.
+///
+/// When serializing or deserializing, the [BaseInterface] will
 /// be flatted and [BondConfig] stored as `link-aggregation` section. The yaml
 /// output [crate::NetworkState] containing an example bond interface:
 /// ```yml
@@ -700,13 +702,14 @@ impl From<BondAllPortsActive> for u8 {
     }
 }
 
+/// The `arp_all_targets` kernel bond option.
+///
+/// Specifies the quantity of arp_ip_targets that must be reachable in order for
+/// the ARP monitor to consider a port as being up. This option affects only
+/// active-backup mode for ports with arp_validation enabled.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case", remote = "BondArpAllTargets")]
 #[non_exhaustive]
-/// The `arp_all_targets` kernel bond option: Specifies the quantity of
-/// arp_ip_targets that must be reachable in order for the ARP monitor to
-/// consider a port as being up. This option affects only active-backup mode
-/// for ports with arp_validation enabled.
 pub enum BondArpAllTargets {
     /// consider the port up only when any of the `arp_ip_targets` is reachable
     #[serde(alias = "0")]
@@ -752,13 +755,14 @@ impl std::fmt::Display for BondArpAllTargets {
     }
 }
 
+/// The `arp_validate` kernel bond option.
+///
+/// Specifies whether or not ARP probes and replies should be validated in any
+/// mode that supports arp monitoring, or whether non-ARP traffic should be
+/// filtered (disregarded) for link monitoring purposes.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case", remote = "BondArpValidate")]
 #[non_exhaustive]
-/// The `arp_validate` kernel bond option: Specifies whether or not ARP probes
-/// and replies should be validated in any mode that supports arp monitoring, or
-/// whether non-ARP traffic should be filtered (disregarded) for link monitoring
-/// purposes.
 pub enum BondArpValidate {
     /// No validation or filtering is performed.
     /// Serialize to `none`.
@@ -839,13 +843,15 @@ impl std::fmt::Display for BondArpValidate {
     }
 }
 
+/// The `fail_over_mac` kernel bond option.
+///
+/// Specifies whether active-backup mode should set all ports to the same MAC
+/// address at port attachment (the traditional behavior), or, when enabled,
+/// perform special handling of the bond's MAC address in accordance with the
+/// selected policy.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "kebab-case", remote = "BondFailOverMac")]
 #[non_exhaustive]
-/// The `fail_over_mac` kernel bond option: Specifies whether active-backup mode
-/// should set all ports to the same MAC address at port attachment (the
-/// traditional behavior), or, when enabled, perform special handling of the
-/// bond's MAC address in accordance with the selected policy.
 pub enum BondFailOverMac {
     /// This setting disables fail_over_mac, and causes bonding to set all
     /// ports of an active-backup bond to the same MAC address at attachment
@@ -910,14 +916,15 @@ impl std::fmt::Display for BondFailOverMac {
     }
 }
 
+/// The `primary_reselect` kernel bond option.
+///
+/// Specifies the reselection policy for the primary port. This affects how the
+/// primary port is chosen to become the active port when failure of the active
+/// port or recovery of the primary port occurs. This option is designed to
+/// prevent flip-flopping between the primary port and other ports.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case", remote = "BondPrimaryReselect")]
 #[non_exhaustive]
-/// The `primary_reselect` kernel bond option: Specifies the reselection policy
-/// for the primary port. This affects how the primary port is chosen to
-/// become the active port when failure of the active port or recovery of the
-/// primary port occurs. This option is designed to prevent flip-flopping
-/// between the primary port and other ports.
 pub enum BondPrimaryReselect {
     ///The primary port becomes the active port whenever it comes back up.
     /// Serialize to `always`.
@@ -974,11 +981,13 @@ impl std::fmt::Display for BondPrimaryReselect {
     }
 }
 
+/// The `xmit_hash_policy` kernel bond option.
+///
+/// Selects the transmit hash policy to use for port selection in balance-xor,
+/// 802.3ad, and tlb modes.
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 #[serde(remote = "BondXmitHashPolicy")]
-/// The `xmit_hash_policy` kernel bond option: Selects the transmit hash policy
-/// to use for port selection in balance-xor, 802.3ad, and tlb modes.
 pub enum BondXmitHashPolicy {
     #[serde(rename = "layer2", alias = "0")]
     /// Serialize to `layer2`.

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -23,14 +23,14 @@ const COPY_MAC_ALLOWED_IFACE_TYPES: [InterfaceType; 3] = [
     InterfaceType::OvsInterface,
 ];
 
+/// Represent a list of [Interface].
+///
+/// With special [serde::Deserializer] and [serde::Serializer].  When applying
+/// complex nested interface(e.g. bridge over bond over vlan of eth1), the
+/// supported maximum nest level is 4 like previous example.  For 5+ nested
+/// level, you need to place controller interface before its ports.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
-/// Represent a list of [Interface] with special [serde::Deserializer] and
-/// [serde::Serializer].
-/// When applying complex nested interface(e.g. bridge over bond over vlan of
-/// eth1), the supported maximum nest level is 4 like previous example.
-/// For 5+ nested level, you need to place controller interface before its
-/// ports.
 pub struct Interfaces {
     pub(crate) kernel_ifaces: HashMap<String, Interface>,
     pub(crate) user_ifaces: HashMap<(String, InterfaceType), Interface>,

--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -4,12 +4,11 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{BaseInterface, InterfaceType, NetworkState};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-/// The libreswan Ipsec interface. This interface does not exist in kernel
-/// space but only exist in user space tools.
-/// This is the example yaml output of [crate::NetworkState] with a libreswan
-/// ipsec connection:
+/// The libreswan Ipsec interface.
+///
+/// This interface does not exist in kernel space but only exist in user space
+/// tools.  This is the example yaml output of [crate::NetworkState] with a
+/// libreswan ipsec connection:
 /// ```yaml
 /// ---
 /// interfaces:
@@ -26,6 +25,8 @@ use crate::{BaseInterface, InterfaceType, NetworkState};
 ///     leftcert: hosta.example.org
 ///     ikev2: insist
 /// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct IpsecInterface {
     #[serde(flatten)]
     pub base: BaseInterface,

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -14,6 +14,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 /// Bridge interface provided by linux kernel.
+///
 /// When serializing or deserializing, the [BaseInterface] will
 /// be flatted and [LinuxBridgeConfig] stored as `bridge` section. The yaml
 /// output [crate::NetworkState] containing an example linux bridge interface:

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -132,7 +132,7 @@ impl VrfInterface {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct VrfConfig {
-    #[serde(alias = "ports")]
+    #[serde(alias = "ports", skip_serializing_if = "Option::is_none")]
     /// Port list.
     /// Deserialize and serialize from/to `port`.
     /// Also deserialize from `ports`.

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -85,3 +85,21 @@ fn test_vrf_on_bond_vlan_got_auto_remove() {
         .unwrap();
     assert!(iface.is_absent());
 }
+
+#[test]
+fn test_vrf_skip_port_if_null() {
+    let iface: VrfInterface = serde_yaml::from_str(
+        r#"---
+        name: vrf1
+        type: vrf
+        state: up
+        vrf:
+          route-table-id: "101"
+        "#,
+    )
+    .unwrap();
+
+    let iface_yaml = serde_yaml::to_string(&iface).unwrap();
+
+    assert!(!iface_yaml.contains("port"))
+}


### PR DESCRIPTION
The `gen_diff()` will return `port: null` if port is not changed for
existing VRF. Fixed by skip serializing if port is undefined.

Unit test case included.