### PR TITLE
pci: Fix deletion of PCI address identifier config

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -293,7 +293,7 @@ impl<'de> Deserialize<'de> for Interface {
     {
         let mut v = serde_json::Value::deserialize(deserializer)?;
 
-        // Ignore all properties except type if state: absent
+        // Only included minimum properties for state: absent
         if matches!(
             Option::deserialize(&v["state"])
                 .map_err(serde::de::Error::custom)?,
@@ -314,6 +314,9 @@ impl<'de> Deserialize<'de> for Interface {
             }
             if let Some(s) = v.get("mac-address") {
                 new_value.insert("mac-address".to_string(), s.clone());
+            }
+            if let Some(s) = v.get("pci-address") {
+                new_value.insert("pci-address".to_string(), s.clone());
             }
             v = serde_json::value::Value::Object(new_value);
         }

--- a/tests/integration/pci_identifer_test.py
+++ b/tests/integration/pci_identifer_test.py
@@ -200,3 +200,22 @@ class TestPciIdentifer:
             """
         )
         assert_state_match(expected_state)
+
+    def test_delete_pci_ref_eth(self, eth_pci_ref):
+        iface_name = _test_nic_name()
+        pci_address = _test_nic_pci()
+        desired_state = load_yaml(
+            f"""---
+            interfaces:
+            - name: {ETH_PROFILE_NAME}
+              type: ethernet
+              state: absent
+              identifier: pci-address
+              pci-address: "{pci_address}"
+            """
+        )
+        libnmstate.apply(desired_state)
+
+        # the profile name should not be found any more in current
+        iface_state = show_only((iface_name,))[Interface.KEY][0]
+        assert Interface.PROFILE_NAME not in iface_state


### PR DESCRIPTION
When deleting config of PCI address identifier interface via YAML:

```
---
interfaces:
  - name: wan0
    type: ethernet
    state: absent
    identifier: pci-address
    pci-address: 0000:07:00.0
```

Nmstate failed to delete so because nmstate discard the `pci-address`
during deserialization. Fixed by include `pci-address` for `absent`
interface during deserialization.

Integration test case included.