### PR TITLE
nm dns: Store DNS to interface also when global DNS been used

### DIFF
--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -92,6 +92,7 @@ pub(crate) fn reselect_dns_ifaces(
         cur_v4_ifaces,
         nm_acs,
         nm_devs,
+        false,
     )
     .unwrap_or_default();
 
@@ -105,6 +106,7 @@ pub(crate) fn reselect_dns_ifaces(
             cur_v6_ifaces,
             nm_acs,
             nm_devs,
+            false,
         )
     })
     .unwrap_or_default();
@@ -124,12 +126,15 @@ fn find_dns_iface(
     cur_dns_ifaces: &[String],
     nm_acs: &[NmActiveConnection],
     nm_devs: &[NmDevice],
+    desired_only: bool,
 ) -> Option<String> {
     // Try using current DNS interface if in desired list
-    for iface_name in cur_dns_ifaces {
-        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
-            if iface.is_changed() && iface.is_iface_valid_for_dns(is_ipv6) {
-                return Some(iface_name.to_string());
+    if !desired_only {
+        for iface_name in cur_dns_ifaces {
+            if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
+                if iface.is_changed() && iface.is_iface_valid_for_dns(is_ipv6) {
+                    return Some(iface_name.to_string());
+                }
             }
         }
     }
@@ -182,6 +187,10 @@ fn find_dns_iface(
                 return Some(iface_name.to_string());
             }
         }
+    }
+
+    if desired_only {
+        return None;
     }
 
     let mut cur_iface_names: Vec<&str> = merged_ifaces
@@ -912,4 +921,33 @@ fn store_dns_search_or_options_to_ip_enabled_iface(
 
 fn is_supported_kernel_iface(nm_iface_type: &NmIfaceType) -> bool {
     SUPPORT_NM_KERNEL_IFACES.contains(nm_iface_type)
+}
+
+// Use first desired interface with IP enabled to stored desired DNS.
+// Do nothing when:
+//  * Mixing IPv4 and IPv6 DNS server.
+//  * No desired interface has IP enabled in desired state(ignore current state
+//    because we don't want to touch IP config unless desired)
+//  * ipv6 link local address as DNS nameserver. It should be handled by
+//    `reselect_dns_ifaces()`
+#[cfg(feature = "query_apply")]
+pub(crate) fn store_dns_config_to_desired_iface(
+    merged_state: &mut MergedNetworkState,
+) {
+    let srvs = merged_state.dns.servers.as_slice();
+
+    //  Mixing IPv4 and IPv6 DNS server. (Cannot split them into ipv4.dns and
+    //  ipv6.dns section but still preserve desired order)
+    if srvs.len() > 2 && is_mixed_dns_servers(srvs) {
+        return;
+    }
+
+    let v4_iface_name =
+        find_dns_iface(false, &merged_state.interfaces, &[], &[], &[], true)
+            .unwrap_or_default();
+    let v6_iface_name =
+        find_dns_iface(true, &merged_state.interfaces, &[], &[], &[], true)
+            .unwrap_or_default();
+
+    save_dns_to_iface(&v4_iface_name, &v6_iface_name, merged_state).ok();
 }

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -4,7 +4,10 @@ use std::collections::HashSet;
 
 use super::super::{
     device::create_index_for_nm_devs,
-    dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
+    dns::{
+        store_dns_config_to_desired_iface, store_dns_config_to_iface,
+        store_dns_search_or_option_to_iface,
+    },
     error::nm_error_to_nmstate,
     nm_dbus::{NmApi, NmConnection, NmIfaceType, NmVersion, NmVersionInfo},
     profile::{perpare_nm_conns, PerparedNmConnections},
@@ -134,6 +137,10 @@ pub(crate) async fn nm_apply(
                 merged_state.dns.options.as_slice(),
             )
             .await?;
+            // Still store DNS into desired interface to provides backwards
+            // compatibility for user who uses NM keyfiles only:
+            // https://github.com/coreos/fedora-coreos-tracker/issues/1947
+            store_dns_config_to_desired_iface(&mut merged_state);
         }
     }
     let PerparedNmConnections {

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -302,3 +302,28 @@ def test_reselect_iface_dns_if_desired(eth1_up):
     assert cmdlib.exec_cmd(
         "nmcli -g ipv4.dns c show eth1".split(), check=True
     )[1].strip() == ",".join(TEST_DNS_SRVS)
+
+
+# https://issues.redhat.com/browse/RHEL-91250
+@pytest.mark.tier1
+def test_write_both_global_dns_and_iface_dns(eth1_up):
+
+    state = load_yaml(
+        """---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            dhcp: true
+            auto-dns: false
+            enabled: true
+        """
+    )
+    state[DNS.KEY] = {DNS.CONFIG: {DNS.SERVER: TEST_DNS_SRVS}}
+
+    libnmstate.apply(state)
+    assert_global_dns(TEST_DNS_SRVS)
+    assert cmdlib.exec_cmd(
+        "nmcli -g ipv4.dns c show eth1".split(), check=True
+    )[1].strip() == ",".join(TEST_DNS_SRVS)


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/1947 indicate
OpenShift assisted installer depend on NM keyfile for installation from
PXE image where only NM keyfile can be preserved after switching from
minimum ramfs to full ramfs and finally to on-disk OS.

To workaround that issue, also store DNS information into desired interface even
when global DNS been used.

Integrator test case included and marked as tier1.

Resolves: https://issues.redhat.com/browse/RHEL-91250