### PR TITLE
ovsdb: return an error if ovsdb socket is not available when applying

### DIFF
--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -162,11 +162,24 @@ impl NetworkState {
             );
         }
         if self.interfaces.has_up_ovs_iface() && !ovsdb_is_running() {
-            log::warn!(
-                "Desired state contains OVS interfaces, but not able \
-                to connect OVS daemon at socket {}",
-                DEFAULT_OVS_DB_SOCKET_PATH
-            );
+            if self.no_verify {
+                log::warn!(
+                    "Desired state contains OVS interfaces, but not able \
+                    to connect OVS daemon at socket {}",
+                    DEFAULT_OVS_DB_SOCKET_PATH
+                );
+            } else {
+                let e = NmstateError::new(
+                    ErrorKind::PluginFailure,
+                    format!(
+                        "Desired state contains OVS interfaces, but \
+                            not able to connect OVS daemon at socket {}",
+                        DEFAULT_OVS_DB_SOCKET_PATH
+                    ),
+                );
+                log::error!("{}", e);
+                return Err(e);
+            }
         }
 
         if !self.kernel_only {


### PR DESCRIPTION
Return an error instead of warning when the desired state contains OVS interfaces but Nmstate is not able to connect to the OVS daemon socket and verification is not disabled.

If NetworkManager is in a different namespace with the OVS socket mounted, then Nmstate could apply the configuration correctly but it will fail the verification. Therefore, this operation should only be allowed with `--no-verify`.

```
[2025-02-20T10:47:57Z INFO  nmstatectl] Nmstate version: 2.2.41
[2025-02-20T10:47:58Z ERROR nmstate::query_apply::net_state] PluginFailure: Desired state contains OVS interfaces, but not able to connect OVS daemon at socket /run/openvswitch/db.sock
NmstateError: PluginFailure: Desired state contains OVS interfaces, but not able to connect OVS daemon at socket /run/openvswitch/db.sock
```