### PR TITLE
nm: Preserve identifier information when detaching bond port

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -1014,6 +1014,7 @@ impl MergedInterface {
                 let iface = cur_iface.clone_name_type_only();
                 self.for_apply = Some(iface);
                 self.preserve_current_controller_info();
+                self.preserve_current_identifer_info();
             }
         }
     }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -364,4 +364,35 @@ impl MergedInterface {
         }
         Ok(())
     }
+
+    /// Copy MAC address when identifier is [InterfaceIdentifier::MacAddress]
+    pub(crate) fn preserve_current_identifer_info(&mut self) {
+        if self.for_apply.as_ref().map(|i| i.is_up()) == Some(true) {
+            if let (Some(apply_iface), Some(cur_iface)) =
+                (self.for_apply.as_mut(), self.current.as_ref())
+            {
+                if cur_iface.base_iface().identifier
+                    == Some(InterfaceIdentifier::MacAddress)
+                    && apply_iface.base_iface().identifier.is_none()
+                {
+                    apply_iface
+                        .base_iface_mut()
+                        .identifier
+                        .clone_from(&cur_iface.base_iface().identifier);
+                    if apply_iface.base_iface().mac_address.is_none() {
+                        apply_iface
+                            .base_iface_mut()
+                            .mac_address
+                            .clone_from(&cur_iface.base_iface().mac_address);
+                    }
+                    if apply_iface.base_iface().profile_name.is_none() {
+                        apply_iface
+                            .base_iface_mut()
+                            .profile_name
+                            .clone_from(&cur_iface.base_iface().profile_name);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1459,7 +1459,23 @@ def test_change_mtu_of_bond_port(bond99_with_2_port):
     )
 
 
-def test_attach_mac_based_iface_to_bond_port(eth1_up, eth2_up):
+@pytest.fixture
+def cleanup_bond0():
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "bond0",
+                    Interface.TYPE: InterfaceType.BOND,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+def test_attach_mac_based_iface_to_bond_port(eth1_up, eth2_up, cleanup_bond0):
     eth1_mac = get_mac_address(ETH1)
     eth2_mac = get_mac_address(ETH2)
 

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -4,6 +4,8 @@ import json
 import os
 
 import pytest
+import yaml
+from subprocess import SubprocessError
 
 import libnmstate
 from libnmstate.schema import Bond
@@ -21,6 +23,7 @@ from ..testlib.bondlib import bond_interface
 from ..testlib.env import is_el8
 from ..testlib.env import is_k8s
 from ..testlib.env import nm_minor_version
+from ..testlib.ifacelib import get_mac_address
 from ..testlib.nmplugin import nm_service_restart
 from ..testlib.retry import retry_till_true_or_timeout
 from ..testlib.vlan import vlan_interface
@@ -214,3 +217,117 @@ def test_vlan_over_bond_reconnect_on_link_revive(
     cmdlib.exec_cmd("ip link set eth1 up".split(), check=True)
     cmdlib.exec_cmd("ip link set eth2 up".split(), check=True)
     assert retry_till_true_or_timeout(RETRY_TIMEOUT, vlan_is_up_with_ip)
+
+
+@pytest.fixture
+def bond0_with_mac_ref_ports(eth1_up, eth2_up):
+    cmdlib.exec_cmd("nmcli c del eth1".split(), check=False)
+    cmdlib.exec_cmd("nmcli c del eth2".split(), check=False)
+    eth1_mac = get_mac_address("eth1")
+    eth2_mac = get_mac_address("eth2")
+
+    state = yaml.load(
+        f"""---
+        interfaces:
+         - name: port1
+           type: ethernet
+           state: up
+           identifier: mac-address
+           mac-address: {eth1_mac}
+         - name: port2
+           type: ethernet
+           state: up
+           identifier: mac-address
+           mac-address: {eth2_mac}
+         - name: bond0
+           type: bond
+           state: up
+           link-aggregation:
+             mode: balance-rr
+             port:
+               - eth1
+               - eth2""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)
+
+    yield (eth1_mac, eth2_mac)
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "bond0",
+                    Interface.TYPE: InterfaceType.BOND,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+def test_absent_bond_peserve_bond_port_in_mac_ref(bond0_with_mac_ref_ports):
+    (eth1_mac, eth2_mac) = bond0_with_mac_ref_ports
+    port1_nm_conn_uuid = cmdlib.exec_cmd(
+        "nmcli -g connection.uuid c show port1".split(),
+        check=True,
+    )[1].strip()
+    port2_nm_conn_uuid = cmdlib.exec_cmd(
+        "nmcli -g connection.uuid c show port2".split(),
+        check=True,
+    )[1].strip()
+
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "bond0",
+                    Interface.TYPE: InterfaceType.BOND,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g 802-3-ethernet.mac-address c show port1".split(),
+            check=True,
+        )[1]
+        .replace("\\", "")
+        .strip()
+        == eth1_mac
+    )
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g 802-3-ethernet.mac-address c show port2".split(),
+            check=True,
+        )[1]
+        .replace("\\", "")
+        .strip()
+        == eth2_mac
+    )
+
+    # Make sure nmstate re-use existing NM connection instead of creating new.
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g connection.uuid c show port1".split(),
+            check=True,
+        )[1]
+        .replace("\\", "")
+        .strip()
+        == port1_nm_conn_uuid
+    )
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g connection.uuid c show port2".split(),
+            check=True,
+        )[1]
+        .replace("\\", "")
+        .strip()
+        == port2_nm_conn_uuid
+    )
+
+    with pytest.raises(SubprocessError):
+        cmdlib.exec_cmd("nmcli c show eth1".split(), check=True)
+    with pytest.raises(SubprocessError):
+        cmdlib.exec_cmd("nmcli c show eth2".split(), check=True)

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -317,6 +317,7 @@ def test_add_route_to_vlan_with_empty_connection_iface_name(
 
 @pytest.fixture
 def port1_ref_by_mac_with_static_route(eth1_up):
+    exec_cmd("nmcli c del eth1".split())
     port1_mac = get_mac_address("eth1")
 
     routes = [


### PR DESCRIPTION
With bond port was referred by MAC address, when marking bond as absent,
the bond port will be converted into interface name referring.

The fix is preserve `identifier`, `profile_name`, `mac-address` in
`MergedInterface::mark_as_changed()` when current state is mac-ref
based. With this, `rust/src/lib/nm` code will reused existing NM
connection without creating new ones.

Integration test case included.