### PR TITLE
nm: Bump minimum supported NetworkManager version 1.46

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,9 +138,9 @@ jobs:
           - job_type: "c9s-nm_main-integ_tier2"
           - job_type: "c9s-nm_main-integ_slow"
           - job_type: "c9s-nm_main-rust_go"
-          - job_type: "c9s-nm_1.42-integ_tier1"
-          - job_type: "c9s-nm_1.42-integ_tier2"
-          - job_type: "c9s-nm_1.42-integ_slow"
+          - job_type: "c9s-nm_min-integ_tier1"
+          - job_type: "c9s-nm_min-integ_tier2"
+          - job_type: "c9s-nm_min-integ_slow"
           - job_type: "fed-nm_main-integ_tier1"
           - job_type: "c10s-nm_stable-integ_tier1"
     steps:

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -41,9 +41,13 @@ if [ $NM_TYPE == "nm_main" ];then
     TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-main"
 fi
 
-if [ $NM_TYPE == "nm_1.42" ];then
-    TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-1.42"
-    PRETEST_EXEC='dnf copr enable -y nmstate/nm-libreswan-rhel9.2; dnf install -y NetworkManager-libreswan-1.2.14-4.el9'
+if [ $NM_TYPE == "nm_min" ];then
+    TEST_ARG="$TEST_ARG --copr nmstate/nm-rhel9"
+    PRETEST_EXEC='dnf copr enable -y nmstate/nm-libreswan-rhel9; \
+        dnf remove -y NetworkManager-libreswan; \
+        dnf install -y NetworkManager-libreswan \
+            --disablerepo="*" \
+            --enablerepo="copr:copr.fedorainfracloud.org:nmstate:nm-libreswan-rhel9"'
 fi
 
 

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -448,13 +448,13 @@ async fn check_nm_version(
             .has_capability(NmVersionInfo::CAPABILITY_SYNC_ROUTE_WITH_TABLE);
         Ok(ver_info.version())
     } else {
-        // VersionInfo was added to NM 1.42. As we support 1.40+, fallback to
+        // VersionInfo was added to NM 1.42. For older version we fallback to
         // parsing from Version string if VersionInfo is not available.
         *route_remove_needs_deactivate = true;
         nm_api.version().await
     };
 
