### PR TITLE
route: add support for advmss option

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -208,6 +208,7 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry.initrwnd = np_route.initrwnd;
     route_entry.mtu = np_route.mtu;
     route_entry.quickack = np_route.quickack.map(|q| q > 0);
+    route_entry.advmss = np_route.advmss;
 
     route_entry
 }

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -27,6 +27,7 @@ pub struct NmIpRoute {
     pub initrwnd: Option<u32>,
     pub mtu: Option<u32>,
     pub quickack: Option<bool>,
+    pub advmss: Option<u32>,
     _other: DbusDictionary,
 }
 
@@ -54,6 +55,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             initrwnd: _from_map!(v, "initrwnd", u32::try_from)?,
             mtu: _from_map!(v, "mtu", u32::try_from)?,
             quickack: _from_map!(v, "quickack", bool::try_from)?,
+            advmss: _from_map!(v, "advmss", u32::try_from)?,
             _other: v,
         })
     }
@@ -146,6 +148,12 @@ impl NmIpRoute {
         if let Some(v) = &self.quickack {
             ret.append(
                 zvariant::Value::new("quickack"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.advmss {
+            ret.append(
+                zvariant::Value::new("advmss"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -50,6 +50,9 @@ impl NmIpRoute {
             if let Some(v) = self.quickack.as_ref() {
                 write!(opt_string, ",quickack={v}").ok();
             }
+            if let Some(v) = self.advmss.as_ref() {
+                write!(opt_string, ",advmss={v}").ok();
+            }
             ret.insert("options".to_string(), opt_string);
         }
         ret

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -66,6 +66,7 @@ pub(crate) fn gen_nm_ip_routes(
         nm_route.initrwnd = route.initrwnd;
         nm_route.mtu = route.mtu;
         nm_route.quickack = route.quickack;
+        nm_route.advmss = route.advmss;
         ret.push(nm_route);
     }
     Ok(ret)

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -270,6 +270,13 @@ pub struct RouteEntry {
         deserialize_with = "crate::deserializer::option_bool_or_string"
     )]
     pub quickack: Option<bool>,
+    /// Maximal Segment Size to advertise for TCP connections
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
+    pub advmss: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -373,6 +380,9 @@ impl RouteEntry {
         if self.quickack.is_some() && self.quickack != other.quickack {
             return false;
         }
+        if self.advmss.is_some() && self.advmss != other.advmss {
+            return false;
+        }
         true
     }
 
@@ -411,6 +421,7 @@ impl RouteEntry {
                     .map(|t| u8::from(*t))
                     .unwrap_or_default()
                     .into(),
+                self.advmss.unwrap_or_default(),
             ],
         )
     }
@@ -485,6 +496,12 @@ impl RouteEntry {
             return Err(NmstateError::new(
                 ErrorKind::InvalidArgument,
                 "The value of 'mtu' cannot be 0".to_string(),
+            ));
+        }
+        if self.advmss == Some(0) {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "The value of 'advmss' cannot be 0".to_string(),
             ));
         }
         Ok(())
@@ -572,6 +589,9 @@ impl std::fmt::Display for RouteEntry {
         }
         if let Some(v) = self.quickack {
             props.push(format!("quickack: {v}"));
+        }
+        if let Some(v) = self.advmss {
+            props.push(format!("advmss: {v}"));
         }
 
         write!(f, "{}", props.join(" "))

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -795,3 +795,72 @@ fn test_route_mtu_deserilize_from_string() {
 
     assert_eq!(route.mtu, Some(1280));
 }
+
+#[test]
+fn test_route_advmss_not_equal() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        advmss: 1500
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        advmss: 1501
+        "#,
+    )
+    .unwrap();
+
+    assert!(route1 != route2);
+}
+
+#[test]
+fn test_route_advmss_is_match() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        advmss: 1500
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        state: absent
+        advmss: 1500
+        "#,
+    )
+    .unwrap();
+
+    assert!(route2.is_match(&route1));
+}
+
+#[test]
+fn test_route_advmss_display() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        advmss: 1500
+        "#,
+    )
+    .unwrap();
+
+    let route1_str = route1.to_string();
+
+    assert!(route1_str.contains("advmss: 1500"));
+}
+
+#[test]
+fn test_route_advmss_deserialize_from_string() {
+    let route = serde_yaml::from_str::<RouteEntry>(
+        r#"
+        advmss: "1500"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(route.advmss, Some(1500));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -54,6 +54,7 @@ class Route:
     INITRWND = "initrwnd"
     MTU = "mtu"
     QUICKACK = "quickack"
+    ADVMSS = "advmss"
 
 
 class RouteRule:

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -459,13 +459,14 @@ def test_gen_conf_route_next_hop_iface_ref_by_mac(eth1_eth2_up_with_no_config):
         assert_routes(expected_routes, cur_state)
 
 
-def test_gen_conf_route_initcwnd_mtu_quickack():
+def test_gen_conf_route_initcwnd_mtu_quickack_advmss():
     desired_state = load_yaml(
         """---
         routes:
           config:
               - destination: 203.0.113.0/24
                 mtu: 1550
+                advmss: 1200
                 next-hop-address: 192.0.2.252
                 next-hop-interface: eth1
                 table-id: 200
@@ -474,6 +475,7 @@ def test_gen_conf_route_initcwnd_mtu_quickack():
                 quickack: true
               - destination: 2001:db8:a::/64
                 mtu: 1280
+                advmss: 1300
                 next-hop-address: 2001:db8:1::2
                 next-hop-interface: eth1
                 table-id: 200

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2447,3 +2447,30 @@ def test_add_route_with_quickack(eth1_up):
     )
     cur_state = libnmstate.show()
     assert_routes(routes, cur_state)
+
+
+# https://github.com/nmstate/nmstate/issues/2881
+@pytest.mark.tier1
+def test_add_route_with_advmss(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS1,
+            Route.ADVMSS: 1500,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+            Route.ADVMSS: 1580,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)


### PR DESCRIPTION
Example:
```
routes:
  config:
    - destination: 2001:db8:c::/64
      next-hop-interface: eth1
      next-hop-address: 2001:db8:1::2
      advmss: 1500
```

Closes #2881