### PR TITLE
mptcp: fix comparison of flags in is_mptcp_flags_changed()

### DIFF
--- a/rust/src/lib/nm/query_apply/mptcp.rs
+++ b/rust/src/lib/nm/query_apply/mptcp.rs
@@ -13,7 +13,7 @@ pub(crate) fn is_mptcp_flags_changed(
             .as_ref()
             .and_then(|c| c.mptcp_flags),
     ) {
-        (Some(flags), Some(cur_flags)) => flags == cur_flags,
+        (Some(flags), Some(cur_flags)) => flags != cur_flags,
         _ => false,
     }
 }


### PR DESCRIPTION
When showing and applying a state containing MPTCP flags definition, it was always bringing down and up the interface. This was caused by a wrong comparison in `is_mptcp_flags_changed()` function. This function was checking if the MPTCP flags changed and is used to decide if we can reapply or not.

Fixes: https://issues.redhat.com/browse/RHEL-73700