### PR TITLE
nm dns: Re-evaluate DNS settings if desired even not changed

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -288,31 +288,6 @@ impl MergedDnsState {
         })
     }
 
-    pub(crate) fn is_changed(&self) -> bool {
-        let cur_servers = self
-            .current
-            .config
-            .as_ref()
-            .and_then(|c| c.server.clone())
-            .unwrap_or_default();
-        let cur_searches = self
-            .current
-            .config
-            .as_ref()
-            .and_then(|c| c.search.clone())
-            .unwrap_or_default();
-        let cur_options = self
-            .current
-            .config
-            .as_ref()
-            .and_then(|c| c.options.clone())
-            .unwrap_or_default();
-
-        self.servers != cur_servers
-            || self.searches != cur_searches
-            || self.options != cur_options
-    }
-
     pub(crate) fn is_search_or_option_only(&self) -> bool {
         self.servers.is_empty()
             && (!self.searches.is_empty() || !self.options.is_empty())

--- a/rust/src/lib/query_apply/dns.rs
+++ b/rust/src/lib/query_apply/dns.rs
@@ -3,11 +3,40 @@
 use crate::{DnsState, ErrorKind, MergedDnsState, NmstateError};
 
 impl MergedDnsState {
-    pub(crate) fn is_purge(&self) -> bool {
+    pub(crate) fn is_desired(&self) -> bool {
         self.desired.is_some()
+    }
+
+    pub(crate) fn is_purge(&self) -> bool {
+        self.is_desired()
             && self.servers.is_empty()
             && self.searches.is_empty()
             && self.options.is_empty()
+    }
+
+    pub(crate) fn is_changed(&self) -> bool {
+        let cur_servers = self
+            .current
+            .config
+            .as_ref()
+            .and_then(|c| c.server.clone())
+            .unwrap_or_default();
+        let cur_searches = self
+            .current
+            .config
+            .as_ref()
+            .and_then(|c| c.search.clone())
+            .unwrap_or_default();
+        let cur_options = self
+            .current
+            .config
+            .as_ref()
+            .and_then(|c| c.options.clone())
+            .unwrap_or_default();
+
+        self.servers != cur_servers
+            || self.searches != cur_searches
+            || self.options != cur_options
     }
 
     pub(crate) fn verify(&self, current: DnsState) -> Result<(), NmstateError> {


### PR DESCRIPTION
When user want to change from global DNS to interface DNS by explicitly
define static IP and static DNS, it only works if DNS config actual
changed. Because nmstate only re-evaluate the DNS config if that is
actually changed.

This patch will do re-evaluate if DNS config is desired.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-56557