### PR TITLE
controller: Refer port by profile name

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -755,6 +755,8 @@ impl Interface {
             iface.change_port_name(org_port_name, new_port_name);
         } else if let Interface::Bond(iface) = self {
             iface.change_port_name(org_port_name, new_port_name);
+        } else if let Interface::Vrf(iface) = self {
+            iface.change_port_name(org_port_name, new_port_name);
         }
     }
 }

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -361,21 +361,30 @@ impl BondInterface {
         origin_name: &str,
         new_name: String,
     ) {
-        if let Some(index) = self
+        if let Some(port_name) = self
             .bond
-            .as_ref()
-            .and_then(|bond_conf| bond_conf.port.as_ref())
+            .as_mut()
+            .and_then(|bond_conf| bond_conf.port.as_mut())
             .and_then(|ports| {
-                ports.iter().position(|port_name| port_name == origin_name)
+                ports
+                    .iter_mut()
+                    .find(|port_name| port_name.as_str() == origin_name)
             })
         {
-            if let Some(ports) = self
-                .bond
-                .as_mut()
-                .and_then(|bond_conf| bond_conf.port.as_mut())
-            {
-                ports[index] = new_name;
-            }
+            *port_name = new_name.clone();
+        }
+
+        if let Some(port_conf) = self
+            .bond
+            .as_mut()
+            .and_then(|bond_conf| bond_conf.ports_config.as_mut())
+            .and_then(|port_confs| {
+                port_confs
+                    .iter_mut()
+                    .find(|port_conf| port_conf.name == origin_name)
+            })
+        {
+            port_conf.name = new_name;
         }
     }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -789,6 +789,7 @@ impl MergedInterfaces {
         self.process_allow_extra_ovs_patch_ports_for_apply();
         self.apply_copy_mac_from()?;
         self.validate_controller_and_port_list_confliction()?;
+        self.resolve_port_name_ref()?;
         self.handle_changed_ports()?;
         self.resolve_port_iface_controller_type()?;
         self._set_up_priority()?;

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -126,6 +126,25 @@ impl VrfInterface {
         }
         Ok(())
     }
