### PR TITLE
test: Fix rollback assertion failure and improve assert_route in downstream env

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -24,6 +24,7 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
 from .testlib.assertlib import assert_mac_address
+from .testlib.assertlib import assert_state
 from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
@@ -335,12 +336,7 @@ def test_rollback_for_bond(eth1_up, eth2_up):
         libnmstate.apply(desired_state)
 
     time.sleep(5)
-
-    current_state_after_apply = libnmstate.show()
-    assert (
-        current_state[Interface.KEY]
-        == current_state_after_apply[Interface.KEY]
-    )
+    assert_state({Interface.KEY: current_state[Interface.KEY]})
 
 
 @pytest.mark.tier1

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -24,6 +24,7 @@ from libnmstate.schema import VLAN
 from .testlib import assertlib
 from .testlib.apply import apply_with_description
 from .testlib.assertlib import assert_mac_address
+from .testlib.assertlib import assert_state
 from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import generate_vlan_filtering_config
@@ -410,8 +411,7 @@ def test_rollback_for_linux_bridge():
             libnmstate.apply(desired_state)
 
     time.sleep(5)  # Give some time for NetworkManager to rollback
-    current_state = libnmstate.show()
-    assert original_state == current_state
+    assert_state({Interface.KEY: original_state[Interface.KEY]})
 
 
 @pytest.mark.tier1

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -49,6 +49,16 @@ def _clone_prepare_routes(routes, nic=None):
             # Treat no quickack as False
             if Route.QUICKACK not in route:
                 route[Route.QUICKACK] = False
+            # suffix /32 or /128 when missing
+            if "/" not in route[Route.DESTINATION]:
+                if ":" in route[Route.DESTINATION]:
+                    route[Route.DESTINATION] += "/128"
+                else:
+                    route[Route.DESTINATION] += "/32"
+            # kernel automatically set next-hop-interface to lo for IPv6
+            # special type route like blackhole
+            if Route.ROUTETYPE in route and ":" in route[Route.DESTINATION]:
+                route.setdefault(Route.NEXT_HOP_INTERFACE, "lo")
 
             routes_out.append(route)
 

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -17,6 +17,7 @@ from .testlib import assertlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
 from .testlib.assertlib import assert_mac_address
+from .testlib.assertlib import assert_state
 from .testlib.env import nm_minor_version
 from .testlib.vlan import vlan_interface
 
@@ -146,8 +147,7 @@ def test_rollback_for_vlans(eth1_up):
         libnmstate.apply(desired_state)
 
     time.sleep(5)  # Give some time for NetworkManager to rollback
-    current_state_after_apply = libnmstate.show()
-    assert current_state == current_state_after_apply
+    assert_state({Interface.KEY: current_state[Interface.KEY]})
 
 
 def test_set_vlan_iface_down(eth1_up):

--- a/tests/integration/vxlan_test.py
+++ b/tests/integration/vxlan_test.py
@@ -13,6 +13,7 @@ from libnmstate.schema import VXLAN
 
 from .testlib import assertlib
 from .testlib.apply import apply_with_description
+from .testlib.assertlib import assert_state
 from .testlib.bondlib import bond_interface
 from .testlib.cmdlib import RC_SUCCESS
 from .testlib.cmdlib import exec_cmd
@@ -100,8 +101,7 @@ def test_rollback_for_vxlans(eth1_up):
         libnmstate.apply(desired_state)
 
     time.sleep(5)  # Give some time for NetworkManager to rollback
-    current_state_after_apply = libnmstate.show()
-    assert current_state == current_state_after_apply
+    assert_state({Interface.KEY: current_state[Interface.KEY]})
 
 
 def test_set_vxlan_iface_down(eth1_up):


### PR DESCRIPTION
Including 2 commits, to fix:  
Rollback assertion:  
* Use `assert_state` for some rollback tests to remove `*-life-time` properties in dynamic IP addresses, which exist in downstream test env


assert_route:
* Append `/32` or `/128` for single host route destination
* Fill in `next-hop-address: lo` for ipv6 special route types (like `blackhole`), since kernel automatically set `lo` as next hop for ipv6 special route types