### PR TITLE
ip forward: Fix error on enable forwarding with DHCP

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -303,16 +303,11 @@ impl InterfaceIpv4 {
             }
         }
 
-        if let Some(forwarding) = self.forwarding {
-            if !self.enabled && forwarding {
-                if is_desired {
-                    log::warn!(
-                        "Ignoring `forwarding: {forwarding}` as IPv4 is \
-                         disabled",
-                    );
-                }
-                self.forwarding = None;
+        if !self.enabled {
+            if is_desired && self.forwarding == Some(true) {
+                log::warn!("Ignoring `forwarding: true` as IPv4 is disabled",);
             }
+            self.forwarding = None;
         }
 
         if let Some(addrs) = self.addresses.as_mut() {

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -21,6 +21,7 @@ const ADDR_GEN_MODE_STABLE_DEFAULT: i32 = 3;
 
 pub(crate) fn nm_ip_setting_to_nmstate4(
     nm_ip_setting: &NmSettingIp,
+    saved_nm_ip_setting: Option<&NmSettingIp>,
 ) -> InterfaceIpv4 {
     if let Some(nm_ip_method) = &nm_ip_setting.method {
         let (enabled, dhcp) = match nm_ip_method {
@@ -38,6 +39,19 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             nm_ip_setting.dhcp_send_hostname.unwrap_or(true)
         } else {
             false
+        };
+
+        // When interface been set to DHCP, NetworkManager only set IP
+        // forwarding after DHCP lease acquired.
+        // During DHCP process, the kernel will have no IP show as disabled,
+        // NM backend should provide forwarding value to override nispor
+        // data when DHCP enabled.
+        let forwarding = if dhcp == Some(true) {
+            saved_nm_ip_setting
+                .and_then(|s| s.forwarding)
+                .map(|f| f > 0)
+        } else {
+            None
         };
 
         let (auto_dns, auto_gateway, auto_routes, auto_table_id) =
@@ -75,6 +89,7 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             } else {
                 None
             },
+            forwarding,
             ..Default::default()
         }
     } else {

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -206,8 +206,17 @@ pub(crate) async fn nm_retrieve(
     Ok(net_state)
 }
 
-fn fill_ip_settings(base_iface: &mut BaseInterface, nm_conn: &NmConnection) {
-    base_iface.ipv4 = nm_conn.ipv4.as_ref().map(nm_ip_setting_to_nmstate4);
+fn fill_ip_settings(
+    base_iface: &mut BaseInterface,
+    nm_conn: &NmConnection,
+    nm_saved_conn: Option<&NmConnection>,
+) {
+    base_iface.ipv4 = nm_conn.ipv4.as_ref().map(|nm_conn| {
+        nm_ip_setting_to_nmstate4(
+            nm_conn,
+            nm_saved_conn.and_then(|c| c.ipv4.as_ref()),
+        )
+    });
     base_iface.ipv6 = nm_conn.ipv6.as_ref().map(|nm_ip_set| {
         nm_ip_setting_to_nmstate6(base_iface.name.as_str(), nm_ip_set)
     });
@@ -227,7 +236,7 @@ pub(crate) fn fill_iface_by_nm_conn_data(
 
     // Fallback to saved NmConnection when applied is empty
     if let Some(nm_conn) = nm_applied_conn.or(nm_saved_conn) {
-        fill_ip_settings(base_iface, nm_conn);
+        fill_ip_settings(base_iface, nm_conn, nm_saved_conn);
         base_iface.description = get_description(nm_conn);
         fill_identifier(base_iface, nm_conn);
         base_iface.profile_name = get_connection_name(nm_conn, nm_saved_conn);

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -22,6 +22,11 @@ impl InterfaceIpv4 {
         if self.dhcp.is_none() {
             self.dhcp = Some(false);
         }
+
+        // No forwarding means off
+        if self.forwarding.is_none() {
+            self.forwarding = Some(false);
+        }
     }
 
     // Sort addresses and dedup
@@ -81,6 +86,9 @@ impl InterfaceIpv4 {
         if other.dhcp_custom_hostname.is_some() {
             self.dhcp_custom_hostname
                 .clone_from(&other.dhcp_custom_hostname);
+        }
+        if other.forwarding.is_some() {
+            self.forwarding = other.forwarding;
         }
     }
 }

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -32,6 +32,7 @@ from .testlib import bondlib
 from .testlib import ifacelib
 from .testlib import statelib
 from .testlib.env import is_k8s
+from .testlib.env import nm_minor_version
 from .testlib.apply import apply_with_description
 from .testlib.ifacelib import get_mac_address
 from .testlib.bridgelib import add_port_to_bridge
@@ -2371,3 +2372,55 @@ def get_dhcp_addr(iface_state):
         and addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH] == 128
     ]
     return (DHCPV4_ADDRS, DHCPV6_ADDRS)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 54,
+    reason="IPv4 forwarding is not supported on NM 1.54-",
+)
+@pytest.mark.parametrize(
+    "forward_val",
+    [True, False],
+    ids=["forward_on", "forward_off"],
+)
+def test_ip_forwarding_with_dhcp_enabled_on_dummy_interface(
+    forward_val, dummy00
+):
+    """
+    NetworkManager only apply ip forwarding after DHCP done.
+    Nmstate should not wait DHCP and should pass the verification even DHCP
+    server is down.
+    """
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+          - name: dummy00
+            type: dummy
+            ipv4:
+              dhcp: true
+              enabled: true
+              forwarding: {forward_val}
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() >= 54,
+    reason="IPv4 forwarding is supported on NM 1.54+",
+)
+def test_ip_forwarding_on_dhcp_dummy_interface_with_old_nm(dummy00):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+          - name: dummy00
+            type: dummy
+            ipv4:
+              dhcp: true
+              enabled: true
+              forwarding: false
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)


### PR DESCRIPTION
NetworkManager only apply IP forward setting after DHCP finished.
On interface with DHCP server down or bridge STP enabled, nmstate will
get verification error because NM not set desired IP forward setting
yet.

Fixed by using NetworkManager config for forwarding when DHCP enabled.

On older NetworkManager without IP forward settings, during DHCP
process, nispor see the interface as IP disabled while NM see it as IP
enabled with DHCP. Nmstate will get verification error on desired
`false` vs current `null`.

Fixed by sanitize `forwarding: None` to `forwarding: false` when IP
enabled.

Integration test cases included.