### PR TITLE
nm: route rules: don't duplicate rules in NM profile

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::fmt::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
@@ -191,7 +192,7 @@ pub struct InterfaceIpv4 {
     /// Deserialize from `dhcp-custom-hostname`
     pub dhcp_custom_hostname: Option<String>,
     pub(crate) dns: Option<DnsClientState>,
-    pub(crate) rules: Option<Vec<RouteRuleEntry>>,
+    pub(crate) rules: Option<HashSet<RouteRuleEntry>>,
 }
 
 impl InterfaceIpv4 {
@@ -547,7 +548,7 @@ pub struct InterfaceIpv6 {
     pub dhcp_custom_hostname: Option<String>,
 
     pub(crate) dns: Option<DnsClientState>,
-    pub(crate) rules: Option<Vec<RouteRuleEntry>>,
+    pub(crate) rules: Option<HashSet<RouteRuleEntry>>,
 }
 
 impl InterfaceIpv6 {

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::ops::BitXor;
 
 use super::super::nm_dbus::{
@@ -249,8 +250,8 @@ pub(crate) fn query_nmstate_wait_ip(
 fn nm_rules_to_nmstate(
     is_ipv6: bool,
     ip_set: &NmSettingIp,
-) -> Option<Vec<RouteRuleEntry>> {
-    let mut ret = Vec::new();
+) -> Option<HashSet<RouteRuleEntry>> {
+    let mut ret = HashSet::new();
     for nm_rule in ip_set.route_rules.as_slice() {
         let mut rule = RouteRuleEntry::new();
         if is_ipv6 {
@@ -307,7 +308,7 @@ fn nm_rules_to_nmstate(
                 }
             });
         }
-        ret.push(rule);
+        ret.insert(rule);
     }
     Some(ret)
 }

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use crate::{
     ErrorKind, MergedInterfaces, MergedNetworkState, NmstateError, RouteEntry,
     RouteRuleEntry,
@@ -94,7 +96,7 @@ fn apply_absent_rule(
             }
         }
 
-        let mut remain_rules = Vec::new();
+        let mut remain_rules = HashSet::new();
         if absent_rule.is_ipv6() {
             let full_rules = if let Some(rules) = iface
                 .for_apply
@@ -113,7 +115,7 @@ fn apply_absent_rule(
             if let Some(rules) = full_rules {
                 for rule in rules {
                     if !absent_rule.is_match(rule) {
-                        remain_rules.push(rule.clone());
+                        remain_rules.insert(rule.clone());
                     }
                 }
             }
@@ -142,7 +144,7 @@ fn apply_absent_rule(
             if let Some(rules) = full_rules {
                 for rule in rules {
                     if !absent_rule.is_match(rule) {
-                        remain_rules.push(rule.clone());
+                        remain_rules.insert(rule.clone());
                     }
                 }
             }
@@ -182,19 +184,16 @@ fn append_route_rule(
                 {
                     // When desired state has no rules defined, we should
                     // copy current rules first, then append.
-                    if ip_conf.rules.is_none() {
-                        ip_conf.rules = iface
+                    let rules = ip_conf.rules.get_or_insert_with(|| {
+                        iface
                             .merged
                             .base_iface()
                             .ipv6
                             .as_ref()
-                            .and_then(|i| i.rules.clone());
-                    }
-                    if let Some(rules) = ip_conf.rules.as_mut() {
-                        rules.push(rule.clone());
-                    } else {
-                        ip_conf.rules = Some(vec![rule.clone()]);
-                    }
+                            .and_then(|ipv6| ipv6.rules.clone())
+                            .unwrap_or_default()
+                    });
+                    rules.insert(rule.clone());
                 }
             } else {
                 if apply_iface.base_iface().ipv4.is_none() {
@@ -208,19 +207,16 @@ fn append_route_rule(
                 {
                     // When desired state has no rules defined, we should
                     // copy current rules first, then append.
-                    if ip_conf.rules.is_none() {
-                        ip_conf.rules = iface
+                    let rules = ip_conf.rules.get_or_insert_with(|| {
+                        iface
                             .merged
                             .base_iface()
                             .ipv4
                             .as_ref()
-                            .and_then(|i| i.rules.clone());
-                    }
-                    if let Some(rules) = ip_conf.rules.as_mut() {
-                        rules.push(rule.clone());
-                    } else {
-                        ip_conf.rules = Some(vec![rule.clone()]);
-                    }
+                            .and_then(|ipv4| ipv4.rules.clone())
+                            .unwrap_or_default()
+                    });
+                    rules.insert(rule.clone());
                 }
             }
         }

--- a/rust/src/lib/nm/settings/route_rule.rs
+++ b/rust/src/lib/nm/settings/route_rule.rs
@@ -10,8 +10,8 @@ use crate::{
 const AF_INET6: i32 = 10;
 const AF_INET: i32 = 2;
 
-pub(crate) fn gen_nm_ip_rules(
-    rules: &[RouteRuleEntry],
+pub(crate) fn gen_nm_ip_rules<'a>(
+    rules: impl IntoIterator<Item = &'a RouteRuleEntry>,
     is_ipv6: bool,
 ) -> Result<Vec<NmIpRouteRule>, NmstateError> {
     let mut ret = Vec::new();

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -9,9 +9,33 @@ use crate::{
         TEST_RULE_PRIORITY1, TEST_RULE_PRIORITY2, TEST_TABLE_ID1,
         TEST_TABLE_ID2,
     },
-    InterfaceType, Interfaces, MergedNetworkState, NetworkState,
+    Interface, InterfaceType, Interfaces, MergedNetworkState, NetworkState,
     RouteRuleEntry,
 };
+
+fn get_iface<'a>(
+    merged_state: &'a MergedNetworkState,
+    ifname: &str,
+    iface_type: InterfaceType,
+) -> &'a Interface {
+    merged_state
+        .interfaces
+        .get_iface(ifname, iface_type)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap()
+}
+
+fn get_routing_rules<'a>(iface: &Interface, ipv6: bool) -> Vec<RouteRuleEntry> {
+    let rules = match ipv6 {
+        false => iface.base_iface().ipv4.as_ref().unwrap().rules.as_ref(),
+        true => iface.base_iface().ipv6.as_ref().unwrap().rules.as_ref(),
+    };
+    let mut rules: Vec<_> = rules.unwrap().into_iter().cloned().collect();
+    rules.sort();
+    rules
+}
 
 #[test]
 fn test_add_rules_to_new_interface() {
@@ -31,25 +55,11 @@ fn test_add_rules_to_new_interface() {
             .unwrap();
     store_route_rule_config(&mut merged_state).unwrap();
 
-    let iface = merged_state
-        .interfaces
-        .get_iface(TEST_NIC, InterfaceType::Unknown)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
-
-    let ipv6_config_rules = iface
-        .base_iface()
-        .ipv6
-        .as_ref()
-        .unwrap()
-        .rules
-        .as_ref()
-        .unwrap();
+    let iface = get_iface(&merged_state, TEST_NIC, InterfaceType::Unknown);
+    let ipv6_config_rules = get_routing_rules(iface, true);
+    let ipv4_config_rules = get_routing_rules(iface, false);
 
     assert_eq!(ipv6_config_rules.len(), 1);
-
     assert_eq!(
         ipv6_config_rules[0].ip_from.as_ref().unwrap().as_str(),
         TEST_RULE_IPV6_FROM,
@@ -61,17 +71,7 @@ fn test_add_rules_to_new_interface() {
     assert_eq!(ipv6_config_rules[0].priority.unwrap(), TEST_RULE_PRIORITY1);
     assert_eq!(ipv6_config_rules[0].table_id.unwrap(), TEST_TABLE_ID1);
 
-    let ipv4_config_rules = iface
-        .base_iface()
-        .ipv4
-        .as_ref()
-        .unwrap()
-        .rules
-        .as_ref()
-        .unwrap();
-
     assert_eq!(ipv4_config_rules.len(), 1);
-
     assert_eq!(
         ipv4_config_rules[0].ip_from.as_ref().unwrap().as_str(),
         TEST_RULE_IPV4_FROM,
@@ -88,51 +88,51 @@ fn test_add_rules_to_new_interface() {
 fn test_route_rule_ignore_absent_ifaces() {
     let desired: NetworkState = serde_yaml::from_str(
         r"
-interfaces:
-- name: br0
-  state: absent
-  type: linux-bridge
-route-rules:
-  config:
-  - route-table: 200
-    state: absent
-",
+        interfaces:
+        - name: br0
+          state: absent
+          type: linux-bridge
+        route-rules:
+          config:
+          - route-table: 200
+            state: absent
+        ",
     )
     .unwrap();
 
     let current: NetworkState = serde_yaml::from_str(
         r"
-interfaces:
-- name: eth1
-  type: ethernet
-  state: up
-- name: br0
-  type: linux-bridge
-  state: up
-  ipv4:
-    address:
-    - ip: 192.0.2.251
-      prefix-length: 24
-    dhcp: false
-    enabled: true
-  bridge:
-    options:
-      stp:
-        enabled: false
-    port:
-    - name: eth1
-routes:
-  config:
-    - destination: 198.51.100.0/24
-      metric: 150
-      next-hop-address: 192.0.2.1
-      next-hop-interface: br0
-      table-id: 200
-route-rules:
-  config:
-    - ip-from: 192.51.100.2/32
-      route-table: 200
-",
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: eth1
+        routes:
+          config:
+            - destination: 198.51.100.0/24
+              metric: 150
+              next-hop-address: 192.0.2.1
+              next-hop-interface: br0
+              table-id: 200
+        route-rules:
+          config:
+            - ip-from: 192.51.100.2/32
+              route-table: 200
+        ",
     )
     .unwrap();
 
@@ -141,21 +141,8 @@ route-rules:
 
     store_route_rule_config(&mut merged_state).unwrap();
 
-    let eth1_iface = merged_state
-        .interfaces
-        .get_iface("eth1", InterfaceType::Ethernet)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
-
-    let br0_iface = merged_state
-        .interfaces
-        .get_iface("br0", InterfaceType::LinuxBridge)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
+    let eth1_iface = get_iface(&merged_state, "eth1", InterfaceType::Ethernet);
+    let br0_iface = get_iface(&merged_state, "br0", InterfaceType::LinuxBridge);
 
     assert!(eth1_iface.is_up());
     assert!(br0_iface.is_absent());
@@ -164,58 +151,56 @@ route-rules:
 #[test]
 fn test_route_rule_use_auto_route_table_id() {
     let current: NetworkState = serde_yaml::from_str(
-        r"
----
-interfaces:
-  - name: br0
-    type: ovs-interface
-    state: up
-    ipv4:
-      enabled: true
-      dhcp: true
-      auto-dns: false
-      auto-routes: true
-      auto-gateway: true
-      auto-route-table-id: 500
-    ipv6:
-      enabled: false
-  - name: br0
-    type: ovs-bridge
-    state: up
-    bridge:
-      port:
-        - name: br0
-",
+        r"---
+        interfaces:
+          - name: br0
+            type: ovs-interface
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-dns: false
+              auto-routes: true
+              auto-gateway: true
+              auto-route-table-id: 500
+            ipv6:
+              enabled: false
+          - name: br0
+            type: ovs-bridge
+            state: up
+            bridge:
+              port:
+                - name: br0
+        ",
     )
     .unwrap();
 
     let desired: NetworkState = serde_yaml::from_str(
-        r"
----
-route-rules:
-  config:
-    - route-table: 500
-      priority: 3200
-      ip-to: 192.0.3.0/24
-    - route-table: 500
-      priority: 3200
-      ip-from: 192.0.3.0/24
-interfaces:
-  - name: br0
-    type: ovs-interface
-",
+        r"---
+        route-rules:
+          config:
+            - route-table: 500
+              priority: 3200
+              ip-to: 192.0.3.0/24
+            - route-table: 500
+              priority: 3200
+              ip-from: 192.0.3.0/24
+        interfaces:
+          - name: br0
+            type: ovs-interface
+        ",
     )
     .unwrap();
 
     let expected_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
         r"
-- route-table: 500
-  priority: 3200
-  ip-to: 192.0.3.0/24
-- route-table: 500
-  priority: 3200
-  ip-from: 192.0.3.0/24
-",
+        - route-table: 500
+          priority: 3200
+          ip-to: 192.0.3.0/24
+        - route-table: 500
+          priority: 3200
+          ip-from: 192.0.3.0/24
+        ",
     )
     .unwrap();
 
@@ -224,39 +209,31 @@ interfaces:
 
     store_route_rule_config(&mut merged_state).unwrap();
 
-    let ovs_iface = merged_state
-        .interfaces
-        .get_iface("br0", InterfaceType::OvsInterface)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
+    let ovs_iface =
+        get_iface(&merged_state, "br0", InterfaceType::OvsInterface);
+    let ipv4_rules = get_routing_rules(ovs_iface, false);
 
     assert_eq!(ovs_iface.iface_type(), InterfaceType::OvsInterface);
-    assert_eq!(
-        ovs_iface.base_iface().ipv4.as_ref().unwrap().rules,
-        Some(expected_rules)
-    );
+    assert_eq!(ipv4_rules, expected_rules);
 }
 
 #[test]
 fn test_route_rule_use_default_auto_route_table_id() {
     let current: NetworkState = serde_yaml::from_str(
-        r"
----
-interfaces:
-  - name: eth1
-    type: ethernet
-    state: up
-    ipv4:
-      enabled: true
-      dhcp: true
-      auto-dns: true
-      auto-routes: true
-      auto-gateway: true
-    ipv6:
-      enabled: false
-",
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-dns: true
+              auto-routes: true
+              auto-gateway: true
+            ipv6:
+              enabled: false
+        ",
     )
     .unwrap();
 
@@ -275,13 +252,13 @@ interfaces:
 
     let expected_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
         r"
-- route-table: 254
-  priority: 3200
-  ip-to: 192.0.3.0/24
-- route-table: 254
-  priority: 3200
-  ip-from: 192.0.3.0/24
-",
+        - route-table: 254
+          priority: 3200
+          ip-to: 192.0.3.0/24
+        - route-table: 254
+          priority: 3200
+          ip-from: 192.0.3.0/24
+        ",
     )
     .unwrap();
 
@@ -290,18 +267,10 @@ interfaces:
 
     store_route_rule_config(&mut merged_state).unwrap();
 
-    let iface = merged_state
-        .interfaces
-        .get_iface("eth1", InterfaceType::Ethernet)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
+    let iface = get_iface(&merged_state, "eth1", InterfaceType::Ethernet);
+    let ipv4_rules = get_routing_rules(iface, false);
 
-    assert_eq!(
-        iface.base_iface().ipv4.as_ref().unwrap().rules,
-        Some(expected_rules)
-    );
+    assert_eq!(ipv4_rules, expected_rules);
 }
 
 #[test]
@@ -360,20 +329,68 @@ fn test_route_rule_use_loopback() {
 
     store_route_rule_config(&mut merged_state).unwrap();
 
-    let iface = merged_state
-        .interfaces
-        .get_iface("lo", InterfaceType::Loopback)
-        .unwrap()
-        .for_apply
-        .as_ref()
-        .unwrap();
+    let iface = get_iface(&merged_state, "lo", InterfaceType::Loopback);
+    let ipv4_rules = get_routing_rules(iface, false);
+    let ipv6_rules = get_routing_rules(iface, true);
 
-    assert_eq!(
-        iface.base_iface().ipv4.as_ref().unwrap().rules,
-        Some(expected_ipv4_rules)
-    );
-    assert_eq!(
-        iface.base_iface().ipv6.as_ref().unwrap().rules,
-        Some(expected_ipv6_rules)
-    );
+    assert_eq!(ipv4_rules, expected_ipv4_rules);
+    assert_eq!(ipv6_rules, expected_ipv6_rules);
+}
+
+#[test]
+fn test_route_rule_add_twice() {
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-dns: true
+              auto-routes: true
+              auto-gateway: true
+            ipv6:
+              enabled: false
+        ",
+    )
+    .unwrap();
+
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        route-rules:
+          config:
+            - priority: 3200
+              ip-to: 192.0.3.0/24
+            - priority: 3200
+              ip-from: 192.0.3.0/24
+        interfaces:
+          - name: eth1",
+    )
+    .unwrap();
+
+    let mut expected_rules: Vec<RouteRuleEntry> = serde_yaml::from_str(
+        r"
+        - route-table: 254
+          priority: 3200
+          ip-to: 192.0.3.0/24
+        - route-table: 254
+          priority: 3200
+          ip-from: 192.0.3.0/24
+        ",
+    )
+    .unwrap();
+    expected_rules.sort();
+
+    let mut merged_state =
+        MergedNetworkState::new(desired, current, false, false).unwrap();
+
+    store_route_rule_config(&mut merged_state).unwrap();
+    store_route_rule_config(&mut merged_state).unwrap();
+
+    let iface = get_iface(&merged_state, "eth1", InterfaceType::Ethernet);
+    let ipv4_rules = get_routing_rules(iface, false);
+
+    assert_eq!(ipv4_rules, expected_rules);
 }


### PR DESCRIPTION
Each time that a routing rule was applied it was appended to the routing rules of the NM profile. If it already existed in the profile, it was added again, resulting in duplicated rules. As the kernel does not allow duplicated rules, they were effectively applied only once, though.

Nonetheless, we shouldn't duplicate again and again the same rule in the NM profile. Fix that by converting `InterfaceIPv4/6::rules` from `Vec` to `HashSet`, so we can only add rules that are not present yet.

Resolves: https://issues.redhat.com/browse/NMT-1649