### PR TITLE
nm: Do not bring up deactivated NmConnection when purging DNS

### DIFF
--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -253,6 +253,12 @@ pub(crate) fn purge_dns_config(
             }
             if !iface.is_changed() {
                 iface.mark_as_changed();
+                // For DNS stored in deactivate NmConnection, we should not
+                // activate it
+                if let Some(apply_iface) = iface.for_apply.as_mut() {
+                    apply_iface.base_iface_mut().state =
+                        iface.merged.base_iface().state;
+                }
             }
             if let Some(apply_iface) = iface.for_apply.as_mut() {
                 if apply_iface.base_iface().can_have_ip() {

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -20,6 +20,7 @@ from .testlib import cmdlib
 from .testlib.bondlib import bond_interface
 from .testlib.genconf import gen_conf_apply
 from .testlib.servicelib import disable_service
+from .testlib.statelib import show_only
 from .testlib.yaml import load_yaml
 
 
@@ -669,3 +670,54 @@ def test_kernel_mode_dns_and_purge():
         libnmstate.apply(desired_state, kernel_only=True)
         cur_state = libnmstate.show(kernel_only=True)
         assert not cur_state[DNS.KEY][DNS.CONFIG]
+
+
+@pytest.fixture
+def down_eth1_eth2_with_dns(static_dns):
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.DOWN,
+                },
+                {
+                    Interface.NAME: "eth2",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.DOWN,
+                },
+            ]
+        }
+    )
+    yield
+
+
+# https://issues.redhat.com/browse/RHEL-102333
+@pytest.mark.tier1
+def test_do_not_activate_down_iface_with_dns_when_purging(
+    down_eth1_eth2_with_dns,
+):
+    eth1_state = show_only(("eth1",))[Interface.KEY][0]
+    eth2_state = show_only(("eth2",))[Interface.KEY][0]
+
+    assert eth1_state[Interface.STATE] == InterfaceState.DOWN
+    assert eth2_state[Interface.STATE] == InterfaceState.DOWN
+
+    purge_dns = {
+        DNS.KEY: {
+            DNS.CONFIG: {
+                DNS.SERVER: [],
+                DNS.SEARCH: [],
+                DNS.OPTIONS: [],
+            }
+        }
+    }
+
+    libnmstate.apply(purge_dns)
+
+    eth1_state = show_only(("eth1",))[Interface.KEY][0]
+    eth2_state = show_only(("eth2",))[Interface.KEY][0]
+
+    assert eth1_state[Interface.STATE] == InterfaceState.DOWN
+    assert eth2_state[Interface.STATE] == InterfaceState.DOWN


### PR DESCRIPTION
Given deactivated NmConnection holding DNS informations,
When purging DNS via nmstate
Then nmstate will remove the DNS setting in deactivated NmConnection and
activate it afterwards.

Fix it by copy current interface state when marking interface with DNS
as changed.

Resolves: https://issues.redhat.com/browse/RHEL-102333