### PR TITLE
vxlan: Skip serialize destination-port if it is None

### DIFF
--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -81,7 +81,8 @@ pub struct VxlanConfig {
     #[serde(
         rename = "destination-port",
         default,
-        deserialize_with = "crate::deserializer::option_u16_or_string"
+        deserialize_with = "crate::deserializer::option_u16_or_string",
+        skip_serializing_if = "Option::is_none"
     )]
     /// Deserialize and serialize from/to `destination-port`.
     pub dst_port: Option<u16>,

--- a/rust/src/lib/unit_tests/vxlan.rs
+++ b/rust/src/lib/unit_tests/vxlan.rs
@@ -47,3 +47,22 @@ vxlan:
         Some(std::net::IpAddr::V4("1.2.3.4".parse().unwrap()))
     );
 }
+
+#[test]
+fn test_vxlan_serialization_skips_none_destination_port() {
+    let iface: VxlanInterface = serde_yaml::from_str(
+        r#"---
+name: vxlan1
+type: vxlan
+state: up
+vxlan:
+  id: "101"
+  base-iface: "eth1"
+"#,
+    )
+    .unwrap();
+    let new: VxlanInterface =
+        serde_yaml::from_str(&serde_yaml::to_string(&iface).unwrap()).unwrap();
+
+    assert_eq!(iface, new);
+}


### PR DESCRIPTION
This commit addresses an issue where the `destination-port` field in VxLAN configurations defaulted to `null` when not explicitly specified, causing serialization and `apply_with_description()` failures. For instance, in the `test_add_vxlan_and_modify_vxlan_id` test, the presence of `null` for `destination-port` resulted in errors such as "Invalid YAML string: interfaces: invalid digit found in string at line 1 column 16." To resolve this, the serialization logic has been updated to completely skip the `destination-port` field if its value is `None`. This ensures that the field is omitted from the serialized output unless explicitly set, preventing invalid configurations and maintaining backward compatibility. The change improves robustness and aligns the serialization behavior with expected standards.