### PR TITLE
nm vlan: Support nm connection with empty `connection.interface-name`

### DIFF
--- a/rust/src/lib/nm/nm_dbus/active_connection.rs
+++ b/rust/src/lib/nm/nm_dbus/active_connection.rs
@@ -5,6 +5,7 @@ use super::NmIfaceType;
 use super::{
     connection::nm_con_get_from_obj_path,
     dbus::{obj_path_to_string, NM_DBUS_INTERFACE_AC, NM_DBUS_INTERFACE_ROOT},
+    query_apply::device::nm_dev_from_obj_path,
     ErrorKind, NmError,
 };
 
@@ -102,7 +103,19 @@ pub(crate) async fn get_nm_ac_by_obj_path(
             nm_con_get_from_obj_path(connection, &nm_conn_obj_path).await?;
         let iface_name = match nm_conn.iface_name() {
             Some(i) => i.to_string(),
-            None => "".to_string(),
+            None => {
+                // Try to get interface name from NmDevice
+                if let Some(nm_dev_obj_path) =
+                    nm_ac_obj_path_nm_dev_obj_path_get(connection, obj_path)
+                        .await?
+                {
+                    nm_dev_from_obj_path(connection, &nm_dev_obj_path)
+                        .await?
+                        .name
+                } else {
+                    String::new()
+                }
+            }
         };
         let iface_type = nm_conn.iface_type().cloned().unwrap_or_default();
         Ok(Some(NmActiveConnection {
@@ -114,5 +127,30 @@ pub(crate) async fn get_nm_ac_by_obj_path(
         }))
     } else {
         Ok(None)
+    }
+}
+
+#[cfg(feature = "query_apply")]
+async fn nm_ac_obj_path_nm_dev_obj_path_get(
+    dbus_conn: &zbus::Connection,
+    obj_path: &str,
+) -> Result<Option<String>, NmError> {
+    let proxy = zbus::Proxy::new(
+        dbus_conn,
+        NM_DBUS_INTERFACE_ROOT,
+        obj_path,
+        NM_DBUS_INTERFACE_AC,
+    )
+    .await?;
+    // According to NetworkManager code:
+    //      src/core/nm-active-connection.c:get_property()
+    // Even the return is array of string, NmActiveConnection can only
+    // have at most one device.
+    match proxy
+        .get_property::<Vec<zvariant::OwnedObjectPath>>("Devices")
+        .await
+    {
+        Ok(mut p) => Ok(p.pop().map(obj_path_to_string)),
+        Err(_) => Ok(None),
     }
 }

--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -343,6 +343,14 @@ impl NmConnection {
         }
         None
     }
+
+    pub fn is_multi_connect(&self) -> bool {
+        matches!(
+            self.connection.as_ref().and_then(|c| c.multi_connect),
+            Some(NmConnectionMultiConnect::Multiple)
+                | Some(NmConnectionMultiConnect::ManualMultiple)
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
@@ -359,6 +367,7 @@ pub struct NmSettingConnection {
     pub autoconnect_ports: Option<bool>,
     pub lldp: Option<bool>,
     pub mptcp_flags: Option<u32>,
+    pub multi_connect: Option<NmConnectionMultiConnect>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -383,6 +392,8 @@ impl TryFrom<DbusDictionary> for NmSettingConnection {
             ),
             lldp: _from_map!(v, "lldp", i32::try_from)?.map(|i| i == 1),
             mptcp_flags: _from_map!(v, "mptcp-flags", u32::try_from)?,
+            multi_connect: _from_map!(v, "multi-connect", i32::try_from)?
+                .map(NmConnectionMultiConnect::from),
             _other: v,
         })
     }
