### PR TITLE
route rule: ensure idempotency for USE_DEFAULT_PRIORITY

### DIFF
--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -527,8 +527,14 @@ impl MergedRouteRules {
 
         let mut des_absent_rules: Vec<&RouteRuleEntry> = Vec::new();
         if let Some(rules) = desired.config.as_ref() {
-            for rule in rules.as_slice().iter().filter(|r| r.is_absent()) {
-                des_absent_rules.push(rule);
+            for rule in rules.as_slice().iter() {
+                if !rule.is_absent() {
+                    let mut new_rule = rule.clone();
+                    new_rule.sanitize()?;
+                    for_apply.push(new_rule);
+                } else {
+                    des_absent_rules.push(rule);
+                }
             }
         }
 
@@ -544,17 +550,16 @@ impl MergedRouteRules {
                     new_rule.sanitize()?;
                     for_apply.push(new_rule);
                 } else {
-                    merged_rules.push(rule.clone());
+                    let mut new_rule = rule.clone();
+                    new_rule.sanitize()?;
+                    merged_rules.push(new_rule);
                 }
             }
         }
 
-        if let Some(rules) = desired.config.as_ref() {
-            for rule in rules.as_slice().iter().filter(|r| !r.is_absent()) {
-                let mut rule = rule.clone();
-                rule.sanitize()?;
+        for rule in for_apply.iter().filter(|rule| !rule.is_absent()) {
+            if !merged_rules.iter().any(|mer_rule| rule.is_match(mer_rule)) {
                 merged_rules.push(rule.clone());
-                for_apply.push(rule);
             }
         }
 

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -601,6 +601,10 @@ impl MergedRouteRules {
     }
 }
 
+/// Set a proper priority on rules with USE_DEFAULT_PRIORITY: if a matching
+/// rule already existed, use its priority so we don't create a new one. If
+/// not, use an increasing priority number so we don't create rules with the
+/// same priority.
 fn set_auto_priority(
     for_apply: &mut [RouteRuleEntry],
     merged: &[RouteRuleEntry],
@@ -615,8 +619,18 @@ fn set_auto_priority(
             && (r.priority.is_none()
                 || r.priority == Some(RouteRuleEntry::USE_DEFAULT_PRIORITY))
     }) {
-        max_priority += 1;
-        rule.priority = Some(max_priority);
+        let cur_prio =
+            merged.iter().find_map(|cur_rule| match cur_rule.priority {
+                Some(RouteRuleEntry::USE_DEFAULT_PRIORITY) => None,
+                Some(n) => rule.is_match(cur_rule).then_some(n),
+                None => None,
+            });
+        if cur_prio.is_some() {
+            rule.priority = cur_prio;
+        } else {
+            max_priority += 1;
+            rule.priority = Some(max_priority);
+        }
     }
 }
 

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -320,3 +320,119 @@ fn test_route_rule_auto_priority_increasing_from_empty() {
     );
     assert_eq!(rules[2].priority, Some(30002));
 }
+
+#[test]
+fn test_route_rule_auto_priority_existing() {
+    let des_rules: RouteRules = serde_yaml::from_str(
+        r"
+        config:
+        - ip-to: 192.168.2.30
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.31
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.32
+          route-table: 200
+          family: ipv4
+        ",
+    )
+    .unwrap();
+
+    let cur_rules: RouteRules = serde_yaml::from_str(
+        r"
+        config:
+        - ip-to: 192.168.2.30
+          priority: 100
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.31
+          priority: 30001
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.32
+          priority: 101
+          route-table: 200
+          family: ipv4
+        ",
+    )
+    .unwrap();
+
+    let merged = MergedRouteRules::new(des_rules, cur_rules).unwrap();
+
+    let mut rules = merged.for_apply;
+    rules.sort_unstable();
+
+    assert_eq!(rules.len(), 3);
+    assert_eq!(
+        rules[0].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.30/32".to_string())
+    );
+    assert_eq!(rules[0].priority, Some(100));
+    assert_eq!(
+        rules[1].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.31/32".to_string())
+    );
+    assert_eq!(rules[1].priority, Some(30001));
+    assert_eq!(
+        rules[2].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.32/32".to_string())
+    );
+    assert_eq!(rules[2].priority, Some(101));
+}
+
+#[test]
+fn test_route_rule_auto_priority_some_existing_and_some_new() {
+    let des_rules: RouteRules = serde_yaml::from_str(
+        r"
+        config:
+        - ip-to: 192.168.2.30
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.31
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.32
+          route-table: 200
+          family: ipv4
+        ",
+    )
+    .unwrap();
+
+    let cur_rules: RouteRules = serde_yaml::from_str(
+        r"
+        config:
+        - ip-to: 192.168.2.30
+          priority: 100
+          route-table: 200
+          family: ipv4
+        - ip-to: 192.168.2.100
+          priority: 30001
+          route-table: 200
+          family: ipv4
+        ",
+    )
+    .unwrap();
+
+    let merged = MergedRouteRules::new(des_rules, cur_rules).unwrap();
+
+    let mut rules = merged.for_apply;
+    rules.sort_unstable();
+
+    assert_eq!(rules.len(), 3);
+    assert_eq!(
+        rules[0].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.30/32".to_string())
+    );
+    assert_eq!(rules[0].priority, Some(100));
+    assert_eq!(
+        rules[1].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.31/32".to_string())
+    );
+    assert_eq!(rules[1].priority, Some(30002));
+    assert_eq!(
+        rules[2].ip_to.as_ref().map(|i| i.to_string()),
+        Some("192.168.2.32/32".to_string())
+    );
+    assert_eq!(rules[2].priority, Some(30003));
+}

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -37,24 +37,26 @@ def ip_rule_exist_in_os(rule):
     logging.debug(f"Current ip rules in OS: {result[1]}")
     assert result[0] == 0
     current_rules = json.loads(result[1])
