### PR TITLE
packaging: add alternative basic deps with low prio

### DIFF
--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -2,6 +2,16 @@ FROM quay.io/centos/centos:stream9
 
 RUN echo "2024-04-09" > /build_time
 
+# Add alter-baseos and alter-appstream repositories with lower priority
+COPY c9s-alter-baseos.repo \
+     /etc/yum.repos.d/c9s-alter-baseos.repo
+COPY c9s-alter-appstream.repo \
+     /etc/yum.repos.d/c9s-alter-appstream.repo
+
+RUN grep -q "^skip_if_unavailable=" /etc/dnf/dnf.conf && \
+    sed -i 's/^skip_if_unavailable=.*/skip_if_unavailable=True/' /etc/dnf/dnf.conf || \
+    echo "skip_if_unavailable=True" >> /etc/dnf/dnf.conf
+
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core epel-release \
         centos-release-nfv-openvswitch && \

--- a/packaging/c9s-alter-appstream.repo
+++ b/packaging/c9s-alter-appstream.repo
@@ -1,0 +1,7 @@
+[9-stream-alter-appstream]
+name=CentOS Stream 9 - Alter AppStream
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+enabled=1
+gpgcheck=1
+priority=1000

--- a/packaging/c9s-alter-baseos.repo
+++ b/packaging/c9s-alter-baseos.repo
@@ -1,0 +1,7 @@
+[9-stream-alter-baseos]
+name=CentOS Stream 9 - Alter BaseOS
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+enabled=1
+gpgcheck=1
+priority=100


### PR DESCRIPTION
Add alternative baseurl repos as We see some issues lately with mirrorlink based repos. This should workaround it together with skip_if_unavailable=True. If all repos are OK, this is doing nothing.