### PR TITLE
nm: Preserve current IP setting for multiconnect profile

### DIFF
--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -676,3 +676,39 @@ def test_change_profile_name(eth1_up):
         ].strip()
         == "eth1-new"
     )
+
+
+@pytest.fixture
+def multiconnect_profile_with_ip_enabled(eth1_up):
+    cmdlib.exec_cmd("nmcli c del eth1".split(), check=True)
+    cmdlib.exec_cmd(
+        "nmcli c add type ethernet connection.id nmstate-test-default "
+        "connection.multi-connect multiple "
+        "ipv4.method auto ipv6.method auto".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd("nmcli c del nmstate-test-default".split(), check=False)
+
+
+def test_preserve_ip_settings_from_multiconnect(
+    multiconnect_profile_with_ip_enabled,
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assert (
+        cmdlib.exec_cmd("nmcli -g ipv4.method c show eth1".split())[1].strip()
+        == "auto"
+    )
+    assert (
+        cmdlib.exec_cmd("nmcli -g ipv6.method c show eth1".split())[1].strip()
+        == "auto"
+    )


### PR DESCRIPTION
Given a interface is activated by a NM profile of multiconnect
When applying empty state for this interface,
Then this interface will get IPv4 and IPv6 disabled.

This is because current nmstate code treat multiconnect or NM connection
without interface name as not matched, hence `exist_nm_conn` is set to
None which lead to nmstate discarding current IP settings.

Cloning multiconnect profiles could have risk when NM added more
properties impacting activation but nmstate not aware.

Hence we create NM connection from scratch in this case by only
preserving IP settings from multiconnect. Other non-ip settings applied
by multiconnect profile will be discard if not mentioned in desired
state.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-61890