### PR TITLE
test: Remove TEST_TYPE_FORMAT

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -327,10 +327,7 @@ done
 : ${INSTALL_DEPS:="false"}
 : ${COMPILED_RPMS_DIR:=""}
 
-if [ $TEST_TYPE != $TEST_TYPE_ALL ] && \
-   [ $TEST_TYPE != $TEST_TYPE_FORMAT ];then
-    modprobe_ovs
-fi
+modprobe_ovs
 
 if [ -n "${RUN_BAREMETAL}" ];then
     CONTAINER_WORKSPACE="."


### PR DESCRIPTION
Since the lint test moved to `automation/run-lint-tests.sh`, we should
always load OVS kernel module.