### PR TITLE
dns: don't add DNS search and/or options to down NM connection

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -382,6 +382,9 @@ pub(crate) fn parse_dns_ipv6_link_local_srv(
 impl MergedInterface {
     // IP stack is merged with current at this point.
     pub(crate) fn is_iface_valid_for_dns(&self, is_ipv6: bool) -> bool {
+        if !self.merged.is_up() {
+            return false;
+        }
         if is_ipv6 {
             self.merged.base_iface().ipv6.as_ref().map(|ip_conf| {
                 ip_conf.enabled && (ip_conf.is_static() || (ip_conf.is_auto()))

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -37,8 +37,11 @@ fn np_iface_type_to_nmstate(
 impl From<(&nispor::IfaceState, &[nispor::IfaceFlag])> for InterfaceState {
     fn from(tuple: (&nispor::IfaceState, &[nispor::IfaceFlag])) -> Self {
         let (state, flags) = tuple;
+        // nispor::IfaceState::Up means operational up.
+        // Check also the Running flag with, according to [1], means operational
+        // state Up or Unknown.
+        // [1] https://www.kernel.org/doc/Documentation/networking/operstates.txt
         if *state == nispor::IfaceState::Up
-            || flags.contains(&nispor::IfaceFlag::Up)
             || flags.contains(&nispor::IfaceFlag::Running)
         {
             InterfaceState::Up

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -693,13 +693,14 @@ fn store_dns_search_or_options_to_auto_iface(
                 Some(i) => i,
                 None => continue,
             };
-        if iface
-            .merged
-            .base_iface()
-            .ipv6
-            .as_ref()
-            .map(|i| i.is_auto())
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(true)
+            && iface
+                .merged
+                .base_iface()
+                .ipv6
+                .as_ref()
+                .map(|i| i.is_auto())
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -708,13 +709,14 @@ fn store_dns_search_or_options_to_auto_iface(
                 true,
             );
         }
-        if iface
-            .merged
-            .base_iface()
-            .ipv4
-            .as_ref()
-            .map(|i| i.is_auto())
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(false)
+            && iface
+                .merged
+                .base_iface()
+                .ipv4
+                .as_ref()
+                .map(|i| i.is_auto())
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -754,13 +756,14 @@ fn store_dns_search_or_options_to_auto_iface(
                 Some(i) => i,
                 None => continue,
             };
-        if iface
-            .merged
-            .base_iface()
-            .ipv6
-            .as_ref()
-            .map(|i| i.is_auto())
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(true)
+            && iface
+                .merged
+                .base_iface()
+                .ipv6
+                .as_ref()
+                .map(|i| i.is_auto())
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -769,13 +772,14 @@ fn store_dns_search_or_options_to_auto_iface(
                 true,
             );
         }
-        if iface
-            .merged
-            .base_iface()
-            .ipv4
-            .as_ref()
-            .map(|i| i.is_auto())
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(false)
+            && iface
+                .merged
+                .base_iface()
+                .ipv4
+                .as_ref()
+                .map(|i| i.is_auto())
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -821,13 +825,14 @@ fn store_dns_search_or_options_to_ip_enabled_iface(
                 Some(i) => i,
                 None => continue,
             };
-        if iface
-            .merged
-            .base_iface()
-            .ipv6
-            .as_ref()
-            .map(|i| i.enabled)
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(true)
+            && iface
+                .merged
+                .base_iface()
+                .ipv6
+                .as_ref()
+                .map(|i| i.enabled)
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -836,13 +841,14 @@ fn store_dns_search_or_options_to_ip_enabled_iface(
                 true,
             );
         }
-        if iface
-            .merged
-            .base_iface()
-            .ipv4
-            .as_ref()
-            .map(|i| i.enabled)
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(false)
+            && iface
+                .merged
+                .base_iface()
+                .ipv4
+                .as_ref()
+                .map(|i| i.enabled)
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -882,13 +888,14 @@ fn store_dns_search_or_options_to_ip_enabled_iface(
                 Some(i) => i,
                 None => continue,
             };
-        if iface
-            .merged
-            .base_iface()
-            .ipv6
-            .as_ref()
-            .map(|i| i.enabled)
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(true)
+            && iface
+                .merged
+                .base_iface()
+                .ipv6
+                .as_ref()
+                .map(|i| i.enabled)
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,
@@ -897,13 +904,14 @@ fn store_dns_search_or_options_to_ip_enabled_iface(
                 true,
             );
         }
-        if iface
-            .merged
-            .base_iface()
-            .ipv4
-            .as_ref()
-            .map(|i| i.enabled)
-            .unwrap_or_default()
+        if iface.is_iface_valid_for_dns(false)
+            && iface
+                .merged
+                .base_iface()
+                .ipv4
+                .as_ref()
+                .map(|i| i.enabled)
+                .unwrap_or_default()
         {
             return set_iface_dns_search_or_option(
                 iface,

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -579,6 +579,10 @@ pub(crate) fn store_dns_search_or_option_to_iface(
     let (cur_v4_ifaces, cur_v6_ifaces) =
         get_cur_dns_ifaces(&merged_state.interfaces);
 
+    // First purge existing configs
+    purge_dns_config(false, &cur_v4_ifaces, merged_state)?;
+    purge_dns_config(true, &cur_v6_ifaces, merged_state)?;
+
     // Use current DNS interface if they are desired
     for iface_name in cur_v6_ifaces {
         if let Some(iface) =

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -285,7 +285,9 @@ fn nm_dev_to_nm_iface(nm_dev: &NmDevice) -> Option<Interface> {
                 base_iface.state = InterfaceState::Ignore;
             }
         }
-        NmDeviceState::Disconnected => base_iface.state = InterfaceState::Down,
+        NmDeviceState::Disconnected | NmDeviceState::Unavailable => {
+            base_iface.state = InterfaceState::Down
+        }
         _ => base_iface.state = InterfaceState::Up,
     }
     base_iface.iface_type = nm_dev_iface_type_to_nmstate(nm_dev);

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -328,3 +328,36 @@ def test_write_both_global_dns_and_iface_dns(eth1_up):
     assert cmdlib.exec_cmd(
         "nmcli -g ipv4.dns c show eth1".split(), check=True
     )[1].strip() == ",".join(TEST_DNS_SRVS)
+
+
+# https://issues.redhat.com/browse/RHEL-102333
+def test_set_dns_search_only_in_down_iface(auto_eth1, eth2_up):
+    # Add a DNS search domain to a down interface
+    cmdlib.exec_cmd("nmcli device down eth2".split(), check=True)
+    cmdlib.exec_cmd("nmcli c modify eth2 ipv4.method auto".split(), check=True)
+    cmdlib.exec_cmd(
+        "nmcli c modify eth2 ipv4.dns-search 'example.com'".split(),
+        check=True,
+    )
+
+    # Assert that the DNS searches configuration can change correctly
+    libnmstate.apply(
+        {
+            DNS.KEY: {DNS.CONFIG: {DNS.SEARCH: ["example2.com"]}},
+        }
+    )
+
+    # Assert that the old configuration has been purged from the down interface
+    # and the new one hasn't been added to it.
+    _r, search4, _e = cmdlib.exec_cmd(
+        "nmcli -g ipv4.dns-search c show eth2".split(), check=True
+    )
+    _r, search6, _e = cmdlib.exec_cmd(
+        "nmcli -g ipv6.dns-search c show eth2".split(), check=True
+    )
+    assert "example.com" not in search4 and "example.com" not in search6
+    assert "example2.com" not in search4 and "example2.com" not in search6
+
+    # It is not possible to assert that the new configuration has been put into
+    # eth1 because, if there are more interfaces in the host, it might be in
+    # any of them


### PR DESCRIPTION
When configuring only search and/or options in dns-resolver we add them to a NM connection and not to NM's global config, but nmstate may choose a down interface, which results on errors at apply time or even on the configurations being accepted but stay unused by NetworkManager. Fix that by always checking that the interface is valid for DNS, and by adding the requirement of the interface being up.

Additionally, in certain uncommon circumstances we consider an interface as "up" incorrectly despite it being actually down. As a consequence, if the interface doesn't appear in the desired state we rely only on the detected current state, and we might consider that the interface is up and put some DNS configurations on it. Fix the detection of down interfaces.

Fixes https://github.com/nmstate/nmstate/issues/2798

Resolves: https://issues.redhat.com/browse/RHEL-102333