### PR TITLE
Policy support unordered references

### DIFF
--- a/examples/policy/enable_lldp/policy.yml
+++ b/examples/policy/enable_lldp/policy.yml
@@ -1,8 +1,8 @@
 ---
 capture:
   ethernets: interfaces.type=="ethernet"
-  ethernets-up: capture.ethernets | interfaces.state=="up"
   ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
+  ethernets-up: capture.ethernets | interfaces.state=="up"
   ethernets-lldp-skip-eth-conf: >-
     capture.ethernets-lldp | interfaces.ethernet := null
 desiredState:

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 
 use crate::{
     policy::{
-        capture::{NetworkCaptureAction, NetworkCaptureCommand},
+        capture::{
+            NetworkCaptureAction, NetworkCaptureCommand, NetworkCaptureRules,
+        },
         token::NetworkCaptureToken,
     },
     NetworkState,
@@ -263,4 +265,19 @@ fn test_policy_capture_route_rule() {
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].ip_from, Some("2001:db8:b::/64".to_string()));
     assert_eq!(rules[0].table_id, Some(500));
+}
+
+#[test]
+fn test_policy_rules_unordered() {
+    let result = serde_yaml::from_str::<NetworkCaptureRules>(
+        r#"
+a: interfaces.name=="a"
+c: capture.b | interfaces.name=="c"
+b: capture.a | interfaces.name=="b"
+d: capture.c | interfaces.name=="d"
+dummy: interfaces.name=="dummy"
+  "#,
+    );
+    println!("{:?}", result);
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
This change allow the capture commands to be ordered independently of how they reference between them.

It's done by ordering the cmds vector according to how capture entries are referenced between each other, also a cycle reference mechanism is implemeneted.