### PR TITLE
rust: fix unused mut in test

### DIFF
--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -665,7 +665,7 @@ link-aggregation:
 
 #[test]
 fn test_bond_link_aggregation_alias() {
-    let mut des_iface: BondInterface = serde_yaml::from_str(
+    let des_iface: BondInterface = serde_yaml::from_str(
         r"---
         name: bond99
         type: bond


### PR DESCRIPTION
Warning:
```
   Compiling nmstate v2.2.47 (/home/rrajesh/projects/nmstate/rust/src/lib)
warning: variable does not need to be mutable
   --> src/lib/unit_tests/bond.rs:668:9
    |
668 |     let mut des_iface: BondInterface = serde_yaml::from_str(
    |         ----^^^^^^^^^
    |         |
    |         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

   Compiling nmstate-clib v2.2.47 (/home/rrajesh/projects/nmstate/rust/src/clib)
   Compiling nmstatectl v2.2.47 (/home/rrajesh/projects/nmstate/rust/src/cli)
warning: `nmstate` (lib test) generated 1 warning (run `cargo fix --lib -p nmstate --tests` to apply 1 suggestion)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.54s
     Running unittests lib.rs (target/debug/deps/nmstate-ba635cbad55d1d19)
 ```
     
     Cargo version: cargo 1.87.0 (99624be96 2025-05-06)