### PR TITLE
vlan: Add support of QoS mapping

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "1.2.21"
+nispor = "1.2.22"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.26.2", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -70,7 +70,8 @@ pub use ovs::{
 };
 pub use sriov::{SrIovConfig, SrIovVfConfig};
 pub use vlan::{
-    VlanConfig, VlanInterface, VlanProtocol, VlanRegistrationProtocol,
+    VlanConfig, VlanInterface, VlanProtocol, VlanQosMapping,
+    VlanRegistrationProtocol,
 };
 pub use vrf::{VrfConfig, VrfInterface};
 pub use vxlan::{VxlanConfig, VxlanInterface};

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -7,6 +7,10 @@ use crate::{
     NmstateError,
 };
 
+/// The maximum of VLAN priority is 7 according to
+/// 802.1Q-2018 PCP field definition.
+const MAX_VLAN_PRIORITY: u32 = 7;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 /// Linux kernel VLAN interface. The example yaml output of
@@ -64,15 +68,55 @@ impl VlanInterface {
         &mut self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if let Some(vlan_conf) = &self.vlan {
-            if is_desired && vlan_conf.base_iface.is_none() {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Missing 'vlan.base-iface' for interface '{}'",
-                        &self.base.name
-                    ),
-                ));
+        if let Some(vlan_conf) = self.vlan.as_mut() {
+            if let Some(maps) = vlan_conf.ingress_qos_map.as_mut() {
+                maps.sort_unstable()
+            }
+            if let Some(maps) = vlan_conf.egress_qos_map.as_mut() {
+                maps.sort_unstable()
+            }
+            if is_desired {
+                if vlan_conf.base_iface.is_none() {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Missing 'vlan.base-iface' for interface '{}'",
+                            &self.base.name
+                        ),
+                    ));
+                }
+                if let Some(maps) = vlan_conf.ingress_qos_map.as_ref() {
+                    for in_map in maps.as_slice() {
+                        if in_map.from > MAX_VLAN_PRIORITY {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "The maximum VLAN priority is 7, \
+                                    but got VLAN {} ingress qos map from \
+                                    value set as {}",
+                                    self.base.name.as_str(),
+                                    in_map.from
+                                ),
+                            ));
+                        }
+                    }
+                }
+                if let Some(maps) = vlan_conf.egress_qos_map.as_ref() {
+                    for eg_map in maps.as_slice() {
+                        if eg_map.to > MAX_VLAN_PRIORITY {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "The maximum VLAN priority is 7, \
+                                    but got VLAN {} egress qos map to \
+                                    value set as {}",
+                                    self.base.name.as_str(),
+                                    eg_map.to
+                                ),
+                            ));
+                        }
+                    }
+                }
             }
         }
         Ok(())
@@ -105,6 +149,18 @@ pub struct VlanConfig {
     /// loose binding of the interface to its master device's operating state
     #[serde(skip_serializing_if = "Option::is_none")]
     pub loose_binding: Option<bool>,
+    /// Mapping VLAN header priority to linux internal packet priority for
+    /// incoming packet.
+    /// The maximum of VLAN priority is 7 according to
+    /// 802.1Q-2018 PCP field definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ingress_qos_map: Option<Vec<VlanQosMapping>>,
+    /// Mapping linux internal packet priority to VLAN header priority for
+    /// outgoing packet.
+    /// The maximum of VLAN priority is 7 according to
+    /// 802.1Q-2018 PCP field definition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub egress_qos_map: Option<Vec<VlanQosMapping>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -197,5 +253,38 @@ impl MergedInterface {
                 }
             }
         }
