### PR TITLE
policy: Add --validate option

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -326,6 +326,12 @@ fn main() {
                         .takes_value(false)
                         .help("Show state in json format"),
                 )
+                .arg(
+                    clap::Arg::new("VALIDATE")
+                        .long("validate")
+                        .takes_value(false)
+                        .help("Only validate policy"),
+                )
         )
         .subcommand(
             clap::Command::new(SUB_CMD_FORMAT)

--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -34,6 +34,10 @@ pub(crate) fn policy(matches: &clap::ArgMatches) -> Result<String, CliError> {
     if net_policy.is_empty() {
         return Ok(String::new());
     }
+
+    if matches.contains_id("VALIDATE") {
+        return Ok(String::new());
+    }
     let current_state =
         if let Some(current_state_file) = matches.value_of("CURRENT_STATE") {
             deserilize_from_file::<NetworkState>(current_state_file)?


### PR DESCRIPTION
This change add a --validate option that for now just run the NetworkPolicy serialization and ends with success is this is ok otherwise dump the error.