### PR TITLE
nm: Fix profile name changing

### DIFF
--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -347,7 +347,12 @@ pub(crate) fn gen_nm_conn_setting(
     stable_uuid: bool,
 ) -> Result<(), NmstateError> {
     let mut nm_conn_set = if let Some(cur_nm_conn_set) = &nm_conn.connection {
-        cur_nm_conn_set.clone()
+        let mut new_nm_conn_set = cur_nm_conn_set.clone();
+        // Change existing connection's profile_name if desired explicitly
+        if let Some(n) = iface.base_iface().profile_name.as_deref() {
+            new_nm_conn_set.id = Some(n.to_string());
+        }
+        new_nm_conn_set
     } else {
         let mut new_nm_conn_set = NmSettingConnection::default();
         let conn_name =

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -654,3 +654,25 @@ def test_delete_mac_based_profile_using_profile_name(mac_based_profile_eth1):
         )[0]
         != 0
     )
+
+
+# https://issues.redhat.com/browse/RHEL-59239
+@pytest.mark.tier1
+def test_change_profile_name(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.PROFILE_NAME: "eth1-new",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assert (
+        cmdlib.exec_cmd("nmcli -g connection.id c show eth1-new".split())[
+            1
+        ].strip()
+        == "eth1-new"
+    )


### PR DESCRIPTION
Previously, nmstate can not change profile name on existing connection.
This patch will update the profile name when `interface.profile-name`
been desired explicitly.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-59239