### PR TITLE
cli: Fix control+c panic

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -262,7 +262,7 @@ async fn apply_state_async(
     .map_err(|e| format!("tokio failed to hook on signal SIGINT: {e}"))?;
     tokio::select! {
         _ = ctrlc_stream.recv() => {
-            rollback("")?;
+            NetworkState::checkpoint_rollback_async("").await?;
             Err("Interrupted by SIGINT".into())
         }
         result = net_state.apply_async() => {


### PR DESCRIPTION
When user want to hit `Control+C` during nmstatectl apply, there will be
a panic error:

    thread 'main' panicked at src/lib/query_apply/net_state.rs:46:12:
    Cannot start a runtime from within a runtime. This happens because a
    function (like `block_on`) attempted to block the current thread
    while the thread is being used to drive asynchronous tasks.

This is caused by running new `block_on` against checkpoint rollback
inside of async function.

Fixed by changed to
`NetworkState::checkpoint_rollback_async("").await?`.

To complex to code automatic integration test case, and very simple to
verify manually, hence no test code included.