### PR TITLE
Use specific logger instead of global one

### DIFF
--- a/rust/src/python/libnmstate/clib_wrapper.py
+++ b/rust/src/python/libnmstate/clib_wrapper.py
@@ -315,15 +315,16 @@ def parse_log(logs):
         log_entries = json.loads(logs.decode("utf-8"))
     except Exception:
         pass
+    logger = logging.getLogger("libnmstate")
     for log_entry in log_entries:
         msg = f"{log_entry['time']}:{log_entry['file']}: {log_entry['msg']}"
         level = log_entry["level"]
 
         if level == "ERROR":
-            logging.error(msg)
+            logger.error(msg)
         elif level == "WARN":
-            logging.warning(msg)
+            logger.warning(msg)
         elif level == "INFO":
-            logging.info(msg)
+            logger.info(msg)
         else:
-            logging.debug(msg)
+            logger.debug(msg)


### PR DESCRIPTION
Instead of using global logger, this patch is using dedicate logger
named as `libnmstate` for python logging.

This allows user to control the logging level of nmstate module only.

For example, this python script will disable nmstate logs but still
enable debug logging for others:

```python

import logging
import libnmstate

logging.basicConfig(level=logging.DEBUG)

logger = logging.getLogger("libnmstate")
logger.disabled = True

print(libnmstate.show())

logging.debug("DEBUGGING")
```