### PR TITLE
test: Pull the container image before run

### DIFF
--- a/.github/workflows/build_rpm.sh
+++ b/.github/workflows/build_rpm.sh
@@ -8,7 +8,13 @@ CONTAINER_OUTPUT_DIR="$CONTAINER_WORKSPACE/rpms"
 CONTAINER_C8S_IMG="quay.io/nmstate/c8s-nmstate-build"
 CONTAINER_C9S_IMG="quay.io/nmstate/c9s-nmstate-build"
 
+
 if [ $1 == "el8" ];then
+    # pull the image to local, and retry if fails up to 5 times
+    for i in {1..5};do
+        ${CONTAINER_CMD} pull $CONTAINER_C8S_IMG && break
+    done
+
     podman run -v $PROJECT_PATH:$CONTAINER_WORKSPACE:rw \
         $CONTAINER_C8S_IMG /bin/bash -c \
         "cd $CONTAINER_WORKSPACE && make rpm"
@@ -16,6 +22,11 @@ if [ $1 == "el8" ];then
     mkdir -p $OUTPUT_DIR/el8 || true
     mv -v *.rpm $OUTPUT_DIR/el8/
 else
+    # pull the image to local, and retry if fails up to 5 times
+    for i in {1..5};do
+        ${CONTAINER_CMD} pull $CONTAINER_C9S_IMG && break
+    done
+
     podman run -v $PROJECT_PATH:$CONTAINER_WORKSPACE:rw \
         $CONTAINER_C9S_IMG /bin/bash -c \
         "cd $CONTAINER_WORKSPACE && make rpm"

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -42,6 +42,11 @@ function rebuild_container_images {
     if is_file_changed "$PROJECT_PATH/packaging"; then
         IMAGE_NAME=$(basename $CONTAINER_IMAGE)
         ${PROJECT_PATH}/packaging/build-container.sh $IMAGE_NAME
+    else
+        # pull the image to local, and retry if fails up to 5 times
+        for i in {1..5};do
+            ${CONTAINER_CMD} pull $CONTAINER_IMAGE && break
+        done
     fi
 }
 


### PR DESCRIPTION
The github action CI might hit error when trying to pull container image
for `podman run`:

    Error: writing blob: storing blob to file
    "/var/tmp/storage2845006379/1": happened during read: unexpected EOF

No luck on finding root cause of this.

To workaround that, use `podman pull <image_name>` before `podman run`,
and retry on failure of `podman pull` for 5 times.