+    }
+}
+
+/// VLAN QoS Mapping
+/// Mapping between linux internal packet priority and VLAN header priority for
+/// incoming or outgoing packet.
+#[derive(
+    Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Default,
+)]
+pub struct VlanQosMapping {
+    #[serde(deserialize_with = "crate::deserializer::u32_or_string")]
+    pub from: u32,
+    #[serde(deserialize_with = "crate::deserializer::u32_or_string")]
+    pub to: u32,
+}
+
+impl std::fmt::Display for VlanQosMapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.from, self.to)
+    }
+}
+
+// For Ord
+impl PartialOrd for VlanQosMapping {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// For Vec::sort_unstable()
+impl Ord for VlanQosMapping {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.from, self.to).cmp(&(other.from, other.to))
     }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -152,8 +152,8 @@ pub use crate::ifaces::{
     OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
     OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
     SrIovConfig, SrIovVfConfig, VethConfig, VlanConfig, VlanInterface,
-    VlanProtocol, VlanRegistrationProtocol, VrfConfig, VrfInterface,
-    VxlanConfig, VxlanInterface, XfrmInterface,
+    VlanProtocol, VlanQosMapping, VlanRegistrationProtocol, VrfConfig,
+    VrfInterface, VxlanConfig, VxlanInterface, XfrmInterface,
 };
 pub use crate::ip::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,

--- a/rust/src/lib/nispor/vlan.rs
+++ b/rust/src/lib/nispor/vlan.rs
@@ -34,6 +34,8 @@ pub(crate) fn np_vlan_to_nmstate(
         } else {
             Some(VlanRegistrationProtocol::None)
         },
+        ingress_qos_map: get_qos_map(&np_vlan_info.ingress_qos_map),
+        egress_qos_map: get_qos_map(&np_vlan_info.egress_qos_map),
     });
 
     VlanInterface {
@@ -53,4 +55,22 @@ pub(crate) fn nms_vlan_conf_to_np(
         }
         np_vlan_conf
     })
+}
+
+fn get_qos_map(
+    np_maps: &[nispor::VlanQosMapping],
+) -> Option<Vec<crate::VlanQosMapping>> {
+    if np_maps.is_empty() {
+        None
+    } else {
+        let mut ret = Vec::new();
+        for np_map in np_maps {
+            ret.push(crate::VlanQosMapping {
+                from: np_map.from,
+                to: np_map.to,
+            });
+        }
+        ret.sort_unstable();
+        Some(ret)
+    }
 }

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -18,6 +18,8 @@ pub struct NmSettingVlan {
     pub id: Option<u32>,
     pub protocol: Option<String>,
     pub flags: Vec<NmSettingVlanFlag>,
+    pub egress_priority_map: Vec<String>,
+    pub ingress_priority_map: Vec<String>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -73,6 +75,19 @@ impl TryFrom<DbusDictionary> for NmSettingVlan {
             id: _from_map!(v, "id", u32::try_from)?,
             protocol: _from_map!(v, "protocol", String::try_from)?,
             flags: from_dic_to_vec_nm_vlan_flags(&mut v, "flags")?,
+            egress_priority_map: _from_map!(
+                v,
+                "egress-priority-map",
+                Vec::<String>::try_from
+            )?
+            .unwrap_or_default(),
+            ingress_priority_map: _from_map!(
+                v,
+                "ingress-priority-map",
+                Vec::<String>::try_from
+            )?
+            .unwrap_or_default(),
+
             _other: v,
         })
     }
@@ -95,6 +110,15 @@ impl ToDbusValue for NmSettingVlan {
             zvariant::Value::new(from_vec_nm_vlan_flags_u32(
                 self.flags.clone(),
             )),
+        );
+
+        ret.insert(
+            "egress-priority-map",
+            zvariant::Value::new(self.egress_priority_map.as_slice()),
+        );
+        ret.insert(
+            "ingress-priority-map",
+            zvariant::Value::new(self.ingress_priority_map.as_slice()),
         );
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -75,6 +75,16 @@ pub(crate) fn gen_nm_vlan_setting(
                     .retain(|x| !matches!(x, NmSettingVlanFlag::LooseBinding));
             }
         }
