### PR TITLE
route: detect nexthop conflicts and raise error

### DIFF
--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -766,6 +766,8 @@ impl MergedRoutes {
         merged_routes.sort_unstable();
         merged_routes.dedup();
 
+        validate_conflicting_routes(&merged_routes, &desired_routes)?;
+
         let mut merged: HashMap<String, Vec<RouteEntry>> = HashMap::new();
 
         for rt in merged_routes {
@@ -873,5 +875,64 @@ fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
             return Ok(());
         }
     }
+    Ok(())
+}
+
+fn validate_conflicting_routes(
+    merged: &[RouteEntry],
+    desired: &[RouteEntry],
+) -> Result<(), NmstateError> {
+    let mut conflict_map = HashMap::new();
+    let desired: HashSet<&RouteEntry> = HashSet::from_iter(desired.iter());
+
+    for route in merged.iter() {
+        let destination =
+            if let Some(destination) = route.destination.as_deref() {
+                destination
+            } else {
+                return Err(NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "Route to {} is present, but has no destination",
+                        route.next_hop_addr.as_deref().unwrap_or("")
+                    ),
+                ));
+            };
+
+        let nexthop = route.next_hop_addr.as_deref().unwrap_or("");
+        let existing_nexthop = conflict_map.insert(
+            (
+                destination,
+                route.metric.unwrap_or_default(),
+                route.table_id.unwrap_or(DEFAULT_TABLE_ID),
+                route
+                    .route_type
+                    .as_ref()
+                    .map(|t| u8::from(*t))
+                    .unwrap_or_default(),
+            ),
+            nexthop,
+        );
+
+        if existing_nexthop.is_some()
+            && existing_nexthop != Some(nexthop)
+            && route.weight.is_none()
+            && desired.contains(route)
+        {
+            let nexthop_a = existing_nexthop.unwrap_or("");
+            let nexthop_b = route.next_hop_addr.as_deref().unwrap_or("");
+
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Route to {destination} has conflicting nexthop \
+                     ({nexthop_a}; {nexthop_b}). Either set the existing \
+                     route to 'absent', or set their 'weight' (for ECMP) or \
+                     'metric' value"
+                ),
+            ));
+        }
+    }
+
     Ok(())
 }

--- a/rust/src/lib/unit_tests/gen_diff_test_files/change_routes_only/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/change_routes_only/desired.yml
@@ -29,6 +29,14 @@ interfaces:
 routes:
   config:
   - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    state: absent
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+    state: absent
+  - destination: 0.0.0.0/0
     next-hop-address: 192.0.2.2
     next-hop-interface: eth1
   - destination: ::/0

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -864,3 +864,157 @@ fn test_route_advmss_deserialize_from_string() {
 
     assert_eq!(route.advmss, Some(1500));
 }
+
+#[test]
+fn test_implicit_route_nexthop_change_forbidden() {
+    let cur_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-interface: eth1
+          next-hop-address: 192.0.2.1
+          table-id: 200
+        - destination: ::/0
+          next-hop-interface: eth1
+          next-hop-address: 2001:db8:1::3
+          table-id: 200
+        ",
+    )
+    .unwrap();
+
+    let des_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-address: 192.0.2.2
+          next-hop-interface: eth1
+          table-id: 200
+        - destination: ::/0
+          next-hop-address: 2001:db8:1::2
+          next-hop-interface: eth1
+          table-id: 200
+        ",
+    )
+    .unwrap();
+
+    let (merged_ifaces, _current_ifaces) = gen_merged_ifaces_for_route_test();
+    let merged_err =
+        MergedRoutes::new(des_routes, cur_routes, &merged_ifaces).unwrap_err();
+
+    assert_eq!(merged_err.kind(), ErrorKind::InvalidArgument);
+    assert!(merged_err.msg().contains("conflicting nexthop"));
+}
+
+#[test]
+fn test_explicit_route_nexthop_change() {
+    let cur_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-interface: eth1
+          next-hop-address: 192.0.2.1
+          table-id: 200
+        - destination: ::/0
+          next-hop-interface: eth2
+          next-hop-address: 2001:db8:1::3
+          table-id: 200
+        ",
+    )
+    .unwrap();
+
+    let des_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-interface: eth1
+          next-hop-address: 192.0.2.1
+          table-id: 200
+          state: absent
+        - destination: 0.0.0.0/0
+          next-hop-address: 192.0.2.2
+          next-hop-interface: eth1
+          table-id: 200
+        - destination: ::/0
+          next-hop-interface: eth2
+          next-hop-address: 2001:db8:1::3
+          table-id: 200
+          state: absent
+        - destination: ::/0
+          next-hop-address: 2001:db8:1::2
+          next-hop-interface: eth2
+          table-id: 200
+        ",
+    )
+    .unwrap();
+
+    let (merged_ifaces, _current_ifaces) = gen_merged_ifaces_for_route_test();
+    let merged_routes =
+        MergedRoutes::new(des_routes, cur_routes, &merged_ifaces).unwrap();
+
+    assert_eq!(
+        merged_routes.merged.get("eth1").unwrap()[0].destination,
+        Some("0.0.0.0/0".to_string())
+    );
+    assert_eq!(
+        merged_routes.merged.get("eth1").unwrap()[0].next_hop_addr,
+        Some("192.0.2.2".to_string())
+    );
+
+    assert_eq!(
+        merged_routes.merged.get("eth2").unwrap()[0].destination,
+        Some("::/0".to_string())
+    );
+    assert_eq!(
+        merged_routes.merged.get("eth2").unwrap()[0].next_hop_addr,
+        Some("2001:db8:1::2".to_string())
+    );
+}
+
+// Ensures that absent routes are not detected as
+// conflicting with other (desired) routes.
+#[test]
+fn test_nexthop_change_absent_routes() {
+    let cur_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - destination: 0.0.0.0/0
+          next-hop-interface: eth1
+          next-hop-address: 192.0.2.1
+          table-id: 200
+          mtu: 1280
+        ",
+    )
+    .unwrap();
+
+    let des_routes: Routes = serde_yaml::from_str(
+        r"
+        config:
+        - mtu: 1280
+          state: absent
+        - next-hop-address: 192.0.2.1
+          state: absent
+        - next-hop-address: 192.0.2.2
+          state: absent
+        - destination: 0.0.0.0/0
+          next-hop-address: 192.0.2.2
+          next-hop-interface: eth1
+          table-id: 200
+        ",
+    )
+    .unwrap();
+
+    let (merged_ifaces, _current_ifaces) = gen_merged_ifaces_for_route_test();
+    let merged_routes =
+        MergedRoutes::new(des_routes, cur_routes, &merged_ifaces).unwrap();
+
+    assert_eq!(merged_routes.merged.len(), 1);
+
+    assert_eq!(
+        merged_routes.merged.get("eth1").unwrap()[0].destination,
+        Some("0.0.0.0/0".to_string())
+    );
+    assert_eq!(
+        merged_routes.merged.get("eth1").unwrap()[0].next_hop_addr,
+        Some("192.0.2.2".to_string())
+    );
+}


### PR DESCRIPTION
Currently, when a user tries to create a route which already exists, but has a different nexthop, nmstate returns a cryptic error:

Got netlink unknown error: code -22, msg: Invalid argument (os error 22)

When this happens, it is unclear whether the user
wants to create a new route, or alter existing
routes. Raise an error explaining what needs to
be changed by the user.

Resolves: https://issues.redhat.com/browse/NMT-1537