### PR TITLE
nm log: Do not use debug print for Option<String>

### DIFF
--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -72,12 +72,10 @@ pub(crate) async fn delete_exist_profiles(
             if let Some(uuid) = exist_nm_conn.uuid() {
                 uuids_to_delete.push(uuid);
                 log::info!(
-                    "Deleting existing connection \
-                UUID {}, id {:?} type {:?} name {:?}",
+                    "Deleting existing duplicate connection {}: {}/{}",
                     uuid,
-                    exist_nm_conn.id(),
-                    exist_nm_conn.iface_type(),
-                    exist_nm_conn.iface_name(),
+                    iface_name,
+                    nm_iface_type,
                 );
             }
         }
@@ -91,21 +89,27 @@ pub(crate) async fn save_nm_profiles(
     memory_only: bool,
 ) -> Result<(), NmstateError> {
     for nm_conn in nm_conns {
+        let uuid = nm_conn.uuid().unwrap_or_default();
+        let nm_iface_type = nm_conn.iface_type().cloned().unwrap_or_default();
+        // For MAC identifier interface, it does not have interface name
+        // in NM connection, print connection id instead.
+        let iface_name = nm_conn
+            .iface_name()
+            .or_else(|| nm_conn.id())
+            .unwrap_or("undefined");
         if nm_conn.obj_path.is_empty() {
             log::info!(
-                "Creating connection UUID {:?}, ID {:?}, type {:?} name {:?}",
-                nm_conn.uuid(),
-                nm_conn.id(),
-                nm_conn.iface_type(),
-                nm_conn.iface_name(),
+                "Creating connection {}: {}/{}",
+                uuid,
+                iface_name,
+                nm_iface_type
             );
         } else {
             log::info!(
-                "Modifying connection UUID {:?}, ID {:?}, type {:?} name {:?}",
-                nm_conn.uuid(),
-                nm_conn.id(),
-                nm_conn.iface_type(),
-                nm_conn.iface_name(),
+                "Modifying connection {}: {}/{}",
+                uuid,
+                iface_name,
+                nm_iface_type
             );
         }
         nm_api


### PR DESCRIPTION
For log of `Modifying connection`, `Creating connection` and
`Deleting existing duplicate connection`, current code is using debug
output showing Option<String> as `Some(foo)` in log which is not user
friendly.

Unified them into:

```
Creating connection 2cab4431-bcae-4498-83aa-5ae1cfbdc8fa: eth1/ethernet
Reapplying connection 2cab4431-bcae-4498-83aa-5ae1cfbdc8fa: eth1/ethernet
Modifying connection 2cab4431-bcae-4498-83aa-5ae1cfbdc8fa: eth1/ethernet
Activating connection 2cab4431-bcae-4498-83aa-5ae1cfbdc8fa: eth1/ethernet
```