### PR TITLE
Update error.rs misspelling

### DIFF
--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -117,7 +117,7 @@ impl From<serde_json::Error> for NmstateError {
     fn from(e: serde_json::Error) -> Self {
         NmstateError::new(
             ErrorKind::InvalidArgument,
-            format!("Invalid propriety: {e}"),
+            format!("Invalid property : {e}"),
         )
     }
 }


### PR DESCRIPTION
Small fix to correct misspelling of  "propriety" to "property" in error.rs