### PR TITLE
DO NOT MERGE: nm: Fix incorrect pre-deactivation on route changes

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -24,8 +24,6 @@ const SUPPORTED_STATIC_ROUTE_PROTOCOL: [nispor::RouteProtocol; 2] =
 
 const IPV4_DEFAULT_GATEWAY: &str = "0.0.0.0/0";
 const IPV6_DEFAULT_GATEWAY: &str = "::/0";
-const IPV4_EMPTY_NEXT_HOP_ADDRESS: &str = "0.0.0.0";
-const IPV6_EMPTY_NEXT_HOP_ADDRESS: &str = "::";
 
 // kernel values
 const RTAX_CWND: u32 = 7;
@@ -174,24 +172,8 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
 
     let next_hop_addr = if let Some(via) = &np_route.via {
         Some(via.to_string())
-    } else if let Some(gateway) = &np_route.gateway {
-        Some(gateway.to_string())
     } else {
-        match np_route.address_family {
-            nispor::AddressFamily::IPv4 => {
-                Some(IPV4_EMPTY_NEXT_HOP_ADDRESS.to_string())
-            }
-            nispor::AddressFamily::IPv6 => {
-                Some(IPV6_EMPTY_NEXT_HOP_ADDRESS.to_string())
-            }
-            _ => {
-                warn!(
-                    "Route {:?} is holding unknown IP family {:?}",
-                    np_route, np_route.address_family
-                );
-                None
-            }
-        }
+        np_route.gateway.as_ref().map(|gateway| gateway.to_string())
     };
 
     let source = np_route.prefered_src.as_ref().map(|src| src.to_string());

--- a/rust/src/lib/nm/query_apply/route.rs
+++ b/rust/src/lib/nm/query_apply/route.rs
@@ -1,8 +1,70 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{RouteEntry, RouteType};
+
 use super::super::nm_dbus::{NmConnection, NmIpRoute};
 
 const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
