### PR TITLE
[nmstate-1.4] dns: Fix incorrect error message

### DIFF
--- a/libnmstate/dns.py
+++ b/libnmstate/dns.py
@@ -82,18 +82,20 @@ class DnsState:
                     raise NmstateValueError(
                         "Option '{}' is not supported to hold "
                         "a value, only support these without "
-                        "value: {} and these with values: {}:n",
-                        opt,
-                        ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
-                        ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
+                        "value: {} and these with values: {}:n".format(
+                            opt,
+                            ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
+                            ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
+                        )
                     )
             elif opt not in SUPPORTED_DNS_OPTS_NO_VALUE:
                 raise NmstateValueError(
                     "Option '{}' is not supported, only support these "
-                    "without value: {} and these with values: {}:n",
-                    opt,
-                    ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
-                    ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
+                    "without value: {} and these with values: {}:n".format(
+                        opt,
+                        ", ".join(SUPPORTED_DNS_OPTS_NO_VALUE),
+                        ":n, ".join(SUPPORTED_DNS_OPTS_WITH_VALUE),
+                    )
                 )
 
     @property


### PR DESCRIPTION
When applying invalid DNS option, we got error like:

    "Option '{}' is not supported, only support these without value: {}
    and these with values: {}:n"

This is caused by incorrect error string generation. Changed to use
`"Option '{}'...".format()`.

This is cosmetic and error message is not API, hence no test case
required for this patch. Manually checked the error message.

Resolves: https://issues.redhat.com/browse/RHEL-16860