### PR TITLE
bond: Add support of bond option `lacp_active` and `ns_ip6_target`

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::net::Ipv6Addr;
 
 use serde::{
     de::IntoDeserializer, Deserialize, Deserializer, Serialize, Serializer,
@@ -95,6 +96,11 @@ impl BondInterface {
                 if let Some(ref mut arp_ip_target) = bond_opts.arp_ip_target {
                     if arp_ip_target.is_empty() {
                         bond_opts.arp_ip_target = None;
+                    }
+                }
+                if let Some(ref mut v) = bond_opts.ns_ip6_target {
+                    if v.is_empty() {
+                        bond_opts.ns_ip6_target = None;
                     }
                 }
             }
@@ -715,17 +721,17 @@ impl From<BondAllPortsActive> for u8 {
 
 /// The `arp_all_targets` kernel bond option.
 ///
-/// Specifies the quantity of arp_ip_targets that must be reachable in order for
+/// Specifies the quantity of arp_ip_target that must be reachable in order for
 /// the ARP monitor to consider a port as being up. This option affects only
 /// active-backup mode for ports with arp_validation enabled.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case", remote = "BondArpAllTargets")]
 #[non_exhaustive]
 pub enum BondArpAllTargets {
-    /// consider the port up only when any of the `arp_ip_targets` is reachable
+    /// consider the port up only when any of the `arp_ip_target` is reachable
     #[serde(alias = "0")]
     Any,
-    /// consider the port up only when all of the `arp_ip_targets` are
+    /// consider the port up only when all of the `arp_ip_target` are
     /// reachable
     #[serde(alias = "1")]
     All,
@@ -1118,7 +1124,7 @@ pub struct BondOptions {
     /// is nice to allow duplicate frames to be delivered.
     pub all_slaves_active: Option<BondAllPortsActive>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Specifies the quantity of arp_ip_targets that must be reachable in
+    /// Specifies the quantity of arp_ip_target that must be reachable in
     /// order for the ARP monitor to consider a port as being up. This
     /// option affects only active-backup mode for ports with
     /// arp_validation enabled.
@@ -1147,6 +1153,10 @@ pub struct BondOptions {
     /// team members to fail. ARP monitoring should not be used in conjunction
     /// with miimon. A value of 0 disables ARP monitoring. The default value
     /// is 0.
+    /// Invalid for setting `arp_interval` bigger than 0 for bond in mode:
+    ///  * `802.3ad`
+    ///  * `balance-tlb`
+    ///  * `balance-alb`
     pub arp_interval: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Specifies the IP addresses to use as ARP monitoring peers when
@@ -1377,6 +1387,18 @@ pub struct BondOptions {
         deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
     pub arp_missed_max: Option<u8>,
+    /// Whether send LACPDU frames periodically. Only valid for bond in
+    /// `802.3ad` mode.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub lacp_active: Option<bool>,
+    /// Specifies the IPv6 addresses to use as IPv6 monitoring peers when
+    /// `arp_interval` is > 0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ns_ip6_target: Option<Vec<Ipv6Addr>>,
 }
 
 impl BondOptions {
@@ -1443,6 +1465,79 @@ impl BondOptions {
         }
         Ok(())
     }
+
+    fn validate_lacp_opts(&self, mode: BondMode) -> Result<(), NmstateError> {
+        if mode != BondMode::LACP {
+            if self.lacp_rate.is_some() {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "The `lacp_rate` option is only valid for bond in \
+                     '802.3ad' mode"
+                        .to_string(),
+                ));
+            }
+            if self.lacp_active.is_some() {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "The `lacp_active` option is only valid for bond in \
+                     '802.3ad' mode"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    // `arp_interval` should bigger than 0 when `arp_ip_target` or
+    // `ns_ip6_target` defined.
+    // The `arp_interval` cannot be used in `802.3ad`, `balance-tlb`
+    // `balance-alb` mode.
+    fn validate_arp_interval(
+        &self,
+        current: Option<&Self>,
+        mode: BondMode,
+    ) -> Result<(), NmstateError> {
+        if let Some(arp_interval) = self
+            .arp_interval
+            .or_else(|| current.and_then(|c| c.arp_interval))
+        {
+            if arp_interval > 0 {
+                if mode == BondMode::LACP
+                    || mode == BondMode::TLB
+                    || mode == BondMode::ALB
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "The `arp_interval` option is invalid for bond in \
+                         '802.3ad', 'balance-tlb' or 'balance-alb' mode"
+                            .to_string(),
+                    ));
+                }
+            } else {
+                if let Some(arp_ip_target) = self.arp_ip_target.as_ref() {
+                    if !arp_ip_target.is_empty() {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            "The `arp_ip_target` option is only valid when \
+                             'arp_interval' is enabled(>0)."
+                                .to_string(),
+                        ));
+                    }
+                }
+                if let Some(ns_ip6_target) = self.ns_ip6_target.as_ref() {
+                    if !ns_ip6_target.is_empty() {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            "The `ns_ip6_target` option is only valid when \
+                             'arp_interval' is enabled(>0)."
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl MergedInterface {
@@ -1476,7 +1571,9 @@ impl MergedInterface {
                             } else {
                                 None
                             };
-                        bond_opts.validate_balance_slb(cur_bond_opts, mode)?
+                        bond_opts.validate_balance_slb(cur_bond_opts, mode)?;
+                        bond_opts.validate_lacp_opts(mode)?;
+                        bond_opts.validate_arp_interval(cur_bond_opts, mode)?;
                     }
                 }
             }

--- a/rust/src/lib/nispor/bond.rs
+++ b/rust/src/lib/nispor/bond.rs
@@ -219,6 +219,8 @@ fn np_bond_options_to_nmstate(np_iface: &nispor::Iface) -> BondOptions {
                 }
             });
         options.arp_missed_max = np_bond.arp_missed_max;
+        options.lacp_active = np_bond.lacp_active;
+        options.ns_ip6_target = np_bond.ns_ip6_target.clone();
     }
     options
 }

