### PR TITLE
Makefile: Stop generating vendor tarball for rust 1.66

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,33 @@
+name: Minium Support Rust Version Test
+
+concurrency:
+  group: msrv-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+   types: [opened, synchronize, reopened]
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
+
+jobs:
+  build_on_msrv:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - msrv: "1.77"
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust ${{ matrix.msrv }}
+      run: rustup install ${{ matrix.msrv }}
+
+    - name: Build test
+      run: cd rust && cargo +${{ matrix.msrv }} build --ignore-rust-version
+
+    - name: Unit tests
+      run: cd rust && cargo +${{ matrix.msrv }} test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ COMMIT_COUNT=$(shell git rev-list --count HEAD --)
 ifeq ($(RELEASE), 1)
     TARBALL=nmstate-$(VERSION).tar.gz
     VENDOR_TARBALL=nmstate-vendor-$(VERSION).tar.xz
-    VENDOR_TARBALL_RUST_1_66=nmstate-vendor-$(VERSION)-rust-1-66.tar.xz
 else
     TARBALL=nmstate-$(VERSION)-alpha-0.$(TIMESTAMP).$(COMMIT_COUNT)git$(GIT_COMMIT).tar.gz
     VENDOR_TARBALL=nmstate-vendor-$(VERSION)-alpha-0.$(TIMESTAMP).$(COMMIT_COUNT)git$(GIT_COMMIT).tar.xz
@@ -150,14 +149,6 @@ dist: manpage $(SPEC_FILE) $(CLIB_HEADER)
 		 echo -e "'cargo install cargo-vendor-filterer'\n";); \
 		cd $(TMPDIR); \
 		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL) vendor ; \
-		rm -rf $(TMPDIR)/vendor/mio*; \
-		rm -rf $(TMPDIR)/vendor/tokio*; \
-		cd $(TMPDIR)/vendor; \
-		$(ROOT_DIR)/packaging/download_rust_crate.py mio 0.8.9; \
-		$(ROOT_DIR)/packaging/download_rust_crate.py tokio 1.38.1; \
-		$(ROOT_DIR)/packaging/download_rust_crate.py tokio-macros 2.3.0; \
-		cd $(TMPDIR); \
-		tar cfJ $(ROOT_DIR)/$(VENDOR_TARBALL_RUST_1_66) vendor ; \
 	else \
 		cd rust; \
 		cargo vendor $(TMPDIR)/vendor; \


### PR DESCRIPTION
Also add CI test for build and unit test on minimum support rust version 1.77.