### PR TITLE
validate: Check state and policy

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -22,6 +22,8 @@ mod service;
 mod state;
 #[cfg(feature = "query_apply")]
 mod statistic;
+#[cfg(feature = "query_apply")]
+mod validate;
 
 use env_logger::Builder;
 use log::LevelFilter;
@@ -30,6 +32,7 @@ use log::LevelFilter;
 use crate::apply::{
     apply_from_files, apply_from_stdin, commit, rollback, state_edit,
 };
+
 #[cfg(feature = "query_apply")]
 use crate::autoconf::autoconf;
 #[cfg(feature = "gen_conf")]
@@ -45,6 +48,8 @@ use crate::result::print_result_and_exit;
 use crate::service::ncl_service;
 #[cfg(feature = "query_apply")]
 use crate::statistic::statistic;
+#[cfg(feature = "query_apply")]
+use validate::validate;
 
 pub(crate) const DEFAULT_SERVICE_FOLDER: &str = "/etc/nmstate";
 pub(crate) const CONFIG_FOLDER_KEY: &str = "CONFIG_FOLDER";
@@ -65,6 +70,7 @@ const SUB_CMD_POLICY: &str = "policy";
 const SUB_CMD_FORMAT: &str = "format";
 const SUB_CMD_GEN_REVERT: &str = "gr";
 const SUB_CMD_STATISTIC: &str = "statistic";
+const SUB_CMD_VALIDATE: &str = "validate";
 
 fn main() {
     let argv: Vec<String> = std::env::args().collect();
@@ -389,6 +395,17 @@ fn main() {
                 )
         )
         .subcommand(
+            clap::Command::new(SUB_CMD_VALIDATE)
+                .about("Validate network state or network policy")
+                .arg(
+                    clap::Arg::new("STATE_FILE")
+                        .required(false)
+                        .multiple_occurrences(false)
+                        .index(1)
+                        .help("Network state file"),
+                )
+        )
+        .subcommand(
             clap::Command::new(SUB_CMD_VERSION)
             .about("Show version")
        );
