### PR TITLE
route: Add support for route source

### DIFF
--- a/examples/eth1_add_route.yml
+++ b/examples/eth1_add_route.yml
@@ -13,6 +13,7 @@ interfaces:
 routes:
   config:
     - destination: 198.51.100.0/24
+      source: 192.0.2.251
       metric: 150
       next-hop-address: 192.0.2.1
       next-hop-interface: eth1

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -194,10 +194,12 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
         }
     };
 
+    let source = np_route.prefered_src.as_ref().map(|src| src.to_string());
     let mut route_entry = RouteEntry::new();
     route_entry.destination = destination;
     route_entry.next_hop_iface = np_route.oif.as_ref().cloned();
     route_entry.next_hop_addr = next_hop_addr;
+    route_entry.source = source;
     route_entry.metric = np_route.metric.map(i64::from);
     route_entry.table_id = Some(np_route.table);
     // according to `man ip-route`, cwnd is useless without the lock flag, so

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -13,6 +13,7 @@ pub struct NmIpRoute {
     pub dest: Option<String>,
     pub prefix: Option<u32>,
     pub next_hop: Option<String>,
+    pub src: Option<String>,
     pub table: Option<u32>,
     pub metric: Option<u32>,
     pub weight: Option<u32>,
@@ -35,6 +36,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             dest: _from_map!(v, "dest", String::try_from)?,
             prefix: _from_map!(v, "prefix", u32::try_from)?,
             next_hop: _from_map!(v, "next-hop", String::try_from)?,
+            src: _from_map!(v, "src", String::try_from)?,
             table: _from_map!(v, "table", u32::try_from)?,
             metric: _from_map!(v, "metric", u32::try_from)?,
             weight,
@@ -67,6 +69,12 @@ impl NmIpRoute {
         if let Some(v) = &self.next_hop {
             ret.append(
                 zvariant::Value::new("next-hop"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.src {
+            ret.append(
+                zvariant::Value::new("src"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -35,6 +35,9 @@ impl NmIpRoute {
             if let Some(lock_cwnd) = self.lock_cwnd {
                 write!(opt_string, ",lock-cwnd={}", lock_cwnd).ok();
             }
+            if let Some(src) = self.src.as_ref() {
+                write!(opt_string, ",src={}", src).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -32,6 +32,7 @@ pub(crate) fn gen_nm_ip_routes(
             None => None,
         };
         nm_route.next_hop = route.next_hop_addr.as_ref().cloned();
+        nm_route.src = route.source.as_ref().cloned();
         if let Some(weight) = route.weight {
             nm_route.weight = Some(weight as u32);
         }

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -260,12 +260,17 @@ fn test_route_sanitize_ipv6_host_not_compact() {
         r#"
 destination: "2001:db8:1:0000:000::1"
 next-hop-address: "2001:db8:a:0000:000::1"
+source: "2001:0db8:85a3:0000:0000:8a2e:0370:7001"
 "#,
     )
     .unwrap();
     route.sanitize().unwrap();
     assert_eq!(route.destination, Some("2001:db8:1::1/128".to_string()));
     assert_eq!(route.next_hop_addr, Some("2001:db8:a::1".to_string()));
+    assert_eq!(
+        route.source,
+        Some("2001:db8:85a3::8a2e:370:7001".to_string())
+    );
 }
 
 #[test]

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -38,6 +38,7 @@ class Route:
     DESTINATION = "destination"
     NEXT_HOP_INTERFACE = "next-hop-interface"
     NEXT_HOP_ADDRESS = "next-hop-address"
+    SOURCE = "source"
     METRIC = "metric"
     WEIGHT = "weight"
     ROUTETYPE = "route-type"

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -330,6 +330,31 @@ def test_add_gateway(eth1_up):
     assert_routes(routes, cur_state)
 
 
+def test_add_static_route_with_route_src(eth1_up):
+    routes = [
+        {
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.SOURCE: IPV4_ADDRESS1,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        },
+        {
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.SOURCE: IPV6_ADDRESS1,
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)
+
+
 def test_add_route_without_metric(eth1_up):
     routes = _get_ipv4_test_routes() + _get_ipv6_test_routes()
     for route in routes:


### PR DESCRIPTION
In a scenario where you have a machine with multiple public IP
addresses, typically due to a multi-WAN setup, the src parameter in the
context of routes allows you to specify which source IP address should
be used when sending packets via a specific route. This is crucial when
you want to ensure that outbound traffic uses a specific IP address tied
to a particular network interface, especially when dealing with multiple
WAN connections.

Adding support for the src parameter in routes results in a more
powerful and flexible network configuration capability, especially
important in environments with multiple network interfaces or multiple
IP addresses, it provides better control over traffic routing.

The following is the example for specifying the route src in Nmstate:

```
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      address:
        - ip: 192.0.2.251
          prefix-length: 24
        - ip: 192.0.2.252
          prefix-length: 24
      dhcp: false
      enabled: true
routes:
  config:
    - destination: 198.51.100.0/24
      source: 192.0.2.251
      next-hop-address: 192.0.2.1
      next-hop-interface: eth1
      table-id: 254
      metric: 150
```

Resolves: https://issues.redhat.com/browse/RHEL-56258