-    let min = NmVersion::new(1, 40, 0);
+    let min = NmVersion::new(1, 46, 0);
     if let Ok(version) = version {
         if version < min {
             log::warn!(

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -21,12 +21,7 @@ pub(crate) fn gen_nm_vlan_setting(
                     nm_vlan.protocol = Some(NM_802_1_AD.to_string());
                 }
                 VlanProtocol::Ieee8021Q => {
-                    // To support old NetworkManager 1.41- which VLAN protocol
-                    // is not supported, we only set 802.1q protocol explicitly
-                    // when protocol is already defined in NM connection.
-                    if nm_vlan.protocol.is_some() {
-                        nm_vlan.protocol = Some(NM_802_1_Q.to_string());
-                    }
+                    nm_vlan.protocol = Some(NM_802_1_Q.to_string());
                 }
             }
         }

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -30,7 +30,6 @@ from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
 from .testlib.env import is_k8s
-from .testlib.env import nm_minor_version
 from .testlib.ifacelib import get_mac_address
 from .testlib.ifacelib import ifaces_init
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
@@ -177,10 +176,6 @@ def test_remove_bond_with_minimum_desired_state(eth1_up, eth2_up):
     assert not state[Interface.KEY]
 
 
-@pytest.mark.skipif(
-    nm_minor_version() <= 44,
-    reason="Bond port config is not supported on NetworkManager 1.44-",
-)
 def test_add_and_remove_bond_with_port_config(eth1_up, eth2_up):
     state = yaml.load(BOND99_PORT_YAML_BASE, Loader=yaml.SafeLoader)
     try:
@@ -197,10 +192,6 @@ def test_add_and_remove_bond_with_port_config(eth1_up, eth2_up):
         apply_with_description("Delete the bond device bond99", state)
 
 
-@pytest.mark.skipif(
-    nm_minor_version() <= 44,
-    reason="Bond port config is not supported on NetworkManager 1.44-",
-)
 def test_add_bond_with_port_config_and_modify(eth1_up, eth2_up):
     state = yaml.load(BOND99_PORT_YAML_BASE, Loader=yaml.SafeLoader)
     try:
@@ -232,10 +223,6 @@ def test_add_bond_with_port_config_and_modify(eth1_up, eth2_up):
         apply_with_description("Delete bond interface bond99", state)
 
 
-@pytest.mark.skipif(
-    nm_minor_version() <= 44,
-    reason="Bond port config is not supported on NetworkManager 1.44-",
-)
 def test_conflict_port_name_between_port_and_ports_config(eth1_up, eth2_up):
     state = yaml.load(BOND99_PORT_YAML_BASE, Loader=yaml.SafeLoader)
     state[Interface.KEY][0][Bond.CONFIG_SUBTREE][Bond.PORT] = ["eth1"]
@@ -1426,7 +1413,7 @@ def test_remove_bond_and_assign_ip_to_bond_port(bond99_with_2_port):
 
 
 @pytest.mark.skipif(
-    os.environ.get("CI") == "true" or nm_minor_version() < 43,
+    os.environ.get("CI") == "true",
     reason="bond arp_missed_max is not supported by "
     "Github CI Ubuntu 5.15 kernel",
 )

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -18,7 +18,6 @@ from libnmstate.schema import DNS
 from libnmstate.schema import HostNameState
 from libnmstate.schema import RouteRule
 
-from .testlib.env import is_el8
 from .testlib.env import is_k8s
 from .testlib.env import nm_minor_version
 
@@ -129,11 +128,6 @@ def test_add_remove_routes(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_add_remove_special_routes(eth1_up):
     """
     Test adding an special route and removing it.
@@ -268,10 +262,6 @@ def test_add_macsec_and_remove_example(eth1_up):
     assertlib.assert_absent("macsec0")
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 45 or is_el8(),
-    reason="HSR is supported only in NetworkManager 1.45+",
-)
 @pytest.mark.tier1
 def test_add_hsr_and_remove_example(eth1_up):
     with example_state(
@@ -282,10 +272,6 @@ def test_add_hsr_and_remove_example(eth1_up):
     assertlib.assert_absent("hsr0")
 
 
-@pytest.mark.skipif(
-    nm_minor_version() <= 44,
-    reason="Bond port config is not supported on NetworkManager 1.44-",
-)
 def test_bond_port(eth1_up, eth2_up):
     with example_state(
         "bond_port_up.yml",

--- a/tests/integration/hsr_test.py
+++ b/tests/integration/hsr_test.py
@@ -9,8 +9,6 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Hsr
 
 from .testlib import assertlib
-from .testlib.env import is_el8
-from .testlib.env import nm_minor_version
 
 
 ETH1 = "eth1"
@@ -18,10 +16,6 @@ ETH2 = "eth2"
 HSR0 = "hsr0"
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 45 or is_el8(),
-    reason=("HSR is only supported by NetworkManager 1.45+ and RHEL 9+"),
-)
 @pytest.mark.tier1
 def test_add_hsr_and_remove(eth1_up, eth2_up):
     desired_state = {

--- a/tests/integration/loopback_test.py
+++ b/tests/integration/loopback_test.py
@@ -2,9 +2,6 @@
 
 import pytest
 
-import libnmstate
-
-from libnmstate.error import NmstateDependencyError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -14,7 +11,6 @@ from libnmstate.schema import InterfaceState
 from .testlib import assertlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
-from .testlib.env import nm_minor_version
 from .testlib.retry import retry_till_true_or_timeout
 
 IPV4_ADDRESS1 = "192.0.2.251"
@@ -41,29 +37,6 @@ def loopback_cleanup():
     )
 
 
-@pytest.mark.skipif(
-    nm_minor_version() >= 41,
-    reason=("Loopback is supported by NetworkManager 1.41+"),
-)
-def test_loopback_not_supported_by_nm():
-    with pytest.raises(NmstateDependencyError):
-        libnmstate.apply(
-            {
-                Interface.KEY: [
-                    {
-                        Interface.NAME: "lo",
-                        Interface.TYPE: InterfaceType.LOOPBACK,
-                        Interface.STATE: InterfaceState.UP,
-                    }
-                ]
-            }
-        )
-
-
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason=("Loopback is only supported by NetworkManager 1.41+"),
-)
 class TestLoopback:
     def test_change_loopback_mtu_and_restore_back(self, loopback_cleanup):
         cur_state = statelib.show_only(("lo",))

--- a/tests/integration/macsec_test.py
+++ b/tests/integration/macsec_test.py
@@ -9,7 +9,6 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import MacSec
 
 from .testlib import assertlib
-from .testlib.env import nm_minor_version
 
 MKA_CAK = "50b71a8ef0bd5751ea76de6d6c98c03a"
 MKA_CKN = "f2b4297d39da7330910a74abc0449feb45b5c0b9fc23df1430e1898fcf1c4550"
@@ -83,10 +82,6 @@ def test_add_macsec_and_modify(eth1_up):
 
 
 # https://issues.redhat.com/browse/RHEL-24337
-@pytest.mark.xfail(
-    nm_minor_version() < 46,
-    reason="NetworkManager 1.46- does not support MacSec offload",
-)
 @pytest.mark.tier1
 def test_macsec_offload(eth1_up):
     desired_state = {

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -20,9 +20,7 @@ from ..testlib import assertlib
 from ..testlib import cmdlib
 from ..testlib import statelib
 from ..testlib.bondlib import bond_interface
-from ..testlib.env import is_el8
 from ..testlib.env import is_k8s
-from ..testlib.env import nm_minor_version
 from ..testlib.ifacelib import get_mac_address
 from ..testlib.nmplugin import nm_service_restart
 from ..testlib.retry import retry_till_true_or_timeout
@@ -63,7 +61,7 @@ def test_bond_all_zero_ad_actor_system():
 
 
 @pytest.mark.skipif(
-    nm_minor_version() <= 40 or os.environ.get("CI") == "true",
+    os.environ.get("CI") == "true",
     reason="Bond SLB is only supported by NM 1.41 with patched kernel",
 )
 def test_bond_balance_slb():
@@ -207,9 +205,6 @@ def vlan_is_up_with_ip():
     is_k8s(), reason="K8S cannot restart NetworkManager daemon"
 )
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    is_el8(), reason="CentOS Stream 8 does not have the fix yet"
-)
 # Detailed context is https://bugzilla.redhat.com/show_bug.cgi?id=2207690
 def test_vlan_over_bond_reconnect_on_link_revive(
     ignore_carrier_no, vlan_over_bond_with_port_down

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -190,9 +190,6 @@ def verify_ovs_ports(bridge_name, port_names):
     assert cur_ports == port_names
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 41, reason="ECMP route is only support on NM 1.41+"
-)
 def test_gen_conf_ecmp_routes():
     desired_state = load_yaml(
         """---

--- a/tests/integration/nm/route_rule_test.py
+++ b/tests/integration/nm/route_rule_test.py
@@ -4,7 +4,6 @@ import libnmstate
 import pytest
 import yaml
 
-from ..testlib.env import nm_minor_version
 from ..testlib.cmdlib import exec_cmd
 
 
@@ -24,10 +23,6 @@ def cleanup_loopback():
     )
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason=("Loopback is only supported by NetworkManager 1.41+"),
-)
 def test_store_route_table_local_rule_to_loopback(cleanup_loopback):
     libnmstate.apply(
         yaml.load(

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -11,7 +11,6 @@ import yaml
 
 from ..testlib.cmdlib import exec_cmd
 from ..testlib.dummy import dummy_interface
-from ..testlib.env import nm_minor_version
 from ..testlib.ifacelib import get_mac_address
 from ..testlib.iproutelib import ip_monitor_assert_stable_link_up
 from ..testlib.route import assert_routes
@@ -102,10 +101,6 @@ def test_preserve_old_gateway(eth1_with_old_gateway_format):
     )
 
 
-@pytest.mark.skipif(
-    nm_minor_version() <= 42,
-    reason="NM does not wait DHCP to assign static route",
-)
 @pytest.mark.tier1
 def test_route_delayed_by_nm_fails(eth1_up):
     with pytest.raises(NmstateVerificationError):

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -32,7 +32,6 @@ from .testlib import statelib
 from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import linux_bridge
 from .testlib.env import is_k8s
-from .testlib.env import nm_minor_version
 from .testlib.genconf import gen_conf_apply
 from .testlib.nmplugin import disable_nm_plugin
 from .testlib.ovslib import Bridge
@@ -465,19 +464,11 @@ def bridge_port_with_trunks():
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="OVS VLAN trunks was not supported in NM",
-)
 def test_ovs_vlan_trunks(bridge_port_with_trunks):
     assertlib.assert_state_match(bridge_port_with_trunks)
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="OVS VLAN trunks was not supported in NM",
-)
 def test_remove_ovs_vlan_trunks(bridge_port_with_trunks):
     br1_state = statelib.show_only((BRIDGE1,))[Interface.KEY][0]
     port_state = br1_state[OVSBridge.CONFIG_SUBTREE][OVSBridge.PORT_SUBTREE][0]
