### PR TITLE
ovn: Raise error if OVN map bridge not exist or marked as absent

### DIFF
--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -377,7 +377,8 @@ impl MergedNetworkState {
         let hostname =
             MergedHostNameState::new(desired.hostname, current.hostname);
 
-        let ovn = MergedOvnConfiguration::new(desired.ovn, current.ovn)?;
+        let ovn =
+            MergedOvnConfiguration::new(desired.ovn, current.ovn, &interfaces)?;
 
         let ovsdb = MergedOvsDbGlobalConfig::new(
             desired.ovsdb,

--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ErrorKind, NmstateError};
+use crate::{ErrorKind, InterfaceType, MergedInterfaces, NmstateError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -65,6 +65,45 @@ impl OvnConfiguration {
                             map.localnet
                         ),
                     ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_local_bridge(
+        &self,
+        merged_ifaces: &MergedInterfaces,
+    ) -> Result<(), NmstateError> {
+        if let Some(maps) = self.bridge_mappings.as_ref() {
+            for map in maps
+                .iter()
+                .filter(|map| map.state != Some(OvnBridgeMappingState::Absent))
+            {
+                if let Some(br_name) = map.bridge.as_deref() {
+                    if let Some(ovs_br_iface) = merged_ifaces
+                        .get_iface(br_name, InterfaceType::OvsBridge)
+                    {
+                        if ovs_br_iface.merged.is_absent() {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "The OVS bridge {br_name} used for OVN \
+                                     localnet {} is marked as absent",
+                                    map.localnet
+                                ),
+                            ));
+                        }
+                    } else {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "There is no OVS bridge holding name desired \
+                                 by OVN bridge {br_name} localnet {}",
+                                map.localnet
+                            ),
+                        ));
+                    }
                 }
             }
         }
@@ -134,9 +173,12 @@ impl MergedOvnConfiguration {
     pub(crate) fn new(
         desired: OvnConfiguration,
         current: OvnConfiguration,
+        merged_ifaces: &MergedInterfaces,
     ) -> Result<Self, NmstateError> {
         let mut desired = desired;
         desired.sanitize()?;
+
+        desired.validate_local_bridge(merged_ifaces)?;
 
         let empty_vec: Vec<OvnBridgeMapping> = Vec::new();
         let deleted_localnets: HashSet<&str> = desired

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/current.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/current.yml
@@ -1,4 +1,30 @@
 ---
+interfaces:
+ - name: eth1
+   type: ethernet
+   state: up
+ - name: eth2
+   type: ethernet
+   state: up
+ - name: eth3
+   type: ethernet
+   state: up
+ - name: ovsbr1
+   type: ovs-bridge
+   state: up
+   bridge:
+     options:
+       stp: true
+     port:
+     - name: eth1
+ - name: ovsbr2
+   type: ovs-bridge
+   state: up
+   bridge:
+     options:
+       stp: true
+     port:
+     - name: eth2
 ovn:
   bridge-mappings:
     - localnet: blue

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/desired.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/desired.yml
@@ -1,4 +1,13 @@
 ---
+interfaces:
+ - name: ovsbr3
+   type: ovs-bridge
+   state: up
+   bridge:
+     options:
+       stp: true
+     port:
+     - name: eth3
 ovn:
   bridge-mappings:
     - localnet: red

--- a/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/revert.yml
+++ b/rust/src/lib/unit_tests/gen_revert_test_files/change_ovn/revert.yml
@@ -1,4 +1,11 @@
 ---
+interfaces:
+- name: eth3
+  type: ethernet
+  state: up
+- name: ovsbr3
+  type: ovs-bridge
+  state: absent
 ovn:
   bridge-mappings:
     - localnet: green

--- a/rust/src/lib/unit_tests/ovn.rs
+++ b/rust/src/lib/unit_tests/ovn.rs
@@ -1,9 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ErrorKind, MergedOvnConfiguration, OvnBridgeMapping, OvnBridgeMappingState,
-    OvnConfiguration,
+    ErrorKind, Interfaces, MergedInterfaces, MergedNetworkState,
+    MergedOvnConfiguration, NetworkState, OvnBridgeMapping,
+    OvnBridgeMappingState, OvnConfiguration,
 };
+
+fn gen_br1_merged_ifaces() -> MergedInterfaces {
+    let desired_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+         - name: br1
+           type: ovs-bridge
+           state: up
+           bridge:
+             options:
+               stp: true
+             port:
+             - name: eth1
+        ",
+    )
+    .unwrap();
+    let current_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+         - name: eth1
+           type: ethernet
+           state: up
+        ",
+    )
+    .unwrap();
+    MergedInterfaces::new(
+        desired_ifaces,
+        current_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap()
+}
 
 #[test]
 fn test_ovsdb_merge_with_mappings() {
@@ -22,7 +54,9 @@ bridge-mappings: []
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvnConfiguration::new(desired, current, &gen_br1_merged_ifaces())
+            .unwrap();
 
     assert_eq!(
         merged_ovsdb.to_ovsdb_external_id_value().unwrap(),
@@ -49,7 +83,9 @@ fn test_ovsdb_merge_delete_existing_mappings() {
     )
     .unwrap();
 
-    let merged_ovsdb = MergedOvnConfiguration::new(desired, current).unwrap();
+    let merged_ovsdb =
+        MergedOvnConfiguration::new(desired, current, &gen_br1_merged_ifaces())
+            .unwrap();
     assert_eq!(merged_ovsdb.to_ovsdb_external_id_value(), None);
 }
 
@@ -73,7 +109,8 @@ fn test_ovn_duplicate_localnet_keys_are_forbidden_on_desired_state() {
     )
     .unwrap();
 
-    let result = MergedOvnConfiguration::new(desired, current);
+    let result =
+        MergedOvnConfiguration::new(desired, current, &gen_br1_merged_ifaces());
 
     assert!(result.is_err());
 
@@ -285,4 +322,122 @@ fn test_ovn_serialize_state_absent() {
             .unwrap();
 
     assert_eq!(desired, new);
+}
+
+#[test]
+fn test_ovn_bridge_not_found() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+        - name: br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              stp: true
+            port:
+            - name: eth1
+        ovn:
+          bridge-mappings:
+          - localnet: vlan-99
+            bridge: ovs-not-exist
+            state: present"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+        ",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_ovn_ref_to_absent_bridge() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+        - name: br1
+          type: ovs-bridge
+          state: absent
+        ovn:
+          bridge-mappings:
+          - localnet: vlan-99
+            bridge: br1
+            state: present"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              stp: true
+            port:
+            - name: eth1
+        ",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_ovn_absent_ref_to_absent_bridge() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"---
+        interfaces:
+        - name: br1
+          type: ovs-bridge
+          state: absent
+        ovn:
+          bridge-mappings:
+          - localnet: vlan-99
+            bridge: br1
+            state: absent"#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: br1
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              stp: true
+            port:
+            - name: eth1
+        ",
+    )
+    .unwrap();
+
+    MergedNetworkState::new(desired, current, Default::default(), false)
+        .unwrap();
 }

