### PR TITLE
DEMO: Support waiting on missing interfaces

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -10,6 +10,7 @@ use nmstate::NetworkState;
 use crate::{error::CliError, state::state_from_fd};
 
 const DEFAULT_TIMEOUT: u32 = 60;
+const DEFAULT_MISSING_IFACE_TMO: u32 = 60;
 
 pub(crate) fn apply_from_stdin(
     matches: &clap::ArgMatches,
@@ -63,12 +64,39 @@ where
     } else {
         DEFAULT_TIMEOUT
     };
+    let wait_missing_iface = if matches
+        .try_contains_id("WAIT_MISSING_IFACE")
+        .unwrap_or_default()
+    {
+        match matches.try_get_one::<String>("WAIT_MISSING_IFACE") {
+            Ok(Some(t)) => match u32::from_str(t) {
+                Ok(i) => i,
+                Err(e) => {
+                    return Err(CliError {
+                        code: crate::error::EX_DATAERR,
+                        error_msg: e.to_string(),
+                    });
+                }
+            },
+            Ok(None) => DEFAULT_MISSING_IFACE_TMO,
+            Err(e) => {
+                return Err(CliError {
+                    code: crate::error::EX_DATAERR,
+                    error_msg: e.to_string(),
+                });
+            }
+        }
+    } else {
+        // No wait
+        0
+    };
     let mut net_state = state_from_fd(reader)?;
     net_state.set_kernel_only(kernel_only);
     net_state.set_verify_change(!no_verify);
     net_state.set_commit(!no_commit);
     net_state.set_timeout(timeout);
     net_state.set_override_iface(override_iface);
+    net_state.set_wait_missing_iface(wait_missing_iface);
     net_state.set_memory_only(
         matches.try_contains_id("MEMORY_ONLY").unwrap_or_default(),
     );

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -204,6 +204,14 @@ fn main() {
                             "Override interface settings without merge \
                              current network state",
                         ),
