### PR TITLE
route: Support refer route next hop interface by profile name

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -7,7 +7,7 @@ use crate::{
     MergedInterface, MergedInterfaces, NmstateError, OvsInterface,
 };
 
-use super::inter_ifaces::InterfaceNameSearch;
+use super::InterfaceNameSearch;
 
 fn is_port_overbook(
     port_to_ctrl: &mut HashMap<String, String>,

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -25,6 +25,7 @@ mod ovs;
 mod sriov;
 mod vlan;
 
+pub(crate) use self::inter_ifaces::{InterfaceNameSearch, MergedInterfaces};
 pub use self::xfrm::XfrmInterface;
 pub use base::*;
 pub use bond::{
@@ -46,7 +47,6 @@ pub use ethtool::{
 };
 pub use hsr::{HsrConfig, HsrInterface, HsrProtocol};
 pub use infiniband::{InfiniBandConfig, InfiniBandInterface, InfiniBandMode};
-pub(crate) use inter_ifaces::MergedInterfaces;
 pub use inter_ifaces::*;
 pub use ipsec::{
     IpsecInterface, LibreswanAddressFamily, LibreswanConfig,

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    ifaces::InterfaceNameSearch,
     ip::{is_ipv6_addr, sanitize_ip_network},
     ErrorKind, InterfaceType, MergedInterfaces, NmstateError,
 };
@@ -100,6 +101,57 @@ impl Routes {
                     }
                 }
                 validate_route_dst(route)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn resolve_next_hop_iface_ref(
+        &mut self,
+        merged_ifaces: &MergedInterfaces,
+    ) -> Result<(), NmstateError> {
+        let iface_name_search = InterfaceNameSearch::new(merged_ifaces);
+
+        if let Some(config_routes) = self.config.as_mut() {
+            for route in config_routes.iter_mut() {
+                let new_iface_name = if let Some(next_hop_iface) =
+                    route.next_hop_iface.as_ref()
+                {
+                    let kernel_names = iface_name_search.get(next_hop_iface);
+                    // Prefer kernel name as port name
+                    if kernel_names.contains(&next_hop_iface.as_str()) {
+                        continue;
+                    }
+                    if kernel_names.is_empty() && !route.is_absent() {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Route '{}': next hop interface {} not found",
+                                route,
+                                next_hop_iface.as_str()
+                            ),
+                        ));
+                    } else if kernel_names.len() > 1 {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Route '{}' defined with next \
+                                hop interface {} but \
+                                multiple interfaces are sharing \
+                                this profile name",
+                                route,
+                                next_hop_iface.as_str()
+                            ),
+                        ));
+                    } else {
+                        kernel_names.first().map(|s| s.to_string())
+                    }
+                } else {
+                    None
+                };
+                if let Some(new_iface_name) = new_iface_name {
+                    route.next_hop_iface.replace(new_iface_name);
+                }
             }
         }
         Ok(())