--- a/rust/src/lib/unit_tests/statistic.rs
+++ b/rust/src/lib/unit_tests/statistic.rs
@@ -304,6 +304,27 @@ fn test_statistic_feature_ovs_patch_with_iface_ovsdb() {
 fn test_statistic_feature_ovn_map() {
     let desired: NetworkState = serde_yaml::from_str(
         r#"---
+        interfaces:
+         - name: eth1
+           type: ethernet
+         - name: eth2
+           type: ethernet
+         - name: ovsbr1
+           type: ovs-bridge
+           state: up
+           bridge:
+             options:
+               stp: true
+             port:
+             - name: eth1
+         - name: ovsbr2
+           type: ovs-bridge
+           state: up
+           bridge:
+             options:
+               stp: true
+             port:
+             - name: eth2
         ovn:
           bridge-mappings:
             - localnet: blue

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -45,6 +45,7 @@ from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 BOND1 = "bond1"
 BRIDGE0 = "br0"
 BRIDGE1 = "br1"
+BRIDGE2 = "br2"
 PORT1 = "ovs1"
 PORT2 = "ovs2"
 PATCH0 = "patch0"
@@ -659,7 +660,7 @@ def test_remove_all_ovsdb_global_config():
     }
 
 
-def test_ovsdb_global_config_add_delete_mapping():
+def test_ovsdb_global_config_add_delete_mapping(ovs_bridge1):
     desired_ovs_config = {
         Ovn.BRIDGE_MAPPINGS: [
             {
@@ -689,12 +690,28 @@ def test_ovsdb_global_config_add_delete_mapping():
 
 
 @pytest.fixture
-def ovn_bridge_mapping_net1():
+def ovs_bridge1():
+    bridge = Bridge(BRIDGE1)
+    bridge.add_internal_port(PORT1, ipv4_state={InterfaceIPv4.ENABLED: False})
+    with bridge.create():
+        yield
+
+
+@pytest.fixture
+def ovs_bridge2():
+    bridge = Bridge(BRIDGE2)
+    bridge.add_internal_port(PORT2, ipv4_state={InterfaceIPv4.ENABLED: False})
+    with bridge.create():
+        yield
+
+
+@pytest.fixture
+def ovn_bridge_mapping_net1(ovs_bridge1):
     ovn_config = {
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
-                Ovn.BridgeMappings.BRIDGE: "br1",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE1,
             },
         ]
     }
@@ -715,12 +732,12 @@ def ovn_bridge_mapping_net1():
 
 
 @pytest.fixture
-def ovn_bridge_mapping_net2():
+def ovn_bridge_mapping_net2(ovs_bridge2):
     ovn_config = {
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net2",
-                Ovn.BridgeMappings.BRIDGE: "br2",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE2,
                 Ovn.BridgeMappings.STATE: "present",
             },
         ]
@@ -732,7 +749,7 @@ def ovn_bridge_mapping_net2():
             Ovn.KEY: {
                 Ovn.BRIDGE_MAPPINGS: [
                     {
-                        Ovn.BridgeMappings.LOCALNET: "net1",
+                        Ovn.BridgeMappings.LOCALNET: "net2",
                         Ovn.BridgeMappings.STATE: "absent",
                     },
                 ]
@@ -741,12 +758,14 @@ def ovn_bridge_mapping_net2():
     )
 
 
-def test_ovn_global_config_add_delete_single_mapping(ovn_bridge_mapping_net1):
+def test_ovn_global_config_add_delete_single_mapping(
+    ovs_bridge2, ovn_bridge_mapping_net1
+):
     desired_ovs_config = {
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net123",
-                Ovn.BridgeMappings.BRIDGE: "br321",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE2,
                 Ovn.BridgeMappings.STATE: "present",
             },
         ]
@@ -786,7 +805,7 @@ def test_ovn_global_config_modify_and_delete_mappings(
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
-                Ovn.BridgeMappings.BRIDGE: "br321",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE2,
             },
             {
                 Ovn.BridgeMappings.LOCALNET: "net2",
@@ -800,7 +819,7 @@ def test_ovn_global_config_modify_and_delete_mappings(
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
-                Ovn.BridgeMappings.BRIDGE: "br321",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE2,
             },
         ]
     }
