### PR TITLE
rust: fix clippy warning

### DIFF
--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -18,13 +18,6 @@ pub(crate) struct OvsDbJsonRpc {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
-struct OvsDbRpcRequest {
-    method: String,
-    params: Value,
-    id: u64,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
 struct OvsDbRpcError {
     error: String,
     details: Option<String>,


### PR DESCRIPTION
Remove unused struct OvsDbRpcRequest.

merge if this is not needed. Breaks CI linting.