### PR TITLE
 nm: dbus: fix reapply for mac address identified connections 

### DIFF
--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -271,11 +271,19 @@ impl NmApi<'_> {
         // We cannot use `org.freedesktop.NetworkManager.GetDeviceByIpIface`
         // because OVS bridge/port/iface might hold identical device name.
         // Need to check interface type also.
-        if let (Some(iface_name), Some(nm_iface_type)) =
-            (nm_conn.iface_name(), nm_conn.iface_type())
-        {
-            let nm_dev_obj_path =
-                self.get_disk_obj_path(iface_name, nm_iface_type).await?;
+        if let Some(nm_iface_type) = nm_conn.iface_type() {
+            let mac_address = nm_conn
+                .wired
+                .as_ref()
+                .and_then(|w| w.mac_address.as_deref())
+                .unwrap_or("");
+            let nm_dev_obj_path = self
+                .get_disk_obj_path(
+                    nm_conn.iface_name().unwrap_or(""),
+                    mac_address,
+                    nm_iface_type,
+                )
+                .await?;
             self.dbus
                 .nm_dev_reapply(nm_dev_obj_path.as_str(), nm_conn)
                 .await
@@ -283,7 +291,7 @@ impl NmApi<'_> {
             Err(NmError::new(
                 ErrorKind::Bug,
                 format!(
-                    "Failed to extract interface name and type from \
+                    "Failed to extract interface type, name or MAC from \
                     connection {nm_conn:?}"
                 ),
             ))
@@ -472,10 +480,19 @@ impl NmApi<'_> {
     async fn get_disk_obj_path(
         &mut self,
         iface_name: &str,
+        mac_address: &str,
         nm_iface_type: &NmIfaceType,
     ) -> Result<String, NmError> {
         if let Some(nm_dev) = self.devices_get().await?.into_iter().find(|d| {
-            d.name == iface_name
+            let mut ifname_matched = false;
+            let mut mac_matched = false;
+
+            if !iface_name.is_empty() {
+                ifname_matched = d.name == iface_name;
+            } else if !mac_address.is_empty() {
+                mac_matched = d.mac_address == mac_address;
+            }
+            (ifname_matched || mac_matched)
                 && ((&d.iface_type == nm_iface_type)
                     || ([NmIfaceType::Veth, NmIfaceType::Ethernet]
                         .contains(nm_iface_type)

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -32,6 +32,7 @@ from .testlib.env import is_k8s
 from .testlib.env import nm_minor_version
 from .testlib.ifacelib import get_mac_address
 from .testlib.ifacelib import ifaces_init
+from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.vlan import vlan_interface
 
@@ -1511,3 +1512,55 @@ def test_attach_mac_based_iface_to_bond_port(eth1_up, eth2_up, cleanup_bond0):
         statelib.show_only((ETH2,))[Interface.KEY][0][Interface.MAC]
         == eth2_mac
     )
+
+
+@pytest.fixture
+def bond0_with_eth1_ref_by_mac(eth1_up):
+    eth1_mac = get_mac_address(ETH1)
+
+    state = yaml.load(
+        f"""---
+        interfaces:
+         - name: port1
+           type: ethernet
+           state: up
+           identifier: mac-address
+           mac-address: {eth1_mac}
+         - name: bond0
+           type: bond
+           state: up
+           link-aggregation:
+             mode: balance-rr
+             port:
+               - eth1""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)
+    yield
+    libnmstate.apply(
+        yaml.load(
+            """---
+            interfaces:
+             - name: bond0
+               type: bond
+               state: absent""",
+            Loader=yaml.SafeLoader,
+        )
+    )
+
+
+@ip_monitor_assert_stable_link_up("bond0")
+def test_reapply_bond_port_ref_by_mac(bond0_with_eth1_ref_by_mac):
+    eth1_mac = get_mac_address(ETH1)
+
+    state = yaml.load(
+        f"""---
+        interfaces:
+         - name: port1
+           type: ethernet
+           state: up
+           identifier: mac-address
+           mac-address: {eth1_mac}""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)


### PR DESCRIPTION
connection_reapply() is always throwing an error if the connection has an empty interface name. That is wrong as an MAC address identified connection will have an empty name and we should match it by device MAC address.

This is fixing the following reapply error which was causing the connection to fallback on activation.

```
[2025-04-04T13:22:33Z INFO  nmstate::nm::query_apply::profile] Reapply operation failed on 802-3-ethernet  f867f6db-0b83-40cf-ac29-00c8fceefd29, reason: Bug:Failed to extract interface name and type from connection NmConnection { connection: Some(NmSettingConnection { id: Some("ethernet-enx30d0425666c9-8544"), uuid: Some("f867f6db-0b83-40cf-ac29-00c8fceefd29"), iface_type: Some(Ethernet), iface_name: None, controller: Some("bond0"), controller_type: Some(OvsPort), autoconnect: Some(true), autoconnect_ports: None, lldp: None, mptcp_flags: None, multi_connect: None, _other: {"timestamp": OwnedValue(U64(1743772921)), "permissions": OwnedValue(Array(Array { elements: [], signature: Array(Dynamic { child: Str }) }))} }), bond: None, bond_port: None, bridge: None, bridge_port: None, ipv4: None, ipv6: None, ovs_bridge: None, ovs_port: None, ovs_iface: None, ovs_ext_ids: None, ovs_other_config: None, ovs_patch: None, ovs_dpdk: None, wired: Some(NmSettingWired { cloned_mac_address: None, mac_address: Some("52:54:00:21:44:99"), mtu: None, accept_all_mac_addresses: None, speed: None, duplex: None, auto_negotiate: Some(false), _other: {"s390-options": OwnedValue(Dict(Dict { map: {}, signature: Dict { key: Dynamic { child: Str }, value: Dynamic { child: Str } } }))} }), vlan: None, vxlan: None, mac_vlan: None, sriov: None, vrf: None, veth: None, ieee8021x: None, user: Some(NmSettingUser { data: Some({"nmstate.interface.description": "secondary"}), _other: {} }), ethtool: None, infiniband: None, loopback: None, macsec: None, hsr: None, vpn: None, ipvlan: None, obj_path: "/org/freedesktop/NetworkManager/Settings/38", flags: [], _other: {"proxy": {}} }, retry on normal activation
```

An integration test cannot be added on our environment because this error requires NIC to use MAC address identifier.

Fixes: https://issues.redhat.com/browse/RHEL-86035