### PR TITLE
parent: Refer parent by profile name

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -744,6 +744,23 @@ impl Interface {
         }
     }
 
+    pub(crate) fn change_parent_name(&mut self, parent_name: &str) {
+        match self {
+            Interface::Vlan(vlan) => vlan.change_parent_name(parent_name),
+            Interface::Vxlan(vxlan) => vxlan.change_parent_name(parent_name),
+            Interface::MacVlan(vlan) => vlan.change_parent_name(parent_name),
+            Interface::MacVtap(vtap) => vtap.change_parent_name(parent_name),
+            Interface::MacSec(macsec) => macsec.change_parent_name(parent_name),
+            _ => {
+                log::warn!(
+                    "BUG: change_parent_name() invoked against \
+                    unsupported interface type {:?}",
+                    self
+                )
+            }
+        }
+    }
+
     pub(crate) fn change_port_name(
         &mut self,
         org_port_name: &str,

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -70,6 +70,12 @@ impl MacVlanInterface {
     pub(crate) fn parent(&self) -> Option<&str> {
         self.mac_vlan.as_ref().map(|cfg| cfg.base_iface.as_str())
     }
+
+    pub(crate) fn change_parent_name(&mut self, name: &str) {
+        if let Some(mac_vlan_conf) = self.mac_vlan.as_mut() {
+            mac_vlan_conf.base_iface = name.to_string();
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -70,6 +70,12 @@ impl MacVtapInterface {
     pub(crate) fn parent(&self) -> Option<&str> {
         self.mac_vtap.as_ref().map(|cfg| cfg.base_iface.as_str())
     }
+
+    pub(crate) fn change_parent_name(&mut self, name: &str) {
+        if let Some(mac_vtap_conf) = self.mac_vtap.as_mut() {
+            mac_vtap_conf.base_iface = name.to_string();
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/ifaces/macsec.rs
+++ b/rust/src/lib/ifaces/macsec.rs
@@ -97,6 +97,12 @@ impl MacSecInterface {
     pub(crate) fn parent(&self) -> Option<&str> {
         self.macsec.as_ref().map(|cfg| cfg.base_iface.as_str())
     }
+
+    pub(crate) fn change_parent_name(&mut self, name: &str) {
+        if let Some(macsec) = self.macsec.as_mut() {
+            macsec.base_iface = name.to_string();
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -77,6 +77,12 @@ impl VlanInterface {
         }
         Ok(())
     }
+
+    pub(crate) fn change_parent_name(&mut self, name: &str) {
+        if let Some(vlan_conf) = self.vlan.as_mut() {
+            vlan_conf.base_iface = Some(name.to_string());
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/ifaces/vxlan.rs
+++ b/rust/src/lib/ifaces/vxlan.rs
@@ -56,6 +56,12 @@ impl VxlanInterface {
             }
         })
     }
+
+    pub(crate) fn change_parent_name(&mut self, name: &str) {
+        if let Some(vxlan_conf) = self.vxlan.as_mut() {
+            vxlan_conf.base_iface = name.to_string();
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/unit_tests/identifier.rs
+++ b/rust/src/lib/unit_tests/identifier.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ErrorKind, Interfaces, MergedInterfaces};
+use crate::{ErrorKind, Interface, Interfaces, MergedInterfaces};
 
 #[test]
 fn test_can_have_dup_profile_name_when_not_refered() {
@@ -137,5 +137,291 @@ fn test_port_cannot_refer_to_interfaces_holding_profile_name() {
 
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_port_ref_not_found() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            ports:
+            - name: port1
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: port2
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let result = MergedInterfaces::new(desired, current, false, false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_vlan_parent_ref_by_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: vlan0
+          type: vlan
+          state: up
+          vlan:
+            base-iface: wan0
+            id: 100
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: wan0
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    let merged_iface = merged_ifaces.kernel_ifaces.get("vlan0").unwrap();
+
+    if let Interface::Vlan(vlan_iface) = merged_iface.desired.as_ref().unwrap()
+    {
+        assert_eq!(
+            vlan_iface.vlan.as_ref().unwrap().base_iface.as_deref(),
+            Some("dummy1")
+        );
+    } else {
+        panic!("failed to find VLAN interface");
+    }
+
+    if let Interface::Vlan(vlan_iface) =
+        merged_iface.for_apply.as_ref().unwrap()
+    {
+        assert_eq!(
+            vlan_iface.vlan.as_ref().unwrap().base_iface.as_deref(),
+            Some("dummy1")
+        );
+    } else {
+        panic!("failed to find VLAN interface");
+    }
+
+    if let Interface::Vlan(vlan_iface) =
+        merged_iface.for_verify.as_ref().unwrap()
+    {
+        assert_eq!(
+            vlan_iface.vlan.as_ref().unwrap().base_iface.as_deref(),
+            Some("dummy1")
+        );
+    } else {
+        panic!("failed to find VLAN interface");
+    }
+}
+
+#[test]
+fn test_vxlan_parent_ref_by_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: vxlan0
+          type: vxlan
+          state: up
+          vxlan:
+            base-iface: wan0
+            id: 100
+            remote: 192.0.2.251
+            destination-port: 1235
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: wan0
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    let merged_iface = merged_ifaces.kernel_ifaces.get("vxlan0").unwrap();
+
+    if let Interface::Vxlan(vxlan_iface) =
+        merged_iface.for_apply.as_ref().unwrap()
+    {
+        assert_eq!(
+            vxlan_iface.vxlan.as_ref().unwrap().base_iface.as_str(),
+            "dummy1"
+        );
+    } else {
+        panic!("failed to find VxLAN interface");
+    }
+}
+
+#[test]
+fn test_macsec_parent_ref_by_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: macsec0
+  type: macsec
+  state: up
+  macsec:
+    encrypt: true
+    base-iface: wan0
+    mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
+    mka-ckn: f2b4297d39da7330910a74abc0449feb45b5c0b9fc23df1430e1898fcf1c4550
+    port: 0
+    validation: strict
+    send-sci: true
+    offload: off",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: wan0
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    let merged_iface = merged_ifaces.kernel_ifaces.get("macsec0").unwrap();
+
+    if let Interface::MacSec(macsec_iface) =
+        merged_iface.for_apply.as_ref().unwrap()
+    {
+        assert_eq!(
+            macsec_iface.macsec.as_ref().unwrap().base_iface.as_str(),
+            "dummy1"
+        );
+    } else {
+        panic!("failed to find MacSec interface");
+    }
+}
+
+#[test]
+fn test_macvlan_parent_ref_by_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: macvlan0
+          type: mac-vlan
+          state: up
+          mac-vlan:
+            base-iface: wan0
+            mode: passthru",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: wan0
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    let merged_iface = merged_ifaces.kernel_ifaces.get("macvlan0").unwrap();
+
+    if let Interface::MacVlan(mac_vlan_iface) =
+        merged_iface.for_apply.as_ref().unwrap()
+    {
+        assert_eq!(
+            mac_vlan_iface
+                .mac_vlan
+                .as_ref()
+                .unwrap()
+                .base_iface
+                .as_str(),
+            "dummy1"
+        );
+    } else {
+        panic!("failed to find MacSec interface");
+    }
+}
+
+#[test]
+fn test_macvtap_parent_ref_by_profile_name() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: macvtap0
+          type: mac-vtap
+          state: up
+          mac-vtap:
+            base-iface: wan0
+            mode: passthru",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          profile-name: wan0
+          type: dummy
+          state: up
+          identifier: mac-address
+          mac-address: 32:BB:72:65:19:2A
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, false, false).unwrap();
+
+    let merged_iface = merged_ifaces.kernel_ifaces.get("macvtap0").unwrap();
+
+    if let Interface::MacVtap(mac_vtap_iface) =
+        merged_iface.for_apply.as_ref().unwrap()
+    {
+        assert_eq!(
+            mac_vtap_iface
+                .mac_vtap
+                .as_ref()
+                .unwrap()
+                .base_iface
+                .as_str(),
+            "dummy1"
+        );
+    } else {
+        panic!("failed to find MacSec interface");
     }
 }


### PR DESCRIPTION
Allowing referring VLAN/VxLAN/MacSec/MacVLAN/MacVtap parent by profile name.

For example:

```yml
---
interfaces:
  - name: port1
    type: ethernet
    identifier: mac-address
    mac-address: 00:23:45:67:89:1a
  - name: vlan101
    type: vlan
    state: up
    vlan:
      base-iface: port1
      id: 101
```