+const NM_EMPTY_NEXT_HOP_ADDRV4: &str = "0.0.0.0";
+const NM_EMPTY_NEXT_HOP_ADDRV6: &str = "::";
+const NM_DEFAULT_IPV4_METRIC: u32 = 0;
+
+// Both `nm_dbus` are supposed to be a standalone crates,
+// `RouteEntry` and `NmIpRoute` are defined outside of `nm` crate,
+// Hence we cannot do `impl From<NmIpRoute> for RouteEntry` here.
+
+fn nm_route_to_route_entry(nm_route: &NmIpRoute) -> RouteEntry {
+    let mut route = RouteEntry {
+        state: None,
+        next_hop_iface: None,
+        destination: nm_route.dest.clone(),
+        next_hop_addr: {
+            if let Some(next_hop) = nm_route.next_hop.as_deref() {
+                if next_hop != NM_EMPTY_NEXT_HOP_ADDRV4
+                    && next_hop != NM_EMPTY_NEXT_HOP_ADDRV6
+                {
+                    Some(next_hop.to_string())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        },
+        metric: nm_route.metric.as_ref().and_then(|metric| {
+            if *metric == NM_DEFAULT_IPV4_METRIC {
+                None
+            } else {
+                Some(*metric as i64)
+            }
+        }),
+        table_id: nm_route.table.or(Some(DEFAULT_TABLE_ID)),
+        weight: nm_route.weight.and_then(|weight| {
+            if weight == NM_DEFAULT_IPV4_METRIC {
+                None
+            } else {
+                Some(weight as u16)
+            }
+        }),
+        route_type: match nm_route.route_type.as_deref() {
+            Some(t) if t == RouteType::Blackhole.to_string().as_str() => {
+                Some(RouteType::Blackhole)
+            }
+            Some(t) if t == RouteType::Unreachable.to_string().as_str() => {
+                Some(RouteType::Unreachable)
+            }
+            Some(t) if t == RouteType::Prohibit.to_string().as_str() => {
+                Some(RouteType::Unreachable)
+            }
+            _ => None,
+        },
+        cwnd: nm_route.cwnd,
+        source: nm_route.src.clone(),
+    };
+
+    route.sanitize().ok();
+    route
+}
 
 pub(crate) fn is_route_removed(
     new_nm_conn: &NmConnection,
@@ -37,12 +99,16 @@ fn is_nm_ip_route_removed(
     new_routes: &[NmIpRoute],
     cur_routes: &[NmIpRoute],
 ) -> bool {
-    for cur_route in cur_routes {
-        let mut cur_route_norm = cur_route.clone();
-        if cur_route_norm.table.is_none() {
-            cur_route_norm.table = Some(DEFAULT_TABLE_ID);
-        }
-        if !new_routes.contains(&cur_route_norm) {
+    let desired_routes: Vec<RouteEntry> =
+        new_routes.iter().map(nm_route_to_route_entry).collect();
+    let current_routes: Vec<RouteEntry> =
+        cur_routes.iter().map(nm_route_to_route_entry).collect();
+
+    for current_route in current_routes.as_slice() {
+        if !desired_routes
+            .iter()
+            .any(|desired_route| desired_route.is_match(current_route))
+        {
             return true;
         }
     }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -321,14 +321,20 @@ impl RouteEntry {
             }
         }
         if let Some(via) = self.next_hop_addr.as_ref() {
-            let new_via = format!("{}", via.parse::<std::net::IpAddr>()?);
-            if via != &new_via {
-                log::warn!(
-                    "Route next-hop-address {} sanitized to {}",
-                    via,
-                    new_via
-                );
-                self.next_hop_addr = Some(new_via);
+            // Linux kernel is discarding all zero `next_hop_addr`.
+            let via_addr = via.parse::<std::net::IpAddr>()?;
+            if via_addr.is_unspecified() {
+                self.next_hop_addr = None;
+            } else {
+                let new_via = format!("{}", via_addr);
+                if via != &new_via {
+                    log::warn!(
+                        "Route next-hop-address {} sanitized to {}",
+                        via,
+                        new_via
+                    );
+                    self.next_hop_addr = Some(new_via);
+                }
             }
         }
         if let Some(src) = self.source.as_ref() {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -21,6 +21,7 @@ from .testlib import iprule
 from .testlib.bridgelib import linux_bridge
 from .testlib.env import nm_minor_version
 from .testlib.genconf import gen_conf_apply
+from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.route import assert_routes
 from .testlib.route import assert_routes_missing
 from .testlib.servicelib import disable_service
@@ -140,6 +141,11 @@ def test_add_static_route_without_next_hop_address(eth1_up):
         }
     )
     cur_state = libnmstate.show()
+    # Both linux kernel and iproute are discarding all-zero IP address for
+    # `next-hop-address`, hence the nmstate query should not include these
+    # all zero IP address.
+    routes[0].pop(Route.NEXT_HOP_ADDRESS)
+    routes[1].pop(Route.NEXT_HOP_ADDRESS)
     assert_routes(routes, cur_state)
 
 
@@ -2189,3 +2195,55 @@ def test_kernel_mode_static_route_and_remove(cleanup_veth1_kernel_mode):
     assert_routes_missing(
         desired_state[Route.KEY][Route.CONFIG], cur_state, nic="veth1"
     )
+
+
+# https://issues.redhat.com/browse/RHEL-64707
+@pytest.fixture
+@pytest.mark.tier1
+def eth1_route_to_external_next_hop_address(eth1_up):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        routes:
+         config:
+           - destination: 203.0.113.0/24
+             next-hop-address: 198.51.100.1
+             next-hop-interface: veth1
+             state: absent
+           - destination: 203.0.113.0/24
+             next-hop-address: 198.51.100.1
+             next-hop-interface: veth1
+             metric: 109
+        """
+    )
+    libnmstate.apply(desired_state)
+    # applying twice so nmstate persist the direct route
+    # to 198.51.100.1 into config.
+    libnmstate.apply(desired_state)
+    yield desired_state
+
+
+@ip_monitor_assert_stable_link_up("eth1")
+def test_route_link_stable_for_external_next_hop_address(
+    eth1_route_to_external_next_hop_address,
+):
+    state = eth1_route_to_external_next_hop_address
+    libnmstate.apply(state)


### PR DESCRIPTION
With route next-hop-address pointing to external(not in the CIDR of
interface IP), NM will automatically create direct route to this
next-hop-address. When applying this YAML with route desired but not
changed, nmstate incorrect treat it as route removed which lead to
full deactivation on the interface.

The root cause is `is_nm_ip_route_removed()` treat `Some(0.0.0.0)` !=
`None` for next-hop-address.

Both linux kernel and iproute tool are discarding this all-zero address
both for querying and changing.

To fix this issue:
 * Change `RouteEntry.sanitize()` to change all-zero address of
   next-hop-address to `None`.
 * Convert `NmIpRoute` to `RouteEntry`, so we can re-use `RouteEntry.is_match()`
   to tell whether route is changed or not in `is_nm_ip_route_removed()`.

Integration test case included.