--- a/rust/src/lib/nm/settings/bond.rs
+++ b/rust/src/lib/nm/settings/bond.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::net::Ipv6Addr;
 
 use crate::nm::nm_dbus::{NmConnection, NmSettingBond};
 
@@ -100,6 +101,9 @@ fn apply_bond_options(
             nm_bond_set
                 .options
                 .insert("arp_ip_target".to_string(), String::new());
+            nm_bond_set
+                .options
+                .insert("arp_ip6_target".to_string(), String::new());
         }
         nm_bond_set
             .options
@@ -211,6 +215,23 @@ fn apply_bond_options(
             nm_bond_set
                 .options
                 .insert("arp_missed_max".to_string(), v.to_string());
+        }
+    }
+
+    if let Some(v) = bond_opts.lacp_active {
+        nm_bond_set.options.insert(
+            "lacp_active".to_string(),
+            if v { "1".to_string() } else { "0".to_string() },
+        );
+    }
+    if let Some(v) = bond_opts.ns_ip6_target.as_ref() {
+        if !v.is_empty() {
+            let ip6_targets: Vec<String> =
+                v.iter().map(Ipv6Addr::to_string).collect();
+            nm_bond_set.options.insert(
+                "ns_ip6_target".to_string(),
+                ip6_targets.join(",").to_string(),
+            );
         }
     }
 

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -683,3 +683,101 @@ fn test_bond_link_aggregation_alias() {
 
     assert_eq!(des_iface.bond.unwrap().mode, Some(BondMode::ActiveBackup));
 }
