### PR TITLE
route: Add support of initcwnd and initrwnd

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -206,6 +206,8 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     // we require both cwnd and its lock flag to consider cwnd as set.
     let cwnd_lock = np_route.lock.unwrap_or(0) & (1 << RTAX_CWND) != 0;
     route_entry.cwnd = if cwnd_lock { np_route.cwnd } else { None };
+    route_entry.initcwnd = np_route.initcwnd;
+    route_entry.initrwnd = np_route.initrwnd;
 
     route_entry
 }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -23,6 +23,8 @@ pub struct NmIpRoute {
     pub route_type: Option<String>,
     pub cwnd: Option<u32>,
     pub lock_cwnd: Option<bool>,
+    pub initcwnd: Option<u32>,
+    pub initrwnd: Option<u32>,
     _other: DbusDictionary,
 }
 
@@ -46,6 +48,8 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             route_type: _from_map!(v, "type", String::try_from)?,
             cwnd: _from_map!(v, "cwnd", u32::try_from)?,
             lock_cwnd: _from_map!(v, "lock-cwnd", bool::try_from)?,
+            initcwnd: _from_map!(v, "initcwnd", u32::try_from)?,
+            initrwnd: _from_map!(v, "initrwnd", u32::try_from)?,
             _other: v,
         })
     }
@@ -114,6 +118,18 @@ impl NmIpRoute {
         if let Some(v) = &self.lock_cwnd {
             ret.append(
                 zvariant::Value::new("lock-cwnd"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.initcwnd {
+            ret.append(
+                zvariant::Value::new("initcwnd"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.initrwnd {
+            ret.append(
+                zvariant::Value::new("initrwnd"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -62,6 +62,8 @@ pub(crate) fn gen_nm_ip_routes(
         };
         nm_route.cwnd = route.cwnd;
         nm_route.lock_cwnd = route.cwnd.map(|_| true);
+        nm_route.initcwnd = route.initcwnd;
+        nm_route.initrwnd = route.initrwnd;
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -181,7 +181,11 @@ pub struct RouteEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route_type: Option<RouteType>,
     /// Congestion window clamp
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
     pub cwnd: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Route source defines which IP address should be used as the source

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -629,3 +629,100 @@ fn test_route_without_options_is_match_with_any() {
     assert!(!desired_route.is_match(&not_match_route));
     assert!(desired_route.is_match(&match_route));
 }
+
+#[test]
+fn test_route_initcwnd_initrcwnd_deserilize_from_string() {
+    let route = serde_yaml::from_str::<RouteEntry>(
+        r#"
+        initcwnd: "100"
+        initrwnd: "20"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(route.initcwnd, Some(100));
+    assert_eq!(route.initrwnd, Some(20));
+}
+
+#[test]
+fn test_route_initcwnd_equal() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "192.0.2.1"
+        initcwnd: 201
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "192.0.2.1"
+        initcwnd: 202
+        "#,
+    )
+    .unwrap();
+
+    assert!(route1 != route2);
+}
+
+#[test]
+fn test_route_initrwnd_equal() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        initrwnd: 2010
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        initrwnd: 2020
+        "#,
+    )
+    .unwrap();
+
+    assert!(route1 != route2);
+}
+
+#[test]
+fn test_route_initrwnd_and_initcwnd_is_match() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        initrwnd: 20
+        initcwnd: 10
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        state: absent
+        initrwnd: 20
+        initcwnd: 10
+        "#,
+    )
+    .unwrap();
+
+    assert!(route2.is_match(&route1));
+}
+
+#[test]
+fn test_route_initcwnd_initrwnd_display() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        initrwnd: 2010
+        initcwnd: 2011
+        "#,
+    )
+    .unwrap();
+
+    let route1_str = route1.to_string();
+
+    assert!(route1_str.contains("initrwnd: 2010"));
+    assert!(route1_str.contains("initcwnd: 2011"));
+}

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -525,6 +525,18 @@ fn test_routes_not_delayed_by_nm() {
 }
 
 #[test]
+fn test_route_cwnd_deserilize_from_string() {
+    let route = serde_yaml::from_str::<RouteEntry>(
+        r#"
+        cwnd: "100"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(route.cwnd, Some(100));
+}
+
+#[test]
 fn test_route_cwnd_zero_invalid() {
     let route = serde_yaml::from_str::<RouteEntry>(
         r"

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -48,6 +48,8 @@ class Route:
     USE_DEFAULT_METRIC = -1
     USE_DEFAULT_ROUTE_TABLE = 0
     CWND = "cwnd"
+    INITCWND = "initcwnd"
+    INITRWND = "initrwnd"
 
 
 class RouteRule:

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2233,3 +2233,32 @@ def test_apply_routes_twice_only_reapplies(dummy0_up):
 
     cur_state = libnmstate.show()
     assert_routes(routes, cur_state)
+
+
+# https://issues.redhat.com/browse/RHEL-59589
+@pytest.mark.tier1
+def test_add_route_with_initcwnd_and_initrwnd(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS1,
+            Route.INITCWND: 20,
+            Route.INITRWND: 40,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+            Route.INITCWND: 40,
+            Route.INITRWND: 20,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)


### PR DESCRIPTION
Supporting changing TCP initial congestion and receive window size of
route destination defined by RFC 2414 and RFC 5681.

Example:

```yml
---
routes:
  config:
    - destination: 203.0.113.0/24
      next-hop-address: 192.0.2.1
      next-hop-interface: eth1
      initcwnd: 20
      initrwnd: 40
    - destination: 2001:db8:c::/64
      next-hop-address: 2001:db8:1::2
      next-hop-interface: eth1
      initcwnd: 40
      initrwnd: 20
```

Unit and integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-59589