### PR TITLE
gen_conf: Support special route type

### DIFF
--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -2,7 +2,9 @@
 
 use std::collections::HashMap;
 
-use crate::{nm::nm_gen_conf, MergedNetworkState, NetworkState, NmstateError};
+use crate::{
+    nm::nm_gen_conf, Interface, MergedNetworkState, NetworkState, NmstateError,
+};
 
 impl NetworkState {
     /// Generate offline network configurations.
@@ -17,9 +19,16 @@ impl NetworkState {
         &self,
     ) -> Result<HashMap<String, Vec<(String, String)>>, NmstateError> {
         let mut ret = HashMap::new();
+        // Passing a current state with loopback interface, so special
+        // route(like blackhole) can be stored there.
+        let mut cur_state = NetworkState::new();
+        cur_state
+            .interfaces
+            .push(Interface::Loopback(Default::default()));
+
         let merged_state = MergedNetworkState::new(
             self.clone(),
-            NetworkState::new(),
+            cur_state,
             true,  // gen_conf mode
             false, // memory only
         )?;

--- a/rust/src/lib/ifaces/loopback.rs
+++ b/rust/src/lib/ifaces/loopback.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, ErrorKind, InterfaceType, NmstateError};
+use crate::{
+    BaseInterface, ErrorKind, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
+    InterfaceState, InterfaceType, NmstateError,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -44,6 +49,29 @@ impl Default for LoopbackInterface {
     fn default() -> Self {
         let mut base = BaseInterface::new();
         base.iface_type = InterfaceType::Loopback;
+        base.name = "lo".to_string();
+        base.state = InterfaceState::Up;
+        base.ipv4 = Some(InterfaceIpv4 {
+            enabled: true,
+            enabled_defined: true,
+            addresses: Some(vec![InterfaceIpAddr {
+                ip: Ipv4Addr::LOCALHOST.into(),
+                prefix_length: 8,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        base.ipv6 = Some(InterfaceIpv6 {
+            enabled: true,
+            enabled_defined: true,
+            addresses: Some(vec![InterfaceIpAddr {
+                ip: Ipv6Addr::LOCALHOST.into(),
+                prefix_length: 128,
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+
         Self { base }
     }
 }

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -9,7 +9,7 @@ KERNEL_DEFAULT_TABLE_ID = 254
 
 
 def assert_routes(routes, state, nic="eth1"):
-    routes = _clone_prepare_routes(routes)
+    routes = _clone_prepare_routes(routes, nic=nic)
     config_routes = _clone_prepare_routes(state[Route.KEY][Route.CONFIG], nic)
     running_routes = _clone_prepare_routes(
         state[Route.KEY][Route.RUNNING], nic


### PR DESCRIPTION
Currently the `gen_conf` will discard routes with special
types(blackhole, unreachable, prohibit).

The root cause: `gen_conf` is taking empty network state as current
state lacking loopback interface `lo`, hence routes stored to that
interface will be ignored when generating NetworkManager connection
file.

Fixed by passing default loopback interface as current interface.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-56727