### PR TITLE
Avoid some unnecessary deactivations due to routes mismatches

### DIFF
--- a/rust/src/lib/nm/query_apply/route.rs
+++ b/rust/src/lib/nm/query_apply/route.rs
@@ -1,50 +1,69 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::{NmConnection, NmIpRoute};
+use super::super::nm_dbus::{NmConnection, NmIpRoute, NmSettingIp};
 
-const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
+const NM_IP_SETTING_ROUTE_TABLE_DEFAULT: u32 = 0;
+const NM_IP_SETTING_ROUTE_METRIC_DEFAULT: i64 = -1;
+const IPV6_METRIC_COHERCED_DEFAULT: u32 = 1024; // Coherced by kernel 0->1024
 
 pub(crate) fn is_route_removed(
     new_nm_conn: &NmConnection,
     cur_nm_conn: &NmConnection,
 ) -> bool {
-    is_nm_ip_route_removed(
-        new_nm_conn
-            .ipv4
-            .as_ref()
-            .map(|ip| ip.routes.as_slice())
-            .unwrap_or(&[]),
-        cur_nm_conn
-            .ipv4
-            .as_ref()
-            .map(|ip| ip.routes.as_slice())
-            .unwrap_or(&[]),
-    ) || is_nm_ip_route_removed(
-        new_nm_conn
-            .ipv6
-            .as_ref()
-            .map(|ip| ip.routes.as_slice())
-            .unwrap_or(&[]),
-        cur_nm_conn
-            .ipv6
-            .as_ref()
-            .map(|ip| ip.routes.as_slice())
-            .unwrap_or(&[]),
+    nm_setting_is_route_removed(
+        new_nm_conn.ipv4.as_ref(),
+        cur_nm_conn.ipv4.as_ref(),
+        false,
+    ) || nm_setting_is_route_removed(
+        new_nm_conn.ipv6.as_ref(),
+        cur_nm_conn.ipv6.as_ref(),
+        true,
     )
 }
 
-fn is_nm_ip_route_removed(
-    new_routes: &[NmIpRoute],
-    cur_routes: &[NmIpRoute],
+fn nm_setting_is_route_removed(
+    new_nm_sett: Option<&NmSettingIp>,
+    cur_nm_sett: Option<&NmSettingIp>,
+    is_ipv6: bool,
 ) -> bool {
-    for cur_route in cur_routes {
-        let mut cur_route_norm = cur_route.clone();
-        if cur_route_norm.table.is_none() {
-            cur_route_norm.table = Some(DEFAULT_TABLE_ID);
-        }
-        if !new_routes.contains(&cur_route_norm) {
-            return true;
-        }
+    let new_routes = clone_normalized_routes(new_nm_sett, is_ipv6);
+    let cur_routes = clone_normalized_routes(cur_nm_sett, is_ipv6);
+    cur_routes
+        .iter()
+        .any(|cur_route| !new_routes.contains(cur_route))
+}
+
+fn clone_normalized_routes(
+    ip_sett: Option<&NmSettingIp>,
+    is_ipv6: bool,
+) -> Vec<NmIpRoute> {
+    // Routes defined by nmstate will always has table and metric set, so there
+    // is no problem comparing them.
+    // On routes defined in NM directly, they may depend on the route-metric and
+    // route-table properties of the ipv4 and ipv6 settings. Use them to get the
+    // actual values.
+    // They may even fall back to a globally default value. In that case we can
+    // not know what value is. Use None to fail the comparison so we can
+    // properly install the new desired route, with table and metric defined.
+    let default_table = ip_sett
+        .and_then(|ip| ip.route_table)
+        .filter(|tbl| *tbl != NM_IP_SETTING_ROUTE_TABLE_DEFAULT);
+    let mut default_metric = ip_sett
+        .and_then(|ip| ip.route_metric)
+        .filter(|mtr| *mtr != NM_IP_SETTING_ROUTE_METRIC_DEFAULT)
+        .map(|mtr| mtr as u32);
+    if is_ipv6 && default_metric == Some(0) {
+        default_metric = Some(IPV6_METRIC_COHERCED_DEFAULT);
     }
-    false
+
+    let routes = ip_sett.map(|ip| ip.routes.as_slice()).unwrap_or(&[]);
+    routes
+        .iter()
+        .map(|rt| {
+            let mut new_rt = rt.clone();
+            new_rt.table = rt.table.or(default_table);
+            new_rt.metric = rt.metric.or(default_metric);
+            new_rt
+        })
+        .collect()
 }

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2211,15 +2211,11 @@ def test_apply_routes_twice_only_reapplies(dummy0_up):
             Route.NEXT_HOP_INTERFACE: "dummy0",
             Route.DESTINATION: IPV4_TEST_NET1,
             Route.NEXT_HOP_ADDRESS: IPV4_EMPTY_ADDRESS,
-            Route.METRIC: 100,
-            Route.TABLE_ID: 254,
         },
         {
             Route.NEXT_HOP_INTERFACE: "dummy0",
             Route.DESTINATION: IPV6_TEST_NET1,
             Route.NEXT_HOP_ADDRESS: IPV6_EMPTY_ADDRESS,
-            Route.METRIC: 100,
-            Route.TABLE_ID: 254,
         },
     ]
     state = {
@@ -2228,8 +2224,8 @@ def test_apply_routes_twice_only_reapplies(dummy0_up):
     }
     libnmstate.apply(state)
 
-    # Apply a second time to test that empty next-hop is treated
-    # correctly. Per issue RHEL-64707, the next-hop didn't match between the
+    # Apply a second time to test that empty next-hop, metric and table are
+    # treated correctly. Per issue RHEL-64707, they didn't match between the
     # nmstate generated routes and those retrieved from NM, causing nmstate to
     # incorrectly think that there were routes to remove.
     # This caused deactivate & activate instead of reapply.

--- a/tests/integration/testlib/dummy.py
+++ b/tests/integration/testlib/dummy.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
 
 from . import cmdlib
 
@@ -32,3 +33,30 @@ def nm_unmanaged_dummy(name):
         except Exception:
             # dummy1 might not became managed by NM, hence removal might fail
             cmdlib.exec_cmd(f"ip link del {name}".split())
+
+
+@contextmanager
+def dummy_interface(ifname):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: ifname,
+                Interface.TYPE: InterfaceType.DUMMY,
+                Interface.STATE: InterfaceState.UP,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    try:
+        yield desired_state
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: ifname,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            }
+        )


