### PR TITLE
bond: use as_ref() instead of clone

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -109,16 +109,16 @@ impl BondInterface {
 
     fn sort_ports(&mut self) {
         if let Some(ref mut bond_conf) = self.bond {
-            if let Some(ref mut port_conf) = &mut bond_conf.port {
-                port_conf.sort_unstable_by_key(|p| p.clone())
+            if let Some(port_list) = bond_conf.port.as_mut() {
+                port_list.sort_unstable_by_key(|p| p.clone())
             }
         }
     }
 
     fn sort_ports_config(&mut self) {
         if let Some(ref mut bond_conf) = self.bond {
-            if let Some(ref mut port_conf) = &mut bond_conf.ports_config {
-                port_conf.sort_unstable_by_key(|p| p.name.clone())
+            if let Some(ports_conf_list) = bond_conf.ports_config.as_mut() {
+                ports_conf_list.sort_unstable_by_key(|p| p.name.clone())
             }
         }
     }
@@ -167,24 +167,18 @@ impl BondInterface {
         Ok(())
     }
 
-    // Return None when desire state does not mention ports
     pub(crate) fn ports(&self) -> Option<Vec<&str>> {
-        let config = self.bond.clone().unwrap_or_default();
-        if config.port.is_some() {
-            self.bond
+        self.bond.as_ref().and_then(|bond_conf| {
+            bond_conf
+                .port
                 .as_ref()
-                .and_then(|bond_conf| bond_conf.port.as_ref())
                 .map(|ports| {
                     ports.as_slice().iter().map(|p| p.as_str()).collect()
                 })
-        } else {
-            self.bond
-                .as_ref()
-                .and_then(|bond_conf| bond_conf.ports_config.as_ref())
-                .map(|ports| {
+                .or(bond_conf.ports_config.as_ref().map(|ports| {
                     ports.as_slice().iter().map(|p| p.name.as_str()).collect()
-                })
-        }
+                }))
+        })
     }
 
     pub(crate) fn get_port_conf(
@@ -289,39 +283,34 @@ impl BondInterface {
     fn validate_conflict_in_port_and_port_configs(
         &self,
     ) -> Result<(), NmstateError> {
-        let bond_config = self.bond.clone().unwrap_or_default();
-        if bond_config.port.is_some() && bond_config.ports_config.is_some() {
-            let mut port_list = bond_config.port.unwrap_or_default();
-            let mut port_config_list: Vec<String> = bond_config
-                .ports_config
-                .unwrap_or_default()
-                .into_iter()
-                .map(|p| p.name)
-                .collect();
-            port_list.sort_unstable();
-            port_config_list.sort_unstable();
-            let matching = port_list
-                .iter()
-                .zip(port_config_list.iter())
-                .filter(|&(port_name, port_config_name)| {
-                    port_name == port_config_name
-                })
-                .count();
-            if matching != port_list.len() || matching != port_config_list.len()
+        if let Some(bond_conf) = self.bond.as_ref() {
+            if let (Some(ports), Some(ports_config)) =
+                (&bond_conf.port, &bond_conf.ports_config)
             {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "The port names specified in `port` conflict with the \
-                         port names specified in `ports-config` for bond \
-                         interface: {}",
-                        &self.base.name
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
+                let mut ports: Vec<&str> =
+                    ports.iter().map(String::as_str).collect();
+                let mut port_confs: Vec<&str> =
+                    ports_config.iter().map(|p| p.name.as_str()).collect();
+
+                ports.sort_unstable();
+                port_confs.sort_unstable();
+
+                if ports != port_confs {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "The port names specified in `port` conflict with \
+                             the port names specified in `ports-config` for \
+                             bond interface: {}",
+                            &self.base.name
+                        ),
+                    );
+                    log::error!("{e}");
+                    return Err(e);
+                }
             }
         }
+
         Ok(())
     }
 

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::net::Ipv6Addr;
 
 use serde::{
@@ -108,18 +109,16 @@ impl BondInterface {
     }
 
     fn sort_ports(&mut self) {
-        if let Some(ref mut bond_conf) = self.bond {
-            if let Some(port_list) = bond_conf.port.as_mut() {
-                port_list.sort_unstable_by_key(|p| p.clone())
-            }
+        if let Some(ports) = self.bond.as_mut().and_then(|b| b.port.as_mut()) {
+            ports.sort_unstable_by_key(|p| p.clone());
         }
     }
 
     fn sort_ports_config(&mut self) {
-        if let Some(ref mut bond_conf) = self.bond {
-            if let Some(ports_conf_list) = bond_conf.ports_config.as_mut() {
-                ports_conf_list.sort_unstable_by_key(|p| p.name.clone())
-            }
+        if let Some(port_confs) =
+            self.bond.as_mut().and_then(|b| b.ports_config.as_mut())
+        {
+            port_confs.sort_unstable_by_key(|p| p.name.clone());
         }
     }
 
@@ -175,9 +174,15 @@ impl BondInterface {
                 .map(|ports| {
                     ports.as_slice().iter().map(|p| p.as_str()).collect()
                 })
-                .or(bond_conf.ports_config.as_ref().map(|ports| {
-                    ports.as_slice().iter().map(|p| p.name.as_str()).collect()
-                }))
+                .or_else(|| {
+                    bond_conf.ports_config.as_ref().map(|ports| {
+                        ports
+                            .as_slice()
+                            .iter()
+                            .map(|p| p.name.as_str())
+                            .collect()
+                    })
+                })
         })
     }
 
@@ -287,22 +292,38 @@ impl BondInterface {
             if let (Some(ports), Some(ports_config)) =
                 (&bond_conf.port, &bond_conf.ports_config)
             {
-                let mut ports: Vec<&str> =
+                let ports: HashSet<&str> =
                     ports.iter().map(String::as_str).collect();
-                let mut port_confs: Vec<&str> =
+                let port_confs: HashSet<&str> =
                     ports_config.iter().map(|p| p.name.as_str()).collect();
 
-                ports.sort_unstable();
-                port_confs.sort_unstable();
-
                 if ports != port_confs {
+                    let missing_in_config: Vec<&str> =
+                        ports.difference(&port_confs).copied().collect();
+                    let missing_in_ports: Vec<&str> =
+                        port_confs.difference(&ports).copied().collect();
+
+                    let mut error_msg_detail = String::new();
+
+                    if !missing_in_config.is_empty() {
+                        error_msg_detail.push_str(&format!(
+                            "Ports in `port`` but not in `ports_config`: {}",
+                            missing_in_config.join(", ")
+                        ));
+                    } else if !missing_in_ports.is_empty() {
+                        error_msg_detail.push_str(&format!(
+                            "Ports in `ports_config`` but not in `port`: {}",
+                            missing_in_config.join(", ")
+                        ));
+                    }
+
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
                             "The port names specified in `port` conflict with \
                              the port names specified in `ports-config` for \
-                             bond interface: {}",
-                            &self.base.name
+                             bond interface: {}. {}",
+                            &self.base.name, error_msg_detail
                         ),
                     );
                     log::error!("{e}");

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -781,3 +781,32 @@ fn test_bond_opt_ns_ip6_target() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_bond_ports_ports_config_conflict() {
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: active-backup
+          ports:
+          - eth1
+          - eth3
+          ports-config:
+          - name: eth1
+            queue-id: 0
+          - name: eth2
+            queue-id: 0
+        ",
+    )
+    .unwrap();
+
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+    let result = merged_iface.post_inter_ifaces_process_bond();
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -781,32 +781,3 @@ fn test_bond_opt_ns_ip6_target() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
-
-#[test]
-fn test_bond_ports_ports_config_conflict() {
-    let iface: Interface = serde_yaml::from_str(
-        r"---
-        name: bond99
-        type: bond
-        state: up
-        link-aggregation:
-          mode: active-backup
-          ports:
-          - eth1
-          - eth3
-          ports-config:
-          - name: eth1
-            queue-id: 0
-          - name: eth2
-            queue-id: 0
-        ",
-    )
-    .unwrap();
-
-    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
-    let result = merged_iface.post_inter_ifaces_process_bond();
-    assert!(result.is_err());
-    if let Err(e) = result {
-        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
-    }
-}


### PR DESCRIPTION
fixes https://github.com/nmstate/nmstate/issues/2709

Refactored functions to not use `clone()`. User `as_ref()` instead.
Cleaner function, less allocations and copying.

Added a test case for port and ports-config conflict.