### PR TITLE
gh: Add option to upload hidden files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,6 +186,7 @@ jobs:
           name: nmstate-test-apply-show-dump-artifact-${{ matrix.job_type }}
           path: tests/integration/.states/*
           retention-days: 5
+          include-hidden-files: true
 
       - name: Set artifacts permissions
         if: ${{ failure() }}


### PR DESCRIPTION
As of latest upload github action by default is not uploading hidden files [1]. This change configures the flag to do so, so the .states are uploades.

[1] https://github.com/actions/upload-artifact/releases/tag/v4.4.0

We are going to need to regenerate assets from versions > 2.2.33