### PR TITLE
nm: Handle `ipv6.method: ignore`

### DIFF
--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -93,7 +93,16 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             | NmSettingIpMethod::Shared => (true, Some(false), Some(false)),
             NmSettingIpMethod::Auto => (true, Some(true), Some(true)),
             NmSettingIpMethod::Dhcp => (true, Some(true), Some(false)),
-            NmSettingIpMethod::Ignore => (true, Some(false), Some(false)),
+            NmSettingIpMethod::Ignore => {
+                log::debug!(
+                    "Found NmSettingIpMethod::Ignore for ipv6, \
+                    reply on nispor for setting IPv6 query"
+                );
+                return InterfaceIpv6 {
+                    enabled_defined: false,
+                    ..Default::default()
+                };
+            }
         };
         let (auto_dns, auto_gateway, auto_routes, auto_table_id) =
             parse_dhcp_opts(nm_ip_setting);


### PR DESCRIPTION
With NetworkManager holding `ipv6.method: ignore`, we should trust
nispor on querying the correct ipv6 status.

Current code is blindly treat it as ipv6.enabled, this fix is only use
nispor information for ipv6 status if NetworkManager found
`ipv6.method: ignore`

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-58406