### PR TITLE
nm ipsec: Wait `NmActiveConnection::STATE_ACTIVATED`

### DIFF
--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -8,7 +8,6 @@ use crate::{
 
 use super::nm_dbus::{
     NmActiveConnection, NmDevice, NmDeviceState, NmIfaceType,
-    NM_ACTIVATION_STATE_FLAG_EXTERNAL,
 };
 
 const DEFAULT_DNS_PRIORITY: i32 = 40;
@@ -538,7 +537,7 @@ fn is_external_managed(
     for nm_ac in nm_acs {
         if nm_ac.iface_name.as_str() == iface_name
             && is_supported_kernel_iface(&nm_ac.iface_type)
-            && nm_ac.state_flags & NM_ACTIVATION_STATE_FLAG_EXTERNAL > 0
+            && nm_ac.state_flags & NmActiveConnection::STATE_FLAG_EXTERNAL > 0
         {
             return true;
         }

--- a/rust/src/lib/nm/nm_dbus/active_connection.rs
+++ b/rust/src/lib/nm/nm_dbus/active_connection.rs
@@ -9,15 +9,23 @@ use super::{
     ErrorKind, NmError,
 };
 
-pub const NM_ACTIVATION_STATE_FLAG_EXTERNAL: u32 = 0x80;
-
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct NmActiveConnection {
     pub uuid: String,
     pub iface_type: NmIfaceType,
     pub iface_name: String,
+    pub state: u32,
     pub state_flags: u32,
     pub dev_obj_path: Option<String>,
+}
+
+#[cfg_attr(not(feature = "query_apply"), allow(dead_code))]
+impl NmActiveConnection {
+    // NM_ACTIVATION_STATE_FLAG_EXTERNAL
+    pub const STATE_FLAG_EXTERNAL: u32 = 0x80;
+
+    // NM_ACTIVE_CONNECTION_STATE_ACTIVATED
+    pub const STATE_ACTIVATED: u32 = 2;
 }
 
 #[cfg(feature = "query_apply")]
@@ -124,6 +132,7 @@ pub(crate) async fn get_nm_ac_by_obj_path(
             uuid: nm_ac_obj_path_uuid_get(connection, obj_path).await?,
             iface_name,
             iface_type,
+            state: nm_ac_obj_path_state_get(connection, obj_path).await?,
             state_flags: nm_ac_obj_path_state_flags_get(connection, obj_path)
                 .await?,
             dev_obj_path: nm_dev_obj_path,
@@ -155,5 +164,28 @@ async fn nm_ac_obj_path_nm_dev_obj_path_get(
     {
         Ok(mut p) => Ok(p.pop().map(obj_path_to_string)),
         Err(_) => Ok(None),
+    }
+}
+
+#[cfg(feature = "query_apply")]
+async fn nm_ac_obj_path_state_get(
+    dbus_conn: &zbus::Connection,
+    obj_path: &str,
+) -> Result<u32, NmError> {
+    let proxy = zbus::Proxy::new(
+        dbus_conn,
+        NM_DBUS_INTERFACE_ROOT,
+        obj_path,
+        NM_DBUS_INTERFACE_AC,
+    )
+    .await?;
+    match proxy.get_property::<u32>("State").await {
+        Ok(uuid) => Ok(uuid),
+        Err(e) => Err(NmError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to retrieve State of active connection {obj_path}: {e}"
+            ),
+        )),
     }
 }

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -19,9 +19,7 @@ mod gen_conf;
 #[cfg(feature = "query_apply")]
 mod query_apply;
 
-pub use self::active_connection::{
-    NmActiveConnection, NM_ACTIVATION_STATE_FLAG_EXTERNAL,
-};
+pub use self::active_connection::NmActiveConnection;
 pub use self::connection::{
     NmConnection, NmConnectionMultiConnect, NmIfaceType, NmIpRoute,
     NmIpRouteRule, NmIpRouteRuleAction, NmRange, NmSetting8021X, NmSettingBond,

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::super::{
-    nm_dbus::{NmIfaceType, NmSettingVpn},
+    nm_dbus::{NmActiveConnection, NmIfaceType, NmSettingVpn},
     show::fill_iface_by_nm_conn_data,
     NmConnectionMatcher,
 };
@@ -18,7 +18,6 @@ pub(crate) fn get_supported_vpn_ifaces(
     conn_matcher: &NmConnectionMatcher,
 ) -> Result<Vec<Interface>, NmstateError> {
     let mut ret = Vec::new();
-
     for nm_conn in conn_matcher.saved_iter().filter(|nm_conn| {
         nm_conn
             .uuid()
@@ -27,6 +26,14 @@ pub(crate) fn get_supported_vpn_ifaces(
             .unwrap()
             && nm_conn.iface_type() == Some(&NmIfaceType::Vpn)
     }) {
+        let nm_ac = if let Some(nm_ac) = nm_conn
+            .uuid()
+            .and_then(|uuid| conn_matcher.get_nm_ac_by_uuid(uuid))
+        {
+            nm_ac
+        } else {
+            continue;
+        };
         if let Some(nm_set_vpn) = nm_conn.vpn.as_ref() {
             if nm_set_vpn.service_type.as_deref()
                 == Some(NmSettingVpn::SERVICE_TYPE_LIBRESWAN)
@@ -38,7 +45,15 @@ pub(crate) fn get_supported_vpn_ifaces(
                 // taking profile name as interface name of VPN.
                 let mut iface = IpsecInterface::new();
                 iface.base.iface_type = InterfaceType::Ipsec;
-                iface.base.state = InterfaceState::Up;
+                // We are solely depend on NetworkManager reporting IPSec
+                // connection status, hence use NmActiveConnection.state
+                // for interface.state
+                iface.base.state =
+                    if nm_ac.state == NmActiveConnection::STATE_ACTIVATED {
+                        InterfaceState::Up
+                    } else {
+                        InterfaceState::Down
+                    };
                 iface.base.name = name;
                 iface.libreswan = Some(get_libreswan_conf(nm_set_vpn));
                 let mut iface = Interface::Ipsec(Box::new(iface));

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::nm::nm_dbus::{
-    NmApi, NmConnection, NmDevice, NmDeviceState, NmIfaceType, NmLldpNeighbor,
-    NM_ACTIVATION_STATE_FLAG_EXTERNAL,
+    NmActiveConnection, NmApi, NmConnection, NmDevice, NmDeviceState,
+    NmIfaceType, NmLldpNeighbor,
 };
 
 use super::{
@@ -108,7 +108,7 @@ pub(crate) async fn nm_retrieve(
         let nm_ac = conn_matcher.get_nm_ac(iface.base_iface());
 
         if let Some(state_flag) = nm_ac.map(|nm_ac| nm_ac.state_flags) {
-            if (state_flag & NM_ACTIVATION_STATE_FLAG_EXTERNAL) > 0 {
+            if (state_flag & NmActiveConnection::STATE_FLAG_EXTERNAL) > 0 {
                 log::debug!(
                     "Found external managed interface {}/{}",
                     iface.name(),

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import time
 import yaml
 
 import libnmstate
@@ -976,9 +975,8 @@ def test_ipsec_require_id_on_certificate(ipsec_srv_cert_gw, load_both_keys):
     desired_iface = desired_state[Interface.KEY][0]
 
     desired_iface["libreswan"]["rightid"] = "other.fail"
-    libnmstate.apply(desired_state)
-    time.sleep(5)
-    assert not _check_ipsec(IpsecTestEnv.CLI_ADDR_V4, IpsecTestEnv.SRV_ADDR_V4)
+    with pytest.raises(libnmstate.error.NmstateVerificationError):
+        libnmstate.apply(desired_state)
 
     desired_iface["libreswan"]["require-id-on-certificate"] = False
     libnmstate.apply(desired_state)


### PR DESCRIPTION
Previously we blindly treat all VPN connection as `state: up`, this is
incorrect because when any VPN connection has authentication failure,
NetworkManager still create NmActiveConnection and NmConnection for it.

This patch fixed it by only treat `NmActiveConnection::STATE_ACTIVATED`
as `state: up` for IPSec connection.

With this fix, the test case `test_ipsec_require_id_on_certificate`
should got a correct `NmstateVerificationError` for incorrect `rightid`.

The side-effect of this patch also cause nmstate to wait IPSec
connection been fully activated instead of quitting at connection
creation.