### PR TITLE
bond: followup for PR 2832

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -110,7 +110,7 @@ impl BondInterface {
 
     fn sort_ports(&mut self) {
         if let Some(ports) = self.bond.as_mut().and_then(|b| b.port.as_mut()) {
-            ports.sort_unstable_by_key(|p| p.clone());
+            ports.sort_unstable();
         }
     }
 
@@ -306,13 +306,14 @@ impl BondInterface {
 
                     if !missing_in_config.is_empty() {
                         error_msg_detail.push_str(&format!(
-                            "Ports in `port`` but not in `ports_config`: {}",
+                            "Ports in `port` but not in `ports_config`: {}. ",
                             missing_in_config.join(", ")
                         ));
-                    } else if !missing_in_ports.is_empty() {
+                    }
+                    if !missing_in_ports.is_empty() {
                         error_msg_detail.push_str(&format!(
-                            "Ports in `ports_config`` but not in `port`: {}",
-                            missing_in_config.join(", ")
+                            "Ports in `ports_config` but not in `port`: {}. ",
+                            missing_in_ports.join(", ")
                         ));
                     }
 

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -773,3 +773,60 @@ fn test_bond_opt_ns_ip6_target() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_bond_ports_ports_config_conflict() {
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: active-backup
+          ports:
+          - eth1
+          - eth2
+          ports-config:
+          - name: eth1
+            queue-id: 0
+          - name: eth2
+            queue-id: 0
+        ",
+    )
+    .unwrap();
+
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+    merged_iface.post_inter_ifaces_process_bond().unwrap();
+
+    let iface: Interface = serde_yaml::from_str(
+        r"---
+        name: bond99
+        type: bond
+        state: up
+        link-aggregation:
+          mode: active-backup
+          ports:
+          - eth1
+          - eth3
+          ports-config:
+          - name: eth1
+            queue-id: 0
+          - name: eth2
+            queue-id: 0
+        ",
+    )
+    .unwrap();
+
+    let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
+    let result = merged_iface.post_inter_ifaces_process_bond();
+
+    assert!(result.is_err());
+
+    let error = result.as_ref().err().unwrap();
+
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+    assert!(
+        error.msg().contains("conflict with")
+            && error.msg().contains("The port names specified in")
+    );
+}


### PR DESCRIPTION
Use `sort_unstable` instead of `sort_unstable_by_key`. Fix extra ` in error message.