### PR TITLE
packaging: Generate vendor tarbal for Rust 1.66 also

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
             sudo apt-get install -y fdupes
             fdupes -d -N tests/integration/.states/
           fi
-      
+
       - uses: actions/upload-artifact@v4
         with:
           name: nmstate-test-apply-show-dump-artifact-${{ matrix.job_type }}
@@ -209,7 +209,7 @@ jobs:
     - name: Use rust vendoring
       run: |
         cd rust
-        wget -qO- https://github.com/nmstate/nmstate/releases/download/v2.2.33/nmstate-vendor-2.2.33.tar.xz | tar xJ
+        wget -qO- https://github.com/nmstate/nmstate/releases/download/v2.2.36/nmstate-vendor-2.2.36-rust-1.66.tar.xz | tar xJ
         mkdir .cargo
         echo '[source.crates-io]' > .cargo/config.toml
         echo 'replace-with = "vendored-sources"' >> .cargo/config.toml

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ COMMIT_COUNT=$(shell git rev-list --count HEAD --)
 ifeq ($(RELEASE), 1)
     TARBALL=nmstate-$(VERSION).tar.gz
     VENDOR_TARBALL=nmstate-vendor-$(VERSION).tar.xz
+    VENDOR_TARBALL_RUST_1_66=nmstate-vendor-$(VERSION)-rust-1-66.tar.xz
 else
     TARBALL=nmstate-$(VERSION)-alpha-0.$(TIMESTAMP).$(COMMIT_COUNT)git$(GIT_COMMIT).tar.gz
     VENDOR_TARBALL=nmstate-vendor-$(VERSION)-alpha-0.$(TIMESTAMP).$(COMMIT_COUNT)git$(GIT_COMMIT).tar.xz
@@ -141,6 +142,14 @@ dist: manpage $(SPEC_FILE) $(CLIB_HEADER)
 		 echo -e "'cargo install cargo-vendor-filterer'\n";); \
 		cd $(TMPDIR); \
 		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL) vendor ; \
+		rm -rf $(TMPDIR)/vendor/mio*; \
+		rm -rf $(TMPDIR)/vendor/tokio*; \
+		cd $(TMPDIR)/vendor; \
+		$(ROOT_DIR)/packaging/download_rust_crate.py mio 0.8.9; \
+		$(ROOT_DIR)/packaging/download_rust_crate.py tokio 1.38.1; \
+		$(ROOT_DIR)/packaging/download_rust_crate.py tokio-macros 2.3.0; \
+		cd $(TMPDIR); \
+		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL_RUST_1_66) vendor ; \
 	else \
 		cd rust; \
 		cargo vendor $(TMPDIR)/vendor; \
@@ -148,13 +157,12 @@ dist: manpage $(SPEC_FILE) $(CLIB_HEADER)
 		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL) vendor ; \
 	fi
 	rm -rf $(TMPDIR)
-	if [ $(RELEASE) == 1 ];then \
-		gpg2 --armor --detach-sign $(TARBALL); \
-	fi
 	echo $(TARBALL)
 
 release: dist
-	gpg2 --armor --detach-sign $(TARBALL);
+	if [ $(RELEASE) == 1 ];then \
+		gpg2 --armor --detach-sign $(TARBALL); \
+	fi
 
 upstream_release:
 	$(ROOT_DIR)/automation/upstream_release.sh

--- a/packaging/download_rust_crate.py
+++ b/packaging/download_rust_crate.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+# Steel from https://users.rust-lang.org/t/manually-vendoring-dependencies-work-around-cargo-vendor-bug/65540
+# No idea which license it is
+
+import os
+import ssl
+import subprocess
+import sys
+import urllib.request
+
+
+def sha256sum(path):
+    output = subprocess.run(["sha256sum", path], capture_output=True).stdout
+    print(path + " output: " + str(output))
+    return output.split()[0]
+
+
+package_name = sys.argv[1]
+package_version = sys.argv[2]
+
+package_url = (
+    f"https://crates.io/api/v1/crates/{package_name}/"
+    f"{package_version}/download"
+)
+package_file_name = f"{package_name}-{package_version}.gz"
+
+print(f'Vendoring package "{package_name}" version = "{package_version}"')
+print(f"Package URL: {package_url}")
+
+urllib.request.urlretrieve(package_url, package_file_name)
+
+print(f"Done downloading package: {package_file_name}")
+
+package_checksum = sha256sum(package_file_name)
+
+print(f"Package checksum: {package_checksum}")
+
+subprocess.run(["tar", "-xvf", package_file_name])
+
+package_dir_path = f"{package_name}-{package_version}"
+
+checksum_json_file_path = f"{package_dir_path}/.cargo-checksum.json"
+
+print(f'Creating file "{checksum_json_file_path}"')
+
+with open(checksum_json_file_path, "w") as cargo_checksum:
+    cargo_checksum.write('{"files":{},"package":"{%s}"}' % package_checksum)
+
+os.unlink(package_file_name)

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -301,7 +301,7 @@ def test_static_hostname_for_examples():
 )
 def test_add_ipvlan_and_remove_example(eth1_up):
     with example_state(
-        "ipvlan0_create.yml", cleanup="ipvlan0_absent.yml"
+        "ipvlan_create.yml", cleanup="ipvlan_absent.yml"
     ) as desired_state:
         assertlib.assert_state(desired_state)
 


### PR DESCRIPTION
The `RELEASE=1 make release` will generate rust vendor tarball for Rust
1.66 also now using:

 * mio 0.8.9 (because mio 1.0.2 need new version of rust)
 * tokio 1.38.1 (last version of tokio using mio 0.8)
 * tokio-macros 2.3.0 (required by tokio 1.38.1)

The `packaging/download_rust_crate.py` is used by `make` command to
download specific crate and generate hash like `cargo vendor` did.