### PR TITLE
packaging: add alternative basic deps with low prio for c10s

### DIFF
--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -1,6 +1,16 @@
 FROM quay.io/centos/centos:stream10-development
 
-RUN echo "2024-06-26" > /build_time
+RUN echo "2024-10-17" > /build_time
+
+# Add alter-baseos and alter-appstream repositories with lower priority
+COPY c10s-alter-baseos.repo \
+     /etc/yum.repos.d/c10s-alter-baseos.repo
+COPY c10s-alter-appstream.repo \
+     /etc/yum.repos.d/c10s-alter-appstream.repo
+
+RUN grep -q "^skip_if_unavailable=" /etc/dnf/dnf.conf && \
+    sed -i 's/^skip_if_unavailable=.*/skip_if_unavailable=True/' /etc/dnf/dnf.conf || \
+    echo "skip_if_unavailable=True" >> /etc/dnf/dnf.conf
 
 RUN dnf update -y && \
     dnf -y install dnf-plugins-core  && \

--- a/packaging/c10s-alter-appstream.repo
+++ b/packaging/c10s-alter-appstream.repo
@@ -1,0 +1,7 @@
+[10-stream-alter-appstream]
+name=CentOS Stream 10 - Alter AppStream
+baseurl=https://mirror.stream.centos.org/10-stream/AppStream/$basearch/os/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+enabled=1
+gpgcheck=1
+priority=1000

--- a/packaging/c10s-alter-baseos.repo
+++ b/packaging/c10s-alter-baseos.repo
@@ -1,0 +1,7 @@
+[10-stream-alter-baseos]
+name=CentOS Stream 10 - Alter BaseOS
+baseurl=https://mirror.stream.centos.org/10-stream/BaseOS/$basearch/os/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+enabled=1
+gpgcheck=1
+priority=1000


### PR DESCRIPTION
Add alternative baseurl repos as we see some issues lately with mirrorlink-based repos even on c10s. This should workaround it together with skip_if_unavailable=True. If all repos are OK, this is doing nothing. These were added for c9s but we need those for c10s, too.