### PR TITLE
mptcp: Treat none as empty MPTCP flags in current state when verifying

### DIFF
--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -18,9 +18,11 @@ impl BaseInterface {
         if self.controller.is_none() {
             self.controller = Some(String::new());
         }
-        if let Some(mptcp_conf) = self.mptcp.as_mut() {
-            mptcp_conf.sanitize_current_for_verify();
-        }
+
+        self.mptcp
+            .get_or_insert(Default::default())
+            .sanitize_current_for_verify();
+
         if let Some(ipv4_conf) = self.ipv4.as_mut() {
             ipv4_conf.sanitize_current_for_verify();
         }

--- a/rust/src/lib/query_apply/mptcp.rs
+++ b/rust/src/lib/query_apply/mptcp.rs
@@ -11,9 +11,8 @@ impl MptcpConfig {
     }
 
     pub(crate) fn sanitize_current_for_verify(&mut self) {
-        if let Some(flags) = self.address_flags.as_mut() {
-            flags.dedup();
-            flags.sort_unstable();
-        }
+        let flags = self.address_flags.get_or_insert(Default::default());
+        flags.dedup();
+        flags.sort_unstable();
     }
 }

--- a/tests/integration/mptcp_test.py
+++ b/tests/integration/mptcp_test.py
@@ -172,3 +172,30 @@ def test_invalid_mptcp_flags(eth1_with_static_ip, mptcp_flags):
                 ]
             }
         )
+
+
+# https://issues.redhat.com/browse/RHEL-38607
+def test_purge_mptcp_on_auto_ip_iface_with_dhcp_server(eth1_up):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.MPTCP: {
+                        Mptcp.ADDRESS_FLAGS: [],
+                    },
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTOCONF: True,
+                    },
+                }
+            ]
+        }
+    )


### PR DESCRIPTION
When applying state with empty MPTCP address flags with auto IP, we got
error like:

    VerificationError: Verification failure:
    eth1.interface.mptcp.address-flags desire '[]', current 'null'

The root cause is current state during verify stage has mptcp section as
None when no IP address found, we should treat None mptcp as empty for
verification stage.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-38607