+                )
+                .arg(
+                    clap::Arg::new("WAIT_MISSING_IFACE")
+                        .long("wait-missing-iface")
+                        .takes_value(true)
+                        .help(
+                            "Seconds to wait for missing interface to show up",
+                        ),
                 ),
         )
         .subcommand(

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -51,6 +51,14 @@ optional = true
 workspace = true
 optional = true
 
+# TODO: Only for demo
+[dependencies.rtnetlink]
+version = "0.16"
+
+# TODO: Only for demo
+[dependencies.futures]
+version = "0.3.11"
+
 [dev-dependencies]
 serde_yaml = { workspace = true }
 

--- a/rust/src/lib/error.rs
+++ b/rust/src/lib/error.rs
@@ -17,6 +17,7 @@ pub enum ErrorKind {
     PolicyError,
     PermissionError,
     SrIovVfNotFound,
+    Timeout,
 }
 
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -126,6 +126,8 @@ pub struct NetworkState {
     pub(crate) memory_only: bool,
     #[serde(skip)]
     pub(crate) override_iface: bool,
+    #[serde(skip)]
+    pub(crate) wait_missing_iface_sec: u32,
 }
 
 impl NetworkState {
@@ -227,6 +229,15 @@ impl NetworkState {
     /// will treat it as disabled regardless current network status.
     pub fn set_override_iface(&mut self, value: bool) -> &mut Self {
         self.override_iface = value;
+        self
+    }
+
+    /// Nmstate by default will treat missing interface as
+    /// `ErrorKind::InvalidArgument` error.
+    /// When set to with non-zero integer, nmstate will wait the missing
+    /// interface to show up within specified seconds.
+    pub fn set_wait_missing_iface(&mut self, wait_time_sec: u32) -> &mut Self {
+        self.wait_missing_iface_sec = wait_time_sec;
         self
     }
 

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -24,7 +24,9 @@ mod veth;
 mod vlan;
 mod vrf;
 mod vxlan;
+mod wait_iface;
 
+pub(crate) use self::wait_iface::wait_iface_async;
 pub(crate) use apply::nispor_apply;
 pub(crate) use hostname::set_running_hostname;
 pub(crate) use show::nispor_retrieve;

--- a/rust/src/lib/nispor/wait_iface.rs
+++ b/rust/src/lib/nispor/wait_iface.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The code is copy from https://github.com/rust-netlink/rtnetlink/
+// `examples/ip_monitor.rs`
+
+use crate::{ErrorKind, NmstateError};
+
+use futures::stream::StreamExt;
+use rtnetlink::new_connection;
+use rtnetlink::sys::{AsyncSocket, SocketAddr};
+
+// Even we don't get netlink notification, we should check the
+// links every 5 seconds in case.
+const MANUAL_CHECK_INTERVAL: u64 = 5;
+
+const RTNLGRP_LINK: u32 = 1;
+
+pub(crate) async fn is_missing_ifaces_up(ifaces: &[&str]) -> bool {
+    let mut filter = nispor::NetStateFilter::minimum();
+    filter.iface = Some(Default::default());
+    if let Ok(np_state) =
+        nispor::NetState::retrieve_with_filter_async(&filter).await
+    {
+        ifaces
+            .iter()
+            .all(|iface| np_state.ifaces.contains_key(&iface.to_string()))
+    } else {
+        false
+    }
+}
+
+pub(crate) async fn wait_iface_async(
+    ifaces: &[&str],
+    timeout_sec: u32,
+) -> Result<(), NmstateError> {
+    if is_missing_ifaces_up(ifaces).await {
+        return Ok(());
+    }
+    log::info!(
+        "Waiting missing interfaces to show up: {}",
+        ifaces.join(",")
+    );
+
+    let (mut conn, mut _handle, mut messages) =
+        new_connection().map_err(|e| {
+            NmstateError::new(
+                ErrorKind::Bug,
+                format!("Failed to start rtnetlink socket {e}"),
+            )
+        })?;
+
+    let groups = 1 << (RTNLGRP_LINK - 1);
+
+    let addr = SocketAddr::new(0, groups);
+    conn.socket_mut()
+        .socket_mut()
+        .bind(&addr)
+        .expect("Failed to bind");
+
+    // Spawn `Connection` to start polling netlink socket.
+    tokio::spawn(conn);
+
+    let tmo =
+        tokio::time::sleep(std::time::Duration::from_secs(timeout_sec.into()));
+    tokio::pin!(tmo);
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(
+        MANUAL_CHECK_INTERVAL,
+    ));
+
+    loop {
+        tokio::select! {
+            v = messages.next() => {
+                // TODO: Check whether waiting interfaces included in message
+                if v.is_some() && is_missing_ifaces_up(ifaces).await {
+                    return Ok(());
+                }
+            },
+            _ = interval.tick() => {
+                if is_missing_ifaces_up(ifaces).await {
+                    return Ok(());
+                }
+            },
+            () = &mut tmo => {
+                return Err(
+                    NmstateError::new(
+                        ErrorKind::Timeout,
+                        format!("Timeout on waiting missing interfaces: '{}'",
+                            ifaces.join(","))));
+            }
+        }
+    }
+}

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use crate::{
     state::{gen_diff_json_value, merge_json_value},
     ErrorKind, Interface, InterfaceType, Interfaces, MergedInterfaces,
@@ -94,6 +96,58 @@ impl Interfaces {
                 iface.remove_port(&port_name)
             }
         }
+    }
+
+    pub(crate) fn get_missing_ifaces<'a>(
+        &'a self,
+        current: &Self,
+    ) -> Vec<&'a str> {
+        let mut missing_ifaces: HashSet<&str> = HashSet::new();
+        for iface in self.iter().filter(|iface| iface.is_up()) {
+            if iface.iface_type() == InterfaceType::Ethernet
+                && current
+                    .get_iface(iface.name(), iface.iface_type())
+                    .is_none()
+            {
+                missing_ifaces.insert(iface.name());
+            }
+
+            if let Some(ports) = iface.ports() {
+                // OVS bridge missing port will be treated as OVS internal
+                // interface, hence we cannot tell whether it is a missing
+                // OVS system interface, but OVS bond interface are all OVS
+                // system interface
+                if let Interface::OvsBridge(ovs_iface) = iface {
+                    for port in ovs_iface.get_bond_ports() {
+                        if !current.kernel_ifaces.contains_key(port) {
+                            missing_ifaces.insert(port);
+                        }
+                    }
+                } else {
+                    for port in ports {
+                        if !current.kernel_ifaces.contains_key(port) {
+                            missing_ifaces.insert(port);
+                        }
+                    }
+                }
+            }
+            if let Some(parent) = iface.parent() {
+                if !parent.is_empty()
+                    && !current.kernel_ifaces.contains_key(parent)
+                {
+                    missing_ifaces.insert(parent);
+                }
+            }
+
+            if let Some(controller) = iface.base_iface().controller.as_ref() {
+                if !controller.is_empty()
+                    && !current.kernel_ifaces.contains_key(controller)
+                {
+                    missing_ifaces.insert(controller);
+                }
+            }
+        }
+        missing_ifaces.drain().collect()
     }
 }
 

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -3,7 +3,9 @@
 use std::future::Future;
 
 use crate::{
-    nispor::{nispor_apply, nispor_retrieve, set_running_hostname},
+    nispor::{
+        nispor_apply, nispor_retrieve, set_running_hostname, wait_iface_async,
+    },
     nm::{
         nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
         nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_retrieve,
@@ -183,16 +185,6 @@ impl NetworkState {
             }
         }
 
-        if !self.kernel_only {
-            self.apply_with_nm_backend().await
-        } else {
-            // TODO: Need checkpoint for kernel only mode
-            self.apply_without_nm_backend().await
-        }
-    }
-
-    async fn apply_with_nm_backend(&self) -> Result<(), NmstateError> {
-        let mut merged_state = None;
         let mut cur_net_state = NetworkState::new();
         cur_net_state.set_kernel_only(self.kernel_only);
         cur_net_state.set_include_secrets(true);
@@ -209,6 +201,28 @@ impl NetworkState {
             }
         }
 
