### PR TITLE
go: add generating state from policy support to golang bindings

### DIFF
--- a/rust/src/go/nmstate/nmstate.go
+++ b/rust/src/go/nmstate/nmstate.go
@@ -236,3 +236,46 @@ func (n *Nmstate) GenerateConfiguration(state string) (string, error) {
 	}
 	return C.GoString(config), nil
 }
+
+// GenerateStateFromPolicy generates the state from the provided policy and current state.
+// This function returns the state based on the policy and current state provided.
+func (n *Nmstate) GenerateStateFromPolicy(policy, currentState string) (string, error) {
+	var (
+		c_policy       *C.char
+		c_currentState *C.char
+		state          *C.char
+		log            *C.char
+		err_kind       *C.char
+		err_msg        *C.char
+	)
+
+	c_policy = C.CString(policy)
+	if currentState != "" {
+		c_currentState = C.CString(currentState)
+	} else {
+		c_currentState = nil
+	}
+
+	rc := C.nmstate_net_state_from_policy(c_policy, c_currentState, &state, &log, &err_kind, &err_msg)
+
+	defer func() {
+		C.nmstate_cstring_free(c_policy)
+		if c_currentState != nil {
+			C.nmstate_cstring_free(c_currentState)
+		}
+		C.nmstate_cstring_free(state)
+		C.nmstate_cstring_free(log)
+		C.nmstate_cstring_free(err_kind)
+		C.nmstate_cstring_free(err_msg)
+	}()
+
+	if rc != 0 {
+		return "", fmt.Errorf("failed when generating the state from policy %s with rc: %d, err_msg: %s, err_kind: %s", policy, rc, C.GoString(err_msg), C.GoString(err_kind))
+	}
+
+	if err := n.writeLog(log); err != nil {
+		return "", fmt.Errorf("failed when generating the state from policy: %v", err)
+	}
+
+	return C.GoString(state), nil
+}

--- a/rust/src/go/nmstate/nmstate_test.go
+++ b/rust/src/go/nmstate/nmstate_test.go
@@ -74,3 +74,61 @@ func TestGenerateConfiguration(t *testing.T) {
 	assert.NoError(t, err, "must succeed calling nmstate_generate_configurations c binding")
 	assert.NotEmpty(t, config, "config should not be empty")
 }
+
+func TestGenerateStateFromPolicy(t *testing.T) {
+	nms := New()
+	// Define a sample policy and current state
+	policy := `{
+		"capture": {
+			"ethernets": "interfaces.type==\"ethernet\"",
+			"ethernets-up": "capture.ethernets.interfaces.state==\"up\"",
+			"ethernets-lldp": "capture.ethernets-up | interfaces.lldp.enabled:=true"
+		},
+		"desiredState": {
+			"interfaces": "{{ capture.ethernets-lldp.interfaces }}"
+		}
+	}`
+
+	currentState := `{
+		"interfaces": [
+			{
+				"name": "eth0",
+				"type": "ethernet",
+				"state": "up",
+				"mac-address": "52:55:00:D1:55:01",
+				"accept-all-mac-addresses": false,
+				"lldp": {
+					"enabled": false
+				}
+			},
+			{
+				"name": "eth1",
+				"type": "ethernet",
+				"state": "down",
+				"mac-address": "52:55:00:D1:56:02",
+				"accept-all-mac-addresses": false,
+				"lldp": {
+					"enabled": false
+				}
+			},
+			{
+				"name": "eth2",
+				"type": "ethernet",
+				"state": "down",
+				"mac-address": "52:55:00:D1:56:04",
+				"accept-all-mac-addresses": false
+			},
+			{
+				"name": "eth4",
+				"type": "ethernet",
+				"state": "up",
+				"mac-address": "52:55:00:D1:57:03",
+				"accept-all-mac-addresses": false
+			}
+		]
+	}`
+
+	state, err := nms.GenerateStateFromPolicy(policy, currentState)
+	assert.NoError(t, err, "must succeed calling nmstate_net_state_from_policy c binding")
+	assert.NotEmpty(t, state, "state should not be empty")
+}


### PR DESCRIPTION
Introduce GenerateStateFromPolicy in the Golang bindings to validate YAML files containing nmpolicy. This function behaves similarly to GenerateConfiguration for nmstate YAML, propagating the C binding errors back to the user.

Resolves: https://issues.redhat.com/browse/RHEL-69925