### PR TITLE
github/dependabot: Add github-actions & Rust crates updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,17 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: cargo
+    directory: "/rust"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
github/dependabot: Add github-actions & Rust crates updates

- Enable dependabot update checks for GitHub Actions for GitHub
  Workflows in this repository
- Enable dependabot update checks for Rust dependencies for code in this
  repository

This will make it easier for the progect to keep itself on top of
dependency and GitHub Actions updates.

See: https://github.com/nmstate/nmstate/issues/2803
Signed-off-by: Timothée Ravier <tim@siosm.fr>