### PR TITLE
policy: Fix error when capture is mentioned in the right

### DIFF
--- a/examples/policy/capture_all/current.yml
+++ b/examples/policy/capture_all/current.yml
@@ -1,0 +1,21 @@
+---
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-interface: eth1
+      next-hop-address: 192.0.2.1
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-interface: eth1
+      next-hop-address: 192.0.2.1
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 1c:c1:0c:32:3b:ff
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+        - ip: 192.0.2.251
+          prefix-length: 24

--- a/examples/policy/capture_all/expected.yml
+++ b/examples/policy/capture_all/expected.yml
@@ -1,0 +1,23 @@
+---
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-interface: br1
+      next-hop-address: 192.0.2.1
+interfaces:
+  - name: br1
+    description: Linux bridge with base interface as a port
+    type: linux-bridge
+    state: up
+    ipv4:
+      enabled: true
+      dhcp: false
+      address:
+        - ip: 192.0.2.251
+          prefix-length: 24
+    bridge:
+      options:
+        stp:
+          enabled: false
+      port:
+        - name: eth1

--- a/examples/policy/capture_all/policy.yml
+++ b/examples/policy/capture_all/policy.yml
@@ -1,0 +1,25 @@
+---
+capture:
+  default-gw: override me with the cache
+  base-iface: >-
+    interfaces.name == capture.default-gw.routes.running.0.next-hop-interface
+  base-iface-routes: >-
+    routes.running.next-hop-interface ==
+    capture.default-gw.routes.running.0.next-hop-interface
+  bridge-routes: >-
+    capture.base-iface-routes | routes.running.next-hop-interface:="br1"
+desiredState:
+  interfaces:
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: "{{ capture.base-iface.interfaces.0.name }}"
+      description: Linux bridge with base interface as a port
+      ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
+      name: br1
+      state: up
+      type: linux-bridge
+  routes:
+    config: "{{ capture.bridge-routes.routes.running }}"

--- a/examples/policy/search_route_on_mac/current.yml
+++ b/examples/policy/search_route_on_mac/current.yml
@@ -1,0 +1,40 @@
+---
+dns-resolver:
+  running:
+    server:
+      - 192.0.2.1
+    search:
+      - example.com
+  config: {}
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.0.2.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.0.2.1
+      next-hop-interface: eth2
+      metric: 100
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:00:51:00:00:0A
+    ipv4:
+      enabled: true
+      address:
+        - ip: 192.0.2.9
+          prefix-length: 16
+      dhcp: true
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: 00:00:51:00:00:0B
+    ipv4:
+      enabled: true
+      address:
+        - ip: 192.0.2.10
+          prefix-length: 16
+      dhcp: true

--- a/examples/policy/search_route_on_mac/expected.yml
+++ b/examples/policy/search_route_on_mac/expected.yml
@@ -1,0 +1,20 @@
+---
+dns-resolver:
+  config:
+    server:
+      - 192.0.2.1
+    search:
+      - example.com
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.0.2.1
+      next-hop-interface: eth2
+      metric: 100
+      table-id: 254
+interfaces:
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      dhcp: false

--- a/examples/policy/search_route_on_mac/policy.yml
+++ b/examples/policy/search_route_on_mac/policy.yml
@@ -1,0 +1,20 @@
+---
+capture:
+  des-iface: interfaces.type=="ethernet"
+  des-iface-mac: capture.des-iface.interfaces.mac-address=="00:00:51:00:00:0B"
+  des-routes: >-
+    routes.running.next-hop-interface == capture.des-iface-mac.interfaces.0.name
+  dns: dns-resolver.running
+desiredState:
+  interfaces:
+    - name: "{{ capture.des-iface-mac.interfaces.0.name }}"
+      type: ethernet
+      state: up
+      ipv4:
+        address: "{{ capture.des-iface-mac.interfaces.0.ipv4.address }}"
+        dhcp: false
+        enabled: true
+  routes:
+    config: "{{ capture.des-routes.routes.running }}"
+  dns-resolver:
+    config: "{{ capture.dns.dns-resolver.running }}"

--- a/rust/src/clib/test/nmpolicy_json_test.c
+++ b/rust/src/clib/test/nmpolicy_json_test.c
@@ -89,13 +89,11 @@ int main(void) {
 					  &err_kind, &err_msg) == NMSTATE_PASS)
 	{
 		printf("%s\n", state);
+		assert(state[0] == '{');
 	} else {
-		printf("%s: %s\n", err_kind, err_msg);
+		fprintf(stderr, "%s: %s\n", err_kind, err_msg);
 		rc = EXIT_FAILURE;
 	}
-
-	assert(state[0] == '{');
-
 	nmstate_cstring_free(state);
 	nmstate_cstring_free(err_kind);
 	nmstate_cstring_free(err_msg);

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -196,8 +196,21 @@ impl NetworkCaptureCommand {
             }
         }
 
+        let value_input = if let Some(cap_name) = self.value_capture.as_ref() {
+            if let Some(cap) = captures.get(cap_name) {
+                cap.clone()
+            } else {
+                return Err(NmstateError::new_policy_error(
+                    format!("Capture {cap_name} not found"),
+                    self.line.as_str(),
+                    self.key_capture_pos,
+                ));
+            }
+        } else {
+            current.clone()
+        };
         let matching_value =
-            match get_value(&self.value, &input, self.line.as_str())? {
+            match get_value(&self.value, &value_input, self.line.as_str())? {
                 serde_json::Value::Null => None,
                 v => Some(value_to_string(&v)),
             };

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -192,7 +192,8 @@ impl NetworkCaptureCommand {
                     )
                 });
             } else {
-                return Ok(NetworkState::new());
+                // User just want to store full state to a new name
+                return Ok(input);
             }
         }
 

--- a/rust/src/lib/unit_tests/policy/example.rs
+++ b/rust/src/lib/unit_tests/policy/example.rs
@@ -28,7 +28,6 @@ fn test_policy_examples() {
         .unwrap();
 
         policy.current = Some(current_state);
-        println!("HAHA {:?}", policy.current);
         let state =
             serde_yaml::to_string(&NetworkState::try_from(policy).unwrap())
                 .unwrap();


### PR DESCRIPTION
For capture like:

    des_r: routes.running.next-hop-interface == capture.foo.interfaces.0.name

Incorrectly use current state to resolve capture data in the right part.

Unit test case included as the example file will be tested by
`test_policy_examples` test case.