### PR TITLE
async: Use tokio::time::sleep in stead of std::thread::sleep

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -99,6 +99,7 @@ where
     );
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
+        .enable_time()
         .build()
         .map_err(|e| {
             CliError::from(format!("tokio::runtime::Builder failed with {e}"))

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -35,7 +35,7 @@ use crate::{
 // There is plan to simply the `add_net_state`, `chg_net_state`, `del_net_state`
 // `cur_net_state`, `des_net_state` into single struct. Suppress the clippy
 // warning for now
-pub(crate) fn nm_apply(
+pub(crate) async fn nm_apply(
     merged_state: &MergedNetworkState,
     checkpoint: &str,
     timeout: u32,
@@ -178,7 +178,7 @@ pub(crate) fn nm_apply(
         )?;
     }
 
-    activate_nm_profiles(&mut nm_api, nm_conns_to_activate.as_slice())?;
+    activate_nm_profiles(&mut nm_api, nm_conns_to_activate.as_slice()).await?;
 
     deactivate_nm_profiles(&mut nm_api, nm_conns_to_deactivate.as_slice())?;
 

--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -115,8 +115,8 @@ pub(crate) fn save_nm_profiles(
     Ok(())
 }
 
-pub(crate) fn activate_nm_profiles(
-    nm_api: &mut NmApi,
+pub(crate) async fn activate_nm_profiles(
+    nm_api: &mut NmApi<'_>,
     nm_conns: &[NmConnection],
 ) -> Result<(), NmstateError> {
     let mut nm_conns = nm_conns.to_vec();
@@ -150,7 +150,7 @@ pub(crate) fn activate_nm_profiles(
                 nm_api
                     .extend_timeout_if_required()
                     .map_err(nm_error_to_nmstate)?;
-                std::thread::sleep(std::time::Duration::from_secs(1));
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
         } else {
             break;


### PR DESCRIPTION
The `std::thread::sleep()` is blocking the thread which prevent the
handling of `Control+C` signal in CLI.

Changing to async sleep `tokio::time::sleep()` will fix it.

We still have blocking sleep `nm_dbus` code, cannot change it yet as we
are using the blocking method of DBUS, need to migrate from zbus 1.x to
2.x+ for async support there.

It is hard to have auto test case evaluation `Control+C` got instant
feedback or not. Hence no test case, manually tested.