### PR TITLE
nispor: delete ip addr not in desired state

### DIFF
--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -37,11 +37,11 @@ pub(crate) async fn nispor_apply(
 
     let mut np_ifaces: Vec<nispor::IfaceConf> = Vec::new();
     for merged_iface in ifaces.iter().filter(|i| {
-        i.merged.iface_type() != InterfaceType::Unknown && !i.merged.is_absent()
+        i.merged.iface_type() != InterfaceType::Unknown
+            && !i.merged.is_absent()
+            && i.for_apply.as_ref().is_some()
     }) {
-        if let Some(iface) = merged_iface.for_apply.as_ref() {
-            np_ifaces.push(nmstate_iface_to_np(iface)?);
-        }
+        np_ifaces.push(nmstate_iface_to_np(merged_iface)?);
     }
 
     let mut net_conf = nispor::NetConf::default();
@@ -88,9 +88,17 @@ fn nmstate_iface_type_to_np(
 }
 
 fn nmstate_iface_to_np(
-    nms_iface: &Interface,
+    nms_merged_iface: &MergedInterface,
 ) -> Result<nispor::IfaceConf, NmstateError> {
     let mut np_iface = nispor::IfaceConf::default();
+    let nms_iface = match nms_merged_iface.for_apply.as_ref() {
+        Some(iface) => iface,
+        None => {
+            let error =
+                NmstateError::new(ErrorKind::Bug, "BUG: merged_interface.for_apply was assumed to be Some but None was found".to_string());
+            return Err(error);
+        }
+    };
 
     let mut np_iface_type = nmstate_iface_type_to_np(&nms_iface.iface_type());
 
@@ -113,9 +121,10 @@ fn nmstate_iface_to_np(
     if let Some(ctrl_name) = &base_iface.controller {
         np_iface.controller = Some(ctrl_name.to_string())
     }
+
     if base_iface.can_have_ip() {
-        np_iface.ipv4 = Some(nmstate_ipv4_to_np(base_iface.ipv4.as_ref()));
-        np_iface.ipv6 = Some(nmstate_ipv6_to_np(base_iface.ipv6.as_ref()));
+        np_iface.ipv4 = Some(nmstate_ipv4_to_np(nms_merged_iface));
+        np_iface.ipv6 = Some(nmstate_ipv6_to_np(nms_merged_iface));
     }
 
     np_iface.mac_address.clone_from(&base_iface.mac_address);
@@ -154,8 +163,9 @@ async fn delete_ifaces(
                 deleted_veths.push(peer_name);
             }
         }
-        if let Some(apply_iface) = iface.for_apply.as_ref() {
-            np_ifaces.push(nmstate_iface_to_np(apply_iface)?);
+
+        if iface.for_apply.as_ref().is_some() {
+            np_ifaces.push(nmstate_iface_to_np(iface)?);
         }
     }
 

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use crate::{
     nispor::mptcp::get_mptcp_flags, InterfaceIpAddr, InterfaceIpv4,
-    InterfaceIpv6,
+    InterfaceIpv6, MergedInterface,
 };
 
 pub(crate) fn np_ipv4_to_nmstate(
@@ -32,10 +32,16 @@ pub(crate) fn np_ipv4_to_nmstate(
                 Ok(i) => addresses.push(InterfaceIpAddr {
                     ip: i,
                     prefix_length: np_addr.prefix_len,
-                    mptcp_flags: Some(get_mptcp_flags(
-                        np_iface,
-                        np_addr.address.as_str(),
-                    )),
+                    mptcp_flags: {
+                        let mptcp_flags =
+                            get_mptcp_flags(np_iface, np_addr.address.as_str());
+
+                        if !mptcp_flags.is_empty() {
+                            Some(mptcp_flags)
+                        } else {
+                            None
+                        }
+                    },
                     valid_life_time: if np_addr.valid_lft != "forever" {
                         Some(np_addr.valid_lft.clone())
                     } else {
@@ -99,10 +105,16 @@ pub(crate) fn np_ipv6_to_nmstate(
                 Ok(i) => addresses.push(InterfaceIpAddr {
                     ip: i,
                     prefix_length: np_addr.prefix_len,
-                    mptcp_flags: Some(get_mptcp_flags(
-                        np_iface,
-                        np_addr.address.as_str(),
-                    )),
+                    mptcp_flags: {
+                        let mptcp_flags =
+                            get_mptcp_flags(np_iface, np_addr.address.as_str());
+
+                        if !mptcp_flags.is_empty() {
+                            Some(mptcp_flags)
+                        } else {
+                            None
+                        }
+                    },
                     valid_life_time: if np_addr.valid_lft != "forever" {
                         Some(np_addr.valid_lft.clone())
                     } else {
@@ -137,11 +149,42 @@ pub(crate) fn np_ipv6_to_nmstate(
 }
 
 pub(crate) fn nmstate_ipv4_to_np(
-    nms_ipv4: Option<&InterfaceIpv4>,
+    nms_merged_iface: &MergedInterface,
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
-    if let Some(nms_ipv4) = nms_ipv4 {
-        for nms_addr in nms_ipv4.addresses.as_deref().unwrap_or_default() {
+
+    // delete ip addresses not in desired state
+    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
+        if let (Some(nms_cur_ipv4), Some(nms_des_ipv4)) = (
+            &nms_cur_iface.base_iface().ipv4,
+            &nms_merged_iface.merged.base_iface().ipv4,
+        ) {
+            let des_ips: Vec<_> = nms_des_ipv4
+                .addresses
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .collect();
+
+            for nms_addr in
+                nms_cur_ipv4.addresses.as_deref().unwrap_or_default()
+            {
+                if !des_ips.contains(&nms_addr) {
+                    np_ip_conf.addresses.push({
+                        let mut ip_conf = nispor::IpAddrConf::default();
+                        ip_conf.address = nms_addr.ip.to_string();
+                        ip_conf.prefix_len = nms_addr.prefix_length;
+                        ip_conf.remove = true;
+                        ip_conf
+                    });
+                }
+            }
+        }
+    }
+
+    // Add new ip address entries before deleting
+    if let Some(nms_des_ipv4) = &nms_merged_iface.merged.base_iface().ipv4 {
+        for nms_addr in nms_des_ipv4.addresses.as_deref().unwrap_or_default() {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();
@@ -154,11 +197,42 @@ pub(crate) fn nmstate_ipv4_to_np(
 }
 
 pub(crate) fn nmstate_ipv6_to_np(
-    nms_ipv6: Option<&InterfaceIpv6>,
+    nms_merged_iface: &MergedInterface,
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
-    if let Some(nms_ipv6) = nms_ipv6 {
-        for nms_addr in nms_ipv6.addresses.as_deref().unwrap_or_default() {
+
+    // delete ip addresses not in desired state
+    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
+        if let (Some(nms_cur_ipv6), Some(nms_des_ipv6)) = (
+            &nms_cur_iface.base_iface().ipv6,
+            &nms_merged_iface.merged.base_iface().ipv6,
+        ) {
+            let des_ips: Vec<_> = nms_des_ipv6
+                .addresses
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .collect();
+
+            for nms_addr in
+                nms_cur_ipv6.addresses.as_deref().unwrap_or_default()
+            {
+                if !des_ips.contains(&nms_addr) {
+                    np_ip_conf.addresses.push({
+                        let mut ip_conf = nispor::IpAddrConf::default();
+                        ip_conf.address = nms_addr.ip.to_string();
+                        ip_conf.prefix_len = nms_addr.prefix_length;
+                        ip_conf.remove = true;
+                        ip_conf
+                    });
+                }
+            }
+        }
+    }
+
+    // Add new ip address entries after deleting
+    if let Some(nms_des_ipv6) = &nms_merged_iface.merged.base_iface().ipv6 {
+        for nms_addr in nms_des_ipv6.addresses.as_deref().unwrap_or_default() {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
                 ip_conf.address = nms_addr.ip.to_string();

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1125,3 +1125,98 @@ def test_kernel_mode_static_ip(cleanup_veth1_kernel_mode):
         kernel_only=True,
     )
     assertlib.assert_state_match(desired_state, kernel_only=True)
+
+
+def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.251/24 and 2001:db8:1::1/64",
+        desired_state,
+        kernel_only=True,
+    )
+    assertlib.assert_state_match(desired_state, kernel_only=True)
+
+    new_desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::2
+                prefix-length: 64
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.252/24 and 2001:db8:1::2/64",
+        new_desired_state,
+        kernel_only=True,
+    )
+    assertlib.assert_state_match(new_desired_state, kernel_only=True)
+
+    new_desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 12
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::2
+                prefix-length: 32
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.252/12 and 2001:db8:1::2/32",
+        new_desired_state,
+        kernel_only=True,
+    )
+    assertlib.assert_state_match(new_desired_state, kernel_only=True)


### PR DESCRIPTION
Previously, new IP addr on same interface was being appended to addresses list instead of being updated.

This solution asks nispor to delete ip addresses in the current state not contained in the desired state.

Resolves: https://issues.redhat.com/browse/RHEL-54544
Resolves: #2893 