### PR TITLE
rust: Depend on nispor 1.2.21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,10 @@ jobs:
       run: cd rust && cargo test -- --show-output
 
     - name: C library test
+      # As https://github.com/tokio-rs/tokio/issues/6889 mentioned
+      # rust nightly might lead to valgrind warnings, this project
+      # has no intention to spend time on testing rust nightly for memory leak.
+      if: matrix.rust_version == 'stable'
       run: make clib_check
 
   rpm_build:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,7 +12,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "1.2"
+nispor = "1.2.21"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.26.2", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "1.9.2", default-features = false}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -23,7 +23,7 @@ env_logger = "0.10.0"
 clap = { version = "3.1", features = ["cargo"] }
 chrono = "0.4"
 toml = "0.8.10"
-tokio = { version = "1.30", features = ["rt", "net"] }
+tokio = { version = "1.30", features = ["rt", "net", "time"] }
 
 [workspace.metadata.vendor-filter]
 # For now we only care about tier 1+2 Linux

--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -67,7 +67,7 @@ where
 {
     struct IntegerOrString(PhantomData<fn() -> Option<bool>>);
 
-    impl<'de> Visitor<'de> for IntegerOrString {
+    impl Visitor<'_> for IntegerOrString {
         type Value = Option<bool>;
 
         fn expecting(
@@ -179,7 +179,7 @@ where
 {
     struct IntegerOrString(PhantomData<fn() -> Option<u64>>);
 
-    impl<'de> Visitor<'de> for IntegerOrString {
+    impl Visitor<'_> for IntegerOrString {
         type Value = Option<u64>;
 
         fn expecting(
@@ -241,7 +241,7 @@ where
 {
     struct IntegerOrString(PhantomData<fn() -> Option<i64>>);
 
-    impl<'de> Visitor<'de> for IntegerOrString {
+    impl Visitor<'_> for IntegerOrString {
         type Value = Option<i64>;
 
         fn expecting(

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -781,7 +781,7 @@ where
         PhantomData<fn() -> Option<LinuxBridgeMulticastRouterType>>,
     );
 
-    impl<'de> Visitor<'de> for IntegerOrString {
+    impl Visitor<'_> for IntegerOrString {
         type Value = Option<LinuxBridgeMulticastRouterType>;
 
         fn expecting(

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -45,7 +45,7 @@ pub(crate) struct NmDbus<'a> {
     dns_proxy: NetworkManagerDnsProxy<'a>,
 }
 
-impl<'a> NmDbus<'a> {
+impl NmDbus<'_> {
     pub(crate) fn new() -> Result<Self, NmError> {
         let connection = zbus::Connection::new_system()?;
         let proxy = NetworkManagerProxy::new(&connection)?;

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -29,7 +29,7 @@ pub struct NmApi<'a> {
     auto_cp_refresh: bool,
 }
 
-impl<'a> NmApi<'a> {
+impl NmApi<'_> {
     pub fn new() -> Result<Self, NmError> {
         Ok(Self {
             dbus: NmDbus::new()?,


### PR DESCRIPTION
Since we are depending on IP VLAN support of nispor, we should place
minimum version 1.2.21 in our Cargo.toml for nispor.