### PR TITLE
Fixing CI due to github CI update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,14 @@ jobs:
         sudo apt-get update;
         sudo apt-get -y install valgrind
 
+    - name: Disable MPTCP
+      # Nmstate query will fail due to permission deny when MPTCP is enabled
+      # due to kernel limitation(bug),
+      # once https://github.com/nispor/nispor/pull/276 is released, we
+      # can remove this workaround
+      run: |
+        sudo sysctl -w net.mptcp.enabled=0
+
     - name: Unit test
       run: cd rust && cargo test -- --show-output
 

--- a/rust/src/clib/test/nmstate_json_test.c
+++ b/rust/src/clib/test/nmstate_json_test.c
@@ -19,12 +19,12 @@ int main(void) {
 	if (nmstate_net_state_retrieve(flag, &state, &log, &err_kind, &err_msg)
 	    == NMSTATE_PASS) {
 		printf("%s\n", state);
+		assert(state[0] == '{');
 	} else {
-		printf("%s: %s\n", err_kind, err_msg);
+		fprintf(stderr, "%s: %s\n", err_kind, err_msg);
 		rc = EXIT_FAILURE;
 	}
 
-	assert(state[0] == '{');
 
 	nmstate_cstring_free(state);
 	nmstate_cstring_free(err_kind);

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! To retrieve current network state:
 //!
-//! ```rust
+//! ```no_run
 //! use nmstate::NetworkState;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -10,7 +10,6 @@ import yaml
 import json
 
 import libnmstate
-from libnmstate.error import NmstateKernelIntegerRoundedError
 from libnmstate.error import NmstateValueError
 from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
@@ -31,7 +30,6 @@ from .testlib.bridgelib import generate_vlan_id_config
 from .testlib.bridgelib import generate_vlan_id_range_config
 from .testlib.bridgelib import linux_bridge
 from .testlib.cmdlib import exec_cmd
-from .testlib.env import is_ubuntu_kernel
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.retry import retry_till_true_or_timeout
@@ -709,25 +707,6 @@ def test_change_linux_bridge_group_addr(bridge0_with_port0):
     libnmstate.apply(desired_state)
 
     assertlib.assert_state_match(desired_state)
-
-
-@pytest.mark.skipif(
-    not is_ubuntu_kernel(),
-    reason="Only 250 HZ kernel will fail on NmstateKernelIntergerRounded "
-    "for linux bridge MULTICAST_STARTUP_QUERY_INTERVAL option",
-)
-def test_linux_bridge_option_integer_rounded_on_ubuntu_kernel(
-    bridge0_with_port0,
-):
-    iface_state = bridge0_with_port0[Interface.KEY][0]
-    iface_state[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.OPTIONS_SUBTREE][
-        LinuxBridge.Options.MULTICAST_STARTUP_QUERY_INTERVAL
-    ] = 3125
-
-    desired_state = {Interface.KEY: [iface_state]}
-
-    with pytest.raises(NmstateKernelIntegerRoundedError):
-        libnmstate.apply(desired_state)
 
 
 def test_linux_bridge_option_vlan_default_pvid_no_filtering(

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -9,10 +9,6 @@ def is_fedora():
     return os.path.exists("/etc/fedora-release")
 
 
-def is_ubuntu_kernel():
-    return "Ubuntu" in os.uname().version
-
-
 def nm_minor_version():
     version_str = exec_cmd(
         "rpm -q NetworkManager --qf %{VERSION}".split(),


### PR DESCRIPTION
The Github CI changed Ubuntu kernel to 6.8.0-1013-azure which:
 1. Enabled MPTCP by default
 2. Using 1000 HZ in kernel

With MPTCP enabled, we has problem on state querying due to kernel
limitation(bug) on requiring net_admin permission for querying.
We just disable MPTCP in unit test.

With 1000HZ kernel, we cannot reproduce `NmstateKernelIntegerRoundedError`
anymore, hence remove the
`test_linux_bridge_option_integer_rounded_on_ubuntu_kernel` test case.