### PR TITLE
policy: Sort the capture base on dependent relationship

### DIFF
--- a/examples/policy/bridge-on-default-gw-no-dhcp/policy.yml
+++ b/examples/policy/bridge-on-default-gw-no-dhcp/policy.yml
@@ -1,12 +1,12 @@
 ---
 capture:
   default-gw: routes.running.destination=="0.0.0.0/0"
-  base-iface: >-
-    interfaces.name==capture.default-gw.routes.running.0.next-hop-interface
-  base-iface-routes: >-
-    routes.running.next-hop-interface==capture.base-iface.interfaces.0.name
   bridge-routes: >-
     capture.base-iface-routes | routes.running.next-hop-interface:="br1"
+  base-iface-routes: >-
+    routes.running.next-hop-interface==capture.base-iface.interfaces.0.name
+  base-iface: >-
+    interfaces.name==capture.default-gw.routes.running.0.next-hop-interface
 desiredState:
   interfaces:
     - name: br1

--- a/examples/policy/unsorted_capture/current.yml
+++ b/examples/policy/unsorted_capture/current.yml
@@ -1,0 +1,24 @@
+---
+routes:
+  running:
+    - destination: 0.0.0.0/0
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+    - destination: 1.1.1.0/24
+      next-hop-address: 192.168.100.1
+      next-hop-interface: eth1
+      table-id: 254
+interfaces:
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:00:5E:00:00:01
+    ipv4:
+      address:
+        - ip: 10.244.0.1
+          prefix-length: 24
+        - ip: 169.254.1.0
+          prefix-length: 16
+      dhcp: false
+      enabled: true

--- a/examples/policy/unsorted_capture/expected.yml
+++ b/examples/policy/unsorted_capture/expected.yml
@@ -1,0 +1,7 @@
+---
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-interface: eth1
+      next-hop-address: 192.168.100.1
+      table-id: 254

--- a/examples/policy/unsorted_capture/policy.yml
+++ b/examples/policy/unsorted_capture/policy.yml
@@ -1,0 +1,36 @@
+---
+capture:
+  cap10: >-
+    routes.running.destination==
+    capture.cap9.routes.running.0.destination
+  cap9: >-
+    routes.running.destination==
+    capture.cap8.routes.running.0.destination
+  cap8: >-
+    routes.running.destination==
+    capture.cap7.routes.running.0.destination
+  cap7: >-
+    routes.running.destination==
+    capture.cap6.routes.running.0.destination
+  cap6: >-
+    routes.running.destination==
+    capture.cap5.routes.running.0.destination
+  cap5: >-
+    routes.running.destination==
+    capture.cap4.routes.running.0.destination
+  cap4: >-
+    routes.running.destination==
+    capture.cap3.routes.running.0.destination
+  cap3: >-
+    routes.running.destination==
+    capture.cap2.routes.running.0.destination
+  cap2: >-
+    routes.running.destination==
+    capture.cap1.routes.running.0.destination
+  cap0: routes.running.destination=="0.0.0.0/0"
+  cap1: >-
+    routes.running.destination==
+    capture.cap0.routes.running.0.destination
+desiredState:
+  routes:
+    config: "{{ capture.cap10.routes.running }}"


### PR DESCRIPTION
When child capture been placed before parent capture, nmstate will
complain about capture not found. Like this YAML:

```yml
child: interfaces.name==capture.child.routes.running.0.next-hop-interface
parent: routes.running.next-hop-interface=="eth1"
```

This patch will sort above YAML by placing capture after its parent capture
like:

```yml
parent: routes.running.next-hop-interface=="eth1"
child: interfaces.name==capture.child.routes.running.0.next-hop-interface
```

Implementation detail:
 * Each run of `set_capture_priority()`,
   `NetworkCaptureCommand::capture_priority` will be set to its parent's
   `capture_priority`. For standalone, set to 1. For parent not holding
   `capture_priority`, do nothing and wait next round by return
   false(indicate not finished).
 * Nmstate will run the `set_capture_priority()` up to 10 times allowing
   10 captures in any order.

Changed example policy `bridge-on-default-gw-no-dhcp` to unsorted
captures, the unit test case `test_policy_examples` will use it to test
this patch.