### PR TITLE
apply: Support overriding interface configuration without merging

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -9,19 +9,47 @@ nmstate\&.service
 nmstate\&.service invokes \fBnmstatectl service\fR command which
 apply all network state files ending with \fB.yml\fR in
 \fB/etc/nmstate\fR folder.
+
+.PP
 By default, the network state file will be renamed with the suffix
 \fB.applied\fR after applying it. This is to prevent it being applied again
 when the service runs next.
 
 With \fB/etc/nmstate/nmstate.conf\fR holding below content:
 
+.EX
 \fB
-[service]
+[service]\n
 keep_state_file_after_apply = true
 \fR
+.EE
 
 The nmstate.service will not remove network state file, just copy applied
 network stata to file with the suffix \fB.applied\fR after applying it.
+
+.PP
+By default, nmstate merge network state file with current network state,
+if you want to override interface settings without merging, please set
+`override_iface = true` in `[service]` section in
+\fB/etc/nmstate/nmstate.conf\fR:
+
+.EX
+\fB
+[service]\n
+override_iface = true
+\fR
+.EE
+
+If `override_iface = true`, for network state to apply, nmstate.service will:
+
+ * For `interfaces` section, any defined interface will be configured by
+   desired state information only, undefined properties of this interface will
+   use default value instead of merging from current state.
+
+ * For other sections, no changes to their original behavior.
+
+For example, if desired interface has no IPv4 section defined, nmstate
+will treat it as disabled regardless current network status.
 
 .SH BUG REPORTS
 Report bugs on nmstate GitHub issues <https://github.com/nmstate/nmstate>.

--- a/doc/nmstatectl.8.in
+++ b/doc/nmstatectl.8.in
@@ -166,6 +166,18 @@ rebooting.
 .IP \fB--timeout\fR=<\fITIMEOUT\fR>
 the user must commit the changes within \fItimeout\fR, or they will be
 automatically rolled back. Default: 60 seconds.
+.IP \fB--override-iface\fR
+If defined when applying network state:
+
+ * For `interfaces` section, any defined interface will be configured by
+   desired state information only, undefined properties of this interface will
+   use default value instead of merging from current state.
+
+ * For other sections, no changes to their original behavior.
+
+For example, if desired interface has no IPv4 section defined, nmstate
+will treat it as disabled regardless current network status.
+
 .IP \fB--version
 displays nmstate version.
 .SH LIMITATIONS

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -38,6 +38,9 @@ where
     let kernel_only = matches.try_contains_id("KERNEL").unwrap_or_default();
     let no_verify = matches.try_contains_id("NO_VERIFY").unwrap_or_default();
     let no_commit = matches.try_contains_id("NO_COMMIT").unwrap_or_default();
