### PR TITLE
bond, ovs: add `bond` alias for `link-aggregation`

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -60,7 +60,8 @@ pub struct BondInterface {
     pub base: BaseInterface,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        rename = "link-aggregation"
+        rename = "link-aggregation",
+        alias = "bond"
     )]
     /// Bond specific settings.
     pub bond: Option<BondConfig>,

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -328,7 +328,8 @@ pub struct OvsBridgePortConfig {
     pub name: String,
     #[serde(
         skip_serializing_if = "Option::is_none",
-        rename = "link-aggregation"
+        rename = "link-aggregation",
+        alias = "bond"
     )]
     pub bond: Option<OvsBridgeBondConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -662,3 +662,24 @@ link-aggregation:
 
     assert_eq!(iface.bond.unwrap().mode, Some(BondMode::LACP));
 }
+
+#[test]
+fn test_bond_link_aggregation_alias() {
+    let mut des_iface: BondInterface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        bond:
+          mode: active-backup
+          ports-config:
+          - name: eth1
+            queue-id: 0
+          - name: eth2
+            queue-id: 0
+        ",
+    )
+    .unwrap();
+
+    assert_eq!(des_iface.bond.unwrap().mode, Some(BondMode::ActiveBackup));
+}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ErrorKind, Interface, InterfaceType, Interfaces, MergedInterface,
-    MergedInterfaces, OvsBridgeInterface, OvsInterface,
+    MergedInterfaces, OvsBridgeBondMode, OvsBridgeInterface, OvsInterface,
 };
 
 #[test]
@@ -993,4 +993,32 @@ fn test_deny_unknown_field_in_ovs_bond() {
     );
 
     assert!(result.is_err());
+}
+
+#[test]
+fn test_ovs_bond_alias() {
+    let iface: OvsBridgeInterface = serde_yaml::from_str(
+        r"---
+name: br0
+type: ovs-bridge
+state: up
+bridge:
+  ports:
+  - name: eth1
+  - name: bond1
+    bond:
+      mode: balance-slb
+      ports:
+        - name: eth2
+",
+    )
+    .unwrap();
+
+    let br_conf = iface.bridge.as_ref().unwrap();
+    let port_conf = &br_conf.ports.as_ref().unwrap()[1];
+    let bond_conf = port_conf.bond.as_ref().unwrap();
+
+    assert_eq!(iface.ports(), Some(vec!["eth1", "eth2"]));
+
+    assert_eq!(bond_conf.mode, Some(OvsBridgeBondMode::BalanceSlb));
 }


### PR DESCRIPTION
Easier to remember and use.
Example:
```
name: bond99
type: bond
state: up
bond:
  mode: active-backup
  ports-config:
    - name: eth1
      queue-id: 0
    - name: eth2
      queue-id: 0
```

Unit tests are included.