### PR TITLE
bond: add "lacp" alias for 802.3ad

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -446,9 +446,9 @@ pub enum BondMode {
     /// Deserialize and serialize from/to `broadcast`.
     /// You can use integer 3 for deserializing to this mode.
     Broadcast,
-    #[serde(rename = "802.3ad", alias = "4")]
+    #[serde(rename = "802.3ad", alias = "lacp", alias = "4")]
     /// Deserialize and serialize from/to `802.3ad`.
-    /// You can use integer 4 for deserializing to this mode.
+    /// You can use integer 4, or the alias "lacp" for deserializing to this mode.
     LACP,
     #[serde(rename = "balance-tlb", alias = "5")]
     /// Deserialize and serialize from/to `balance-tlb`.

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -646,3 +646,19 @@ fn test_bond_port_queue_id_not_overlap_on_default() {
 
     des_iface.sanitize().unwrap();
 }
+
+#[test]
+fn test_bond_mode_lacp_alias() {
+    let iface: BondInterface = serde_yaml::from_str(
+        r#"---
+name: bond99
+type: bond
+state: up
+link-aggregation:
+  mode: lacp
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(iface.bond.unwrap().mode, Some(BondMode::LACP));
+}


### PR DESCRIPTION
Allows using the `lacp` keyword in place of `802.3ad` when configuring the link-aggregation mode of a bond.

Resolves #1856