### PR TITLE
sriov: Do not resolve sriov refer in `gen_diff`

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -268,8 +268,8 @@ async fn apply_state_async(
             match net_state.gen_diff(&cur_state) {
                 Ok(s) => Ok(s),
                 Err(e) => {
-                    log::warn!(
-                        "Failed to generate difference: {e}, \
+                    log::error!(
+                        "BUG: Failed to generate difference: {e}, \
                         returning full desired state");
                     Ok(net_state.clone())
                 }

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -265,7 +265,15 @@ async fn apply_state_async(
         }
         result = net_state.apply_async() => {
             result?;
-            Ok(net_state.gen_diff(&cur_state)?)
+            match net_state.gen_diff(&cur_state) {
+                Ok(s) => Ok(s),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to generate difference: {e}, \
+                        returning full desired state");
+                    Ok(net_state.clone())
+                }
+            }
         }
     }
 }

--- a/rust/src/lib/dispatch.rs
+++ b/rust/src/lib/dispatch.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ErrorKind, MergedInterfaces, NmstateError};
+use crate::{ErrorKind, MergedInterfaces, NetworkStateMode, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -35,7 +35,7 @@ impl MergedInterfaces {
                     .map(|f| f.base_iface().dispatch.is_some())
                     .unwrap_or_default()
         }) {
-            if self.gen_conf_mode {
+            if self.mode == NetworkStateMode::GenerateConfig {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
                     "Dispatch script is not supported in gc(gen_conf) mode"

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -3,7 +3,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    nm::nm_gen_conf, Interface, MergedNetworkState, NetworkState, NmstateError,
+    nm::nm_gen_conf, Interface, MergedNetworkState, NetworkState,
+    NetworkStateMode, NmstateError,
 };
 
 impl NetworkState {
@@ -29,7 +30,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             cur_state,
-            true,  // gen_conf mode
+            NetworkStateMode::GenerateConfig,
             false, // memory only
         )?;
         ret.insert("NetworkManager".to_string(), nm_gen_conf(&merged_state)?);

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     BaseInterface, ErrorKind, Interface, InterfaceType, Interfaces,
-    MergedInterfaces, NmstateError, SrIovConfig,
+    MergedInterfaces, NetworkStateMode, NmstateError, SrIovConfig,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -192,8 +192,11 @@ impl MergedInterfaces {
         }) {
             if let Some(Interface::Ethernet(eth_iface)) = &iface.desired {
                 if eth_iface.veth.is_none()
-                    && !self.gen_conf_mode
+                    && self.mode != NetworkStateMode::GenerateConfig
                     && !veth_peers.contains(&eth_iface.base.name.as_str())
+                    // The `resolve_sriov_reference()` will raise error if
+                    // SRIOV VF not found, so we skip check on them here.
+                    && !eth_iface.base.name.starts_with("sriov:")
                 {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -8,7 +8,8 @@ use serde::{
 
 use crate::{
     ErrorKind, EthernetInterface, Interface, InterfaceIdentifier,
-    InterfaceState, InterfaceType, MergedInterface, NmstateError,
+    InterfaceState, InterfaceType, MergedInterface, NetworkStateMode,
+    NmstateError,
 };
 
 // The max loop count for Interfaces.set_ifaces_up_priority()
@@ -659,7 +660,7 @@ pub(crate) struct MergedInterfaces {
     pub(crate) insert_order: Vec<(String, InterfaceType)>,
     pub(crate) ignored_ifaces: Vec<(String, InterfaceType)>,
     pub(crate) memory_only: bool,
-    pub(crate) gen_conf_mode: bool,
+    pub(crate) mode: NetworkStateMode,
 }
 
 impl MergedInterfaces {
@@ -669,7 +670,7 @@ impl MergedInterfaces {
     pub(crate) fn new(
         mut desired: Interfaces,
         mut current: Interfaces,
-        gen_conf_mode: bool,
+        mode: NetworkStateMode,
         memory_only: bool,
     ) -> Result<Self, NmstateError> {
         let mut merged_kernel_ifaces: HashMap<String, MergedInterface> =
@@ -682,12 +683,16 @@ impl MergedInterfaces {
         desired.unify_veth_and_eth();
         current.unify_veth_and_eth();
 
-        if gen_conf_mode {
+        if mode == NetworkStateMode::GenerateConfig {
             desired.set_unknown_iface_to_eth()?;
             desired.set_missing_port_to_eth();
             desired.handle_gen_conf_mac_identifer();
         } else {
-            desired.resolve_sriov_reference(&current)?;
+            // SRIOV VF might not exist in pre-apply current, hence
+            // we do not resolve SRIOV refer for gen_diff() call.
+            if mode != NetworkStateMode::GenerateDiff {
+                desired.resolve_sriov_reference(&current)?;
+            }
             desired.resolve_mac_identifider_in_current(&current)?;
             desired.resolve_unknown_ifaces(&current)?;
             desired.resolve_mac_identifider_in_desired(&current)?;
@@ -763,7 +768,7 @@ impl MergedInterfaces {
             insert_order: desired.insert_order,
             ignored_ifaces,
             memory_only,
-            gen_conf_mode,
+            mode,
         };
 
         ret.process()?;

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -168,8 +168,8 @@ pub use crate::lldp::{
     LldpVlans,
 };
 pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
-pub(crate) use crate::net_state::MergedNetworkState;
 pub use crate::net_state::NetworkState;
+pub(crate) use crate::net_state::{MergedNetworkState, NetworkStateMode};
 pub(crate) use crate::ovn::MergedOvnConfiguration;
 pub use crate::ovn::{
     OvnBridgeMapping, OvnBridgeMappingState, OvnConfiguration,

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -351,7 +351,7 @@ impl MergedNetworkState {
     pub(crate) fn new(
         desired: NetworkState,
         current: NetworkState,
-        gen_conf_mode: bool,
+        mode: NetworkStateMode,
         memory_only: bool,
     ) -> Result<Self, NmstateError> {
         let mut current = current;
@@ -362,7 +362,7 @@ impl MergedNetworkState {
         let interfaces = MergedInterfaces::new(
             desired.interfaces,
             current.interfaces,
-            gen_conf_mode,
+            mode,
             memory_only,
         )?;
         let ignored_ifaces = interfaces.ignored_ifaces.as_slice();
@@ -402,4 +402,12 @@ impl MergedNetworkState {
 
         Ok(ret)
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum NetworkStateMode {
+    #[default]
+    Apply,
+    GenerateConfig,
+    GenerateDiff,
 }

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -24,8 +24,8 @@ use crate::{
     InterfaceIdentifier, InterfaceState, InterfaceType, IpVlanInterface,
     LinuxBridgeInterface, LoopbackInterface, MacSecConfig, MacSecInterface,
     MacVlanInterface, MacVtapInterface, MergedNetworkState, NetworkState,
-    NmstateError, OvsBridgeInterface, OvsInterface, UnknownInterface,
-    VlanInterface, VrfInterface, VxlanInterface,
+    NetworkStateMode, NmstateError, OvsBridgeInterface, OvsInterface,
+    UnknownInterface, VlanInterface, VrfInterface, VxlanInterface,
 };
 
 /// The `current_state` is NetworkState retrieved by nispor, and will be used
@@ -57,7 +57,7 @@ pub(crate) async fn nm_retrieve(
         &MergedNetworkState::new(
             NetworkState::default(),
             current_state.clone(),
-            false,
+            NetworkStateMode::default(),
             false,
         )?
         .interfaces,

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -13,7 +13,7 @@ use crate::{
         DEFAULT_OVS_DB_SOCKET_PATH,
     },
     ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
-    NmstateError,
+    NetworkStateMode, NmstateError,
 };
 
 const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;
@@ -224,7 +224,7 @@ impl NetworkState {
             merged_state = Some(MergedNetworkState::new(
                 self.clone(),
                 cur_net_state.clone(),
-                false,
+                NetworkStateMode::Apply,
                 self.memory_only,
             )?);
         }
@@ -260,7 +260,7 @@ impl NetworkState {
                 let pf_merged_state = MergedNetworkState::new(
                     pf_state,
                     cur_net_state.clone(),
-                    false,
+                    NetworkStateMode::Apply,
                     self.memory_only,
                 )?;
                 let verify_count =
@@ -278,7 +278,7 @@ impl NetworkState {
                 merged_state = Some(MergedNetworkState::new(
                     self.clone(),
                     cur_net_state.clone(),
-                    false,
+                    NetworkStateMode::Apply,
                     self.memory_only,
                 )?);
             }
@@ -365,7 +365,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             cur_net_state.clone(),
-            false,
+            NetworkStateMode::Apply,
             self.memory_only,
         )?;
 
@@ -417,7 +417,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             current.clone(),
-            false,
+            NetworkStateMode::GenerateDiff,
             false,
         )?;
 

--- a/rust/src/lib/revert/net_state.rs
+++ b/rust/src/lib/revert/net_state.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{MergedNetworkState, NetworkState, NmstateError};
+use crate::{MergedNetworkState, NetworkState, NetworkStateMode, NmstateError};
 
 impl NetworkState {
     pub fn generate_revert(
@@ -10,7 +10,7 @@ impl NetworkState {
         let merged_state = MergedNetworkState::new(
             self.clone(),
             current.clone(),
-            false,
+            NetworkStateMode::default(),
             false,
         )?;
         Ok(Self {

--- a/rust/src/lib/statistic/net_state.rs
+++ b/rust/src/lib/statistic/net_state.rs
@@ -2,7 +2,10 @@
 
 use serde::Serialize;
 
-use crate::{MergedNetworkState, NetworkState, NmstateError, NmstateFeature};
+use crate::{
+    MergedNetworkState, NetworkState, NetworkStateMode, NmstateError,
+    NmstateFeature,
+};
 
 #[derive(Clone, Debug, Serialize, Default, PartialEq, Eq)]
 #[non_exhaustive]
@@ -36,8 +39,12 @@ impl NetworkState {
             self.interfaces
                 .use_pseudo_sriov_vf_name(&mut current.interfaces);
         }
-        let merged_state =
-            MergedNetworkState::new(self.clone(), current, false, false)?;
+        let merged_state = MergedNetworkState::new(
+            self.clone(),
+            current,
+            NetworkStateMode::default(),
+            false,
+        )?;
 
         features.append(&mut merged_state.interfaces.get_features());
         features.append(&mut merged_state.dns.get_features());

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -43,8 +43,13 @@ fn test_linux_bridge_ignore_port() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let ignored_ifaces = merged_ifaces.ignored_ifaces.as_slice();
 
@@ -104,9 +109,13 @@ fn test_linux_bridge_verify_ignore_port() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces.clone(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
     merged_ifaces.verify(&cur_ifaces).unwrap();
 }
 
@@ -234,8 +243,13 @@ fn test_linux_bridge_partial_ignored() {
 ",
     )
     .unwrap();
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let ignored_ifaces = merged_ifaces.ignored_ifaces.as_slice();
 

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -75,7 +75,12 @@ fn test_veth_change_peer_away_from_ignored_peer() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(des_ifaces, cur_ifaces, false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -106,7 +111,12 @@ fn test_veth_change_peer_away_from_missing_peer() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(des_ifaces, cur_ifaces, false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -132,9 +142,13 @@ fn test_eth_verify_absent_ignore_current_up() {
 ",
     )
     .unwrap();
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces.clone(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&cur_ifaces).unwrap();
 }
@@ -168,8 +182,13 @@ fn test_eth_change_veth_peer() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let old_peer_iface = merged_ifaces
         .get_iface("veth1peer", InterfaceType::Unknown)
@@ -192,8 +211,12 @@ fn test_new_veth_without_peer_config() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -231,8 +254,13 @@ fn test_mac_identifer_use_permanent_mac_first() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let des_iface = merged_ifaces
         .kernel_ifaces
@@ -282,8 +310,13 @@ fn test_mac_identifer_use_fallback_to_mac() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let des_iface = merged_ifaces
         .kernel_ifaces
@@ -338,8 +371,13 @@ fn test_mac_identifer_check_iface_type_also() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let des_iface = merged_ifaces
         .kernel_ifaces

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/current.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  ethernet:
+    sr-iov:
+      total-vfs: 0

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/desired.yml
@@ -1,0 +1,11 @@
+---
+interfaces:
+- name: sriov:eth1:3
+  type: ethernet
+  ipv4:
+    enabled: false
+- name: eth1
+  type: ethernet
+  ethernet:
+    sr-iov:
+      total-vfs: 6

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_vf_ref/diff.yml
@@ -1,0 +1,11 @@
+---
+interfaces:
+- name: sriov:eth1:3
+  type: ethernet
+  ipv4:
+    enabled: false
+- name: eth1
+  type: ethernet
+  ethernet:
+    sr-iov:
+      total-vfs: 6

--- a/rust/src/lib/unit_tests/identifier.rs
+++ b/rust/src/lib/unit_tests/identifier.rs
@@ -53,7 +53,7 @@ fn test_can_have_dup_profile_name_when_not_refered() {
     )
     .unwrap();
 
-    MergedInterfaces::new(desired, current, false, false).unwrap();
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
 }
 
 #[test]
@@ -79,9 +79,13 @@ fn test_port_refer_to_kernel_interface() {
     )
     .unwrap();
 
-    let mut merged =
-        MergedInterfaces::new(desired, Interfaces::default(), false, false)
-            .unwrap();
+    let mut merged = MergedInterfaces::new(
+        desired,
+        Interfaces::default(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let dummy1 = merged
         .kernel_ifaces
@@ -131,7 +135,8 @@ fn test_port_cannot_refer_to_interfaces_holding_profile_name() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
 
     assert!(result.is_err());
 
@@ -166,7 +171,8 @@ fn test_port_ref_not_found() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
 
     assert!(result.is_err());
 
@@ -202,7 +208,8 @@ fn test_vlan_parent_ref_by_profile_name() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let merged_iface = merged_ifaces.kernel_ifaces.get("vlan0").unwrap();
 
@@ -268,7 +275,8 @@ fn test_vxlan_parent_ref_by_profile_name() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let merged_iface = merged_ifaces.kernel_ifaces.get("vxlan0").unwrap();
 
@@ -316,7 +324,8 @@ fn test_macsec_parent_ref_by_profile_name() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let merged_iface = merged_ifaces.kernel_ifaces.get("macsec0").unwrap();
 
@@ -358,7 +367,8 @@ fn test_macvlan_parent_ref_by_profile_name() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let merged_iface = merged_ifaces.kernel_ifaces.get("macvlan0").unwrap();
 
@@ -405,7 +415,8 @@ fn test_macvtap_parent_ref_by_profile_name() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let merged_iface = merged_ifaces.kernel_ifaces.get("macvtap0").unwrap();
 

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -21,7 +21,8 @@ fn test_resolve_unknown_type_absent_eth() {
     ifaces.push(absent_iface);
 
     let merged_ifaces =
-        MergedInterfaces::new(ifaces, cur_ifaces, false, false).unwrap();
+        MergedInterfaces::new(ifaces, cur_ifaces, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("eth1", InterfaceType::Ethernet)
@@ -46,7 +47,8 @@ fn test_resolve_unknown_type_absent_multiple() {
     ifaces.push(absent_iface);
 
     let merged_ifaces =
-        MergedInterfaces::new(ifaces, cur_ifaces, false, false).unwrap();
+        MergedInterfaces::new(ifaces, cur_ifaces, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("br0", InterfaceType::OvsBridge)
@@ -79,7 +81,8 @@ fn test_vlan_over_ethernet_can_exist_after_ethernet_absent() {
     desired.push(eth0);
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("eth0", InterfaceType::Ethernet)
@@ -110,7 +113,8 @@ fn test_check_orphan_vlan_change_parent() {
     desired.push(new_eth_iface("eth1"));
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
     let iface = merged_ifaces
         .get_iface("eth0", InterfaceType::Ethernet)
         .unwrap()
@@ -169,8 +173,13 @@ fn test_ifaces_resolve_unknown_bond_iface() {
 ",
     )
     .unwrap();
-    let merged_iface =
-        MergedInterfaces::new(desired.clone(), current, false, false).unwrap();
+    let merged_iface = MergedInterfaces::new(
+        desired.clone(),
+        current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let iface = merged_iface
         .get_iface("bond99", InterfaceType::Bond)
@@ -215,7 +224,8 @@ fn test_ifaces_ignore_iface_in_desire() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let mut ignored_ifaces = merged_ifaces.ignored_ifaces;
     ignored_ifaces.sort_unstable();
@@ -252,7 +262,8 @@ fn test_ifaces_ignore_iface_in_current() {
     )
     .unwrap();
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let mut ignored_ifaces = merged_ifaces.ignored_ifaces;
     ignored_ifaces.sort_unstable();
@@ -298,7 +309,8 @@ fn test_ifaces_ignore_iface_in_current_but_desired() {
     )
     .unwrap();
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let mut ignored_ifaces = merged_ifaces.ignored_ifaces;
     ignored_ifaces.sort_unstable();

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -19,7 +19,8 @@ fn test_ifaces_up_order_no_ctrler_reserse_order() {
     ifaces.push(new_eth_iface("eth1"));
 
     let merged_ifaces =
-        MergedInterfaces::new(ifaces, cur_ifaces, false, false).unwrap();
+        MergedInterfaces::new(ifaces, cur_ifaces, Default::default(), false)
+            .unwrap();
 
     let eth1_iface = merged_ifaces
         .get_iface("eth1", InterfaceType::Ethernet)
@@ -59,9 +60,13 @@ fn test_ifaces_up_order_nested_4_depth_worst_case() {
     ifaces.push(br1);
     ifaces.push(br0);
 
-    let merged_ifaces =
-        MergedInterfaces::new(ifaces, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         merged_ifaces.kernel_ifaces["br0"]
@@ -139,8 +144,12 @@ fn test_ifaces_up_order_nested_5_depth_worst_case() {
     ifaces.push(br0);
     ifaces.push(br4);
 
-    let result =
-        MergedInterfaces::new(ifaces, gen_test_eth_ifaces(), false, false);
+    let result = MergedInterfaces::new(
+        ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
 
@@ -168,9 +177,13 @@ fn test_ifaces_up_order_nested_5_depth_good_case() {
     ifaces.push(p2);
     ifaces.push(p1);
 
-    let merged_ifaces =
-        MergedInterfaces::new(ifaces, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         merged_ifaces.kernel_ifaces["br4"]
@@ -242,8 +255,13 @@ fn test_auto_include_ovs_interface() {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_ovs_br_iface("br0", &["p1", "p2"]));
 
-    let merged_ifaces =
-        MergedInterfaces::new(ifaces, Interfaces::new(), false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let p1_iface = merged_ifaces
         .get_iface("p1", InterfaceType::OvsInterface)
@@ -304,7 +322,8 @@ fn test_auto_absent_ovs_interface() {
     ifaces.push(Interface::OvsBridge(Box::new(absent_br0)));
 
     let merged_ifaces =
-        MergedInterfaces::new(ifaces, cur_ifaces, false, false).unwrap();
+        MergedInterfaces::new(ifaces, cur_ifaces, Default::default(), false)
+            .unwrap();
 
     let p1_iface = merged_ifaces
         .get_iface("p1", InterfaceType::OvsInterface)
@@ -352,7 +371,10 @@ fn test_overbook_port_in_single_bridge() {
     let mut current = Interfaces::new();
     current.push(new_eth_iface("eth0"));
 
-    assert!(MergedInterfaces::new(desired, current, false, false).is_ok());
+    assert!(
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -365,7 +387,8 @@ fn test_overbook_port_in_two_bridges() {
     let mut current = Interfaces::new();
     current.push(new_eth_iface("eth0"));
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
     assert!(result.is_err());
     assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidArgument);
 }
@@ -383,7 +406,10 @@ fn test_overbook_port_moves_between_bridges() {
     desired.push(bridge_with_ports("br0", &[]));
     desired.push(bridge_with_ports("br1", &["eth0"]));
 
-    assert!(MergedInterfaces::new(desired, current, false, false).is_ok());
+    assert!(
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -398,7 +424,7 @@ fn test_overbook_current_bridge_is_deleted() {
     absent_iface.base_iface_mut().state = InterfaceState::Absent;
     desired.push(absent_iface);
 
-    MergedInterfaces::new(desired, current, false, false).unwrap();
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
 }
 
 #[test]
@@ -413,7 +439,10 @@ fn test_overbook_port_used_in_current_bridge() {
     let mut desired = Interfaces::new();
     desired.push(bridge_with_ports("br1", &["eth0"]));
 
-    assert!(MergedInterfaces::new(desired, current, false, false).is_ok());
+    assert!(
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -428,7 +457,10 @@ fn test_overbook_port_used_in_current_bond() {
     let mut desired = Interfaces::new();
     desired.push(bond_with_ports("bond1", &["eth0"]));
 
-    assert!(MergedInterfaces::new(desired, current, false, false).is_ok());
+    assert!(
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -449,7 +481,10 @@ fn test_overbook_swap_port_of_bond() {
     desired.push(bond_with_ports("bond1", &["eth0"]));
     desired.push(bond_with_ports("bond0", &["eth1"]));
 
-    assert!(MergedInterfaces::new(desired, current, false, false).is_ok());
+    assert!(
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -472,8 +507,12 @@ fn test_iface_controller_not_conflict_with_bond_ports() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_ok());
 }
 
@@ -487,7 +526,12 @@ fn test_iface_controller_conflict_with_bond_ports() {
     iface.base_iface_mut().controller = Some("bond0".to_string());
     ifaces.push(iface);
 
-    let result = MergedInterfaces::new(ifaces, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -507,7 +551,8 @@ fn test_iface_controller_conflict_with_br_ports() {
     iface.base_iface_mut().controller = Some("br0".to_string());
     ifaces.push(iface);
 
-    let result = MergedInterfaces::new(ifaces, cur_ifaces, false, false);
+    let result =
+        MergedInterfaces::new(ifaces, cur_ifaces, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -526,7 +571,8 @@ fn test_iface_controller_prop_only_in_desire() {
     desired.push(iface);
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let eth1_iface = merged_ifaces
         .get_iface("eth1", InterfaceType::Ethernet)
@@ -558,7 +604,8 @@ fn test_iface_controller_prop_only_in_desire_dup_ovs_br() {
     desired.push(iface);
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let eth1_iface = merged_ifaces
         .get_iface("eth1", InterfaceType::Ethernet)
@@ -589,7 +636,8 @@ fn test_iface_controller_been_list_in_other_port_list() {
     iface.base_iface_mut().controller = Some("bond0".to_string());
     ifaces.push(iface);
 
-    let result = MergedInterfaces::new(ifaces, current, false, false);
+    let result =
+        MergedInterfaces::new(ifaces, current, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -604,7 +652,12 @@ fn test_iface_detach_controller_been_list_in_other_port_list() {
     iface.base_iface_mut().controller = Some("".to_string());
     ifaces.push(iface);
 
-    let result = MergedInterfaces::new(ifaces, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -632,8 +685,12 @@ fn test_iface_controller_conflict_with_empty_br_ports() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -666,8 +723,13 @@ fn test_auto_manage_ports() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let br_iface = merged_ifaces
         .get_iface("br0", InterfaceType::LinuxBridge)
@@ -724,8 +786,13 @@ fn test_auto_manage_ovs_bond_ports() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let br_iface = merged_ifaces
         .get_iface("br0", InterfaceType::OvsBridge)
@@ -789,8 +856,13 @@ fn test_do_not_auto_manage_ports_if_current_has_ignore() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let br_iface = merged_ifaces
         .get_iface("br0", InterfaceType::LinuxBridge)
@@ -844,8 +916,13 @@ fn test_absent_iface_holding_controller_and_ip() {
             Some(InterfaceType::LinuxBridge);
     }
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let iface = merged_ifaces.kernel_ifaces.get("eth1").unwrap();
 
@@ -898,8 +975,13 @@ fn test_gen_topoligies_bridge_over_vlan() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let top = merged_ifaces.gen_topoligies();
 
@@ -955,8 +1037,13 @@ fn test_gen_topoligies_ovs_bridge() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let top = merged_ifaces.gen_topoligies();
 

--- a/rust/src/lib/unit_tests/infiniband.rs
+++ b/rust/src/lib/unit_tests/infiniband.rs
@@ -35,7 +35,8 @@ fn test_ib_autoremove_pkey_if_base_iface_removed() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("mlx5_ib2", InterfaceType::InfiniBand)
@@ -124,8 +125,12 @@ fn test_ib_port_of_bridge_in_desire() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(desired, Interfaces::new(), false, false);
+    let result = MergedInterfaces::new(
+        desired,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -158,7 +163,8 @@ fn test_ib_port_of_bridge_in_current() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -193,7 +199,8 @@ fn test_ib_port_of_bond_mode_in_desire() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -233,7 +240,8 @@ fn test_ib_port_of_bond_mode_in_current() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -273,7 +281,7 @@ fn test_ib_port_of_active_backup_bond_mode_in_current() {
     )
     .unwrap();
 
-    MergedInterfaces::new(desired, current, false, false).unwrap();
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
 }
 
 #[test]
@@ -311,7 +319,8 @@ fn test_ib_port_of_active_backup_bond_mode_in_both() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("bond0", InterfaceType::Bond)
@@ -358,7 +367,8 @@ fn test_ib_port_of_active_backup_bond_mode_in_desire() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("mlx5_ib2", InterfaceType::InfiniBand)

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -126,9 +126,13 @@ fn test_ip_allow_extra_address_by_default() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -167,9 +171,13 @@ fn test_ipv4_not_allow_extra_address() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let result = merged_ifaces.verify(&current);
     assert!(result.is_err());
@@ -212,9 +220,13 @@ fn test_ipv6_not_allow_extra_address() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let result = merged_ifaces.verify(&current);
     assert!(result.is_err());
@@ -274,9 +286,13 @@ fn test_ipv6_verify_emtpy() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&cur_ifaces).unwrap();
 }
@@ -297,8 +313,12 @@ fn test_should_not_have_ipv6_in_ipv4_section() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_err());
 
     if let Err(e) = result {
@@ -322,8 +342,12 @@ fn test_should_not_have_ipv4_in_ipv6_section() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    );
     assert!(result.is_err());
 
     if let Err(e) = result {
@@ -347,8 +371,12 @@ fn test_ipv4_verify_valid_prefix() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidArgument);
@@ -370,8 +398,12 @@ fn test_ipv6_verify_valid_prefix() {
     )
     .unwrap();
 
-    let result =
-        MergedInterfaces::new(des_ifaces, gen_test_eth_ifaces(), false, false);
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        gen_test_eth_ifaces(),
+        Default::default(),
+        false,
+    );
 
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidArgument);

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -47,7 +47,8 @@ interfaces:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 
@@ -85,7 +86,8 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
     )
     .unwrap();
 
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
@@ -126,7 +128,8 @@ fn test_two_dns_ipv6_link_local_iface() {
         ",
     )
     .unwrap();
-    let result = MergedNetworkState::new(desired, current, false, false);
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::NotImplementedError);
@@ -223,7 +226,8 @@ fn test_dns_iface_has_no_ip_stack_info() {
         })
     };
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 }
@@ -266,7 +270,8 @@ fn test_dns_not_prefer_iface_ipv6_with_link_local_only_address() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -325,7 +330,8 @@ fn test_dns_prefer_desired_over_current() {
     .unwrap();
 
     let merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let (v4_iface, v6_iface) =
         reselect_dns_ifaces(&merged_state, &[], &[], &[], &[]);
@@ -371,7 +377,8 @@ fn test_copy_ip_stack_if_marked_for_dns() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
 

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -23,9 +23,13 @@ fn test_add_routes_to_new_interface() {
     des_net_state.interfaces = des_ifaces;
     des_net_state.routes = gen_test_routes_conf();
 
-    let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+    let mut merged_state = MergedNetworkState::new(
+        des_net_state,
+        cur_net_state,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -88,9 +92,13 @@ fn test_wildcard_absent_routes() {
 
     des_net_state.routes.config = Some(absent_routes);
 
-    let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+    let mut merged_state = MergedNetworkState::new(
+        des_net_state,
+        cur_net_state,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -124,9 +132,13 @@ fn test_absent_routes_with_iface_only() {
     absent_routes.push(absent_route);
     des_net_state.routes.config = Some(absent_routes);
 
-    let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+    let mut merged_state = MergedNetworkState::new(
+        des_net_state,
+        cur_net_state,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     store_route_config(&mut merged_state).unwrap();
 
@@ -192,7 +204,8 @@ routes:
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
     store_route_config(&mut merged_state).unwrap();
 
     let br0_iface = merged_state

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -50,9 +50,13 @@ fn test_add_rules_to_new_interface() {
     des_net_state.routes = gen_test_routes_conf();
     des_net_state.rules = gen_test_rules_conf();
 
-    let mut merged_state =
-        MergedNetworkState::new(des_net_state, cur_net_state, false, false)
-            .unwrap();
+    let mut merged_state = MergedNetworkState::new(
+        des_net_state,
+        cur_net_state,
+        Default::default(),
+        false,
+    )
+    .unwrap();
     store_route_rule_config(&mut merged_state).unwrap();
 
     let iface = get_iface(&merged_state, TEST_NIC, InterfaceType::Unknown);
@@ -137,7 +141,8 @@ fn test_route_rule_ignore_absent_ifaces() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -205,7 +210,8 @@ fn test_route_rule_use_auto_route_table_id() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -263,7 +269,8 @@ fn test_route_rule_use_default_auto_route_table_id() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -325,7 +332,8 @@ fn test_route_rule_use_loopback() {
     .unwrap();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
 
@@ -384,7 +392,8 @@ fn test_route_rule_add_twice() {
     expected_rules.sort();
 
     let mut merged_state =
-        MergedNetworkState::new(desired, current, false, false).unwrap();
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
 
     store_route_rule_config(&mut merged_state).unwrap();
     store_route_rule_config(&mut merged_state).unwrap();

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -43,8 +43,13 @@ fn test_ovs_bridge_ignore_port() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let mut ignored_ifaces = merged_ifaces.ignored_ifaces.clone();
     ignored_ifaces.sort_unstable();
@@ -122,9 +127,13 @@ fn test_ovs_bridge_verify_ignore_port() {
     )
     .unwrap();
 
-    let merged_iface =
-        MergedInterfaces::new(des_ifaces, pre_apply_cur_ifaces, false, false)
-            .unwrap();
+    let merged_iface = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_iface.verify(&cur_ifaces).unwrap();
 }
@@ -190,7 +199,8 @@ fn test_ovs_bridge_same_name_absent() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let br1_iface = merged_ifaces
         .get_iface("br1", InterfaceType::OvsBridge)
@@ -241,7 +251,8 @@ fn test_ovs_bridge_resolve_user_space_iface_type() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .get_iface("ovs-br1", InterfaceType::OvsBridge)
@@ -605,7 +616,8 @@ fn test_ovs_orphan_check_on_bridge_with_same_name_iface() {
     )
     .unwrap();
 
-    MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    MergedInterfaces::new(des_ifaces, cur_ifaces, Default::default(), false)
+        .unwrap();
 }
 
 #[test]
@@ -639,7 +651,8 @@ fn test_ovs_mark_orphan_up_on_bridge_with_same_name_iface() {
     )
     .unwrap();
 
-    MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    MergedInterfaces::new(des_ifaces, cur_ifaces, Default::default(), false)
+        .unwrap();
 }
 
 #[test]
@@ -749,9 +762,13 @@ fn test_ignore_patch_ports_for_verify() {
     )
     .unwrap();
 
-    let merged_iface =
-        MergedInterfaces::new(des_ifaces, pre_apply_cur_ifaces, false, false)
-            .unwrap();
+    let merged_iface = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_iface.verify(&cur_ifaces).unwrap();
 }
@@ -821,9 +838,13 @@ fn test_ignore_patch_ports_for_apply() {
     )
     .unwrap();
 
-    let merged_iface =
-        MergedInterfaces::new(des_ifaces, pre_apply_cur_ifaces, false, false)
-            .unwrap();
+    let merged_iface = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let patch0_iface = merged_iface
         .get_iface("patch0", InterfaceType::OvsInterface)

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -47,9 +47,13 @@ fn test_sriov_vf_mac_mix_case() {
     }
     des_ifaces.push(des_iface);
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, pre_apply_cur_ifaces, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&cur_ifaces).unwrap();
 }
@@ -91,9 +95,13 @@ fn test_ignore_sriov_if_not_desired() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, pre_apply_cur_ifaces, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -230,8 +238,13 @@ fn test_verify_sriov_name() {
         ",
     )
     .unwrap();
-    let merged_ifaces =
-        MergedInterfaces::new(desired, current.clone(), false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        current.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -381,9 +394,13 @@ fn test_verify_sriov_port_name_linux_bridge() {
         )
         .unwrap(),
     );
-    let merged_ifaces =
-        MergedInterfaces::new(desired, pre_apply_current, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        pre_apply_current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -419,9 +436,13 @@ fn test_verify_sriov_port_name_bond() {
         .unwrap(),
     );
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, pre_apply_current, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        pre_apply_current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -454,9 +475,13 @@ fn test_verify_sriov_port_name_ovs_bridge() {
         )
         .unwrap(),
     );
-    let merged_ifaces =
-        MergedInterfaces::new(desired, pre_apply_current, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        pre_apply_current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -499,9 +524,13 @@ fn test_verify_sriov_port_name_ovs_bond() {
         )
         .unwrap(),
     );
-    let merged_ifaces =
-        MergedInterfaces::new(desired, pre_apply_current, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        pre_apply_current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&current).unwrap();
 }
@@ -566,9 +595,13 @@ fn test_sriov_vf_auto_fill_vf_conf() {
     }
     des_ifaces.push(des_iface);
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, pre_apply_current, false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_current,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     merged_ifaces.verify(&cur_ifaces).unwrap();
 
@@ -753,7 +786,8 @@ fn test_sriov_vf_revert_to_default() {
     .unwrap();
 
     let mut merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let iface = merged_ifaces
         .kernel_ifaces
@@ -838,7 +872,8 @@ fn test_get_sriov_vf_count() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     assert_eq!(merged_ifaces.get_sriov_vf_count(), 32);
 }

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -288,8 +288,13 @@ pub(crate) fn gen_merged_ifaces_for_route_test(
     current.push(new_eth_iface("eth1"));
     current.push(new_eth_iface("eth2"));
 
-    let merged =
-        MergedInterfaces::new(ifaces, current.clone(), false, false).unwrap();
+    let merged = MergedInterfaces::new(
+        ifaces,
+        current.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     (merged, current)
 }

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -46,9 +46,13 @@ fn test_vlan_get_parent_up_priority_plus_one() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(desired, Interfaces::new(), false, false)
-            .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        desired,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let vrf0_iface = merged_ifaces
         .get_iface("vrf0", InterfaceType::Vrf)
@@ -98,7 +102,8 @@ fn test_vlan_orphan_check_auto_absent() {
     .unwrap();
 
     let merged_ifaces =
-        MergedInterfaces::new(desired, current, false, false).unwrap();
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
 
     let vlan_iface = merged_ifaces
         .get_iface("bond0.100", InterfaceType::Vlan)
@@ -134,7 +139,8 @@ fn test_vlan_orphan_but_desired() {
     )
     .unwrap();
 
-    let result = MergedInterfaces::new(desired, current, false, false);
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
 
     assert!(result.is_err());
     if let Err(e) = result {
@@ -180,7 +186,7 @@ fn test_vlan_orphan_has_now_parent() {
     )
     .unwrap();
 
-    MergedInterfaces::new(desired, current, false, false).unwrap();
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -74,8 +74,13 @@ fn test_vrf_on_bond_vlan_got_auto_remove() {
     )
     .unwrap();
 
-    let merged_ifaces =
-        MergedInterfaces::new(des_ifaces, cur_ifaces, false, false).unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
 
     let iface = merged_ifaces
         .get_iface("test-bond0.100", InterfaceType::Vlan)


### PR DESCRIPTION
When using `nmstatectl apply` for this YAML:

```yml
---
interfaces:
- name: sriov:ens7f1np1:3
  type: ethernet
  ipv4:
    enabled: false
- name: ens7f1np1
  type: ethernet
  ethernet:
    sr-iov:
      total-vfs: 6
```

Nmstate correctly applied the desired state, but got error in
`gen_diff()`:

   InvalidArgument: Failed to find SR-IOV VF interface name for
  sriov:ens7f1np1:3

This is because SRIOV VF information does not exists in pre-apply current
state used for generating this diff state.

The fix is do not resolve SRIV VF reference in `gen_diff` mode.

Unit test case included.

Resolves: https://issues.redhat.com/browse/RHEL-91588