@@ -1893,10 +1884,6 @@ def test_ovs_detach_2_ports_from_4_ports_ovs_bond(
 
 # OpenStack use case
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="OVS interface level other_config is not supported in NM 1.40-",
-)
 def test_ovs_bond_other_config_and_remove(
     cleanup_ovs_bridge, eth1_up, eth2_up
 ):
@@ -1952,10 +1939,6 @@ def test_ovs_bond_other_config_and_remove(
 
 # OpenStack use case
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="OVS interface level other_config is not supported in NM 1.40-",
-)
 def test_ovs_bridge_other_config_and_remove(
     cleanup_ovs_bridge, eth1_up, eth2_up
 ):
@@ -2007,10 +1990,6 @@ def test_ovs_bridge_other_config_and_remove(
 
 # OpenStack use case
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="OVS interface level other_config is not supported in NM 1.40-",
-)
 def test_ovs_sys_iface_other_config_and_remove(
     cleanup_ovs_bridge, eth1_up, eth2_up
 ):

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -20,7 +20,6 @@ from .testlib import cmdlib
 from .testlib import iprule
 from .testlib.bridgelib import linux_bridge
 from .testlib.dummy import dummy_interface
-from .testlib.env import nm_minor_version
 from .testlib.genconf import gen_conf_apply
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
@@ -153,11 +152,6 @@ def test_add_static_route_without_next_hop_address(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_add_static_route_with_route_type(eth1_up):
     route = [
         {
@@ -196,11 +190,6 @@ def test_add_static_route_with_route_type(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_add_static_route_and_apply_route_absent(eth1_up):
     routes = [
         {
@@ -238,11 +227,6 @@ def test_add_static_route_and_apply_route_absent(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_add_static_Ipv4_route_with_route_type(eth1_up):
     routes = [
         {
@@ -265,11 +249,6 @@ def test_add_static_Ipv4_route_with_route_type(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_route_type_with_next_hop_interface(eth1_up):
     route = [
         {
@@ -288,11 +267,6 @@ def test_route_type_with_next_hop_interface(eth1_up):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42,
-    reason="Loopback is only support on NM 1.42+, and blackhole type route "
-    "is stored in loopback",
-)
 def test_apply_route_with_route_type_multiple_times(eth1_up):
     routes = [
         {
@@ -694,11 +668,6 @@ def test_iface_down_with_routes_in_current(eth1_up, get_routes_func):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 46,
-    reason="Assigning static route to device without IP addresses is only "
-    "support on NM 1.46+",
-)
 def test_static_route_with_empty_ip(eth1_up):
     eth1_state = copy.deepcopy(ETH1_INTERFACE_STATE)
     eth1_state[Interface.IPV4] = {
@@ -1353,9 +1322,6 @@ def test_route_rule_from_all_to_all_ipv6(route_rule_test_env):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 42, reason="Loopback is only support on NM 1.42+"
-)
 def test_route_rule_add_and_remove_using_loopback():
     desired_state = {
         RouteRule.KEY: {
@@ -1913,9 +1879,6 @@ def test_preserve_unmanaged_routes(eth1_static_ip):
 
 
 @pytest.mark.tier1
-@pytest.mark.skipif(
-    nm_minor_version() < 41, reason="ECMP route is only support on NM 1.41+"
-)
 def test_add_and_remove_ecmp_route(eth1_static_ip):
     routes = [
         {

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -16,7 +16,6 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
 from .testlib.dummy import nm_unmanaged_dummy
-from .testlib.env import is_el8
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.iproutelib import iproute_get_ip_addrs_with_order
@@ -951,11 +950,6 @@ def test_preserve_ipv4_addresses_order(eth1_up):
     assert ip_addrs[1] == IPV4_ADDRESS1
 
 
-@pytest.mark.skipif(
-    is_el8(),
-    reason="RHEL 8 hold different IPv6 address order in rpm between "
-    "downstream shipped and copr main branch built",
-)
 def test_preserve_ipv6_addresses_order(eth1_up):
     desired_state = {
         Interface.KEY: [

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -21,10 +21,6 @@ def is_k8s():
     return os.getenv("RUN_K8S") == "true"
 
 
-def is_el8():
-    return exec_cmd("rpm -E %{?rhel}".split())[1].strip() == "8"
-
-
 def nm_libreswan_version_int():
     ret_code, version_str, _ = exec_cmd(
         "rpm -q NetworkManager-libreswan --qf %{VERSION}".split()

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -312,10 +312,6 @@ def test_preserve_existing_vlan_conf(eth1_up):
         assertlib.assert_state(desired_state)
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="Modifying VLAN protocol is not supported on NM 1.41-.",
-)
 def test_change_vlan_protocol(vlan_on_eth1):
     dot1q_state = {
         Interface.KEY: [
@@ -360,10 +356,6 @@ def test_change_vlan_protocol(vlan_on_eth1):
     assertlib.assert_state_match(dot1q_state)
 
 
-@pytest.mark.skipif(
-    nm_minor_version() < 41,
-    reason="Modifying VLAN protocol is not supported on NM 1.41-.",
-)
 def test_add_qinq_vlan(eth1_up):
     with vlan_interface(
         VLAN_IFNAME,


### PR DESCRIPTION
Bumping minimum supported NetworkManager version to 1.46 which is
shipped by RHEL 9.4 and Ubuntu 24.04.

Removed the workaround in 802.1Q VLAN for NM 1.41-.

Did not remove other workaround codes because they will cause nmstate
not working in NM 1.46- at all.

Since the RHEL 8.10 is shipping NM 1.40, also removed the code for
running the tests in RHEL 8.

Assuming NM version for test is 1.46+, hence removed all the
conditional skip checker code for 1.46.

Changed github CI to run test on 1.46.