@@ -539,11 +591,13 @@ pub(crate) struct MergedRoutes {
 
 impl MergedRoutes {
     pub(crate) fn new(
-        desired: Routes,
+        mut desired: Routes,
         current: Routes,
         merged_ifaces: &MergedInterfaces,
     ) -> Result<Self, NmstateError> {
         desired.validate()?;
+        desired.resolve_next_hop_iface_ref(merged_ifaces)?;
+
         let mut desired_routes = Vec::new();
         if let Some(rts) = desired.config.as_ref() {
             for rt in rts {

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from subprocess import SubprocessError
+
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import Interface
 from libnmstate.schema import Route
 import libnmstate
 import pytest
@@ -8,8 +12,10 @@ import yaml
 from ..testlib.cmdlib import exec_cmd
 from ..testlib.dummy import dummy_interface
 from ..testlib.env import nm_minor_version
+from ..testlib.ifacelib import get_mac_address
 from ..testlib.iproutelib import ip_monitor_assert_stable_link_up
 from ..testlib.route import assert_routes
+
 
 from libnmstate.error import NmstateVerificationError
 
@@ -307,3 +313,78 @@ def test_add_route_to_vlan_with_empty_connection_iface_name(
         desired_routes,
         cur_state,
     )
+
+
+@pytest.fixture
+def port1_ref_by_mac_with_static_route(eth1_up):
+    port1_mac = get_mac_address("eth1")
+
+    routes = [
+        {
+            Route.DESTINATION: "198.51.100.0/24",
+            Route.NEXT_HOP_INTERFACE: "port1",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        },
+    ]
+
+    iface_state = yaml.load(
+        f"""---
+            name: port1
+            type: ethernet
+            state: up
+            mtu: 1500
+            mac-address: {port1_mac}
+            identifier: mac-address
+            ipv4:
+              address:
+              - ip: 192.0.2.252
+                prefix-length: 24
+              dhcp: false
+              enabled: true
+            """,
+        Loader=yaml.SafeLoader,
+    )
+
+    libnmstate.apply(
+        {
+            Route.KEY: {
+                Route.CONFIG: routes,
+            },
+            Interface.KEY: [iface_state],
+        }
+    )
+    yield routes
+
+
+def test_route_delete_next_hop_iface_by_profile_name_no_leftover(
+    port1_ref_by_mac_with_static_route,
+):
+    libnmstate.apply(
+        {
+            Route.KEY: {
+                Route.CONFIG: [
+                    {
+                        Route.STATE: Route.STATE_ABSENT,
+                        Route.NEXT_HOP_INTERFACE: "port1",
+                    },
+                ]
+            }
+        }
+    )
+
+    with pytest.raises(SubprocessError):
+        exec_cmd("nmcli c show eth1".split(), check=True)
+    exec_cmd("nmcli c show port1".split(), check=True)
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "port1",
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
+    with pytest.raises(SubprocessError):
+        exec_cmd("nmcli c show port1".split(), check=True)

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -22,6 +22,7 @@ from .testlib.bridgelib import linux_bridge
 from .testlib.dummy import dummy_interface
 from .testlib.env import nm_minor_version
 from .testlib.genconf import gen_conf_apply
+from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.route import assert_routes
 from .testlib.route import assert_routes_missing
@@ -2289,3 +2290,133 @@ def test_add_route_with_mtu(eth1_up):
     )
     cur_state = libnmstate.show()
     assert_routes(routes, cur_state)
+
+
+@pytest.fixture
+def port1_ref_by_mac_with_static_route(eth1_up):
+    port1_mac = get_mac_address("eth1")
+
+    routes = [
+        {
+            Route.DESTINATION: "198.51.100.0/24",
+            Route.NEXT_HOP_INTERFACE: "port1",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        },
+    ]
+
+    iface_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    iface_state[Interface.NAME] = "port1"
+    iface_state[Interface.IDENTIFIER] = Interface.IDENTIFIER_MAC
+    iface_state[Interface.MAC] = port1_mac
+
+    libnmstate.apply(
+        {
+            Route.KEY: {
+                Route.CONFIG: routes,
+            },
+            Interface.KEY: [iface_state],
+        }
+    )
+    yield routes
+
+
+def test_route_next_hop_iface_ref_by_mac(port1_ref_by_mac_with_static_route):
+    expected_routes = port1_ref_by_mac_with_static_route
+    expected_routes[0][Route.NEXT_HOP_INTERFACE] = "eth1"
+
+    cur_state = libnmstate.show()
+    assert_routes(expected_routes, cur_state)
+
+
+def test_route_next_hop_iface_ref_by_profile_name(eth1_up):
+    routes = [
+        {
+            Route.DESTINATION: "198.51.100.0/24",
+            Route.NEXT_HOP_INTERFACE: "port1",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        },
+    ]
+
+    iface_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    iface_state[Interface.PROFILE_NAME] = "port1"
+
+    libnmstate.apply(
+        {
+            Route.KEY: {
+                Route.CONFIG: routes,
+            },
+            Interface.KEY: [iface_state],
+        }
+    )
+    expected_routes = routes
+    expected_routes[0][Route.NEXT_HOP_INTERFACE] = "eth1"
+
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)
+
+
+def test_route_next_hop_iface_ref_to_multiple_profiles(eth1_up, eth2_up):
+    routes = [
+        {
+            Route.DESTINATION: "198.51.100.0/24",
+            Route.NEXT_HOP_INTERFACE: "port1",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+        },
+    ]
+
+    iface_state = copy.deepcopy(ETH1_INTERFACE_STATE)
+    iface_state[Interface.PROFILE_NAME] = "port1"
+
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Route.KEY: {
+                    Route.CONFIG: routes,
+                },
+                Interface.KEY: [
+                    iface_state,
+                    {
+                        Interface.NAME: "eth2",
+                        Interface.PROFILE_NAME: "port1",
+                    },
+                ],
+            }
+        )
+
+
+def test_route_next_hop_iface_not_found():
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Route.KEY: {
+                    Route.CONFIG: [
+                        {
+                            Route.DESTINATION: "198.51.100.0/24",
+                            Route.NEXT_HOP_INTERFACE: "port_not_exist",
+                            Route.NEXT_HOP_ADDRESS: "192.0.2.1",
+                        }
+                    ]
+                },
+            }
+        )
+
+
+def test_route_delete_next_hop_iface_by_profile_name(
+    port1_ref_by_mac_with_static_route,
+):
+    libnmstate.apply(
+        {
+            Route.KEY: {
+                Route.CONFIG: [
+                    {
+                        Route.STATE: Route.STATE_ABSENT,
+                        Route.NEXT_HOP_INTERFACE: "port1",
+                    },
+                ]
+            }
+        }
+    )
+
+    cur_routes = libnmstate.show()[Route.KEY]
+    for route in cur_routes[Route.CONFIG]:
+        assert route[Route.NEXT_HOP_INTERFACE] != "eth1"

--- a/tests/integration/testlib/cmdlib.py
+++ b/tests/integration/testlib/cmdlib.py
@@ -54,7 +54,7 @@ def exec_cmd(cmd, env=None, stdin=None, check=False):
     logging.debug(_retcode_log_line(p.returncode, err=err))
 
     if check and p.returncode != 0:
-        raise Exception(
+        raise subprocess.SubprocessError(
             "Failed command {0}:\n{1}".format(
                 command_log_line(cmd), format_exec_cmd_result(p)
             )
@@ -68,7 +68,9 @@ def command_log_line(args, cwd=None):
 
 
 def format_exec_cmd_result(result):
-    return "rc={}, out={}, err={}".format(*result)
+    return "rc={}, out={}, err={}".format(
+        result.returncode, result.stdout, result.stderr
+    )
 
 
 def _retcode_log_line(code, err=None):


### PR DESCRIPTION
Example YAML:

```yaml
---
interfaces:
  - name: port1
    type: ethernet
    mac-address: 00:23:45:67:89:1a
    identifier: mac-address
    ipv4:
      enabled: true
      dhcp: false
      address:
        - ip: 192.0.2.251
          prefix-length: 24
routes:
  config:
  - destination: 0.0.0.0/0
    next-hop-address: 192.0.2.1
    next-hop-interface: port1
```

For route next hop interface, we will prefer kernel name but fallback to
search profile name. Will raise error when route is referring to
multiple interface sharing the same profile name.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-32495
Resolves: https://issues.redhat.com/browse/RHEL-56558