@@ -829,12 +848,12 @@ def test_ovsdb_global_config_clearing_ext_ids_preserves_existing_mappings(
     assert current_ovs_config == ovn_bridge_mapping_net1
 
 
-def test_ovn_bridge_mappings_cannot_have_duplicate_localnet_keys():
+def test_ovn_bridge_mappings_cannot_have_duplicate_localnet_keys(ovs_bridge2):
     desired_ovs_config = {
         Ovn.BRIDGE_MAPPINGS: [
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
-                Ovn.BridgeMappings.BRIDGE: "br321",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE2,
             },
             {
                 Ovn.BridgeMappings.LOCALNET: "net1",
@@ -2268,3 +2287,42 @@ def test_ovsdb_recv_end_of_message(cleanup_test_bridge_afterwards):
     )
     libnmstate.apply(desired_state)
     assertlib.assert_state_match(desired_state)
+
+
+def test_ovn_map_to_non_exist_br():
+    ovn_config = {
+        Ovn.BRIDGE_MAPPINGS: [
+            {
+                Ovn.BridgeMappings.LOCALNET: "net2",
+                Ovn.BridgeMappings.BRIDGE: "not_exist_ovs_bridge",
+                Ovn.BridgeMappings.STATE: "present",
+            },
+        ]
+    }
+    with pytest.raises(ValueError):
+        libnmstate.apply({Ovn.KEY: ovn_config})
+
+
+def test_ovn_map_to_absent_br(ovn_bridge_mapping_net1):
+    ovn_config = {
+        Ovn.BRIDGE_MAPPINGS: [
+            {
+                Ovn.BridgeMappings.LOCALNET: "net2",
+                Ovn.BridgeMappings.BRIDGE: BRIDGE1,
+                Ovn.BridgeMappings.STATE: "present",
+            },
+        ]
+    }
+    with pytest.raises(ValueError):
+        libnmstate.apply(
+            {
+                Ovn.KEY: ovn_config,
+                Interface.KEY: [
+                    {
+                        Interface.NAME: BRIDGE1,
+                        Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ],
+            }
+        )


### PR DESCRIPTION
Raise error when desired OVN mapping is pointing to non-exist OVS bridge
or OVS bridge been marked as absent.

Unit test cases and integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-37922