### PR TITLE
test: ipsec: Rename `pull_ipsec_srv_container_image()` to `IpsecTestEnv.prepare()`

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@ from libnmstate.schema import RouteRule
 from .testlib import ifacelib
 from .testlib.veth import create_veth_pair
 from .testlib.veth import remove_veth_pair
-from .testlib.ipsec import pull_ipsec_srv_container_image
+from .testlib.ipsec import IpsecTestEnv
 
 
 REPORT_HEADER = """RPMs: {rpms}
@@ -94,7 +94,7 @@ def _mark_tier2_tests(items):
 
 @pytest.fixture(scope="session", autouse=True)
 def test_env_setup():
-    pull_ipsec_srv_container_image()
+    IpsecTestEnv.prepare()
     _logging_setup()
     old_state = libnmstate.show()
     old_state = _remove_interfaces_from_env(old_state)

--- a/tests/integration/testlib/ipsec.py
+++ b/tests/integration/testlib/ipsec.py
@@ -83,6 +83,21 @@ class IpsecTestEnv:
         "ZM9ZiX2oLC6i+osr2u2UhvQ6PXVvOwdn19u310kyH+T6T4wQLnZZ68="
     )
 
+    def prepare():
+        """
+        Pull the container image, please run this when you still
+        have internet access.
+        """
+        i = 0
+        while i < 5:
+            try:
+                exec_cmd(
+                    f"podman pull {SRV_CONTAINER_IMG}".split(), check=True
+                )
+                break
+            except SubprocessError:
+                i += 1
+
     def setup():
         try:
             start_ipsec_srv_container()
@@ -377,17 +392,6 @@ def _start_ipsec_connection(conf_path):
         ],
         check=True,
     )
-
-
-def pull_ipsec_srv_container_image():
-    i = 0
-    while i < 5:
-        try:
-            exec_cmd(f"podman pull {SRV_CONTAINER_IMG}".split(), check=True)
-            break
-        except SubprocessError:
-            i += 1
-            pass
 
 
 def _restart_ipsec_service():


### PR DESCRIPTION
Rename `pull_ipsec_srv_container_image()` to `IpsecTestEnv.prepare()` in
`testlib/ipsec.py` so NMCI could consume.