+
+#[test]
+fn test_bond_opt_lacp_active() {
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: active-backup
+          options:
+            lacp_active: true
+        ",
+    )
+    .unwrap();
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+
+    let result = merged_iface.post_inter_ifaces_process_bond();
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_opt_arp_interval() {
+    for mode in ["balance-tlb", "802.3ad", "balance-alb"] {
+        let iface: Interface = serde_yaml::from_str(&format!(
+            r"---
+            name: bond99
+            type: bond
+            state: up
+            link-aggregation:
+              mode: {mode}
+              options:
+                arp_interval: 50
+        ",
+        ))
+        .unwrap();
+        let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+
+        let result = merged_iface.post_inter_ifaces_process_bond();
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        }
+    }
+}
+
+#[test]
+fn test_bond_opt_arp_ip_target() {
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: balance-xor
+          options:
+            arp_interval: 0
+            arp_ip_target: 192.168.1.1
+        ",
+    )
+    .unwrap();
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+
+    let result = merged_iface.post_inter_ifaces_process_bond();
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_bond_opt_ns_ip6_target() {
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: balance-rr
+          options:
+            arp_interval: 0
+            ns_ip6_target:
+            - 2001:db8:a::3
+            - 2001:db8:a::2
+        ",
+    )
+    .unwrap();
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+
+    let result = merged_iface.post_inter_ifaces_process_bond();
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1560,3 +1560,69 @@ def test_reapply_bond_port_ref_by_mac(bond0_with_eth1_ref_by_mac):
         Loader=yaml.SafeLoader,
     )
     libnmstate.apply(state)
+
+
+@pytest.fixture
+def lacp_bond99_with_2_ports(eth1_up, eth2_up, setup_remove_bond99):
+    state = yaml.load(
+        """---
+        interfaces:
+         - name: bond99
+           type: bond
+           state: up
+           link-aggregation:
+             options:
+               lacp_active: true
+             mode: 802.3ad
+             port:
+             - eth1
+             - eth2
+           """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)
+    yield state
+
+
+# https://issues.redhat.com/browse/RHEL-1415
+@pytest.mark.tier1
+def test_bond_opt_lacp_active(lacp_bond99_with_2_ports):
+    state = lacp_bond99_with_2_ports
+    bond_config = state[Interface.KEY][0][Bond.CONFIG_SUBTREE]
+    bond_config[Bond.OPTIONS_SUBTREE]["lacp_active"] = True
+
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)
+
+
+# https://issues.redhat.com/browse/RHEL-1415
+@pytest.mark.tier1
+def test_bond_opt_ns_ip6_target(setup_remove_bond99):
+    state = yaml.load(
+        """---
+        interfaces:
+         - name: bond99
+           type: bond
+           state: up
+           ipv6:
+             enabled: true
+             autoconf: false
+             dhcp: false
+             address:
+               - ip: 2001:db8:a::1
+                 prefix-length: 64
+           link-aggregation:
+             mode: balance-rr
+             options:
+               arp_interval: 50
+               ns_ip6_target:
+               - 2001:db8:a::3
+               - 2001:db8:a::2
+             port:
+             - eth1
+             - eth2
+           """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)
+    assertlib.assert_state_match(state)

--- a/tests/integration/testlib/statelib.py
+++ b/tests/integration/testlib/statelib.py
@@ -241,7 +241,7 @@ class State:
                 options = bond_state.get(Bond.OPTIONS_SUBTREE)
                 if options:
                     for option_name, option_value in options.items():
-                        with contextlib.suppress(ValueError):
+                        with contextlib.suppress(ValueError, TypeError):
                             option_value = int(option_value)
                         options[option_name] = option_value
 


### PR DESCRIPTION
Support these bond options:
 - `lacp_active`: true or false. Currently kernel only allow this option
   in `802.3ad` mode.
 - `ns_ip6_target`: list/array of IPv6 address. Currently kernel only
   support using this along with `arp_interval` > 0.

Unit test cases and integration test cases are included.
Resolves: https://issues.redhat.com/browse/RHEL-1415
Resolves: https://issues.redhat.com/browse/RHEL-85784