+
+        if let Some(ingress_maps) = vlan_conf.ingress_qos_map.as_deref() {
+            nm_vlan.ingress_priority_map =
+                ingress_maps.iter().map(|m| m.to_string()).collect();
+        }
+        if let Some(egress_maps) = vlan_conf.egress_qos_map.as_deref() {
+            nm_vlan.egress_priority_map =
+                egress_maps.iter().map(|m| m.to_string()).collect();
+        }
+
         nm_conn.vlan = Some(nm_vlan);
     }
 }

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -6,11 +6,17 @@ use crate::{
 };
 
 impl BaseInterface {
-    pub(crate) fn include_diff_context(&mut self, current: &Self) {
-        if self.identifier == Some(InterfaceIdentifier::MacAddress)
-            && self.mac_address.is_none()
+    pub(crate) fn include_diff_context(
+        &mut self,
+        desired: &Self,
+        current: &Self,
+    ) {
+        // Always include MAC address if changing to
+        // InterfaceIdentifier::MacAddress
+        if desired.identifier == Some(InterfaceIdentifier::MacAddress)
+            && desired.identifier != current.identifier
         {
-            self.mac_address.clone_from(&current.mac_address)
+            self.mac_address.clone_from(&current.mac_address);
         }
     }
 

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -259,9 +259,21 @@ impl Interface {
         }
     }
 
-    pub(crate) fn include_diff_context(&mut self, current: &Self) {
+    pub(crate) fn include_diff_context(
+        &mut self,
+        desired: &Self,
+        current: &Self,
+    ) {
         self.base_iface_mut()
-            .include_diff_context(current.base_iface());
+            .include_diff_context(desired.base_iface(), current.base_iface());
+        if let (
+            Interface::Vlan(vlan_iface),
+            Interface::Vlan(des_iface),
+            Interface::Vlan(cur_iface),
+        ) = (self, desired, current)
+        {
+            vlan_iface.include_diff_context(des_iface, cur_iface);
+        }
     }
 }
 

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -176,11 +176,11 @@ impl MergedInterfaces {
             {
                 let mut new_iface = des_iface.clone_name_type_only();
                 new_iface.base_iface_mut().state = des_iface.base_iface().state;
+                new_iface.include_diff_context(des_iface, &cur_iface);
                 let mut new_iface_value = serde_json::to_value(&new_iface)?;
                 merge_json_value(&mut new_iface_value, &diff_value);
-                let mut new_iface =
+                let new_iface =
                     serde_json::from_value::<Interface>(new_iface_value)?;
-                new_iface.include_diff_context(&cur_iface);
                 ret.push(new_iface);
             }
         }

--- a/rust/src/lib/query_apply/vlan.rs
+++ b/rust/src/lib/query_apply/vlan.rs
@@ -11,6 +11,31 @@ impl VlanInterface {
             self.vlan.clone_from(&other.vlan);
         }
     }
