### PR TITLE
test: Fix decode error for ipsec test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ SPEC_FILE=packaging/nmstate.spec
 RPM_DATA=$(shell date +"%a %b %d %Y")
 RUST_SOURCES := $(shell find rust/ -name "*.rs" -print)
 
+# Due to tokio bug https://github.com/tokio-rs/tokio/issues/6889
+# We only check for definite memory leak
+define VALGRIND_OPTS
+--errors-for-leak-kinds=definite --trace-children=yes \
+--leak-check=full --error-exitcode=1
+endef
+
+
 #outdir is used by COPR as well: https://docs.pagure.org/copr.copr/user_documentation.html
 outdir ?= $(ROOT_DIR)
 
@@ -209,28 +217,22 @@ clib_check: $(CLIB_SO_DEV_DEBUG) $(CLIB_HEADER)
 		-o $(TMPDIR)/nmstate_fmt_test \
 		rust/src/clib/test/nmstate_fmt_test.c -lnmstate
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmstate_json_test 1>/dev/null
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmpolicy_json_test 1>/dev/null
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmstate_yaml_test 1>/dev/null
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmpolicy_yaml_test 1>/dev/null
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmstate_gen_diff_test 1>/dev/null
 	LD_LIBRARY_PATH=$(TMPDIR) \
-		valgrind --trace-children=yes --leak-check=full \
-		--error-exitcode=1 \
+		valgrind $(VALGRIND_OPTS) \
 		$(TMPDIR)/nmstate_fmt_test 1>/dev/null
 	rm -rf $(TMPDIR)
 

--- a/tests/integration/testlib/cmdlib.py
+++ b/tests/integration/testlib/cmdlib.py
@@ -60,7 +60,7 @@ def exec_cmd(cmd, env=None, stdin=None, check=False):
             )
         )
 
-    return (p.returncode, out.decode("utf-8"), err.decode("utf-8"))
+    return (p.returncode, _decode(out), _decode(err))
 
 
 def command_log_line(args, cwd=None):
@@ -94,3 +94,10 @@ def _list2cmdline(args):
 # for including in a command passed to the shell. The safe characters were
 # stolen from pipes._safechars.
 _needs_quoting = re.compile(r"[^A-Za-z0-9_%+,\-./:=@]").search
+
+
+def _decode(str_bytes):
+    try:
+        return str_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return str_bytes.decode("latin1")


### PR DESCRIPTION
The ipsec test will fail at setup stage with error:

    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 18:
    invalid start byte

This is because `ipsec showhostkey` command is using `latin1` encoding.

Fixed by try utf-8 first and fallback to `latin1` encoding.