### PR TITLE
test: Skip `test_ovs_bridge_port_ref_by_mac` on NM 1.48-

### DIFF
--- a/.github/workflows/build_rpm.sh
+++ b/.github/workflows/build_rpm.sh
@@ -12,7 +12,7 @@ CONTAINER_C9S_IMG="quay.io/nmstate/c9s-nmstate-build"
 if [ $1 == "el8" ];then
     # pull the image to local, and retry if fails up to 5 times
     for i in {1..5};do
-        ${CONTAINER_CMD} pull $CONTAINER_C8S_IMG && break
+        podman pull $CONTAINER_C8S_IMG && break
     done
 
     podman run -v $PROJECT_PATH:$CONTAINER_WORKSPACE:rw \
@@ -24,7 +24,7 @@ if [ $1 == "el8" ];then
 else
     # pull the image to local, and retry if fails up to 5 times
     for i in {1..5};do
-        ${CONTAINER_CMD} pull $CONTAINER_C9S_IMG && break
+        podman pull $CONTAINER_C9S_IMG && break
     done
 
     podman run -v $PROJECT_PATH:$CONTAINER_WORKSPACE:rw \

--- a/tests/integration/identifer_test.py
+++ b/tests/integration/identifer_test.py
@@ -5,6 +5,7 @@ import libnmstate
 from libnmstate.schema import Interface
 
 from .testlib.assertlib import assert_state_match
+from .testlib.env import nm_minor_version
 from .testlib.ifacelib import get_mac_address
 from .testlib.statelib import show_only
 from .testlib.yaml import load_yaml
@@ -194,6 +195,10 @@ def test_linux_bridge_port_ref_by_mac(eth1_up, eth2_up, clean_up):
     assert_state_match(expected_state)
 
 
+@pytest.mark.skipif(
+    nm_minor_version() < 48,
+    reason=("Ref OVS bridge by mac is only supported by NetworkManager 1.48+"),
+)
 def test_ovs_bridge_port_ref_by_mac(eth1_up, eth2_up, clean_up):
     port1_mac = get_mac_address("eth1")
     port2_mac = get_mac_address("eth2")


### PR DESCRIPTION
According to https://issues.redhat.com/browse/RHEL-34617 , only
NetworkManager 1.48+ support referring OVS bridge by mac address, hence
mark test case `test_ovs_bridge_port_ref_by_mac` as skipped when NM is too
old.