### PR TITLE
query_apply: ethernet: ignore speed when auto-negotiation is true

### DIFF
--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -13,6 +13,13 @@ impl EthernetInterface {
         {
             sriov_conf.sanitize_desired_for_verify();
         }
+
+        if let Some(eth_conf) = self.ethernet.as_mut() {
+            if eth_conf.auto_neg == Some(true) {
+                eth_conf.speed = None;
+                eth_conf.duplex = None;
+            }
+        }
     }
 
     pub(crate) fn sriov_is_enabled(&self) -> bool {

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ErrorKind, EthernetInterface, InterfaceIdentifier, InterfaceType,
-    Interfaces, MergedInterfaces,
+    ErrorKind, EthernetConfig, EthernetDuplex, EthernetInterface, Interface,
+    InterfaceIdentifier, InterfaceType, Interfaces, MergedInterfaces,
 };
 
 #[test]
@@ -392,4 +392,68 @@ fn test_mac_identifer_check_iface_type_also() {
         Some(InterfaceIdentifier::MacAddress).as_ref()
     );
     assert_eq!(des_iface.base_iface().profile_name.as_deref(), Some("wan0"))
+}
+
+#[test]
+fn test_ignore_speed_duplex_when_auto_negotiate() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            auto-negotiation: true
+            speed: 900
+            duplex: half
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            auto-negotiation: true
+            speed: 1000
+            duplex: full
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
+    merged_ifaces.verify(&cur_ifaces).unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            auto-negotiation: false
+            speed: 1000
+            duplex: full
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces.clone(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let result = merged_ifaces.verify(&cur_ifaces);
+
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap().kind(), ErrorKind::VerificationError);
 }


### PR DESCRIPTION
Update EthernetInterface sanitize_desired_before_verify to change speed and duplex to None.

Resolves: https://issues.redhat.com/browse/NMT-1542