### PR TITLE
New release 2.2.48

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
 # Changelog
+## [2.2.48] - 2025-07-11
+### Breaking changes
+ - Reverted IP forwarding support, will add back later. (7d1da41d)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - service: Wait on NetworkManager-wait-online.service. (f85f08a9)
+ - pci: Fix typo `MAC address` vs `PCI address`. (719053da)
+
 ## [2.2.47] - 2025-07-10
 ### Breaking changes
  - Bump minimum supported NetworkManager version 1.46. (92f6f1cf)


### PR DESCRIPTION
=== Breaking changes
 - Reverted IP forwarding support, Will add back later. (7d1da41d)

=== New features
 - N/A

=== Bug fixes
 - service: Wait on NetworkManager-wait-online.service. (f85f08a9)
 - pci: Fix typo `MAC address` vs `PCI address`. (719053da)

Signed-off-by: Gris Ge <fge@redhat.com>