### PR TITLE
service: Wait on NetworkManager-wait-online.service

### DIFF
--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Apply nmstate on-disk state
 Documentation=man:nmstate.service(8) https://www.nmstate.io
-After=NetworkManager.service
+After=NetworkManager-wait-online.service
 Before=network-online.target
+Requires=NetworkManager-wait-online.service
 Requires=NetworkManager.service
 
 [Service]


### PR DESCRIPTION
When applying this policy via nmstate.service (`/etc/nmstate/desired.yml`):

```yml
capture:
  default-gw-route: routes.running.destination=="0.0.0.0/0"
  default-gw-iface: interfaces.name==capture.default-gw-route.routes.running.0.next-hop-interface
desired:
  interfaces:
  - name: "{{ capture.default-gw-iface.interfaces.0.name }}"
    type: ethernet
    state: up
  - name: br-ex
    type: linux-bridge
    copy-mac-from: "{{ capture.default-gw-iface.interfaces.0.name }}"
    state: up
    ipv4: "{{ capture.default-gw-iface.interfaces.0.ipv4 }}"
    ipv6: "{{ capture.default-gw-iface.interfaces.0.ipv6 }}"
    bridge:
      port:
      - name: "{{ capture.default-gw-iface.interfaces.0.name }}"
```

We got failure indicate no interface is holding route to `0.0.0.0/0`.

This is because `nmstate.service` did not wait NetworkManager activating
all connections.

Hence change `nmstate.service` to wait on
`NetworkManager-wait-online.service`.

No test case created because this require OS boot up.

Manually tested.