### PR TITLE
rpm: don't call to setup.py directly

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -29,7 +29,12 @@ Source3:        %{url}/releases/download/v%{version}/%{srcname}-vendor-%{version
 %endif
 %endif
 BuildRequires:  python3-devel
+%if 0%{?fedora} >= 43
+%define use_pyproject 1
+%else
+%define use_pyproject 0
 BuildRequires:  python3-setuptools
+%endif
 BuildRequires:  gnupg2
 BuildRequires:  systemd-rpm-macros
 %if 0%{?rhel}
@@ -59,6 +64,13 @@ BuildRequires:  (crate(tokio/net) >= 1.3 with crate(tokio/net) < 2.0)
 BuildRequires:  (crate(tokio/rt) >= 1.3 with crate(tokio/rt) < 2.0)
 BuildRequires:  (crate(tokio/signal) >= 1.3 with crate(tokio/signal) < 2.0)
 %endif
+%endif
+
+%if %{use_pyproject}
+%generate_buildrequires
+pushd rust/src/python >/dev/null
+%pyproject_buildrequires
+popd >/dev/null
 %endif
 
 %description
@@ -188,7 +200,11 @@ pushd rust
 popd
 
 pushd rust/src/python
+%if %{use_pyproject}
+%pyproject_wheel
+%else
 %py3_build
+%endif
 popd
 
 %install
@@ -199,7 +215,11 @@ env SKIP_PYTHON_INSTALL=1 \
     %make_install
 
 pushd rust/src/python
+%if %{use_pyproject}
+%pyproject_install
+%else
 %py3_install
+%endif
 popd
 
 %if ! 0%{?rhel} && ! %{is_snapshot}
@@ -241,7 +261,11 @@ popd
 %files -n python3-%{libname}
 %license LICENSE
 %{python3_sitelib}/%{libname}
+%if %{use_pyproject}
+%{python3_sitelib}/%{srcname}-*.dist-info/
+%else
 %{python3_sitelib}/%{srcname}-*.egg-info/
+%endif
 
 %files static
 %{_libdir}/libnmstate.a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Building by directly calling to setup.py has been deprecated for 5 years now by upstream Setuptools. Because of that, Fedora is deprecating it and it will stop working in Fedora 45, having to change to a pyproject.toml based macros. Macros calling to setup.py are those starting by %py3_*, and the new ones are %pyproject_*. See https://fedoraproject.org/wiki/Changes/DeprecateSetuppyMacros.

Replace the %py3_* macros by their %pyproject_* counterparts.

Also, adapt the pyproject.toml [build-system] section per Setuptool documentation:
- Don't explicitly add the "wheel" dependency. It's not directly used in setup.py, so not needed, see [1].
- Add "build-backend" value.

[1] Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended, as the backend no longer requires the wheel package, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).