### PR TITLE
test: Skip test_write_both_global_dns_and_iface_dns on k8s

### DIFF
--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -306,6 +306,7 @@ def test_reselect_iface_dns_if_desired(eth1_up):
 
 # https://issues.redhat.com/browse/RHEL-91250
 @pytest.mark.tier1
+@pytest.mark.skipif(is_k8s(), reason="K8S cannot check global DNS file")
 def test_write_both_global_dns_and_iface_dns(eth1_up):
 
     state = load_yaml(


### PR DESCRIPTION
In K8S environment, nmstate is in container which does not have access
to `/var/lib/NetworkManager/NetworkManager-intern.conf`, hence skipping
test case `test_write_both_global_dns_and_iface_dns` there.