### PR TITLE
ovsdb: Fix query output when port and interface name differ

### DIFF
--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -80,7 +80,21 @@ fn parse_ovs_bridge_conf(
     for port_uuid in ovsdb_br.ports.as_slice() {
         if let Some(ovsdb_port) = ovsdb_ports.get(port_uuid) {
             let mut port_conf = OvsBridgePortConfig::new();
-            port_conf.name.clone_from(&ovsdb_port.name);
+            // OVS bond will have 2 ports where its logical(in-database) name
+            // should be used instead of kernel interface name.
+            if ovsdb_port.ports.len() == 1 {
+                // The port name is not kernel interface name, so we use
+                // Interface table for kernel interface name if found.
+                if let Some(ovsdb_iface) =
+                    ovsdb_ifaces.get(ovsdb_port.ports.first().unwrap())
+                {
+                    port_conf.name.clone_from(&ovsdb_iface.name);
+                } else {
+                    port_conf.name.clone_from(&ovsdb_port.name);
+                }
+            } else {
+                port_conf.name.clone_from(&ovsdb_port.name);
+            }
             if ovsdb_port.ports.len() > 1 {
                 port_conf.bond =
                     Some(parse_ovs_bond_conf(ovsdb_port, ovsdb_ifaces));

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -520,3 +520,44 @@ def test_gen_conf_route_initcwnd_mtu_quickack():
         desired_routes = desired_state[Route.KEY][Route.CONFIG]
         cur_state = libnmstate.show()
         assert_routes(desired_routes, cur_state, nic=None)
+
+
+def test_gen_conf_ovs_bridge_port_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+    port2_mac = get_mac_address("eth2")
+
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: port2
+          type: ethernet
+          identifier: mac-address
+          mac-address: {}
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: port1
+            - name: port2""".format(
+            port1_mac, port2_mac
+        )
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: br0
+              type: ovs-bridge
+              state: up
+              bridge:
+                port:
+                - name: eth1
+                - name: eth2"""
+        )
+        assertlib.assert_state_match(expected_state)


### PR DESCRIPTION
For OVS like:

```
Bridge br0
  Port port2
      Interface eth2
          type: system
  Port port1
      Interface eth1
          type: system
```

The `nmstatectl show` is taking `port1` as OVS bridge port name.

The fix is to use interface name in database when only one interface
attatched(OVS bond should still use port name).

Integration test case included.