### PR TITLE
tests: Pass kernel_only arg to libnmstate.show() in _custom_apply_with_dump_state

### DIFF
--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -254,37 +254,37 @@ impl LldpSystemCapabilities {
 impl From<u16> for LldpSystemCapabilities {
     fn from(caps: u16) -> Self {
         let mut ret = Vec::new();
-        if (caps & 1 << (LLDP_SYS_CAP_OTHER - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_OTHER - 1))) > 0 {
             ret.push(LldpSystemCapability::Other);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_REPEATER - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_REPEATER - 1))) > 0 {
             ret.push(LldpSystemCapability::Repeater);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_MAC_BRIDGE - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_MAC_BRIDGE - 1))) > 0 {
             ret.push(LldpSystemCapability::MacBridgeComponent);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_AP - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_AP - 1))) > 0 {
             ret.push(LldpSystemCapability::AccessPoint);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_ROUTER - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_ROUTER - 1))) > 0 {
             ret.push(LldpSystemCapability::Router);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_TELEPHONE - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_TELEPHONE - 1))) > 0 {
             ret.push(LldpSystemCapability::Telephone);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_DOCSIS - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_DOCSIS - 1))) > 0 {
             ret.push(LldpSystemCapability::DocsisCableDevice);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_STATION_ONLY - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_STATION_ONLY - 1))) > 0 {
             ret.push(LldpSystemCapability::StationOnly);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_CVLAN - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_CVLAN - 1))) > 0 {
             ret.push(LldpSystemCapability::CVlanComponent);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_SVLAN - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_SVLAN - 1))) > 0 {
             ret.push(LldpSystemCapability::SVlanComponent);
         }
-        if (caps & 1 << (LLDP_SYS_CAP_TWO_PORT_MAC_RELAY - 1)) > 0 {
+        if (caps & (1 << (LLDP_SYS_CAP_TWO_PORT_MAC_RELAY - 1))) > 0 {
             ret.push(LldpSystemCapability::TwoPortMacRelayComponent);
         }
         Self::new(ret)

--- a/rust/src/lib/nispor/dns.rs
+++ b/rust/src/lib/nispor/dns.rs
@@ -34,13 +34,13 @@ pub(crate) fn get_dns() -> Option<DnsState> {
                     line.strip_prefix("options ").map(|s| s.trim())
                 {
                     conf.options =
-                        Some(opts.split(" ").map(|s| s.to_string()).collect());
+                        Some(opts.split(' ').map(|s| s.to_string()).collect());
                 }
                 if let Some(searches) =
                     line.strip_prefix("search ").map(|s| s.trim())
                 {
                     conf.search = Some(
-                        searches.split(" ").map(|s| s.to_string()).collect(),
+                        searches.split(' ').map(|s| s.to_string()).collect(),
                     );
                 }
             }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -232,8 +232,11 @@ def _custom_apply_with_dump_state(
     *args,
     **kwargs,
 ):
+    kernel_only = kwargs.get("kernel_only", False)
+
     if DUMP_AI_TRAIN_YAML:
-        cur_state = libnmstate.show()
+        cur_state = libnmstate.show(kernel_only=kernel_only)
+
     result = LIBNMSTATE_APPLY(
         desired_state,
         *args,


### PR DESCRIPTION
…h_dump_state

Ensure that the `kernel_only` parameter, if specified in the kwargs, is propagated to `libnmstate.show()` when dumping the current state. This change maintains consistency with the behavior of kernel-only operations and avoids unintended D-Bus calls to `NetworkManager` when operating in kernel-only mode.