### PR TITLE
query_apply: nm: don't do connection down to remove routes

### DIFF
--- a/examples/blackhole_add_route.yml
+++ b/examples/blackhole_add_route.yml
@@ -1,0 +1,5 @@
+---
+routes:
+  config:
+    - destination: 198.51.200.0/24
+      route-type: blackhole

--- a/examples/blackhole_del_route.yml
+++ b/examples/blackhole_del_route.yml
@@ -1,0 +1,6 @@
+---
+routes:
+  config:
+    - destination: 198.51.200.0/24
+      route-type: blackhole
+      state: absent

--- a/examples/eth1_add_route.yml
+++ b/examples/eth1_add_route.yml
@@ -19,5 +19,3 @@ routes:
       next-hop-interface: eth1
       table-id: 254
       cwnd: 20
-    - destination: 198.51.200.0/24
-      route-type: blackhole

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -64,6 +64,10 @@ impl NmDbus<'_> {
         Ok(self.proxy.version()?)
     }
 
+    pub(crate) fn version_info(&self) -> Result<Vec<u32>, NmError> {
+        Ok(self.proxy.version_info()?)
+    }
+
     fn _checkpoint_create(
         &self,
         timeout: u32,

--- a/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus_proxy.rs
@@ -14,6 +14,9 @@ trait NetworkManager {
     fn version(&self) -> zbus::Result<String>;
 
     #[dbus_proxy(property)]
+    fn version_info(&self) -> zbus::Result<Vec<u32>>;
+
+    #[dbus_proxy(property)]
     fn active_connections(
         &self,
     ) -> zbus::Result<Vec<zvariant::OwnedObjectPath>>;

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -51,7 +51,7 @@ pub use self::lldp::{
     NmLldpNeighborMgmtAddr,
 };
 #[cfg(feature = "query_apply")]
-pub use self::nm_api::NmApi;
+pub use self::nm_api::{NmApi, NmVersion, NmVersionInfo};
 
 pub(crate) use self::convert::ToDbusValue;
 #[cfg(feature = "gen_conf")]

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -460,20 +460,11 @@ fn gen_nm_conn_need_to_deactivate_first(
 }
 
 fn check_nm_version(nm_api: &NmApi) {
-    if let Ok(versions) = nm_api.version().map(|ver_str| {
-        ver_str
-            .split('.')
-            .map(|v| v.parse::<i32>().unwrap_or_default())
-            .collect::<Vec<i32>>()
-    }) {
-        if let (Some(major), Some(minor)) = (versions.first(), versions.get(1))
-        {
-            if *major < 1 || *minor < 40 {
-                log::warn!(
-                    "Unsupported NetworkManager version {major}.{minor}, \
-                    expecting >= 1.40"
-                );
-            }
+    if let Ok(ver) = nm_api.version() {
+        if ver.major < 1 || ver.minor < 40 {
+            log::warn!(
+                "Unsupported NetworkManager version {ver}, expecting >= 1.40"
+            );
         }
     }
 }

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -116,11 +116,6 @@ def test_dns_edit(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_add_remove_routes(eth1_up):
     """
     Test adding a strict route and removing all routes next hop to eth1.
@@ -131,6 +126,24 @@ def test_add_remove_routes(eth1_up):
         assertlib.assert_state(desired_state)
 
     assertlib.assert_no_config_route_to_iface("eth1")
+
+
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_minor_version() < 42,
+    reason="Loopback is only support on NM 1.42+, and blackhole type route "
+    "is stored in loopback",
+)
+def test_add_remove_special_routes(eth1_up):
+    """
+    Test adding an special route and removing it.
+    """
+    with example_state(
+        "blackhole_add_route.yml", cleanup="blackhole_del_route.yml"
+    ):
+        pass
+
+    assertlib.assert_no_config_route_to_iface("lo")
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
We were doing connection down & up when a route had to be removed
from an NM profile, instead of doing just a reapply. This was due to
some bugs in NM regarding removing routes:
- https://bugzilla.redhat.com/1837254
- https://issues.redhat.com/browse/RHEL-66262
- https://issues.redhat.com/browse/RHEL-67324

Those bugs are fixed since NM-1.51.5. However, instead of relying in the
version number to know if it's fixed, use the D-Bus VersionInfo
property, as NM is exposing there as a capability whether this bug is
fixed or not. This will facilitate to do the right thing on distros'
downstream builds if they fix the bug in NM via downstream patch.

So, nmstate will do the right thing depending on whether NM is fixed or not.
When setting an interface to down, or setting routes to absent:
- Deactivate and reactivate if NM is not fixed
- Only reapply if NM is fixed

Resolves: https://issues.redhat.com/browse/RHEL-70139