### PR TITLE
interface: ignore interface with state 'unknown'

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -356,6 +356,30 @@ impl Interfaces {
         Ok(())
     }
 
+    fn purge_unknown_state_iface(&mut self) {
+        self.user_ifaces.retain(|_, iface| {
+            iface.base_iface().state != InterfaceState::Unknown
+        });
+        self.kernel_ifaces.retain(|_, iface| {
+            iface.base_iface().state != InterfaceState::Unknown
+        });
+
+        // Clean up insert_order Vec by removing entries for interfaces that
+        // were purged. The `insert_order` is used for re-ordering
+        // interfaces based on their controller-port-parent relationship
+        // in `set_ifaces_up_priority()`. We must maintain consistency between
+        // `insert_order` and the HashMap collections to ensure proper interface
+        // dependency.
+        self.insert_order.retain(|(iface_name, iface_type)| {
+            if iface_type.is_userspace() {
+                self.user_ifaces
+                    .contains_key(&(iface_name.clone(), iface_type.clone()))
+            } else {
+                self.kernel_ifaces.contains_key(iface_name)
+            }
+        });
+    }
+
     // If any desired interface has `identifier: mac-address`:
     //  * Resolve interface.name to MAC address match interface name.
     //  * Store interface.name to interface.profile_name.
@@ -749,6 +773,8 @@ impl MergedInterfaces {
 
         desired.unify_veth_and_eth();
         current.unify_veth_and_eth();
+
+        desired.purge_unknown_state_iface();
 
         if mode == NetworkStateMode::GenerateConfig {
             desired.set_unknown_iface_to_eth()?;

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -241,6 +241,55 @@ fn test_ifaces_ignore_iface_in_desire() {
 }
 
 #[test]
+fn test_ifaces_iface_in_unknown_state() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: unknown",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        current,
+        crate::NetworkStateMode::Apply,
+        false,
+    )
+    .unwrap();
+
+    assert!(
+        merged_ifaces
+            .get_iface("eth1", InterfaceType::Ethernet)
+            .unwrap()
+            .for_apply
+            .is_some(),
+        "eth1 should have for apply value"
+    );
+    assert!(
+        merged_ifaces
+            .get_iface("eth2", InterfaceType::Ethernet)
+            .unwrap()
+            .for_apply
+            .is_none(),
+        "eth2 should be purged"
+    );
+}
+
+#[test]
 fn test_ifaces_ignore_iface_in_current() {
     let current = serde_yaml::from_str::<Interfaces>(
         r"---

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -103,6 +103,7 @@ class InterfaceState:
     UP = "up"
     ABSENT = "absent"
     IGNORE = "ignore"
+    UNKNOWN = "unknown"
 
 
 class InterfaceType:

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1626,3 +1626,34 @@ def test_bond_opt_ns_ip6_target(setup_remove_bond99):
     )
     libnmstate.apply(state)
     assertlib.assert_state_match(state)
+
+
+def test_eth1_state_unknown_with_controller_port_info_preserved(
+    eth1_up, eth2_up
+):
+    state = yaml.load(BOND99_YAML_BASE, Loader=yaml.SafeLoader)
+    unknown_state_eth1 = {
+        Interface.NAME: "eth1",
+        Interface.TYPE: InterfaceType.ETHERNET,
+        Interface.STATE: InterfaceState.UNKNOWN,
+    }
+    state[Interface.KEY].append(unknown_state_eth1)
+
+    libnmstate.apply(state)
+    eth1_state = statelib.show_only((state[Interface.KEY][1][Interface.NAME],))
+
+    assert eth1_state[Interface.KEY][0][Interface.CONTROLLER] == BOND99
+
+    remove_bond_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: BOND99,
+                Interface.TYPE: InterfaceType.BOND,
+                Interface.STATE: InterfaceState.ABSENT,
+            }
+        ]
+    }
+
+    apply_with_description("Remove bond interface bond99", remove_bond_state)
+    bond_state = statelib.show_only((BOND99,))
+    assert not bond_state[Interface.KEY]


### PR DESCRIPTION
Fixes https://github.com/nmstate/nmstate/issues/2452

~~modify Interface::is_ignore to include InterfaceState::Unknown.~~
~~Log warn level in get_ignored_ifaces function.~~

Purge desired interfaces with state unknown in MergedInterfaces.
Log warning when doing so.