@@ -512,6 +529,8 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_STATISTIC)
     {
         print_result_and_exit(statistic(matches));
+    } else if let Some(matches) = matches.subcommand_matches(SUB_CMD_VALIDATE) {
+        print_result_and_exit(validate(matches));
     } else if matches.subcommand_matches(SUB_CMD_VERSION).is_some() {
         print_result_and_exit(Ok(format!(
             "{} {}",
@@ -648,6 +667,17 @@ fn statistic(
 ) -> Result<String, crate::error::CliError> {
     Err(
         "The statistic sub-command require `query-apply` feature been \
+        enabled during compiling"
+            .into(),
+    )
+}
+
+#[cfg(not(feature = "query_apply"))]
+fn validate(
+    _matches: &clap::ArgMatches,
+) -> Result<String, crate::error::CliError> {
+    Err(
+        "The validate sub-command require `query-apply` feature been \
         enabled during compiling"
             .into(),
     )

--- a/rust/src/cli/state.rs
+++ b/rust/src/cli/state.rs
@@ -8,32 +8,39 @@ use nmstate::NetworkState;
 
 use crate::error::CliError;
 
-pub(crate) fn state_from_file(
-    file_path: &str,
-) -> Result<NetworkState, CliError> {
-    if file_path == "-" {
-        state_from_fd(&mut std::io::stdin())
-    } else {
-        state_from_fd(&mut std::fs::File::open(file_path)?)
+pub(crate) enum NetworkStateOrPolicy {
+    State(NetworkState),
+    #[cfg(feature = "query_apply")]
+    Policy(NetworkPolicy),
+}
+
+#[cfg(feature = "query_apply")]
+impl TryFrom<NetworkStateOrPolicy> for NetworkState {
+    type Error = CliError;
+    fn try_from(value: NetworkStateOrPolicy) -> Result<Self, Self::Error> {
+        match value {
+            NetworkStateOrPolicy::Policy(policy) => {
+                Ok(NetworkState::try_from(policy)?)
+            }
+            NetworkStateOrPolicy::State(state) => Ok(state),
+        }
     }
 }
 
 #[cfg(not(feature = "query_apply"))]
-pub(crate) fn state_from_fd<R>(fd: &mut R) -> Result<NetworkState, CliError>
-where
-    R: Read,
-{
-    let mut content = String::new();
-    // Replace non-breaking space '\u{A0}'  to normal space
-    fd.read_to_string(&mut content)?;
-    let content = content.replace('\u{A0}', " ");
-
-    match serde_yaml::from_str(&content) {
-        Ok(s) => Ok(s),
-        Err(e) => Err(CliError::from(format!(
-            "Provide file is not valid NetworkState: {e}"
-        ))),
+impl TryFrom<NetworkStateOrPolicy> for NetworkState {
+    type Error = CliError;
+    fn try_from(value: NetworkStateOrPolicy) -> Result<Self, Self::Error> {
+        match value {
+            NetworkStateOrPolicy::State(state) => Ok(state),
+        }
     }
+}
+
+pub(crate) fn state_from_file(
+    file_path: &str,
+) -> Result<NetworkState, CliError> {
+    NetworkState::try_from(state_or_policy_from_file(file_path)?)
 }
 
 #[cfg(feature = "query_apply")]
@@ -41,13 +48,53 @@ pub(crate) fn state_from_fd<R>(fd: &mut R) -> Result<NetworkState, CliError>
 where
     R: Read,
 {
+    NetworkState::try_from(state_or_policy_from_fd(fd)?)
+}
+
+pub(crate) fn state_or_policy_from_file(
+    file_path: &str,
+) -> Result<NetworkStateOrPolicy, CliError> {
+    if file_path == "-" {
+        state_or_policy_from_fd(&mut std::io::stdin())
+    } else {
+        state_or_policy_from_fd(&mut std::fs::File::open(file_path)?)
+    }
+}
+
+#[cfg(not(feature = "query_apply"))]
+pub(crate) fn state_or_policy_from_fd<R>(
+    fd: &mut R,
+) -> Result<NetworkStateOrPolicy, CliError>
+where
+    R: Read,
+{
     let mut content = String::new();
     // Replace non-breaking space '\u{A0}'  to normal space
     fd.read_to_string(&mut content)?;
     let content = content.replace('\u{A0}', " ");
 
     match serde_yaml::from_str(&content) {
-        Ok(s) => Ok(s),
+        Ok(s) => Ok(NetworkStateOrPolicy::State(s)),
+        Err(e) => Err(CliError::from(format!(
+            "Provide file is not valid NetworkState: {e}"
+        ))),
+    }
+}
+
+#[cfg(feature = "query_apply")]
+pub(crate) fn state_or_policy_from_fd<R>(
+    fd: &mut R,
+) -> Result<NetworkStateOrPolicy, CliError>
+where
+    R: Read,
+{
+    let mut content = String::new();
+    // Replace non-breaking space '\u{A0}'  to normal space
+    fd.read_to_string(&mut content)?;
+    let content = content.replace('\u{A0}', " ");
+
+    match serde_yaml::from_str(&content) {
+        Ok(s) => Ok(NetworkStateOrPolicy::State(s)),
         Err(state_error) => {
             // Try NetworkPolicy
             let net_policy: NetworkPolicy = match serde_yaml::from_str(&content)
@@ -67,7 +114,7 @@ where
                     )));
                 }
             };
-            Ok(NetworkState::try_from(net_policy)?)
+            Ok(NetworkStateOrPolicy::Policy(net_policy))
         }
     }
 }

--- a/rust/src/cli/validate.rs
+++ b/rust/src/cli/validate.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state::{state_or_policy_from_file, NetworkStateOrPolicy};
+
+pub(crate) fn validate(
+    matches: &clap::ArgMatches,
+) -> Result<String, crate::error::CliError> {
+    let state_or_policy =
+        if let Some(file_path) = matches.value_of("STATE_FILE") {
+            state_or_policy_from_file(file_path)?
+        } else {
+            state_or_policy_from_file("-")?
+        };
+    match state_or_policy {
+        NetworkStateOrPolicy::Policy(policy) => {
+            Ok(serde_yaml::to_string(&policy)?)
+        }
+        NetworkStateOrPolicy::State(state) => {
+            Ok(serde_yaml::to_string(&state)?)
+        }
+    }
+}

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -32,6 +32,7 @@ SET_CMD = ["nmstatectl", "set"]
 SHOW_CMD = ["nmstatectl", "show"]
 CONFIRM_CMD = ["nmstatectl", "commit"]
 ROLLBACK_CMD = ["nmstatectl", "rollback"]
+VALIDATE_CMD = ["nmstatectl", "validate"]
 
 LOOPBACK_CONFIG = {
     "name": "lo",
@@ -63,6 +64,45 @@ ETH1_YAML_CONFIG = b"""interfaces:
   ipv6:
     enabled: false
   mtu: 1500
+"""
+
+BAD_YAML_STATE_CONFIG = b"""interfaces:
+- name: eth1
+  state: up
+  type: ethernet
+  accept-all-mac-addresses: false
+  ipv4:
+    adress:
+    - ip: 192.0.2.250
+      prefix-length: 24
+    enabled: true
+  ipv6:
+    enabled: false
+  mtu: 1500
+"""
+
+BAD_YAML_POLICY_CONFIG = b"""capture:
+  default-gw: routes.running.destination="0.0.0.0/0"
+  base-iface: >-
+    interfaces.name==capture.default-gw.routes.running.0.next-hop-interface
+desiredState:
+  interfaces:
+    - name: br1
+      description: >-
+        DHCP aware Linux bridge to connect a nic that is referenced by a
+        default gateway
+      type: linux-bridge
+      state: up
+      mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
+      ipv4:
+        dhcp: true
+        enabled: true
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: "{{ capture.base-iface.interfaces.0.name }}"
 """
 
 SET_WARNING = "Using 'set' is deprecated, use 'apply' instead."
@@ -200,6 +240,49 @@ def test_apply_command_with_two_states():
 
     assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
     assertlib.assert_absent("linux-br0")
+
+
+def test_validate_with_file_state():
+    examples = find_examples_dir()
+    cmd = VALIDATE_CMD + [
+        os.path.join(examples, "linuxbrige_eth1_up.yml"),
+    ]
+    ret = cmdlib.exec_cmd(cmd)
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+
+
+def test_validate_with_file_policy():
+    examples = find_examples_dir()
+    cmd = VALIDATE_CMD + [
+        os.path.join(examples, "policy/bridge-on-default-gw-dhcp/policy.yml"),
+    ]
+    ret = cmdlib.exec_cmd(cmd)
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+
+
+def test_validate_command_with_stdin_state():
+    ret = cmdlib.exec_cmd(VALIDATE_CMD, stdin=ETH1_YAML_CONFIG)
+    rc, out, err = ret
+
+    assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+
+
+def test_validate_command_with_stdin_bad_state():
+    ret = cmdlib.exec_cmd(VALIDATE_CMD, stdin=BAD_YAML_STATE_CONFIG)
+    rc, out, err = ret
+
+    assert rc != cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
+
+
+def test_validate_command_with_stdin_bad_policy():
+    ret = cmdlib.exec_cmd(VALIDATE_CMD, stdin=BAD_YAML_POLICY_CONFIG)
+    rc, out, err = ret
+
+    assert rc != cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
Add a `nmstatectl validate` command that will validate state or policy as files or stdin.