### PR DESCRIPTION
When comparing the routes with those already added to NM, sometimes
nmstate considered different routes that were actually equal.
- route1 with table=None vs route2 with table=Some(254)
- route1 with next-hop=None vs route2 with next-hop=Some(0.0.0.0)
- route1 is ipv6 with metric=0, route2 is ipv6 with metric=1024 (see explanation below).

The consequence was that unnecessary deactivate/reactivate were done,
instead of reapply. This was because is_route_removed was returning true
with some of the situations described above. This caused that
gen_nm_conn_need_to_deactivate_first also returned true and the
connection was deactivated.

For next-hop, fix it by normalizing to None at creation time, since 0.0.0.0 and ::
are not used by NM nor by the kernel, they just leave it undefined.

For table, fix it by normalizing to Some(254) because we need to always set
the table for a different reason: if the user doesn't define the table in the
desired state we are supposed to save it to the 254 main table. If we left
table empty, it might happen that a different table is used if auto-route-table-id
is also used.

For IPv6 routes metric is also included. When setting metric=0 on a kernel's IPv6 route,
kernel coherces it to 1024. This make that, when reading back the route from kernel
it doesn't match with the expected value of 0. The fix normalizes 0->1024 for IPv6
routes so the comparison doesn't fail.

Additionally, when comparing NmIpRoutes, this PR add code to handle it correctly
for every possible NMConnection. If the route's table is undefined, it falls back to
ipv4/6.route-table, as this is what NM does. Note that for routes defined by
nmstate this won't happen because, since this PR, we always define the table; but
it will handle better the case of already existing NMConnections. The same for the
metric with route-metric.

Note that this only affects NM specific code, not the RouteEntry
entities from the top level nmstate.

Resolves: https://issues.redhat.com/browse/RHEL-65004