### PR TITLE
ovs: Fix stuck on `nmstatectl show`

### DIFF
--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -45,47 +45,49 @@ impl OvsDbConnection {
     }
 
     // TODO: support environment variable OVS_DB_UNIX_SOCKET_PATH
-    pub(crate) fn new() -> Result<Self, NmstateError> {
+    pub(crate) async fn new() -> Result<Self, NmstateError> {
         Ok(Self {
-            rpc: OvsDbJsonRpc::connect(DEFAULT_OVS_DB_SOCKET_PATH)?,
+            rpc: OvsDbJsonRpc::connect(DEFAULT_OVS_DB_SOCKET_PATH).await?,
             transaction_id: 0,
         })
     }
 
-    pub(crate) fn check_connection(&mut self) -> bool {
+    pub(crate) async fn check_connection(&mut self) -> bool {
         let transaction_id = self.get_transaction_id();
         let value = OvsDbMethodEcho::to_value(transaction_id);
-        if self.rpc.send(&value).is_ok() {
-            self.rpc.recv(transaction_id).is_ok()
+        if self.rpc.send(&value).await.is_ok() {
+            self.rpc.recv(transaction_id).await.is_ok()
         } else {
             false
         }
     }
 
-    pub(crate) fn transact(
+    pub(crate) async fn transact(
         &mut self,
         transact: &OvsDbMethodTransact,
     ) -> Result<Value, NmstateError> {
         let transaction_id = self.get_transaction_id();
         let value = transact.to_value(transaction_id);
-        self.rpc.send(&value)?;
-        let reply = self.rpc.recv(transaction_id)?;
+        self.rpc.send(&value).await?;
+        let reply = self.rpc.recv(transaction_id).await?;
         check_transact_error(reply)
     }
 
-    fn _get_ovs_entry(
+    async fn _get_ovs_entry(
         &mut self,
         table_name: &str,
         columns: Vec<&'static str>,
     ) -> Result<HashMap<String, OvsDbEntry>, NmstateError> {
-        let reply = self.transact(&OvsDbMethodTransact {
-            db_name: OVS_DB_NAME.to_string(),
-            operations: vec![OvsDbOperation::Select(OvsDbSelect {
-                table: table_name.to_string(),
-                conditions: vec![],
-                columns: Some(columns),
-            })],
-        })?;
+        let reply = self
+            .transact(&OvsDbMethodTransact {
+                db_name: OVS_DB_NAME.to_string(),
+                operations: vec![OvsDbOperation::Select(OvsDbSelect {
+                    table: table_name.to_string(),
+                    conditions: vec![],
+                    columns: Some(columns),
+                })],
+            })
+            .await?;
 
         let mut ret: HashMap<String, OvsDbEntry> = HashMap::new();
 
@@ -116,7 +118,7 @@ impl OvsDbConnection {
         }
     }
 
-    pub(crate) fn get_ovs_ifaces(
+    pub(crate) async fn get_ovs_ifaces(
         &mut self,
     ) -> Result<HashMap<String, OvsDbEntry>, NmstateError> {
         self._get_ovs_entry(
@@ -131,9 +133,10 @@ impl OvsDbConnection {
                 "options",
             ],
         )
+        .await
     }
 
-    pub(crate) fn get_ovs_ports(
+    pub(crate) async fn get_ovs_ports(
         &mut self,
     ) -> Result<HashMap<String, OvsDbEntry>, NmstateError> {
         self._get_ovs_entry(
@@ -153,9 +156,10 @@ impl OvsDbConnection {
                 "lacp",
             ],
         )
+        .await
     }
 
-    pub(crate) fn get_ovs_bridges(
+    pub(crate) async fn get_ovs_bridges(
         &mut self,
     ) -> Result<HashMap<String, OvsDbEntry>, NmstateError> {
         self._get_ovs_entry(
@@ -173,6 +177,7 @@ impl OvsDbConnection {
                 "datapath_type",
             ],
         )
+        .await
     }
 }
 

--- a/rust/src/lib/ovsdb/global_conf.rs
+++ b/rust/src/lib/ovsdb/global_conf.rs
@@ -37,17 +37,19 @@ fn convert_map(
 }
 
 impl OvsDbConnection {
-    pub(crate) fn get_global_conf(
+    pub(crate) async fn get_global_conf(
         &mut self,
     ) -> Result<OvsDbGlobalConfig, NmstateError> {
-        let reply = self.transact(&OvsDbMethodTransact {
-            db_name: OVS_DB_NAME.to_string(),
-            operations: vec![OvsDbOperation::Select(OvsDbSelect {
-                table: GLOBAL_CONFIG_TABLE.to_string(),
-                conditions: vec![],
-                columns: Some(vec!["external_ids", "other_config"]),
-            })],
-        })?;
+        let reply = self
+            .transact(&OvsDbMethodTransact {
+                db_name: OVS_DB_NAME.to_string(),
+                operations: vec![OvsDbOperation::Select(OvsDbSelect {
+                    table: GLOBAL_CONFIG_TABLE.to_string(),
+                    conditions: vec![],
+                    columns: Some(vec!["external_ids", "other_config"]),
+                })],
+            })
+            .await?;
 
         if let Some(global_conf) = reply
             .as_array()
@@ -139,7 +141,7 @@ fn append_mutations(
     }
 }
 
-pub(crate) fn ovsdb_apply_global_conf(
+pub(crate) async fn ovsdb_apply_global_conf(
     merged_state: &MergedNetworkState,
 ) -> Result<(), NmstateError> {
     if !merged_state.ovsdb.is_changed() && !merged_state.ovn.is_changed() {
@@ -147,7 +149,7 @@ pub(crate) fn ovsdb_apply_global_conf(
         return Ok(());
     }
 
-    let mut cli = OvsDbConnection::new()?;
+    let mut cli = OvsDbConnection::new().await?;
     let mut operations = Vec::new();
     let mut is_external_ids_purged = false;
 
@@ -229,7 +231,7 @@ pub(crate) fn ovsdb_apply_global_conf(
             db_name: OVS_DB_NAME.to_string(),
             operations,
         };
-        cli.transact(&transact)?;
+        cli.transact(&transact).await?;
     }
     Ok(())
 }

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::{Read, Write};
-use std::os::unix::net::UnixStream;
-
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::{io::AsyncWriteExt, net::UnixStream};
 
 use crate::{ErrorKind, NmstateError};
 
+// This buffer size is hard code in OpenvSwitch code `struct jsonrpc` of
+// `lib/jsonrpc.c`. Changing it will impact `OvsDbJsonRpc::recv()`.
+// Do not change unless OpenvSwitch changed so.
 const BUFFER_SIZE: usize = 4096;
+const MAX_RECV_RETRY_COUNT: usize = 50;
 
 #[derive(Debug)]
 pub(crate) struct OvsDbJsonRpc {
@@ -37,44 +39,125 @@ pub(crate) struct OvsDbRpcReply {
 }
 
 impl OvsDbJsonRpc {
-    pub(crate) fn connect(socket_path: &str) -> Result<Self, NmstateError> {
+    pub(crate) async fn connect(
+        socket_path: &str,
+    ) -> Result<Self, NmstateError> {
         Ok(Self {
-            socket: UnixStream::connect(socket_path).map_err(|e| {
+            socket: UnixStream::connect(socket_path).await.map_err(|e| {
                 NmstateError::new(ErrorKind::Bug, format!("socket error {e}"))
             })?,
         })
     }
 
-    pub(crate) fn send(&mut self, data: &Value) -> Result<(), NmstateError> {
+    pub(crate) async fn send(
+        &mut self,
+        data: &Value,
+    ) -> Result<(), NmstateError> {
         let buffer = serde_json::to_string(&data)?;
         log::debug!("OVSDB: sending command {buffer}");
         self.socket
             .write_all(buffer.as_bytes())
-            .map_err(parse_socket_io_error)?;
+            .await
+            .map_err(|e| {
+                NmstateError::new(
+                    ErrorKind::PluginFailure,
+                    format!("Failed to send message to OVSDB: {e}"),
+                )
+            })?;
+        self.socket.flush().await.map_err(|e| {
+            NmstateError::new(
+                ErrorKind::PluginFailure,
+                format!(
+                    "Failed to flush buffer when sending message to OVSDB: {e}"
+                ),
+            )
+        })?;
         Ok(())
     }
 
-    pub(crate) fn recv(
+    // * JSON-RPC has no indicator for `end-of-message`.
+    // * UnixStream has no indicator for `end-of-message`.
+    // * The OpenvSwitch code `lib/jsonrpc.c` function `jsonrpc_recv` is
+    //   depending on JSON parser to determine whether message ended, and keep
+    //   retry for `MAX_RECV_RETRY_COUNT` count.
+    pub(crate) async fn recv(
         &mut self,
         transaction_id: u64,
     ) -> Result<Value, NmstateError> {
-        let mut response: Vec<u8> = Vec::new();
-        loop {
-            let mut buffer = [0u8; BUFFER_SIZE];
-            let read = self
-                .socket
-                .read(&mut buffer)
-                .map_err(parse_socket_io_error)?;
-            log::debug!("OVSDB: recv data {:?}", &buffer[..read]);
-            response.extend_from_slice(&buffer[..read]);
-            if read < BUFFER_SIZE {
-                break;
+        let mut response: Vec<u8> = Vec::with_capacity(BUFFER_SIZE);
+
+        let mut reply: Result<OvsDbRpcReply, NmstateError> =
+            Err(NmstateError::new(
+                ErrorKind::PluginFailure,
+                "Empty reply from OVSDB".to_string(),
+            ));
+
+        for _ in 0..MAX_RECV_RETRY_COUNT {
+            self.socket.readable().await.map_err(|e| {
+                NmstateError::new(
+                    ErrorKind::PluginFailure,
+                    format!("OVSDB connection is not readable: {e}"),
+                )
+            })?;
+            let mut buffer = [0; BUFFER_SIZE];
+            let read_size = match self.socket.try_read(&mut buffer) {
+                Ok(s) => s,
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    continue;
+                }
+                Err(e) => {
+                    return Err(NmstateError::new(
+                        ErrorKind::PluginFailure,
+                        format!(
+                            "Failed to read data from OVSDB connection: {e}"
+                        ),
+                    ))
+                }
+            };
+            log::debug!(
+                "OVSDB: recv size {read_size}, data {:?}",
+                &buffer[..read_size]
+            );
+            if read_size > 0 {
+                response.extend_from_slice(&buffer[..read_size]);
+            }
+
+            // A better way here to parse Vec as UTF8 is using `str::from_utf8`
+            // without consuming the Vec. But that function only stable
+            // on Rust 1.87. Unless use `unsafe { mem::transmute() }`
+            // converting &[u8] to &str, we have to clone the data here.
+            match String::from_utf8(response.clone()) {
+                Ok(reply_str) => {
+                    log::debug!("OVSDB: recv string {:?}", &reply_str);
+                    // Check whether received data is a valid JSON data which
+                    // is indicator of end-of-message.
+                    match serde_json::from_str::<OvsDbRpcReply>(&reply_str) {
+                        Ok(r) => {
+                            reply = Ok(r);
+                            break;
+                        }
+                        Err(e) => {
+                            reply = Err(NmstateError::new(
+                                ErrorKind::PluginFailure,
+                                format!(
+                                    "OVS db reply is not valid OvsDbRpcReply: \
+                                     {e}"
+                                ),
+                            ));
+                        }
+                    }
+                }
+                Err(e) => {
+                    reply = Err(NmstateError::new(
+                        ErrorKind::PluginFailure,
+                        format!("OVS db reply is not valid UTF8 string: {e}"),
+                    ));
+                }
             }
         }
-        let reply_string =
-            String::from_utf8(response).map_err(parse_str_parse_error)?;
-        log::debug!("OVSDB: recv string {:?}", &reply_string);
-        let reply: OvsDbRpcReply = serde_json::from_str(&reply_string)?;
+
+        let reply = reply?;
+
         if reply.id != transaction_id {
             let e = NmstateError::new(
                 ErrorKind::PluginFailure,
@@ -95,18 +178,4 @@ impl OvsDbJsonRpc {
             Ok(reply.result)
         }
     }
-}
-
-fn parse_str_parse_error(e: std::string::FromUtf8Error) -> NmstateError {
-    NmstateError::new(
-        ErrorKind::PluginFailure,
-        format!("Reply from OVSDB is not valid UTF-8 string: {e}"),
-    )
-}
-
-fn parse_socket_io_error(e: std::io::Error) -> NmstateError {
-    NmstateError::new(
-        ErrorKind::PluginFailure,
-        format!("OVSDB Socket error: {e}"),
-    )
 }

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -16,20 +16,20 @@ use crate::{
 
 use super::db::{parse_str_map, OvsDbConnection, OvsDbEntry};
 
-pub(crate) fn ovsdb_is_running() -> bool {
-    if let Ok(mut cli) = OvsDbConnection::new() {
-        cli.check_connection()
+pub(crate) async fn ovsdb_is_running() -> bool {
+    if let Ok(mut cli) = OvsDbConnection::new().await {
+        cli.check_connection().await
     } else {
         false
     }
 }
 
-pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
+pub(crate) async fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
     let mut ret = NetworkState::new();
-    let mut cli = OvsDbConnection::new()?;
-    let ovsdb_ifaces = cli.get_ovs_ifaces()?;
-    let ovsdb_brs = cli.get_ovs_bridges()?;
-    let ovsdb_ports = cli.get_ovs_ports()?;
+    let mut cli = OvsDbConnection::new().await?;
+    let ovsdb_ifaces = cli.get_ovs_ifaces().await?;
+    let ovsdb_brs = cli.get_ovs_bridges().await?;
+    let ovsdb_ports = cli.get_ovs_ports().await?;
 
     for ovsdb_br in ovsdb_brs.values() {
         let mut iface = OvsBridgeInterface::new();
@@ -65,7 +65,7 @@ pub(crate) fn ovsdb_retrieve() -> Result<NetworkState, NmstateError> {
         }
     }
 
-    ret.ovsdb = Some(cli.get_global_conf()?);
+    ret.ovsdb = Some(cli.get_global_conf().await?);
 
     Ok(ret)
 }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -107,8 +107,8 @@ impl NetworkState {
         self.routes = state.routes;
         self.rules = state.rules;
         self.dns = state.dns;
-        if ovsdb_is_running() {
-            match ovsdb_retrieve() {
+        if ovsdb_is_running().await {
+            match ovsdb_retrieve().await {
                 Ok(mut ovsdb_state) => {
                     ovsdb_state.isolate_ovn()?;
                     self.update_state(&ovsdb_state);
@@ -163,7 +163,7 @@ impl NetworkState {
                  {MAX_SUPPORTED_INTERFACES} in desired state",
             );
         }
-        if self.interfaces.has_up_ovs_iface() && !ovsdb_is_running() {
+        if self.interfaces.has_up_ovs_iface() && !ovsdb_is_running().await {
             if self.no_verify {
                 log::warn!(
                     "Desired state contains OVS interfaces, but not able to \
@@ -323,8 +323,8 @@ impl NetworkState {
         with_retry(RETRY_NM_INTERVAL_MILLISECONDS, RETRY_NM_COUNT, || async {
             nm_checkpoint_timeout_extend(checkpoint, timeout).await?;
             nm_apply(merged_state, checkpoint, timeout).await?;
-            if ovsdb_is_running() {
-                ovsdb_apply_global_conf(merged_state)?;
+            if ovsdb_is_running().await {
+                ovsdb_apply_global_conf(merged_state).await?;
             }
             if let Some(running_hostname) =
                 self.hostname.as_ref().and_then(|c| c.running.as_ref())

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2226,3 +2226,66 @@ def ovs_bridge1_with_bond_as_system_iface(eth1_up, eth2_up):
 def test_ovs_system_iface_link_stable(ovs_bridge1_with_bond_as_system_iface):
     desired_state = ovs_bridge1_with_bond_as_system_iface
     libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def cleanup_test_bridge_afterwards():
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: BRIDGE0,
+                    Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+# https://issues.redhat.com/browse/RHEL-93154
+@pytest.mark.tier1
+def test_ovsdb_recv_end_of_message(cleanup_test_bridge_afterwards):
+    # This special cooked YAML just make the OVSDB query reply exactly 4096
+    # bytes which fit exactly single recv/read buffer.
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: ovs1
+          type: ovs-interface
+          state: up
+          ovs-db:
+            external_ids:
+              a: 1
+              b: 2
+              c: 3
+              d: 4
+              f: 4
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+             - name: ovs1
+             - name: ovs2
+             - name: ovs3
+             - name: ovs4
+             - name: ovs5
+             - name: ovs6
+             - name: ovs7
+             - name: ovs8
+             - name: ovs9
+             - name: ovs10
+             - name: ovs11
+             - name: ovs12
+             - name: ovs13
+             - name: ovs14
+             - name: ovs15
+             - name: ovs16
+             - name: ovs17
+            """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)


### PR DESCRIPTION
When the OVSDB reply is 4096 or multiple of it, `nmstatectl show` will hang
on waiting for more data.

The root cause is nmstate incorrect treating `read_size < buffer_size`
as `end-of-message` indicator. When the `read_size` equal to
`buffer_size`, nmstate start new round of read which will block there
forever because OVS daemon has finished sending.

There is no `end-of-message` indicator in JSON-RPC used by OVSDB. And
there is no `end-of-message` indicator in UNIX stream socket used by
OVSDB neither.

The OVS code `lib/jsonrpc.c` is using `whether received data a valid
json object` as indicator of `end-of-message` using 4096 buffer with 50
max retry rounds. This patch is doing the same in rust using tokio async
`UnixStream`.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-93154