### PR TITLE
route: Add support of quickack

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -209,6 +209,7 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry.initcwnd = np_route.initcwnd;
     route_entry.initrwnd = np_route.initrwnd;
     route_entry.mtu = np_route.mtu;
+    route_entry.quickack = np_route.quickack.map(|q| q > 0);
 
     route_entry
 }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -26,6 +26,7 @@ pub struct NmIpRoute {
     pub initcwnd: Option<u32>,
     pub initrwnd: Option<u32>,
     pub mtu: Option<u32>,
+    pub quickack: Option<bool>,
     _other: DbusDictionary,
 }
 
@@ -52,6 +53,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             initcwnd: _from_map!(v, "initcwnd", u32::try_from)?,
             initrwnd: _from_map!(v, "initrwnd", u32::try_from)?,
             mtu: _from_map!(v, "mtu", u32::try_from)?,
+            quickack: _from_map!(v, "quickack", bool::try_from)?,
             _other: v,
         })
     }
@@ -138,6 +140,12 @@ impl NmIpRoute {
         if let Some(v) = &self.mtu {
             ret.append(
                 zvariant::Value::new("mtu"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.quickack {
+            ret.append(
+                zvariant::Value::new("quickack"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -38,6 +38,15 @@ impl NmIpRoute {
             if let Some(src) = self.src.as_ref() {
                 write!(opt_string, ",src={}", src).ok();
             }
+            if let Some(v) = self.initcwnd.as_ref() {
+                write!(opt_string, ",initcwnd={}", v).ok();
+            }
+            if let Some(v) = self.initrwnd.as_ref() {
+                write!(opt_string, ",initrwnd={}", v).ok();
+            }
+            if let Some(v) = self.mtu.as_ref() {
+                write!(opt_string, ",mtu={}", v).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -47,6 +47,9 @@ impl NmIpRoute {
             if let Some(v) = self.mtu.as_ref() {
                 write!(opt_string, ",mtu={}", v).ok();
             }
+            if let Some(v) = self.quickack.as_ref() {
+                write!(opt_string, ",quickack={}", v).ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -65,6 +65,7 @@ pub(crate) fn gen_nm_ip_routes(
         nm_route.initcwnd = route.initcwnd;
         nm_route.initrwnd = route.initrwnd;
         nm_route.mtu = route.mtu;
+        nm_route.quickack = route.quickack;
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -74,9 +74,9 @@ impl MergedRoutes {
         ignored_ifaces: &[&str],
         current_ifaces: &Interfaces,
     ) -> Result<(), NmstateError> {
-        let mut cur_routes: Vec<&RouteEntry> = Vec::new();
-        if let Some(cur_rts) = current.config.as_ref() {
-            for cur_rt in cur_rts {
+        let mut cur_routes: Vec<RouteEntry> = Vec::new();
+        if let Some(cur_rts) = current.config.clone() {
+            for mut cur_rt in cur_rts {
                 if let Some(via) = cur_rt.next_hop_iface.as_ref() {
                     if ignored_ifaces.contains(&via.as_str())
                         && cur_rt.route_type.is_none()
@@ -84,6 +84,7 @@ impl MergedRoutes {
                         continue;
                     }
                 }
+                cur_rt.sanitize_current_route_for_verify();
                 cur_routes.push(cur_rt);
             }
         }
@@ -194,4 +195,18 @@ pub(crate) fn is_route_delayed_by_nm(
     };
 
     !has_address
+}
+
+impl RouteEntry {
+    // When desire state has `quickack: false`, the post-apply current state
+    // will not have `quickack` at all because `quickack: false` means no
+    // `quickack`. This will lead to verification error.
+    // Instead of always providing `quickack: false` on querying,
+    // this function change `quickack: none` as `quickack: false` in the
+    // current state for verify only.
+    fn sanitize_current_route_for_verify(&mut self) {
+        if self.quickack.is_none() {
+            self.quickack = Some(false);
+        }
+    }
 }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -264,6 +264,13 @@ pub struct RouteEntry {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub mtu: Option<u32>,
+    /// Enable quickack will disable disables delayed acknowledgments.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub quickack: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -364,6 +371,9 @@ impl RouteEntry {
         if self.mtu.is_some() && self.mtu != other.mtu {
             return false;
         }
+        if self.quickack.is_some() && self.quickack != other.quickack {
+            return false;
+        }
         true
     }
 
@@ -380,6 +390,7 @@ impl RouteEntry {
                     .as_ref()
                     .map(|d| is_ipv6_addr(d.as_str()))
                     .unwrap_or_default(),
+                self.quickack.unwrap_or_default(),
             ],
             vec![
                 self.next_hop_iface
@@ -567,6 +578,9 @@ impl std::fmt::Display for RouteEntry {
         }
         if let Some(v) = self.mtu {
             props.push(format!("mtu: {v}"));
+        }
+        if let Some(v) = self.quickack {
+            props.push(format!("quickack: {v}"));
         }
 
         write!(f, "{}", props.join(" "))

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -51,6 +51,7 @@ class Route:
     INITCWND = "initcwnd"
     INITRWND = "initrwnd"
     MTU = "mtu"
+    QUICKACK = "quickack"
 
 
 class RouteRule:

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -459,7 +459,7 @@ def test_gen_conf_route_next_hop_iface_ref_by_mac(eth1_eth2_up_with_no_config):
         assert_routes(expected_routes, cur_state)
 
 
-def test_gen_conf_route_initcwnd_mtu():
+def test_gen_conf_route_initcwnd_mtu_quickack():
     desired_state = load_yaml(
         """---
         routes:
@@ -471,6 +471,7 @@ def test_gen_conf_route_initcwnd_mtu():
                 table-id: 200
                 initcwnd: 20
                 initrwnd: 30
+                quickack: true
               - destination: 2001:db8:a::/64
                 mtu: 1280
                 next-hop-address: 2001:db8:1::2
@@ -478,6 +479,7 @@ def test_gen_conf_route_initcwnd_mtu():
                 table-id: 200
                 initcwnd: 40
                 initrwnd: 50
+                quickack: false
         interfaces:
           - name: eth1
             type: ethernet

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -457,3 +457,64 @@ def test_gen_conf_route_next_hop_iface_ref_by_mac(eth1_eth2_up_with_no_config):
         )
         cur_state = libnmstate.show()
         assert_routes(expected_routes, cur_state)
+
+
+def test_gen_conf_route_initcwnd_mtu():
+    desired_state = load_yaml(
+        """---
+        routes:
+          config:
+              - destination: 203.0.113.0/24
+                mtu: 1550
+                next-hop-address: 192.0.2.252
+                next-hop-interface: eth1
+                table-id: 200
+                initcwnd: 20
+                initrwnd: 30
+              - destination: 2001:db8:a::/64
+                mtu: 1280
+                next-hop-address: 2001:db8:1::2
+                next-hop-interface: eth1
+                table-id: 200
+                initcwnd: 40
+                initrwnd: 50
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+            ipv6:
+              enabled: true
+              dhcp: false
+              autoconf: false
+              address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        """
+    )
+    with gen_conf_apply(desired_state):
+        desired_routes = desired_state[Route.KEY][Route.CONFIG]
+        cur_state = libnmstate.show()
+        assert_routes(desired_routes, cur_state, nic=None)

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2420,3 +2420,30 @@ def test_route_delete_next_hop_iface_by_profile_name(
     cur_routes = libnmstate.show()[Route.KEY]
     for route in cur_routes[Route.CONFIG]:
         assert route[Route.NEXT_HOP_INTERFACE] != "eth1"
+
+
+# https://issues.redhat.com/browse/RHEL-80418
+@pytest.mark.tier1
+def test_add_route_with_quickack(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS1,
+            Route.QUICKACK: True,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+            Route.QUICKACK: False,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -46,6 +46,9 @@ def _clone_prepare_routes(routes, nic=None):
             table_id = route.get(Route.TABLE_ID, Route.USE_DEFAULT_ROUTE_TABLE)
             if table_id == Route.USE_DEFAULT_ROUTE_TABLE:
                 route[Route.TABLE_ID] = KERNEL_DEFAULT_TABLE_ID
+            # Treat no quickack as False
+            if Route.QUICKACK not in route:
+                route[Route.QUICKACK] = False
 
             routes_out.append(route)
 


### PR DESCRIPTION
Support quickack property of route, for example:

```yml
routes:
  config:
    - destination: 203.0.113.0/24
      next-hop-address: 192.0.2.1
      next-hop-interface: eth1
      quickack: true
    - destination: 2001:db8:c::/64
      next-hop-address: 2001:db8:1::2
      next-hop-interface: eth1
      quickack: false
```

Unit and integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-80418