### PR TITLE
nm: Handle empty `connection.interface-name` for VLAN

### DIFF
--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -205,8 +205,23 @@ impl TryFrom<NmConnectionDbusOwnedValue> for NmConnection {
 }
 
 impl NmConnection {
-    pub fn iface_name(&self) -> Option<&str> {
-        _connection_inner_string_member!(self, iface_name)
+    pub fn iface_name(&self) -> Option<String> {
+        if let Some(name) = _connection_inner_string_member!(self, iface_name) {
+            Some(name.to_string())
+        } else if self.iface_type() == Some(&NmIfaceType::Vlan) {
+            // VLAN will use <parent>.<vlan_id> if not defined.
+            if let Some((Some(parent), Some(vlan_id))) = self
+                .vlan
+                .as_ref()
+                .map(|v| (v.parent.as_ref(), v.id.as_ref()))
+            {
+                Some(format!("{parent}.{vlan_id}"))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 
     pub fn iface_type(&self) -> Option<&NmIfaceType> {

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -278,7 +278,7 @@ impl NmApi<'_> {
                 .unwrap_or("");
             let nm_dev_obj_path = self
                 .get_disk_obj_path(
-                    nm_conn.iface_name().unwrap_or(""),
+                    nm_conn.iface_name().unwrap_or_default().as_str(),
                     mac_address,
                     nm_iface_type,
                 )

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -236,12 +236,12 @@ async fn delete_ifaces(
                 all_nm_conns
                     .as_slice()
                     .iter()
-                    .filter(|c| c.iface_name() == Some(iface.name()))
+                    .filter(|c| c.iface_name().as_deref() == Some(iface.name()))
                     .collect()
             } else {
                 let nm_iface_type = iface_type_to_nm(&iface.iface_type())?;
                 nm_conns_name_type_index
-                    .get(&(iface.name(), nm_iface_type))
+                    .get(&(iface.name().to_string(), nm_iface_type))
                     .cloned()
                     .unwrap_or_default()
             };
@@ -308,7 +308,7 @@ async fn delete_ifaces(
                             uuids_to_delete.insert(ctrl);
                         }
                     } else if let Some(nm_conns) = nm_conns_name_type_index
-                        .get(&(ctrl, NmIfaceType::OvsPort))
+                        .get(&(ctrl.to_string(), NmIfaceType::OvsPort))
                     {
                         for nm_conn in nm_conns {
                             if let Some(uuid) = nm_conn.uuid() {
@@ -401,7 +401,7 @@ async fn delete_orphan_ports(
                 if let Some(uuid) = nm_conn.uuid() {
                     log::info!(
                         "Deleting NM orphan profile {}/{}: {}",
-                        nm_conn.iface_name().unwrap_or(""),
+                        nm_conn.iface_name().unwrap_or_default(),
                         nm_conn.iface_type().cloned().unwrap_or_default(),
                         uuid
                     );
@@ -561,7 +561,7 @@ fn is_bond_port_queue_id_changed(
 ) -> bool {
     if nm_conn.controller_type() == Some(&NmIfaceType::Bond) {
         if let Some(iface_name) = nm_conn.iface_name() {
-            if changed_ports.contains(&iface_name) {
+            if changed_ports.contains(&iface_name.as_str()) {
                 log::info!(
                     "Reactivating bond port {iface_name} as its queue ID has \
                      changed"

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -125,7 +125,7 @@ pub(crate) fn merge_ovs_netdev_tun_iface(
             tun_nm_conns
                 .as_slice()
                 .iter()
-                .find(|c| c.iface_name() == Some(iface.name())),
+                .find(|c| c.iface_name().as_deref() == Some(iface.name())),
         ) {
             if let (Some(mut base_iface), Interface::OvsInterface(oiface)) = (
                 nm_conn_to_base_iface(Some(nm_dev), nm_conn, None, None),

--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -18,7 +18,7 @@ pub(crate) async fn delete_exist_profiles(
     nm_conns: &[NmConnection],
 ) -> Result<(), NmstateError> {
     let mut excluded_uuids: Vec<&str> = Vec::new();
-    let mut changed_iface_name_types: Vec<(&str, NmIfaceType)> = Vec::new();
+    let mut changed_iface_name_types: Vec<(String, NmIfaceType)> = Vec::new();
     let mut uuids_to_delete = Vec::new();
     for nm_conn in nm_conns {
         if let Some(uuid) = nm_conn.uuid() {
@@ -31,7 +31,8 @@ pub(crate) async fn delete_exist_profiles(
         } else if nm_conn.iface_type() == Some(&NmIfaceType::Vpn) {
             if let Some(name) = nm_conn.id() {
                 // For VPN, the we use connection id
-                changed_iface_name_types.push((name, NmIfaceType::Vpn));
+                changed_iface_name_types
+                    .push((name.to_string(), NmIfaceType::Vpn));
             }
         }
     }
@@ -45,7 +46,7 @@ pub(crate) async fn delete_exist_profiles(
             i
         } else if exist_nm_conn.iface_type() == Some(&NmIfaceType::Vpn) {
             if let Some(i) = exist_nm_conn.id() {
-                i
+                i.to_string()
             } else {
                 continue;
             }
@@ -67,7 +68,7 @@ pub(crate) async fn delete_exist_profiles(
         }
         if !excluded_uuids.contains(&uuid)
             && changed_iface_name_types
-                .contains(&(iface_name, nm_iface_type.clone()))
+                .contains(&(iface_name.clone(), nm_iface_type.clone()))
         {
             if let Some(uuid) = exist_nm_conn.uuid() {
                 uuids_to_delete.push(uuid);
@@ -93,8 +94,8 @@ pub(crate) async fn save_nm_profiles(
         // in NM connection, print connection id instead.
         let iface_name = nm_conn
             .iface_name()
-            .or_else(|| nm_conn.id())
-            .unwrap_or("undefined");
+            .or_else(|| nm_conn.id().map(|i| i.to_string()))
+            .unwrap_or("undefined".to_string());
         if nm_conn.obj_path.is_empty() {
             log::info!(
                 "Creating connection {uuid}: {iface_name}/{nm_iface_type}"
@@ -166,7 +167,7 @@ async fn _activate_nm_profiles(
     nm_ac_uuids: &[&str],
 ) -> Result<Vec<(NmConnection, NmstateError)>, NmstateError> {
     // Contain a list of `(iface_name, nm_iface_type)`.
-    let mut new_controllers: Vec<(&str, NmIfaceType)> = Vec::new();
+    let mut new_controllers: Vec<(String, NmIfaceType)> = Vec::new();
     let mut failed_nm_conns: Vec<(NmConnection, NmstateError)> = Vec::new();
     for nm_conn in nm_conns
         .iter()
@@ -183,7 +184,7 @@ async fn _activate_nm_profiles(
                 }
             } else {
                 new_controllers.push((
-                    nm_conn.iface_name().unwrap_or(""),
+                    nm_conn.iface_name().unwrap_or_default(),
                     nm_conn.iface_type().cloned().unwrap_or_default(),
                 ));
                 if let Err(e) = nm_api
@@ -209,7 +210,7 @@ async fn _activate_nm_profiles(
                 log::info!(
                     "Reapplying connection {}: {}/{}",
                     uuid,
-                    nm_conn.iface_name().unwrap_or(""),
+                    nm_conn.iface_name().unwrap_or_default(),
                     nm_conn.iface_type().cloned().unwrap_or_default()
                 );
                 if let Err(e) = reapply_or_activate(nm_api, nm_conn).await {
@@ -225,15 +226,16 @@ async fn _activate_nm_profiles(
                 {
                     if nm_conn.iface_type() != Some(&NmIfaceType::OvsIface) {
                         // OVS port does not do auto port activation.
-                        if new_controllers
-                            .contains(&(ctrller, ctrller_type.clone()))
-                            && ctrller_type != &NmIfaceType::OvsPort
+                        if new_controllers.contains(&(
+                            ctrller.to_string(),
+                            ctrller_type.clone(),
+                        )) && ctrller_type != &NmIfaceType::OvsPort
                         {
                             log::info!(
                                 "Skip connection activation as its controller \
                                  already activated its ports: {}: {}/{}",
                                 uuid,
-                                nm_conn.iface_name().unwrap_or(""),
+                                nm_conn.iface_name().unwrap_or_default(),
                                 nm_conn
                                     .iface_type()
                                     .cloned()
@@ -246,7 +248,7 @@ async fn _activate_nm_profiles(
                 log::info!(
                     "Activating connection {}: {}/{}",
                     uuid,
-                    nm_conn.iface_name().unwrap_or(""),
+                    nm_conn.iface_name().unwrap_or_default(),
                     nm_conn.iface_type().cloned().unwrap_or_default()
                 );
                 if let Err(e) = nm_api
@@ -275,7 +277,7 @@ pub(crate) async fn deactivate_nm_profiles(
             log::info!(
                 "Deactivating connection {}: {}/{}",
                 uuid,
-                nm_conn.iface_name().unwrap_or(""),
+                nm_conn.iface_name().unwrap_or_default(),
                 nm_conn.iface_type().cloned().unwrap_or_default()
             );
             if let Err(e) = nm_api.connection_deactivate(uuid).await {
@@ -294,14 +296,15 @@ pub(crate) async fn deactivate_nm_profiles(
 
 pub(crate) fn create_index_for_nm_conns_by_name_type(
     nm_conns: &[NmConnection],
-) -> HashMap<(&str, NmIfaceType), Vec<&NmConnection>> {
-    let mut ret: HashMap<(&str, NmIfaceType), Vec<&NmConnection>> =
+) -> HashMap<(String, NmIfaceType), Vec<&NmConnection>> {
+    let mut ret: HashMap<(String, NmIfaceType), Vec<&NmConnection>> =
         HashMap::new();
     for nm_conn in nm_conns {
         if let Some(iface_name) = nm_conn.iface_name() {
             if let Some(nm_iface_type) = nm_conn.iface_type() {
                 if nm_iface_type == &NmIfaceType::Veth {
-                    match ret.entry((iface_name, NmIfaceType::Ethernet)) {
+                    match ret.entry((iface_name.clone(), NmIfaceType::Ethernet))
+                    {
                         Entry::Occupied(o) => {
                             o.into_mut().push(nm_conn);
                         }
@@ -311,7 +314,7 @@ pub(crate) fn create_index_for_nm_conns_by_name_type(
                     };
                 }
                 if nm_iface_type == &NmIfaceType::Ethernet {
-                    match ret.entry((iface_name, NmIfaceType::Veth)) {
+                    match ret.entry((iface_name.clone(), NmIfaceType::Veth)) {
                         Entry::Occupied(o) => {
                             o.into_mut().push(nm_conn);
                         }
@@ -366,7 +369,7 @@ async fn reapply_or_activate(
     log::info!(
         "Reapplying connection {}: {}/{}",
         uuid,
-        nm_conn.iface_name().unwrap_or(""),
+        nm_conn.iface_name().unwrap_or_default(),
         nm_conn.iface_type().cloned().unwrap_or_default()
     );
     if let Err(e) = nm_api.connection_reapply(nm_conn).await {
@@ -374,7 +377,7 @@ async fn reapply_or_activate(
             "Reapply operation failed on {} {} {uuid}, reason: {}, retry on \
              normal activation",
             nm_conn.iface_type().cloned().unwrap_or_default(),
-            nm_conn.iface_name().unwrap_or(""),
+            nm_conn.iface_name().unwrap_or_default(),
             e
         );
         nm_api

--- a/rust/src/lib/nm/settings/bond.rs
+++ b/rust/src/lib/nm/settings/bond.rs
@@ -225,7 +225,7 @@ pub(crate) fn gen_nm_bond_port_setting(
     let mut nm_set = nm_conn.bond_port.as_ref().cloned().unwrap_or_default();
     let bond_port_conf = if let Some(i) = nm_conn
         .iface_name()
-        .and_then(|iface_name| bond_iface.get_port_conf(iface_name))
+        .and_then(|iface_name| bond_iface.get_port_conf(iface_name.as_str()))
     {
         i
     } else {

--- a/rust/src/lib/nm/settings/bridge.rs
+++ b/rust/src/lib/nm/settings/bridge.rs
@@ -134,7 +134,7 @@ pub(crate) fn gen_nm_br_port_setting(
     let mut nm_set = nm_conn.bridge_port.as_ref().cloned().unwrap_or_default();
     let br_port_conf = if let Some(i) = nm_conn
         .iface_name()
-        .and_then(|iface_name| br_iface.get_port_conf(iface_name))
+        .and_then(|iface_name| br_iface.get_port_conf(iface_name.as_str()))
     {
         i
     } else {

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -539,7 +539,7 @@ pub(crate) fn get_exist_profile<'a>(
 
         exist_nm_conns.iter().find(|&exist_nm_conn| {
             !exist_nm_conn.is_multi_connect()
-                && exist_nm_conn.iface_name() == Some(iface_name)
+                && exist_nm_conn.iface_name().as_deref() == Some(iface_name)
                 && (exist_nm_conn.iface_type() == Some(&nm_iface_type)
                     || (nm_iface_type == NmIfaceType::Ethernet
                         && exist_nm_conn.iface_type()

--- a/rust/src/lib/nm/settings/veth.rs
+++ b/rust/src/lib/nm/settings/veth.rs
@@ -25,7 +25,7 @@ pub(crate) fn create_veth_peer_profile_if_not_found(
 ) -> Result<NmConnection, NmstateError> {
     for nm_conn in exist_nm_conns {
         if let Some(iface_type) = nm_conn.iface_type() {
-            if nm_conn.iface_name() == Some(peer_name)
+            if nm_conn.iface_name().as_deref() == Some(peer_name)
                 && [NmIfaceType::Ethernet, NmIfaceType::Veth]
                     .contains(iface_type)
             {

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -220,16 +220,15 @@ pub(crate) fn nm_conn_to_base_iface(
 ) -> Option<BaseInterface> {
     if let Some(iface_name) = nm_conn.iface_name().or_else(|| {
         if nm_conn.iface_type() == Some(&NmIfaceType::Vpn) {
-            nm_conn.id()
+            nm_conn.id().map(|i| i.to_string())
         } else {
             None
         }
     }) {
         let ipv4 = nm_conn.ipv4.as_ref().map(nm_ip_setting_to_nmstate4);
-        let ipv6 = nm_conn
-            .ipv6
-            .as_ref()
-            .map(|nm_ip_set| nm_ip_setting_to_nmstate6(iface_name, nm_ip_set));
+        let ipv6 = nm_conn.ipv6.as_ref().map(|nm_ip_set| {
+            nm_ip_setting_to_nmstate6(iface_name.as_str(), nm_ip_set)
+        });
 
         let mut base_iface = BaseInterface::new();
         base_iface.name = iface_name.to_string();
@@ -391,7 +390,7 @@ fn iface_get(
 
 fn get_first_nm_conn<'a>(
     nm_conns_name_type_index: &'a HashMap<
-        (&'a str, NmIfaceType),
+        (String, NmIfaceType),
         Vec<&'a NmConnection>,
     >,
     name: &'a str,
@@ -403,7 +402,8 @@ fn get_first_nm_conn<'a>(
     } else {
         nm_iface_type.clone()
     };
-    if let Some(nm_conns) = nm_conns_name_type_index.get(&(name, nm_iface_type))
+    if let Some(nm_conns) =
+        nm_conns_name_type_index.get(&(name.to_string(), nm_iface_type))
     {
         if nm_conns.is_empty() {
             None

--- a/tests/integration/nm/vlan_test.py
+++ b/tests/integration/nm/vlan_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
+from subprocess import SubprocessError
 
 import pytest
 
@@ -11,6 +12,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
 from libnmstate.schema import VLAN
 
+from ..testlib import assertlib
 from ..testlib import cmdlib
 
 TEST_VLAN = "test_vlan0"
@@ -85,3 +87,35 @@ def test_vlan_parent_has_two_profiles(eth1_up_with_two_profiles):
                 ]
             }
         )
+
+
+@pytest.fixture
+def eth1_100_with_empty_interface_name(eth1_up):
+    cmdlib.exec_cmd(
+        "nmcli c add type vlan con-name eth1.100 dev eth1 id 100 "
+        "ipv4.method disabled ipv6.method disabled".split(),
+        check=True,
+    )
+    yield
+
+
+# https://issues.redhat.com/browse/RHEL-92916
+@pytest.mark.tier1
+def test_delete_vlan_connection_with_empty_interface_name(
+    eth1_100_with_empty_interface_name,
+):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1.100",
+                    Interface.TYPE: InterfaceType.VLAN,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+    assertlib.assert_absent("eth1.100")
+    with pytest.raises(SubprocessError):
+        cmdlib.exec_cmd("nmcli c show eth1.100".split(), check=True)


### PR DESCRIPTION
If `connection.interface-name` undefined for VLAN connection,
NetworkManager automatically choose `$parent.$vlan_id` as its name.

Nmstate code does not handle it, so `state:absent` will not delete that
NM connection.

The fix is patch `NmConnection::iface_name()` to return this
auto-generated name for VLAN when `connection.interface-name` is
undefined.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-92916