### PR TITLE
test: Use openvswitch3.4 for c9s testing

### DIFF
--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -18,7 +18,7 @@ RUN dnf update -y && \
     dnf config-manager --set-enabled crb && \
     dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust-toolset NetworkManager NetworkManager-ovs \
-        openvswitch2.17 systemd-udev python3-devel python3-pyyaml \
+        openvswitch3.4 systemd-udev python3-devel python3-pyyaml \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
         libndp procps-ng dpdk libreswan NetworkManager-libreswan \


### PR DESCRIPTION
The OpenShift is using openvswitch3.4, so should our tests.