### PR TITLE
Python: There is no runtime requirement for setuptools

### DIFF
--- a/rust/src/python/requirements.txt
+++ b/rust/src/python/requirements.txt
@@ -6,4 +6,3 @@
 #packageD!=0.13.0,<0.14,>=0.12.0
 
 PyYAML
-setuptools


### PR DESCRIPTION
setuptools|pkg_resources|distutils is only used on build time.