### PR TITLE
nm dispatch: Fix race when modifying dispatch script

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -449,7 +449,8 @@ pub enum BondMode {
     Broadcast,
     #[serde(rename = "802.3ad", alias = "lacp", alias = "4")]
     /// Deserialize and serialize from/to `802.3ad`.
-    /// You can use integer 4, or the alias "lacp" for deserializing to this mode.
+    /// You can use integer 4, or the alias "lacp" for deserializing to this
+    /// mode.
     LACP,
     #[serde(rename = "balance-tlb", alias = "5")]
     /// Deserialize and serialize from/to `balance-tlb`.

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -51,6 +51,8 @@ pub(crate) async fn nm_apply(
     nm_api.set_checkpoint(checkpoint, timeout);
     nm_api.set_checkpoint_auto_refresh(true);
 
+    apply_dispatch_script(&merged_state.interfaces)?;
+
     if !merged_state.memory_only {
         delete_ifaces(&mut nm_api, merged_state).await?;
     }
@@ -204,8 +206,6 @@ pub(crate) async fn nm_apply(
 
     deactivate_nm_connections(&mut nm_api, nm_conns_to_deactivate.as_slice())
         .await?;
-
-    apply_dispatch_script(&merged_state.interfaces)?;
 
     Ok(())
 }

--- a/tests/integration/nm/dispath_test.py
+++ b/tests/integration/nm/dispath_test.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import suppress
 import os
 
 import pytest
@@ -28,9 +29,8 @@ def assert_dispatch_script_not_exist(iface_name, action):
 
 @pytest.fixture
 def eth1_up_with_dispatch_script(eth1_up):
-    libnmstate.apply(
-        load_yaml(
-            """---
+    state = load_yaml(
+        """---
             interfaces:
             - name: eth1
               dispatch:
@@ -39,8 +39,9 @@ def eth1_up_with_dispatch_script(eth1_up):
                 post-deactivation: |
                   echo post-down-eth1 | systemd-cat
             """
-        ),
     )
+    libnmstate.apply(state)
+    yield state
 
 
 def test_add_and_remove_dispatch_script(eth1_up_with_dispatch_script):
@@ -76,7 +77,7 @@ def test_remove_dispatch_script_on_iface_absent(eth1_up):
     assert_dispatch_script_not_exist("eth1", "down")
 
 
-def test_modify_dispatch_script(eth1_up):
+def test_add_dispatch_script(eth1_up):
     libnmstate.apply(
         load_yaml(
             """---
@@ -94,3 +95,69 @@ def test_modify_dispatch_script(eth1_up):
     assert_dispatch_script(
         "eth1", "down", "echo new-post-down-eth1 | systemd-cat"
     )
+
+
+TEST_DISPATCH_STATE_FILE_ETH1 = "/tmp/nmstate_test_dispatch_up_eth1"
+TEST_DISPATCH_STATE_FILE_ETH2 = "/tmp/nmstate_test_dispatch_up_eth2"
+
+
+def assert_dispatch_state_files(expected_content):
+    with open(TEST_DISPATCH_STATE_FILE_ETH1) as fd:
+        content = fd.read()
+        assert content == expected_content
+
+    with open(TEST_DISPATCH_STATE_FILE_ETH2) as fd:
+        content = fd.read()
+        assert content == expected_content
+
+
+@pytest.fixture
+def delete_dispatch_state_file():
+    with suppress(FileNotFoundError):
+        os.remove(TEST_DISPATCH_STATE_FILE_ETH1)
+        os.remove(TEST_DISPATCH_STATE_FILE_ETH2)
+    yield
+    with suppress(FileNotFoundError):
+        os.remove(TEST_DISPATCH_STATE_FILE_ETH1)
+        os.remove(TEST_DISPATCH_STATE_FILE_ETH2)
+
+
+@pytest.fixture
+def eth1_eth2_with_old_dispatch_script(eth1_up, eth2_up):
+    state = load_yaml(
+        f"""---
+            interfaces:
+            - name: eth1
+              dispatch:
+                post-activation: |
+                  echo -n old > {TEST_DISPATCH_STATE_FILE_ETH1}
+            - name: eth2
+              dispatch:
+                post-activation: |
+                  echo -n old > {TEST_DISPATCH_STATE_FILE_ETH2}
+         """
+    )
+    libnmstate.apply(state)
+    assert_dispatch_state_files("old")
+
+
+def test_modify_dispatch_script(
+    delete_dispatch_state_file, eth1_eth2_with_old_dispatch_script
+):
+    libnmstate.apply(
+        load_yaml(
+            f"""---
+            interfaces:
+            - name: eth1
+              dispatch:
+                post-activation: |
+                  echo -n new > {TEST_DISPATCH_STATE_FILE_ETH1}
+            - name: eth2
+              dispatch:
+                post-activation: |
+                  echo -n new > {TEST_DISPATCH_STATE_FILE_ETH2}
+         """
+        ),
+    )
+
+    assert_dispatch_state_files("new")


### PR DESCRIPTION
Previously we reapply/activate the NmConnection before modifying the
dispatcher script, this would cause NetworkManager invoked old dispatcher
script content.

Fixed by modify the dispatcher script before NmConnection actions, also
invoke `File::sync_all()` to ensure dispatch script been sync to file
system for NetworkManager-dispatcher.service to read afterwards.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-94840