+
+    pub(crate) fn change_port_name(
+        &mut self,
+        origin_name: &str,
+        new_name: String,
+    ) {
+        if let Some(port_name) = self
+            .vrf
+            .as_mut()
+            .and_then(|vrf_conf| vrf_conf.port.as_mut())
+            .and_then(|ports| {
+                ports
+                    .iter_mut()
+                    .find(|port_name| port_name.as_str() == origin_name)
+            })
+        {
+            *port_name = new_name;
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/unit_tests/identifier.rs
+++ b/rust/src/lib/unit_tests/identifier.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, Interfaces, MergedInterfaces};
+
+#[test]
+fn test_can_have_dup_profile_name_when_not_refered() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        - name: dummy2
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2B
+        - name: port2
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2C
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - port2
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        - name: dummy2
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2B
+        - name: dummy3
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2C
+        ",
+    )
+    .unwrap();
+
+    MergedInterfaces::new(desired, current, false, false).unwrap();
+}
+
+#[test]
+fn test_port_refer_to_kernel_interface() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2A
+        - name: dummy2
+          profile-name: dummy1
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2B
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            ports:
+            - name: dummy1
+        ",
+    )
+    .unwrap();
+
+    let mut merged =
+        MergedInterfaces::new(desired, Interfaces::default(), false, false)
+            .unwrap();
+
+    let dummy1 = merged
+        .kernel_ifaces
+        .remove("dummy1")
+        .unwrap()
+        .for_apply
+        .unwrap();
+
+    assert_eq!(dummy1.name(), "dummy1");
+    assert_eq!(dummy1.base_iface().controller.as_deref(), Some("br0"));
+    assert!(dummy1.base_iface().identifier.as_ref().is_none());
+    assert_eq!(
+        dummy1.base_iface().mac_address.as_deref(),
+        Some("32:BB:72:65:19:2A")
+    );
+}
+
+#[test]
+fn test_port_cannot_refer_to_interfaces_holding_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            ports:
+            - name: port1
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        - name: dummy2
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2B
+        ",
+    )
+    .unwrap();
+
+    let result = MergedInterfaces::new(desired, current, false, false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -19,6 +19,8 @@ mod gen_diff;
 #[cfg(test)]
 mod gen_revert;
 #[cfg(test)]
+mod identifier;
+#[cfg(test)]
 mod ifaces;
 #[cfg(test)]
 mod ifaces_ctrller;

--- a/tests/integration/identifer_test.py
+++ b/tests/integration/identifer_test.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import libnmstate
+from libnmstate.schema import Interface
+
+from .testlib.assertlib import assert_state_match
+from .testlib.ifacelib import get_mac_address
+from .testlib.statelib import show_only
+from .testlib.yaml import load_yaml
+
+
+@pytest.fixture
+def clean_up():
+    yield
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: dummy1
+              type: dummy
+              state: absent
+            - name: dummy2
+              type: dummy
+              state: absent
+            - name: port1
+              type: ethernet
+              state: absent
+            - name: port2
+              type: ethernet
+              state: absent
+            - name: bond0
+              type: bond
+              state: absent
+            - name: br0
+              type: linux-bridge
+              state: absent
+            - name: ovs-br0
+              type: ovs-bridge
+              state: absent
+            - name: vrf0
+              type: vrf
+              state: absent
+          """
+        )
+    )
+
+
+def test_bond_port_ref_by_mac(eth1_up, eth2_up, clean_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - port1
+            - port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    expected_state = load_yaml(
+        """---
+        interfaces:
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - eth1
+            - eth2"""
+    )
+
+    assert_state_match(expected_state)
+
+
+def test_bond_port_conf_ref_by_mac(eth1_up, eth2_up, clean_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            ports-config:
+            - name: port1
+            - name: port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    expected_state = load_yaml(
+        """---
+        interfaces:
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - eth1
+            - eth2"""
+    )
+
+    assert_state_match(expected_state)
+
+
+def test_linux_bridge_port_ref_by_mac(eth1_up, eth2_up, clean_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: port1
+            - name: port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    expected_state = load_yaml(
+        """---
+        interfaces:
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2"""
+    )
+
+    assert_state_match(expected_state)
+
+
+def test_ovs_bridge_port_ref_by_mac(eth1_up, eth2_up, clean_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: ovs-br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: port1
+            - name: port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    expected_state = load_yaml(
+        """---
+        interfaces:
+        - name: ovs-br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2"""
+    )
+
+    assert_state_match(expected_state)
+
+
+def test_vrf_port_ref_by_mac(eth1_up, eth2_up, clean_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            port:
+            - port1
+            - port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    expected_state = load_yaml(
+        """---
+        interfaces:
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            port:
+            - eth1
+            - eth2"""
+    )
+
+    assert_state_match(expected_state)
+
+
+def test_port_ref_prefer_kernel_name(clean_up):
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: dummy1
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2A
+        - name: dummy2
+          profile-name: dummy1
+          type: dummy
+          state: up
+          mac-address: 32:BB:72:65:19:2B
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            ports:
+            - name: dummy1"""
+    )
+
+    libnmstate.apply(state)
+    dummy1_iface_state = show_only(("dummy1",))[Interface.KEY][0]
+    dummy2_iface_state = show_only(("dummy2",))[Interface.KEY][0]
+
+    assert dummy1_iface_state[Interface.CONTROLLER] == "br0"
+    assert dummy1_iface_state[Interface.MAC] == "32:BB:72:65:19:2A"
+    assert Interface.CONTROLLER not in dummy2_iface_state
+
+
+def test_referring_to_duplicate_profile_names(eth1_up, eth2_up):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            ports:
+            - name: port1
+        - name: eth1
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: {}
+        - name: eth2
+          profile-name: port1
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: {}""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    with pytest.raises(libnmstate.error.NmstateValueError):
+        libnmstate.apply(state)
+
+
+def test_can_have_multiple_iface_holding_same_profile_name(eth1_up, eth2_up):
+    eth1_mac = get_mac_address("eth1")
+    eth2_mac = get_mac_address("eth2")
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: eth1
+          profile-name: port1
+          type: ethernet
+          state: up
+          identifier: mac-address
+          mac-address: {}
+        - name: eth2
+          profile-name: port1
+          type: ethernet
+          state: up
+          identifier: mac-address
+          mac-address: {}""".format(
+            eth1_mac, eth2_mac
+        )
+    )
+
+    libnmstate.apply(state)
+
+    eth1_iface_state = show_only(("eth1",))[Interface.KEY][0]
+    eth2_iface_state = show_only(("eth2",))[Interface.KEY][0]
+
+    assert eth1_iface_state[Interface.MAC] == eth1_mac
+    assert eth1_iface_state[Interface.PROFILE_NAME] == "port1"
+    assert eth2_iface_state[Interface.MAC] == eth2_mac
+    assert eth2_iface_state[Interface.PROFILE_NAME] == "port1"


### PR DESCRIPTION
This allows controller port referring to the profile name:

```yml
---
interfaces:
- name: port1
  type: ethernet
  identifier: mac-address
  mac-address: 00:23:45:67:89:1a
- name: port2
  type: ethernet
  identifier: mac-address
  mac-address: 00:23:45:67:89:1b
- name: br0
  type: linux-bridge
  state: up
  bridge:
    ports:
      - name: port1
      - name: port2
```

This patch enable this support to bond, vrf, linux-bridge and
ovs-bridge.

Crated unit tests and integration tests for these use cases:
 * Refer port by mac address for bond/linux bridge/ovs bridge/vrf
 * Prefer kernel name over profile name when overlap.
 * Raise error if controller refer to the profile name shared by 
   multiple interfaces.
 * Allow multiple interfaces sharing the same profile name as long as
   they are not referred by controller.


Resolves: https://issues.redhat.com/browse/RHEL-1745