### PR TITLE
route: Add support of MTU option

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -208,6 +208,7 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry.cwnd = if cwnd_lock { np_route.cwnd } else { None };
     route_entry.initcwnd = np_route.initcwnd;
     route_entry.initrwnd = np_route.initrwnd;
+    route_entry.mtu = np_route.mtu;
 
     route_entry
 }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -25,6 +25,7 @@ pub struct NmIpRoute {
     pub lock_cwnd: Option<bool>,
     pub initcwnd: Option<u32>,
     pub initrwnd: Option<u32>,
+    pub mtu: Option<u32>,
     _other: DbusDictionary,
 }
 
@@ -50,6 +51,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             lock_cwnd: _from_map!(v, "lock-cwnd", bool::try_from)?,
             initcwnd: _from_map!(v, "initcwnd", u32::try_from)?,
             initrwnd: _from_map!(v, "initrwnd", u32::try_from)?,
+            mtu: _from_map!(v, "mtu", u32::try_from)?,
             _other: v,
         })
     }
@@ -130,6 +132,12 @@ impl NmIpRoute {
         if let Some(v) = &self.initrwnd {
             ret.append(
                 zvariant::Value::new("initrwnd"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.mtu {
+            ret.append(
+                zvariant::Value::new("mtu"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -64,6 +64,7 @@ pub(crate) fn gen_nm_ip_routes(
         nm_route.lock_cwnd = route.cwnd.map(|_| true);
         nm_route.initcwnd = route.initcwnd;
         nm_route.initrwnd = route.initrwnd;
+        nm_route.mtu = route.mtu;
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -35,6 +35,7 @@ impl NetworkState {
     pub fn checkpoint_rollback(checkpoint: &str) -> Result<(), NmstateError> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_io()
+            .enable_time()
             .build()
             .map_err(|e| {
                 NmstateError::new(
@@ -60,6 +61,7 @@ impl NetworkState {
     pub fn checkpoint_commit(checkpoint: &str) -> Result<(), NmstateError> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_io()
+            .enable_time()
             .build()
             .map_err(|e| {
                 NmstateError::new(
@@ -84,6 +86,7 @@ impl NetworkState {
     pub fn retrieve(&mut self) -> Result<&mut Self, NmstateError> {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_io()
+            .enable_time()
             .build()
             .map_err(|e| {
                 NmstateError::new(

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -726,3 +726,72 @@ fn test_route_initcwnd_initrwnd_display() {
     assert!(route1_str.contains("initrwnd: 2010"));
     assert!(route1_str.contains("initcwnd: 2011"));
 }
+
+#[test]
+fn test_route_mtu_equal() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1281
+        "#,
+    )
+    .unwrap();
+
+    assert!(route1 != route2);
+}
+
+#[test]
+fn test_route_mtu_is_match() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        state: absent
+        mtu: 1280
+        "#,
+    )
+    .unwrap();
+
+    assert!(route2.is_match(&route1));
+}
+
+#[test]
+fn test_route_mtu_display() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        "#,
+    )
+    .unwrap();
+
+    let route1_str = route1.to_string();
+
+    assert!(route1_str.contains("mtu: 1280"));
+}
+
+#[test]
+fn test_route_mtu_deserilize_from_string() {
+    let route = serde_yaml::from_str::<RouteEntry>(
+        r#"
+        mtu: "1280"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(route.mtu, Some(1280));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -50,6 +50,7 @@ class Route:
     CWND = "cwnd"
     INITCWND = "initcwnd"
     INITRWND = "initrwnd"
+    MTU = "mtu"
 
 
 class RouteRule:

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2262,3 +2262,30 @@ def test_add_route_with_initcwnd_and_initrwnd(eth1_up):
     )
     cur_state = libnmstate.show()
     assert_routes(routes, cur_state)
+
+
+# https://issues.redhat.com/browse/RHEL-80418
+@pytest.mark.tier1
+def test_add_route_with_mtu(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS1,
+            Route.MTU: 1550,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+            Route.MTU: 1280,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)


### PR DESCRIPTION
Add support of MTU of route, for example:

```yml routes:
 config:
 - destination: 2001:db8:c::/64
   next-hop-interface: eth1
   next-hop-address: 2001:db8:1::2
   mtu: 1280
 - destination: 203.0.113.0/24
   next-hop-interface: eth1
   next-hop-address: 192.0.2.1
   mtu: 1550
```

Unit and integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-80418