### PR TITLE
New release 2.2.39

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [2.2.39] - 2024-11-20
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - route: correctly compare the route's table and metric. (2ce6cb15)
+ - route: correctly compare the route's next-hop. (b4f1aa61)
+
 ## [2.2.38] - 2024-10-24
 ### Breaking changes
  - N/A

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -916,12 +916,9 @@ impl MergedInterface {
                 // lists
                 if let Some(cur_iface) = self.current.as_ref() {
                     if cur_iface.is_ignore() {
-                        match cur_iface.ports().map(|ports| {
+                        cur_iface.ports().map(|ports| {
                             HashSet::<&str>::from_iter(ports.iter().cloned())
-                        }) {
-                            Some(p) => p,
-                            None => return None,
-                        }
+                        })?
                     } else {
                         return None;
                     }


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - route: correctly compare the route's table and metric. (2ce6cb15)
 - route: correctly compare the route's next-hop. (b4f1aa61)

Signed-off-by: Gris Ge <fge@redhat.com>