### PR TITLE
test: Fix dnf error on `/var/cache/dnf/metadata_lock.pid`

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -107,8 +107,12 @@ function create_container {
       -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
       -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
   [ -n "$debug_exit_shell" ] && trap open_shell EXIT || trap run_exit EXIT
-  until [ "`$CONTAINER_CMD inspect -f {{.State.Running}} $CONTAINER_ID`" \
-      == "true" ]; do
+  # Wait systemd started
+  until $CONTAINER_CMD exec $CONTAINER_ID sh -c "
+      [ $(systemctl is-system-running) == 'degraded' ] || \
+      [ $(systemctl is-system-running) == 'running' ]"
+  do
+      echo "Waiting for systemd in container to be ready..."
       sleep 0.1;
-  done;
+  done
 }


### PR DESCRIPTION
In NMCI environment, we got this failure:

    [Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'

This is because `systemd-tmpfiles-setup.service` not finishing creating
the `/var/cache/dnf` folder yet by `/usr/lib/tmpfiles.d/dnf.conf` file.

Fixed by waiting systemd finish its work via checking
`systemctl is-system-running`.