### PR TITLE
bond: Fix removing mac-restricted bond

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1554,6 +1554,9 @@ impl MergedInterface {
     pub(crate) fn post_inter_ifaces_process_bond(
         &mut self,
     ) -> Result<(), NmstateError> {
+        if self.merged.is_absent() {
+            return Ok(());
+        }
         if let Some(Interface::Bond(apply_iface)) = self.for_apply.as_ref() {
             apply_iface
                 .validate_new_iface_with_no_mode(self.current.as_ref())?;

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1669,3 +1669,42 @@ def test_bond_disable_arp_interval_with_existing_ns_ip6_target(
     )
     libnmstate.apply(state)
     assertlib.assert_state_match(state)
+
+
+@pytest.fixture
+def bond99_with_mac_restriction(eth1_up, eth2_up):
+    with bond_interface(
+        name=BOND99,
+        port=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+                Bond.OPTIONS_SUBTREE: {"fail_over_mac": "active"},
+            },
+        },
+    ) as state:
+        yield state
+
+
+# https://issues.redhat.com/browse/RHEL-102600
+@pytest.mark.tier1
+def test_delete_bond_with_mac_restriction(bond99_with_mac_restriction):
+    bond99_mac = get_mac_address(BOND99)
+    state = yaml.load(
+        f"""---
+        interfaces:
+         - name: {BOND99}
+           type: bond
+           state: absent
+           mac-address: {bond99_mac}
+           identifier: name
+           bond:
+             mode: active_backup
+             options:
+               fail_over_mac: active
+           """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(state)
+
+    assertlib.assert_absent(BOND99)


### PR DESCRIPTION
Given a bond cannot hold customized MAC address (active-backup mode with
`fail_over_mac: active`),
When applying desired state with full detail of this bond
Then nmstate will fail with error

```
NmstateValueError: MAC address cannot be specified in bond interface
along with fail_over_mac active on active backup mode
```

This is because nmstate incorrectly run validation on interface been
marked as `absent`.

Fixed by skipping validation on absent bond interface.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-102600