### PR TITLE
ethtool: Fix support of `coalesce.tx-usecs`

### DIFF
--- a/rust/src/lib/nm/settings/ethtool.rs
+++ b/rust/src/lib/nm/settings/ethtool.rs
@@ -109,6 +109,7 @@ fn apply_coalesce_options(
     nm_ethtool_set.coalesce_rx_usecs_irq = coalesce_conf.rx_usecs_irq;
     nm_ethtool_set.coalesce_sample_interval = coalesce_conf.sample_interval;
     nm_ethtool_set.coalesce_stats_block_usecs = coalesce_conf.stats_block_usecs;
+    nm_ethtool_set.coalesce_tx_usecs = coalesce_conf.tx_usecs;
 }
 
 fn apply_ring_options(

--- a/tests/integration/ethtool_test.py
+++ b/tests/integration/ethtool_test.py
@@ -80,14 +80,14 @@ def test_ethtool_pause_on_netdevsim():
     os.environ.get("CI") == "true" or not is_fedora(),
     reason=("Ethtool pause test need netdevsim kernel module"),
 )
-def test_ethtool_pause_auto_on_netdevsim():
+def test_ethtool_pause_off_on_netdevsim():
     desire_iface_state = {
         Interface.NAME: TEST_NETDEVSIM_NIC,
         Ethtool.CONFIG_SUBTREE: {
             Ethtool.Pause.CONFIG_SUBTREE: {
-                Ethtool.Pause.AUTO_NEGOTIATION: True,
-                Ethtool.Pause.RX: True,
-                Ethtool.Pause.TX: True,
+                Ethtool.Pause.AUTO_NEGOTIATION: False,
+                Ethtool.Pause.RX: False,
+                Ethtool.Pause.TX: False,
             }
         },
     }


### PR DESCRIPTION
The `coalesce.tx-usecs` was saliently ignored during apply which lead to
Verification failure.

Existing test case `test_ethtool_coalesce_on_netdevsim` is enough for this
test.