+
+    // When VLAN Qos changed only from or to, we should include the whole map
+    // instead of changed.
+    pub(crate) fn include_diff_context(
+        &mut self,
+        desired: &VlanInterface,
+        current: &VlanInterface,
+    ) {
+        if let (Some(des_conf), Some(cur_conf)) =
+            (desired.vlan.as_ref(), current.vlan.as_ref())
+        {
+            // If changed, always include VLAN ID and base-iface as context
+            if des_conf != cur_conf {
+                let new_conf = VlanConfig {
+                    id: des_conf.id,
+                    base_iface: des_conf
+                        .base_iface
+                        .clone()
+                        .or_else(|| cur_conf.base_iface.clone()),
+                    ..Default::default()
+                };
+                self.vlan = Some(new_conf);
+            }
+        }
+    }
 }
 
 impl VlanConfig {

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_id/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_id/diff.yml
@@ -4,4 +4,5 @@ interfaces:
   type: vlan
   state: up
   vlan:
+    base-iface: veth0
     id: 4

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/current.yml
@@ -1,0 +1,18 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    id: 100
+    base-iface: eth1
+    reorder-headers: true
+    egress-qos-map:
+      - from: 2
+        to: 2
+    ingress-qos-map:
+      - from: 3
+        to: 3
+- name: eth1
+  tyep: ethernet
+  state: up

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/desired.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    id: 100
+    base-iface: eth1
+    egress-qos-map:
+      - from: 2
+        to: 3
+    ingress-qos-map:
+      - from: 3
+        to: 4

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_vlan_qos_map/diff.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+- name: vlan0
+  type: vlan
+  state: up
+  vlan:
+    id: 100
+    base-iface: eth1
+    egress-qos-map:
+      - from: 2
+        to: 3
+    ingress-qos-map:
+      - from: 3
+        to: 4

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -238,3 +238,91 @@ fn test_vlan_base_iface_optional() {
         MergedInterface::new(Some(desired), Some(current)).unwrap();
     merged_iface.post_inter_ifaces_process().unwrap();
 }
+
+#[test]
+fn test_vlan_invalid_egress_qos() {
+    let mut iface: VlanInterface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          base-iface: eth0
+          id: 100
+          egress-qos-map:
+            - from: 4
+              to: 8
+          ",
+    )
+    .unwrap();
+
+    let result = iface.sanitize(true);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_vlan_invalid_ingress_qos() {
+    let mut iface: VlanInterface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          base-iface: eth0
+          id: 100
+          ingress-qos-map:
+            - from: 8
+              to: 3
+          ",
+    )
+    .unwrap();
+
+    let result = iface.sanitize(true);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_vlan_valid_egress_qos() {
+    let mut iface: VlanInterface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          base-iface: eth0
+          id: 100
+          egress-qos-map:
+            - from: 129
+              to: 7
+          ",
+    )
+    .unwrap();
+
+    iface.sanitize(true).unwrap();
+}
+
+#[test]
+fn test_vlan_valid_ingress_qos() {
+    let mut iface: VlanInterface = serde_yaml::from_str(
+        r"---
+        name: vlan1
+        type: vlan
+        vlan:
+          base-iface: eth0
+          id: 100
+          ingress-qos-map:
+            - from: 7
+              to: 254
+          ",
+    )
+    .unwrap();
+
+    iface.sanitize(true).unwrap();
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -329,6 +329,10 @@ class VLAN:
     REGISTRATION_PROTOCOL_NONE = "none"
     REORDER_HEADERS = "reorder-headers"
     LOOSE_BINDING = "loose-binding"
+    INGRESS_QOS_MAP = "ingress-qos-map"
+    EGRESS_QOS_MAP = "egress-qos-map"
+    QOS_MAP_FROM = "from"
+    QOS_MAP_TO = "to"
 
 
 class VXLAN:

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -18,6 +18,7 @@ from libnmstate.schema import InterfaceState
 from libnmstate.schema import LinuxBridge
 from libnmstate.schema import Mptcp
 from libnmstate.schema import OVSBridge
+from libnmstate.schema import VLAN
 
 
 def show_only(ifnames, include_secrets=False):
@@ -113,6 +114,7 @@ class State:
         self._sort_mptcp_flags()
         self._remove_mptcp_flags_of_ip_addr()
         self._remove_top_descriptions()
+        self._sort_vlan_qos_map()
 
     def match(self, other):
         return state_match(self.state, other.state)
@@ -187,6 +189,20 @@ class State:
             for family in (Interface.IPV4, Interface.IPV6):
                 iface_state.get(family, {}).get(InterfaceIP.ADDRESS, []).sort(
                     key=itemgetter(InterfaceIP.ADDRESS_IP)
+                )
+
+    def _sort_vlan_qos_map(self):
+        for iface_state in self.state[Interface.KEY]:
+            if VLAN.CONFIG_SUBTREE in iface_state:
+                iface_state[VLAN.CONFIG_SUBTREE].get(
+                    VLAN.INGRESS_QOS_MAP, []
+                ).sort(
+                    key=lambda m: (m[VLAN.QOS_MAP_FROM], m[VLAN.QOS_MAP_TO])
+                )
+                iface_state[VLAN.CONFIG_SUBTREE].get(
+                    VLAN.EGRESS_QOS_MAP, []
+                ).sort(
+                    key=lambda m: (m[VLAN.QOS_MAP_FROM], m[VLAN.QOS_MAP_TO])
                 )
 
     def _ignore_addr_with_lifetime(self):

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -583,3 +583,191 @@ def test_base_iface_optional(vlan_on_eth1):
 
     libnmstate.apply(new_state)
     assertlib.assert_state_match(new_state)
+
+
+@pytest.fixture
+def vlan_with_qos_map(eth1_up):
+    state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.ID: 102,
+                    VLAN.INGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 4,
+                            VLAN.QOS_MAP_TO: 4,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 2,
+                            VLAN.QOS_MAP_TO: 2,
+                        },
+                    ],
+                    VLAN.EGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 3,
+                            VLAN.QOS_MAP_TO: 3,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 1,
+                            VLAN.QOS_MAP_TO: 1,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+    libnmstate.apply(state)
+    yield state
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: VLAN_IFNAME,
+                    Interface.TYPE: InterfaceType.VLAN,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+# https://issues.redhat.com/browse/RHEL-67631
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_minor_version() < 51,
+    reason=("VLAN QoS map is only fixed by NetworkManager 1.51+"),
+)
+def test_create_vlan_with_qos_map(vlan_with_qos_map):
+    state = vlan_with_qos_map
+    assertlib.assert_state_match(state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 51,
+    reason=("VLAN QoS map is only fixed by NetworkManager 1.51+"),
+)
+def test_change_vlan_with_qos_map(eth1_up):
+    state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.ID: 102,
+                    VLAN.INGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 6,
+                            VLAN.QOS_MAP_TO: 7,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 2,
+                            VLAN.QOS_MAP_TO: 2,
+                        },
+                    ],
+                    VLAN.EGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 7,
+                            VLAN.QOS_MAP_TO: 6,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 2,
+                            VLAN.QOS_MAP_TO: 2,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 51,
+    reason=("VLAN QoS map is only fixed by NetworkManager 1.51+"),
+)
+def test_vlan_add_qos_map_to_existing(vlan_on_eth1):
+    desired_state = statelib.show_only((VLAN_IFNAME,))
+    iface_state = desired_state[Interface.KEY][0]
+    iface_state[VLAN.CONFIG_SUBTREE][VLAN.INGRESS_QOS_MAP] = [
+        {
+            VLAN.QOS_MAP_FROM: 6,
+            VLAN.QOS_MAP_TO: 7,
+        },
+        {
+            VLAN.QOS_MAP_FROM: 2,
+            VLAN.QOS_MAP_TO: 2,
+        },
+    ]
+    iface_state[VLAN.CONFIG_SUBTREE][VLAN.EGRESS_QOS_MAP] = [
+        {
+            VLAN.QOS_MAP_FROM: 6,
+            VLAN.QOS_MAP_TO: 7,
+        },
+        {
+            VLAN.QOS_MAP_FROM: 2,
+            VLAN.QOS_MAP_TO: 2,
+        },
+    ]
+
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 51,
+    reason=("VLAN QoS map is only fixed by NetworkManager 1.51+"),
+)
+def test_vlan_add_multiple_qos_map_in_mixed_order(eth1_up):
+    state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: VLAN_IFNAME,
+                Interface.TYPE: InterfaceType.VLAN,
+                Interface.STATE: InterfaceState.UP,
+                VLAN.CONFIG_SUBTREE: {
+                    VLAN.BASE_IFACE: "eth1",
+                    VLAN.ID: 102,
+                    VLAN.INGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 1,
+                            VLAN.QOS_MAP_TO: 1,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 6,
+                            VLAN.QOS_MAP_TO: 7,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 2,
+                            VLAN.QOS_MAP_TO: 2,
+                        },
+                    ],
+                    VLAN.EGRESS_QOS_MAP: [
+                        {
+                            VLAN.QOS_MAP_FROM: 1,
+                            VLAN.QOS_MAP_TO: 1,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 7,
+                            VLAN.QOS_MAP_TO: 6,
+                        },
+                        {
+                            VLAN.QOS_MAP_FROM: 2,
+                            VLAN.QOS_MAP_TO: 2,
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)


### PR DESCRIPTION
Example YAML:

```yml
---
interfaces:
 - name: eth1.101
   type: vlan
   state: up
   vlan:
     base-iface: eth1
     id: 101
     egress-qos-map:
       - from: 3
         to: 2
       - from: 5
         to: 0
     ingress-qos-map:
       - from: 4
         to: 2
       - from: 0
         to: 5
```

Unit tests included for validating the VLAN priority range(0 - 7) and
gen_diff() function on only QOS changes.

Integration test cases included for creating VLAN with QoS mapping,
changing QoS and adding QoS mapping.

Bump minimum supported rust version to 1.77 in order to compile nispor 1.2.22

Resolves: https://issues.redhat.com/browse/RHEL-67631