+    let override_iface = matches
+        .try_contains_id("OVERRIDE_IFACE")
+        .unwrap_or_default();
     let timeout = if matches.try_contains_id("TIMEOUT").unwrap_or_default() {
         match matches.try_get_one::<String>("TIMEOUT") {
             Ok(Some(t)) => match u32::from_str(t) {
@@ -65,6 +68,7 @@ where
     net_state.set_verify_change(!no_verify);
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
+    net_state.set_override_iface(override_iface);
     net_state.set_memory_only(
         matches.try_contains_id("MEMORY_ONLY").unwrap_or_default(),
     );

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -193,6 +193,15 @@ fn main() {
                         .takes_value(false)
                         .help("Do not make the state persistent"),
                 )
+                .arg(
+                    clap::Arg::new("OVERRIDE_IFACE")
+                        .long("override-iface")
+                        .takes_value(false)
+                        .help(
+                            "Override interface settings \
+                            without merge current network state"
+                        ),
+                )
         )
         .subcommand(
             clap::Command::new(SUB_CMD_GEN_CONF)

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -24,6 +24,8 @@ struct Config {
 struct ServiceConfig {
     #[serde(default)]
     keep_state_file_after_apply: bool,
+    #[serde(default)]
+    override_iface: bool,
 }
 
 #[derive(Eq, Hash, PartialEq, Clone, PartialOrd, Ord)]
@@ -85,7 +87,11 @@ pub(crate) fn ncl_service(
                 continue;
             }
         };
-        let state = state_from_fd(&mut fd)?;
+        let mut state = state_from_fd(&mut fd)?;
+
+        if config.service.override_iface {
+            state.set_override_iface(true);
+        }
 
         match apply_state(&state, false) {
             Ok(_) => {

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::{apply::apply, error::CliError};
+use crate::{apply::apply_state, error::CliError, state::state_from_fd};
 
 const CONFIG_FILE_EXTENTION: &str = "yml";
 const APPLIED_FILE_EXTENTION: &str = "applied";
@@ -85,7 +85,9 @@ pub(crate) fn ncl_service(
                 continue;
             }
         };
-        match apply(&mut fd, matches) {
+        let state = state_from_fd(&mut fd)?;
+
+        match apply_state(&state, false) {
             Ok(_) => {
                 log::info!(
                     "Applied nmstate config: {}",

--- a/rust/src/cli/state.rs
+++ b/rust/src/cli/state.rs
@@ -1,21 +1,73 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use nmstate::NetworkState;
 use std::io::Read;
+
+#[cfg(feature = "query_apply")]
+use nmstate::NetworkPolicy;
+use nmstate::NetworkState;
 
 use crate::error::CliError;
 
 pub(crate) fn state_from_file(
     file_path: &str,
 ) -> Result<NetworkState, CliError> {
-    let mut content = String::new();
     if file_path == "-" {
-        std::io::stdin().read_to_string(&mut content)?;
+        state_from_fd(&mut std::io::stdin())
     } else {
-        std::fs::File::open(file_path)?.read_to_string(&mut content)?;
-    };
+        state_from_fd(&mut std::fs::File::open(file_path)?)
+    }
+}
+
+#[cfg(not(feature = "query_apply"))]
+pub(crate) fn state_from_fd<R>(fd: &mut R) -> Result<NetworkState, CliError>
+where
+    R: Read,
+{
+    let mut content = String::new();
     // Replace non-breaking space '\u{A0}'  to normal space
+    fd.read_to_string(&mut content)?;
     let content = content.replace('\u{A0}', " ");
 
-    Ok(NetworkState::new_from_yaml(&content)?)
+    match serde_yaml::from_str(&content) {
+        Ok(s) => Ok(s),
+        Err(e) => Err(CliError::from(format!(
+            "Provide file is not valid NetworkState: {e}"
+        ))),
+    }
+}
+
+#[cfg(feature = "query_apply")]
+pub(crate) fn state_from_fd<R>(fd: &mut R) -> Result<NetworkState, CliError>
+where
+    R: Read,
+{
+    let mut content = String::new();
+    // Replace non-breaking space '\u{A0}'  to normal space
+    fd.read_to_string(&mut content)?;
+    let content = content.replace('\u{A0}', " ");
+
+    match serde_yaml::from_str(&content) {
+        Ok(s) => Ok(s),
+        Err(state_error) => {
+            // Try NetworkPolicy
+            let net_policy: NetworkPolicy = match serde_yaml::from_str(&content)
+            {
+                Ok(p) => p,
+                Err(policy_error) => {
+                    let e = if content.contains("desiredState")
+                        || content.contains("desired")
+                    {
+                        policy_error
+                    } else {
+                        state_error
+                    };
+                    return Err(CliError::from(format!(
+                        "Provide file is not valid NetworkState or \
+                        NetworkPolicy: {e}"
+                    )));
+                }
+            };
+            Ok(NetworkState::try_from(net_policy)?)
+        }
+    }
 }

--- a/rust/src/clib/apply.rs
+++ b/rust/src/clib/apply.rs
@@ -15,6 +15,8 @@ use crate::{
     NMSTATE_FAIL, NMSTATE_PASS,
 };
 
+const NMSTATE_FLAG_OVERRIDE_IFACE: u32 = 1 << 9;
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn nmstate_net_state_apply(
@@ -73,6 +75,10 @@ pub extern "C" fn nmstate_net_state_apply(
 
     if (flags & NMSTATE_FLAG_MEMORY_ONLY) > 0 {
         net_state.set_memory_only(true);
+    }
+
+    if (flags & NMSTATE_FLAG_OVERRIDE_IFACE) > 0 {
+        net_state.set_override_iface(true);
     }
 
     net_state.set_timeout(rollback_timeout);

--- a/rust/src/clib/nmstate.h.in
+++ b/rust/src/clib/nmstate.h.in
@@ -30,6 +30,7 @@ extern "C" {
 #define NMSTATE_FLAG_MEMORY_ONLY            1 << 6
 #define NMSTATE_FLAG_RUNNING_CONFIG_ONLY    1 << 7
 #define NMSTATE_FLAG_YAML_OUTPUT            1 << 8
+#define NMSTATE_FLAG_OVERRIDE_IFACE         1 << 9
 
 /**
  * nmstate_net_state_retrieve - Retrieve network state
@@ -97,6 +98,8 @@ int nmstate_net_state_retrieve(uint32_t flags, char **state, char **log,
  *              Do not commit new state after verification
  *          * NMSTATE_FLAG_MEMORY_ONLY
  *              No not store network state to persistent.
+ *          * NMSTATE_FLAG_OVERRIDE_IFACE
+ *              Override interface configuration without merging from current.
  * @state:
  *      Pointer of char array for network state in json format.
  * @log:

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -604,6 +604,15 @@ impl Interfaces {
         }
         Ok(())
     }
+
+    pub(crate) fn clone_name_type_only(&self) -> Self {
+        let mut ret = Self::new();
+
+        for iface in self.to_vec() {
+            ret.push(iface.clone_name_type_only())
+        }
+        ret
+    }
 }
 
 fn is_opt_str_empty(opt_string: &Option<String>) -> bool {

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -49,7 +49,9 @@ pub(crate) fn iface_to_nm_connections(
         return Ok(ret);
     };
 
-    let exist_nm_conn = if iface.base_iface().identifier
+    let exist_nm_conn = if merged_state.override_iface {
+        None
+    } else if iface.base_iface().identifier
         == Some(InterfaceIdentifier::MacAddress)
     {
         get_exist_profile_by_profile_name(

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -181,6 +181,7 @@ impl NetworkState {
             for pf_iface in pf_ifaces {
                 pf_state.interfaces.push(pf_iface);
             }
+            pf_state.set_override_iface(self.override_iface);
             Some(pf_state)
         }
     }

--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -40,6 +40,7 @@ NMSTATE_FLAG_INCLUDE_SECRETS = 1 << 4
 NMSTATE_FLAG_NO_COMMIT = 1 << 5
 NMSTATE_FLAG_MEMORY_ONLY = 1 << 6
 NMSTATE_FLAG_RUNNING_CONFIG_ONLY = 1 << 7
+NMSTATE_FLAG_OVERRIDE_IFACE = 1 << 9
 NMSTATE_PASS = 0
 
 
@@ -91,6 +92,7 @@ def apply_net_state(
     verify_change=True,
     save_to_disk=True,
     commit=True,
+    override_iface=False,
     rollback_timeout=60,
 ):
     c_err_msg = c_char_p()
@@ -109,6 +111,9 @@ def apply_net_state(
 
     if not save_to_disk:
         flags |= NMSTATE_FLAG_MEMORY_ONLY
+
+    if override_iface:
+        flags |= NMSTATE_FLAG_OVERRIDE_IFACE
 
     rc = lib.nmstate_net_state_apply(
         flags,

--- a/rust/src/python/libnmstate/netapplier.py
+++ b/rust/src/python/libnmstate/netapplier.py
@@ -27,6 +27,7 @@ def apply(
     save_to_disk=True,
     commit=True,
     rollback_timeout=60,
+    override_iface=False,
 ):
     return apply_net_state(
         desired_state,
@@ -35,6 +36,7 @@ def apply(
         save_to_disk=save_to_disk,
         commit=commit,
         rollback_timeout=rollback_timeout,
+        override_iface=override_iface,
     )
 
 


### PR DESCRIPTION
When using `nmstatectl gc`, unmentioned IP section means disabled, but
in `nmstatectl service` or `nmstatectl apply`, unmentioned IP means
merging from current. In order to be consistent when migrating from
`nmstatectl gc` to `nmstatectl service`, we need to introduce a option
to skip merging IP.

We also have user request us to not merging existing route by only
apply route found in desired state.

So we introduce option to skip merging current state:

 * Rust: `NetworkState.set_override_iface(true)`
 * Python: `libnmstate.apply(state, override_iface=True)`
 * C: `nmstate_net_state_apply()` with `NMSTATE_FLAG_OVERRIDE_IFACE` flag.
 * CLI: `nmstatectl apply --override-iface <state_file>`
 * nmstate.service: `/etc/nmstate/nmstate.conf` with:

    ```toml
    [service]
    override_iface = true
    ```

When in `override_iface` mode, nmstate will:

 * For `interfaces` section, any defined interface will be configured by
   desire state information only.
 * Other sections will ignore this `override_iface` mode and still
   merging as it was.

Technical detail:
 * When `override_iface: true`, we purge current network to only keep
   interface name and type before merging it with desire state.
 * When `override_iface: true`, we do not re-use existing NetworkManager
   connection.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-59935