### PR TITLE
nm ipsec: Do not set default values

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -85,6 +85,11 @@ impl IpsecInterface {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct LibreswanConfig {
+    /// Whether use NetworkManager default value. Default is true.
+    /// Setting false will instruct nmstate to follow libreswan default value
+    /// sets.
+    #[serde(rename = "nm-auto-defaults", default = "default_true")]
+    pub nm_auto_defaults: bool,
     pub right: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rightid: Option<String>,
@@ -159,6 +164,10 @@ pub struct LibreswanConfig {
     pub rightca: Option<String>,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 impl LibreswanConfig {
     pub fn new() -> Self {
         Self::default()
@@ -168,6 +177,7 @@ impl LibreswanConfig {
 impl std::fmt::Debug for LibreswanConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LibreswanConfig")
+            .field("nm-auto-defaults", &self.nm_auto_defaults)
             .field("right", &self.right)
             .field("rightid", &self.rightid)
             .field("rightrsasigkey", &self.rightrsasigkey)

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -76,6 +76,8 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         if let Some(v) = data.get("right") {
             ret.right.clone_from(v);
         }
+        ret.nm_auto_defaults =
+            data.get("nm-auto-defaults").map(|s| s.as_str()) != Some("no");
         ret.rightid = data.get("rightid").cloned();
         ret.rightrsasigkey = data.get("rightrsasigkey").cloned();
         ret.rightcert = data.get("rightcert").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -11,6 +11,10 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
 ) {
     if let Some(conf) = iface.libreswan.as_ref() {
         let mut vpn_data: HashMap<String, String> = HashMap::new();
+        if !conf.nm_auto_defaults {
+            vpn_data.insert("nm-auto-defaults".into(), "no".into());
+        }
+
         vpn_data.insert("right".into(), conf.right.to_string());
         if let Some(v) = conf.rightid.as_deref() {
             vpn_data.insert("rightid".into(), v.to_string());

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -1096,3 +1096,34 @@ def test_ipsec_rightca(ipsec_srv_cert_gw):
         IpsecTestEnv.SRV_POOL_PREFIX_V4,
         IpsecTestEnv.CLI_NIC,
     )
+
+
+def test_ipsec_ipv4_libreswan_p2p_no_nm_auto_defaults(ipsec_srv_p2p):
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: {IPSEC_CONN_NAME}
+          type: ipsec
+          libreswan:
+            nm-auto-defaults: false
+            left: {IpsecTestEnv.CLI_ADDR_V4}
+            leftid: '@{IpsecTestEnv.CLI_KEY_ID}'
+            leftcert: {IpsecTestEnv.CLI_KEY_ID}
+            right: {IpsecTestEnv.SRV_ADDR_V4}
+            rightid: '@{IpsecTestEnv.SRV_KEY_ID}'
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec,
+        IpsecTestEnv.CLI_ADDR_V4,
+        IpsecTestEnv.SRV_ADDR_V4,
+    )
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec_policy,
+        f"{IpsecTestEnv.CLI_ADDR_V4}/32",
+        f"{IpsecTestEnv.SRV_ADDR_V4}/32",
+    )


### PR DESCRIPTION
Introducing new ipsec option `nm-auto-defaults: true|false`, default to
true. When set to false, instruct NetworkManager to not set default
values but pass only desired values to ipsec libreswan daemon as it is.

With this, host-to-host(P2P) mode is not required to set `leftmodecfgclient: no`
explicitly which align with `ipsec.conf` manpage of libreswan.

It is recommend to set `nm-auto-defaults: false` and perform following
steps to align your YAML with libreswan daemon default values:
 * Upgrade NetworkManager-libreswan to 1.2.28 or later version.
 * Set `leftmodecfgclient: yes` explicitly if you need pull config from
   remote.
 * Add `@` to `leftid` and `rightid` if you don't want it been resolved
   to IP address. (e.g. `leftid: '@cli-a.example.org'`).
 * Define `rightsubnet` explicitly. (e.g.`rightsubnet: 0.0.0.0/0`)

Resolves: https://issues.redhat.com/browse/RHEL-26350