+        if self.wait_missing_iface_sec > 0 {
+            let ifaces = self
+                .interfaces
+                .get_missing_ifaces(&cur_net_state.interfaces);
+            if !ifaces.is_empty() {
+                wait_iface_async(&ifaces, self.wait_missing_iface_sec).await?;
+            }
+        }
+
+        if !self.kernel_only {
+            self.apply_with_nm_backend(cur_net_state).await
+        } else {
+            // TODO: Need checkpoint for kernel only mode
+            self.apply_without_nm_backend(cur_net_state).await
+        }
+    }
+
+    async fn apply_with_nm_backend(
+        &self,
+        mut cur_net_state: Self,
+    ) -> Result<(), NmstateError> {
+        let mut merged_state = None;
         // At this point, the `unknown` interface type is not resolved yet,
         // hence when user want `enable-and-use` single-transaction for SR-IOV,
         // they need define the interface type. It is overkill to do resolve at
@@ -352,12 +366,10 @@ impl NetworkState {
         .await
     }
 
-    async fn apply_without_nm_backend(&self) -> Result<(), NmstateError> {
-        let mut cur_net_state = NetworkState::new();
-        cur_net_state.set_kernel_only(self.kernel_only);
-        cur_net_state.set_include_secrets(true);
-        cur_net_state.retrieve_async().await?;
-
+    async fn apply_without_nm_backend(
+        &self,
+        cur_net_state: Self,
+    ) -> Result<(), NmstateError> {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             cur_net_state.clone(),

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -115,6 +115,25 @@ impl OvsBridgeInterface {
             self.bridge.clone_from(&other.bridge);
         }
     }
+
+    pub(crate) fn get_bond_ports(&self) -> Vec<&str> {
+        let mut ret: Vec<&str> = Vec::new();
+        if let Some(ports) = self
+            .bridge
+            .as_ref()
+            .and_then(|br_conf| br_conf.ports.as_ref())
+        {
+            for bond_port_conf in ports.iter().filter_map(|p| p.bond.as_ref()) {
+                if let Some(bond_ports) = bond_port_conf.ports.as_ref() {
+                    for bond_port in bond_ports {
+                        ret.push(bond_port.name.as_str())
+                    }
+                }
+            }
+        }
+
+        ret
+    }
 }
 
 impl OvsInterface {

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -365,3 +365,77 @@ fn test_unknown_iface_type() {
         "foo_type\n"
     );
 }
+
+#[test]
+fn test_get_missing_iface() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: eth1
+  type: ethernet
+  state: up
+- name: eth3
+  type: ethernet
+  state: up
+- name: eth5
+  type: ethernet
+  state: up
+- name: eth7
+  type: ethernet
+  state: up
+- name: eth9
+  type: ethernet
+  state: up
+",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: eth1
+  type: ethernet
+  state: up
+  controller: vrf0
+- name: eth2
+  type: ethernet
+  state: up
+- name: eth4.100
+  type: vlan
+  state: up
+  vlan:
+    id: 100
+    base-iface: eth4
+- name: bond0
+  type: bond
+  link-aggregation:
+    mode: active-backup
+    ports-config:
+      - name: eth5
+      - name: eth6
+- name: br0
+  type: linux-bridge
+  bridge:
+    ports:
+      - name: eth7
+      - name: eth8
+- name: br1
+  type: ovs-bridge
+  bridge:
+    ports:
+    - name: ovs0
+    - name: bond1
+      link-aggregation:
+        mode: balance-slb
+        port:
+          - name: eth9
+          - name: eth10
+",
+    )
+    .unwrap();
+
+    let mut miss_ifaces = desired.get_missing_ifaces(&current);
+    miss_ifaces.sort();
+
+    assert_eq!(
+        miss_ifaces,
+        vec!["eth10", "eth2", "eth4", "eth6", "eth8", "vrf0"]
+    );
+}


### PR DESCRIPTION
When desire state contains missing interface, by default nmstate raise InvalidArgument error, with `NetworkState::set_wait_missing_iface(u32)` set to non-zero, nmstate will wait these interfaces to show up.

For CLI, `nmstatectl apply --wait-missing-iface <timeout_sec>`.