### PR TITLE
gen_revert: Include current interface if desire is absent

### DIFF
--- a/rust/src/lib/revert/ifaces/iface.rs
+++ b/rust/src/lib/revert/ifaces/iface.rs
@@ -33,6 +33,10 @@ impl Interface {
         &self,
         current: &Self,
     ) -> Result<Self, NmstateError> {
+        if self.is_absent() {
+            return Ok(current.clone());
+        }
+
         let mut revert_value =
             serde_json::to_value(current.clone_name_type_only())?;
         let desired_value = serde_json::to_value(self)?;

--- a/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/current.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+  - name: veth1
+    type: ethernet
+    state: up
+    veth:
+      peer: veth1peer

--- a/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/desired.yml
@@ -1,0 +1,5 @@
+---
+interfaces:
+  - name: veth1
+    type: ethernet
+    state: absent

--- a/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/absent_veth/revert.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+  - name: veth1
+    type: ethernet
+    state: up
+    veth:
+      peer: veth1peer


### PR DESCRIPTION
When desire state is marking a interface as absent, its revert state
should be copying current state(or previous applied state).