### PR TITLE
nm: Do not skip activation on failure retry

### DIFF
--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -38,7 +38,8 @@ pub(crate) fn nm_gen_conf(
         &merged_state,
         &Vec::new(),
         &Vec::new(),
-        true, // gen_conf mode
+        true,  // gen_conf mode
+        false, // is_retry
     )?
     .to_store;
 

--- a/rust/src/lib/nm/profile.rs
+++ b/rust/src/lib/nm/profile.rs
@@ -22,6 +22,7 @@ pub(crate) fn perpare_nm_conns(
     exist_nm_conns: &[NmConnection],
     nm_acs: &[NmActiveConnection],
     gen_conf_mode: bool,
+    is_retry: bool,
 ) -> Result<PerparedNmConnections, NmstateError> {
     let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
@@ -75,12 +76,13 @@ pub(crate) fn perpare_nm_conns(
             gen_conf_mode,
         )? {
             if iface.is_up()
-                && !can_skip_activation(
-                    merged_iface,
-                    &merged_state.interfaces,
-                    &nm_conn,
-                    exist_nm_conns,
-                )
+                && (is_retry
+                    || !can_skip_activation(
+                        merged_iface,
+                        &merged_state.interfaces,
+                        &nm_conn,
+                        exist_nm_conns,
+                    ))
             {
                 nm_conns_to_activate.push(nm_conn.clone());
             }

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -43,6 +43,7 @@ pub(crate) async fn nm_apply(
     merged_state: &MergedNetworkState,
     checkpoint: &str,
     timeout: u32,
+    is_retry: bool,
 ) -> Result<(), NmstateError> {
     let mut nm_api = NmApi::new().await.map_err(nm_error_to_nmstate)?;
     let mut nm_route_remove_needs_deactivate = true;
@@ -152,6 +153,7 @@ pub(crate) async fn nm_apply(
         exist_nm_conns.as_slice(),
         nm_acs.as_slice(),
         false,
+        is_retry,
     )?;
 
     let nm_ac_uuids: Vec<&str> =

--- a/rust/src/lib/nm/query_apply/profile.rs
+++ b/rust/src/lib/nm/query_apply/profile.rs
@@ -186,6 +186,12 @@ async fn _activate_nm_profiles(
                     nm_conn.iface_name().unwrap_or(""),
                     nm_conn.iface_type().cloned().unwrap_or_default(),
                 ));
+                log::info!(
+                    "Activating connection {}: {}/{}",
+                    uuid,
+                    nm_conn.iface_name().unwrap_or(""),
+                    nm_conn.iface_type().cloned().unwrap_or_default()
+                );
                 if let Err(e) = nm_api
                     .connection_activate(uuid)
                     .await

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -320,35 +320,39 @@ impl NetworkState {
     ) -> Result<(), NmstateError> {
         // NM might have unknown race problem found by verify stage,
         // we try to apply the state again if so.
-        with_retry(RETRY_NM_INTERVAL_MILLISECONDS, RETRY_NM_COUNT, || async {
-            nm_checkpoint_timeout_extend(checkpoint, timeout).await?;
-            nm_apply(merged_state, checkpoint, timeout).await?;
-            if ovsdb_is_running().await {
-                ovsdb_apply_global_conf(merged_state).await?;
-            }
-            if let Some(running_hostname) =
-                self.hostname.as_ref().and_then(|c| c.running.as_ref())
-            {
-                set_running_hostname(running_hostname)?;
-            }
-            if !self.no_verify {
-                with_retry(
-                    VERIFY_RETRY_INTERVAL_MILLISECONDS,
-                    retry_count,
-                    || async {
-                        nm_checkpoint_timeout_extend(checkpoint, timeout)
-                            .await?;
-                        let mut new_cur_net_state = cur_net_state.clone();
-                        new_cur_net_state.set_include_secrets(true);
-                        new_cur_net_state.retrieve_async().await?;
-                        merged_state.verify(&new_cur_net_state)
-                    },
-                )
-                .await
-            } else {
-                Ok(())
-            }
-        })
+        with_retry(
+            RETRY_NM_INTERVAL_MILLISECONDS,
+            RETRY_NM_COUNT,
+            |is_retry| async move {
+                nm_checkpoint_timeout_extend(checkpoint, timeout).await?;
+                nm_apply(merged_state, checkpoint, timeout, is_retry).await?;
+                if ovsdb_is_running().await {
+                    ovsdb_apply_global_conf(merged_state).await?;
+                }
+                if let Some(running_hostname) =
+                    self.hostname.as_ref().and_then(|c| c.running.as_ref())
+                {
+                    set_running_hostname(running_hostname)?;
+                }
+                if !self.no_verify {
+                    with_retry(
+                        VERIFY_RETRY_INTERVAL_MILLISECONDS,
+                        retry_count,
+                        |_| async {
+                            nm_checkpoint_timeout_extend(checkpoint, timeout)
+                                .await?;
+                            let mut new_cur_net_state = cur_net_state.clone();
+                            new_cur_net_state.set_include_secrets(true);
+                            new_cur_net_state.retrieve_async().await?;
+                            merged_state.verify(&new_cur_net_state)
+                        },
+                    )
+                    .await
+                } else {
+                    Ok(())
+                }
+            },
+        )
         .await
     }
 
@@ -375,7 +379,7 @@ impl NetworkState {
             with_retry(
                 VERIFY_RETRY_INTERVAL_MILLISECONDS,
                 VERIFY_RETRY_COUNT_KERNEL_MODE,
-                || async {
+                |_| async {
                     let mut new_cur_net_state = cur_net_state.clone();
                     new_cur_net_state.retrieve_async().await?;
                     merged_state.verify(&new_cur_net_state)
@@ -480,13 +484,14 @@ async fn with_retry<T, Fut>(
     func: T,
 ) -> Result<(), NmstateError>
 where
-    T: FnOnce() -> Fut + Copy,
+    T: FnOnce(bool) -> Fut + Copy,
     // Once `std::ops::AsyncFnOnce` is stable, use it instead
     Fut: Future<Output = Result<(), NmstateError>>,
 {
     let mut cur_count = 0usize;
     while cur_count < count {
-        if let Err(e) = func().await {
+        let is_retry = cur_count != 0;
+        if let Err(e) = func(is_retry).await {
             if cur_count == count - 1 || !e.kind().can_retry() {
                 if e.kind().can_ignore() {
                     return Ok(());


### PR DESCRIPTION
Originally, we skip some NM connection activation and expecting the
activation of controller could get its ports been activated automatically
by `connection.autoconnect-ports: true`.

But we see bug reports on OVS verification error on OVS port connection not
been activated, without stable reproducer, we cannot know why NM
`connection.autoconnect-ports` is not working on OVS bridge.

To fix this issue, on the second retry of `nm_apply()`, we do not skip any
NM connection activation anymore and forcing modified or desired NM
connection been manually reapply or activated.

Since we do not have stable reproducer on original problem and hard to tell
whether nmstate explicitly requested a reapply/activate or not, this patch
does not come with a test case. Existing test cases is enough to make sure
functionality is not impacted.