-    found = True
+    found = False
     for rule in current_rules:
-        if rule.get("src") == "all" or rule.get("dst") == "all":
-            continue
+        logging.debug(f"Checking ip rule is OS: {rule}")
+        found = True
 
         if rule.get("table") == "main":
             rule["table"] = f"{iplib.KERNEL_MAIN_ROUTE_TABLE_ID}"
+        if rule.get("src") not in (None, "all"):
+            rule["src"] = iplib.to_ip_address_full(
+                rule["src"], rule.get("srclen")
+            )
+        if rule.get("dst") not in (None, "all"):
+            rule["dst"] = iplib.to_ip_address_full(
+                rule["dst"], rule.get("dstlen")
+            )
 
-        logging.debug(f"Checking ip rule is OS: {rule}")
-        found = True
-        if ip_from and ip_from != iplib.to_ip_address_full(
-            rule["src"], rule.get("srclen")
-        ):
+        if ip_from is not None and rule["src"] != ip_from:
             found = False
             continue
-        if ip_to and ip_to != iplib.to_ip_address_full(
-            rule["dst"], rule.get("dstlen")
-        ):
+        if ip_to is not None and rule.get("dst") != ip_to:
             found = False
             continue
         if priority is not None and rule["priority"] != priority:

--- a/tests/integration/testlib/iprule.py
+++ b/tests/integration/testlib/iprule.py
@@ -8,7 +8,7 @@ from libnmstate.schema import RouteRule
 from . import cmdlib
 
 
-def ip_rule_exist_in_os(rule):
+def ip_rule_exist_in_os(rule, unique=True):
     ip_from = rule.get(RouteRule.IP_FROM)
     ip_to = rule.get(RouteRule.IP_TO)
     priority = rule.get(RouteRule.PRIORITY)
@@ -38,6 +38,7 @@ def ip_rule_exist_in_os(rule):
     assert result[0] == 0
     current_rules = json.loads(result[1])
     found = False
+    matches_count = 0
     for rule in current_rules:
         logging.debug(f"Checking ip rule is OS: {rule}")
         found = True
@@ -84,7 +85,10 @@ def ip_rule_exist_in_os(rule):
             found = False
             continue
         if found:
-            break
+            if unique:
+                matches_count += 1
+            else:
+                break
     if not found:
         logging.debug(f"Failed to find expected ip rule: {expected_rule}")
-    assert found
+    assert found if not unique else matches_count == 1


### PR DESCRIPTION
When the desired state has route rules without a priority defined,
nmstate creates them with increasing values of priority. However,
this was causing that applying the same desired state twice created
the rule twice with different priorities. As a result, the operation
was not idempotent.

Fix it by searching for a matching rule in the current state and, if
there is any, use its priority value to fill the priority value of the
desired rule if it's empty. As a result, new rules are not created if
one that matches already exists.

Fix also a helper function of the integration tests to make it asserting
that the rule is not duplicated.

Signed-off-by: Íñigo Huguet <ihuguet@redhat.com>