@@ -414,6 +425,9 @@ impl ToDbusValue for NmSettingConnection {
         }
         if let Some(v) = &self.mptcp_flags {
             ret.insert("mptcp-flags", zvariant::Value::new(v));
+        }
+        if let Some(v) = self.multi_connect {
+            ret.insert("multi-connect", zvariant::Value::new(i32::from(v)));
         }
 
         ret.insert(
@@ -547,5 +561,53 @@ impl NmRange {
             zvariant::Value::new(zvariant::Value::U64(self.end)),
         )?;
         Ok(zvariant::Value::Dict(ret))
+    }
+}
+
+const NM_CONNECTION_MULTI_CONNECT_DEFAULT: i32 = 0;
+const NM_CONNECTION_MULTI_CONNECT_SINGLE: i32 = 1;
+const NM_CONNECTION_MULTI_CONNECT_MANUAL_MULTIPLE: i32 = 2;
+const NM_CONNECTION_MULTI_CONNECT_MULTIPLE: i32 = 3;
+
+#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub enum NmConnectionMultiConnect {
+    #[default]
+    Default,
+    Single,
+    ManualMultiple,
+    Multiple,
+    Other(i32),
+}
+
+impl From<i32> for NmConnectionMultiConnect {
+    fn from(d: i32) -> Self {
+        match d {
+            NM_CONNECTION_MULTI_CONNECT_DEFAULT => Self::Default,
+            NM_CONNECTION_MULTI_CONNECT_SINGLE => Self::Single,
+            NM_CONNECTION_MULTI_CONNECT_MANUAL_MULTIPLE => Self::ManualMultiple,
+            NM_CONNECTION_MULTI_CONNECT_MULTIPLE => Self::Multiple,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<NmConnectionMultiConnect> for i32 {
+    fn from(v: NmConnectionMultiConnect) -> i32 {
+        match v {
+            NmConnectionMultiConnect::Default => {
+                NM_CONNECTION_MULTI_CONNECT_DEFAULT
+            }
+            NmConnectionMultiConnect::Single => {
+                NM_CONNECTION_MULTI_CONNECT_SINGLE
+            }
+            NmConnectionMultiConnect::ManualMultiple => {
+                NM_CONNECTION_MULTI_CONNECT_MANUAL_MULTIPLE
+            }
+            NmConnectionMultiConnect::Multiple => {
+                NM_CONNECTION_MULTI_CONNECT_MULTIPLE
+            }
+            NmConnectionMultiConnect::Other(i) => i,
+        }
     }
 }

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -49,7 +49,8 @@ pub use self::bridge::{
     NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
 };
 pub use self::conn::{
-    NmConnection, NmRange, NmSettingConnection, NmSettingsConnectionFlag,
+    NmConnection, NmConnectionMultiConnect, NmRange, NmSettingConnection,
+    NmSettingsConnectionFlag,
 };
 pub use self::ethtool::NmSettingEthtool;
 pub use self::hsr::NmSettingHsr;

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -23,17 +23,18 @@ pub use self::active_connection::{
     NmActiveConnection, NM_ACTIVATION_STATE_FLAG_EXTERNAL,
 };
 pub use self::connection::{
-    NmConnection, NmIfaceType, NmIpRoute, NmIpRouteRule, NmIpRouteRuleAction,
-    NmRange, NmSetting8021X, NmSettingBond, NmSettingBondPort, NmSettingBridge,
-    NmSettingBridgePort, NmSettingBridgeVlanRange, NmSettingConnection,
-    NmSettingEthtool, NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod,
-    NmSettingIpVlan, NmSettingLoopback, NmSettingMacSec, NmSettingMacVlan,
-    NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
-    NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingUser, NmSettingVeth, NmSettingVlan, NmSettingVlanFlag,
-    NmSettingVpn, NmSettingVrf, NmSettingVxlan, NmSettingWired,
-    NmSettingsConnectionFlag, NmVlanProtocol,
+    NmConnection, NmConnectionMultiConnect, NmIfaceType, NmIpRoute,
+    NmIpRouteRule, NmIpRouteRuleAction, NmRange, NmSetting8021X, NmSettingBond,
+    NmSettingBondPort, NmSettingBridge, NmSettingBridgePort,
+    NmSettingBridgeVlanRange, NmSettingConnection, NmSettingEthtool,
+    NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod, NmSettingIpVlan,
+    NmSettingLoopback, NmSettingMacSec, NmSettingMacVlan, NmSettingOvsBridge,
+    NmSettingOvsDpdk, NmSettingOvsExtIds, NmSettingOvsIface,
+    NmSettingOvsOtherConfig, NmSettingOvsPatch, NmSettingOvsPort,
+    NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan, NmSettingUser,
+    NmSettingVeth, NmSettingVlan, NmSettingVlanFlag, NmSettingVpn,
+    NmSettingVrf, NmSettingVxlan, NmSettingWired, NmSettingsConnectionFlag,
+    NmVlanProtocol,
 };
 pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -26,9 +26,6 @@ pub(crate) fn perpare_nm_conns(
     let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
 
-    let nm_ac_uuids: Vec<&str> =
-        nm_acs.iter().map(|nm_ac| &nm_ac.uuid as &str).collect();
-
     let mut ifaces: Vec<&MergedInterface> = merged_state
         .interfaces
         .iter()
@@ -55,7 +52,7 @@ pub(crate) fn perpare_nm_conns(
                 exist_nm_conns,
                 &iface.merged.base_iface().name,
                 &iface.merged.base_iface().iface_type,
-                &nm_ac_uuids,
+                nm_acs,
             )
         })
         .cloned()
@@ -74,7 +71,7 @@ pub(crate) fn perpare_nm_conns(
             merged_iface,
             merged_state,
             exist_nm_conns,
-            &nm_ac_uuids,
+            nm_acs,
             gen_conf_mode,
         )? {
             if iface.is_up()

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use super::super::nm_dbus::{
-    NmConnection, NmIfaceType, NmSettingConnection, NmSettingMacVlan,
-    NmSettingVeth, NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
+    NmActiveConnection, NmConnection, NmIfaceType, NmSettingConnection,
+    NmSettingMacVlan, NmSettingVeth, NmSettingVrf, NmSettingVxlan,
+    NmSettingsConnectionFlag,
 };
 use super::{
     bond::{gen_nm_bond_port_setting, gen_nm_bond_setting},
@@ -38,7 +41,7 @@ pub(crate) fn iface_to_nm_connections(
     merged_iface: &MergedInterface,
     merged_state: &MergedNetworkState,
     exist_nm_conns: &[NmConnection],
-    nm_ac_uuids: &[&str],
+    nm_acs: &[NmActiveConnection],
     gen_conf_mode: bool,
 ) -> Result<Vec<NmConnection>, NmstateError> {
     let mut ret: Vec<NmConnection> = Vec::new();
@@ -68,7 +71,7 @@ pub(crate) fn iface_to_nm_connections(
             exist_nm_conns,
             &iface.base_iface().name,
             &iface.base_iface().iface_type,
-            nm_ac_uuids,
+            nm_acs,
         )
     };
 
@@ -85,7 +88,7 @@ pub(crate) fn iface_to_nm_connections(
                         cur_iface,
                         merged_state,
                         exist_nm_conns,
-                        nm_ac_uuids,
+                        nm_acs,
                         gen_conf_mode,
                     );
                 }
@@ -99,7 +102,7 @@ pub(crate) fn iface_to_nm_connections(
                         cur_iface,
                         merged_state,
                         exist_nm_conns,
-                        nm_ac_uuids,
+                        nm_acs,
                         gen_conf_mode,
                     );
                 }
@@ -117,6 +120,14 @@ pub(crate) fn iface_to_nm_connections(
     let iface = &iface;
 
     let mut nm_conn = exist_nm_conn.cloned().unwrap_or_default();
+
+    // If existing NmConnection is a multi-connect one, we should
+    // generate new NmSettingConnection (UUID, name and etc)
+    if nm_conn.is_multi_connect() {
+        nm_conn.connection = None;
+        nm_conn.obj_path = String::new();
+    }
+
     nm_conn.flags = Vec::new();
 
     // Use stable UUID if in gen_conf mode.
@@ -150,7 +161,7 @@ pub(crate) fn iface_to_nm_connections(
                     exist_nm_conns,
                     &ovs_port_conf.name,
                     &InterfaceType::Other("ovs-port".to_string()),
-                    nm_ac_uuids,
+                    nm_acs,
                 );
                 ret.push(create_ovs_port_nm_conn(
                     &ovs_br_iface.base.name,
@@ -301,7 +312,7 @@ pub(crate) fn iface_to_nm_connections(
                             exist_nm_conns,
                             &ovs_port_name,
                             &InterfaceType::Other("ovs-port".to_string()),
-                            nm_ac_uuids,
+                            nm_acs,
                         );
                         ret.push(create_ovs_port_nm_conn(
                             ctrl,
@@ -481,40 +492,60 @@ pub(crate) fn get_exist_profile<'a>(
     exist_nm_conns: &'a [NmConnection],
     iface_name: &str,
     iface_type: &InterfaceType,
-    nm_ac_uuids: &[&str],
+    nm_acs: &[NmActiveConnection],
 ) -> Option<&'a NmConnection> {
-    let mut found_nm_conns: Vec<&NmConnection> = Vec::new();
     let nm_iface_type = if let Ok(t) = iface_type_to_nm(iface_type) {
         t
     } else {
         return None;
     };
-    for exist_nm_conn in exist_nm_conns {
-        if nm_iface_type == NmIfaceType::Vpn {
-            if exist_nm_conn.id() == Some(iface_name) {
+    if nm_iface_type == NmIfaceType::Vpn {
+        // For VPN connection, we search `connection.id` and prefer activated
+        let mut found_nm_conn = None;
+        let nm_acs_uuids: HashSet<&str> =
+            nm_acs.iter().map(|nm_ac| nm_ac.uuid.as_str()).collect();
+        for exist_nm_conn in exist_nm_conns.iter() {
+            if exist_nm_conn.id() == Some(iface_name)
+                && exist_nm_conn.iface_type() == Some(&NmIfaceType::Vpn)
+            {
                 if let Some(uuid) = exist_nm_conn.uuid() {
-                    // Prefer activated connection
-                    if nm_ac_uuids.contains(&uuid) {
+                    if nm_acs_uuids.contains(&uuid) {
                         return Some(exist_nm_conn);
+                    } else if found_nm_conn.is_none() {
+                        found_nm_conn = Some(exist_nm_conn);
                     }
                 }
-                found_nm_conns.push(exist_nm_conn);
             }
-        } else if exist_nm_conn.iface_name() == Some(iface_name)
-            && (exist_nm_conn.iface_type() == Some(&nm_iface_type)
-                || (nm_iface_type == NmIfaceType::Ethernet
-                    && exist_nm_conn.iface_type() == Some(&NmIfaceType::Veth)))
-        {
-            if let Some(uuid) = exist_nm_conn.uuid() {
-                // Prefer activated connection
-                if nm_ac_uuids.contains(&uuid) {
-                    return Some(exist_nm_conn);
+        }
+        found_nm_conn
+    } else {
+        // Search activate profiles first
+        for nm_ac in nm_acs {
+            if nm_ac.iface_name == iface_name
+                && (nm_ac.iface_type == nm_iface_type
+                    || (nm_iface_type == NmIfaceType::Ethernet
+                        && nm_ac.iface_type == NmIfaceType::Veth))
+            {
+                if let Some(nm_conn) = exist_nm_conns
+                    .iter()
+                    .find(|c| c.uuid() == Some(nm_ac.uuid.as_str()))
+                {
+                    if !nm_conn.is_multi_connect() {
+                        return Some(nm_conn);
+                    }
                 }
             }
-            found_nm_conns.push(exist_nm_conn);
         }
+
+        exist_nm_conns.iter().find(|&exist_nm_conn| {
+            !exist_nm_conn.is_multi_connect()
+                && exist_nm_conn.iface_name() == Some(iface_name)
+                && (exist_nm_conn.iface_type() == Some(&nm_iface_type)
+                    || (nm_iface_type == NmIfaceType::Ethernet
+                        && exist_nm_conn.iface_type()
+                            == Some(&NmIfaceType::Veth)))
+        })
     }
-    found_nm_conns.pop()
 }
 
 fn get_exist_profile_by_profile_name<'a>(
@@ -541,7 +572,7 @@ fn persisten_iface_cur_conf(
     cur_iface: &Interface,
     merged_state: &MergedNetworkState,
     exist_nm_conns: &[NmConnection],
-    nm_ac_uuids: &[&str],
+    nm_acs: &[NmActiveConnection],
     gen_conf_mode: bool,
 ) -> Result<Vec<NmConnection>, NmstateError> {
     let mut iface = cur_iface.clone();
@@ -557,7 +588,7 @@ fn persisten_iface_cur_conf(
         &merged_iface,
         merged_state,
         exist_nm_conns,
-        nm_ac_uuids,
+        nm_acs,
         gen_conf_mode,
     )
 }

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -274,3 +274,36 @@ def test_reapply_with_ip_setting_table_and_metric_defaults(dummy0_up):
     libnmstate.apply(desired_state)
     cur_state = libnmstate.show()
     assert_routes(desired_state[Route.KEY][Route.CONFIG], cur_state)
+
+
+@pytest.mark.tier1
+@pytest.fixture
+def vlan_with_empty_connection_iface_name(eth1_up):
+    exec_cmd(
+        "nmcli c add type vlan connection.id eth1.100 "
+        "ipv4.method manual ipv4.addresses 192.0.2.1/24 "
+        "ipv6.method disabled vlan.parent eth1 vlan.id 100".split(),
+        check=True,
+    )
+    exec_cmd("nmcli c up eth1.100".split(), check=True)
+    yield
+    exec_cmd("nmcli c delete eth1.100".split(), check=True)
+
+
+def test_add_route_to_vlan_with_empty_connection_iface_name(
+    vlan_with_empty_connection_iface_name,
+):
+    desired_routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1.100",
+            Route.DESTINATION: "203.0.113.0/24",
+            Route.NEXT_HOP_ADDRESS: "192.0.2.2",
+        }
+    ]
+    libnmstate.apply({Route.KEY: {Route.CONFIG: desired_routes}})
+
+    cur_state = libnmstate.show()
+    assert_routes(
+        desired_routes,
+        cur_state,
+    )


### PR DESCRIPTION
When NM VLAN connection with empty `connection.interface-name`, NM will
use `parent.vlan_id` as name of this VLAN. With this setup, adding
routes to this vlan will trigger error in nmstate:

    NmstateError: InvalidArgument: Connection(MissingSetting):vlan:
    setting required for connection of type 'vlan'

This is because nmstate fail to treat this special activated NM connection
as exiting NM connection for desired VLAN interface, when creating it,
nmstate did not passing VLAN setup because nmstate thinks it already
exists.

To fix this issue, patch `get_exist_profile()` to check real
interface name of NmActiveConnection when not found such info from
NmConnection.

When search existing NM connection, we ignore connection with
`multi-connect: multiple|manual-multiple`.

Integration test case include and marked as tier1.

Resolves: https://issues.redhat.com/browse/RHEL-82100