### PR TITLE
hsr: copy mac address from port1 to port2 and hsr interfaces

### DIFF
--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -2,7 +2,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, InterfaceType, NmstateError};
+use crate::{
+    BaseInterface, ErrorKind, Interface, InterfaceType, MergedInterfaces,
+    NmstateError,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -21,6 +24,13 @@ use crate::{BaseInterface, InterfaceType, NmstateError};
 ///       multicast-spec: 40
 ///       protocol: prp
 /// ```
+///
+/// nmstate will configure the MAC addresses of HSR ports
+/// to be matching, to retain failover ability. It will
+/// use the MAC address of port1 by default, and apply it
+/// to port2 and the HSR interface. The MAC address can
+/// be overridden by setting the `mac-address` property
+/// on the HSR interface itself.
 pub struct HsrInterface {
     #[serde(flatten)]
     pub base: BaseInterface,
@@ -61,6 +71,156 @@ impl HsrInterface {
                 }
             }
         }
+        Ok(())
+    }
+}
+
+impl MergedInterfaces {
+    pub(crate) fn get_hsr_mac(&self, iface: &HsrInterface) -> Option<String> {
+        if iface.base.mac_address.is_some() {
+            return iface.base.mac_address.clone();
+        }
+
+        let hsr_conf = iface.hsr.as_ref()?;
+
+        for use_permanent in [false, true] {
+            for port in [&hsr_conf.port1, &hsr_conf.port2] {
+                let mac = self
+                    .get_iface(port, InterfaceType::Unknown)
+                    .and_then(|iface| {
+                        let base = iface.merged.base_iface();
+                        if use_permanent {
+                            base.permanent_mac_address.clone()
+                        } else {
+                            base.mac_address.clone()
+                        }
+                    });
+                if mac.is_some() {
+                    return mac;
+                }
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn validate_hsr_mac(&self) -> Result<(), NmstateError> {
+        for hsr_iface in self.kernel_ifaces.iter().filter_map(|(_, iface)| {
+            if let Interface::Hsr(hsr_iface) = iface.desired.as_ref()? {
+                let hsr_conf = hsr_iface.hsr.as_ref()?;
+
+                if hsr_conf.protocol == HsrProtocol::Prp {
+                    return Some(hsr_iface);
+                }
+            }
+
+            None
+        }) {
+            let macs = [
+                hsr_iface.base.mac_address.as_deref(),
+                hsr_iface
+                    .hsr
+                    .as_ref()
+                    .and_then(|hsr_conf| {
+                        self.get_iface(&hsr_conf.port1, InterfaceType::Unknown)
+                    })
+                    .and_then(|iface| iface.desired.as_ref())
+                    .and_then(|iface| {
+                        iface.base_iface().mac_address.as_deref()
+                    }),
+                hsr_iface
+                    .hsr
+                    .as_ref()
+                    .and_then(|hsr_conf| {
+                        self.get_iface(&hsr_conf.port2, InterfaceType::Unknown)
+                    })
+                    .and_then(|iface| iface.desired.as_ref())
+                    .and_then(|iface| {
+                        iface.base_iface().mac_address.as_deref()
+                    }),
+            ];
+
+            let mut acc = None;
+
+            for &mac in macs.iter().flatten() {
+                if acc.is_some() && Some(mac) != acc {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "HSR ports on interface {} cannot have different \
+                             MAC addresses",
+                            hsr_iface.base.name
+                        ),
+                    ));
+                }
+
+                acc = Some(mac);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn copy_hsr_mac(&mut self) -> Result<(), NmstateError> {
+        let mut pending_changes = Vec::new();
+
+        for (hsr_iface, hsr_conf, mac) in
+            self.kernel_ifaces.iter().filter_map(|(_, iface)| {
+                if !iface.is_desired() {
+                    return None;
+                }
+
+                if let Interface::Hsr(hsr_iface) = &iface.merged {
+                    let mac = self.get_hsr_mac(hsr_iface)?;
+                    let hsr_conf = hsr_iface.hsr.as_ref()?;
+
+                    if hsr_conf.protocol != HsrProtocol::Prp {
+                        return None;
+                    }
+
+                    if iface.current.is_some() {
+                        if Some(mac.as_str())
+                            != self.kernel_ifaces.get(&hsr_conf.port2).and_then(
+                                |iface| {
+                                    iface
+                                        .merged
+                                        .base_iface()
+                                        .mac_address
+                                        .as_deref()
+                                },
+                            )
+                        {
+                            log::warn!(
+                                "Existing HSR PRP interface {} has \
+                                 mismatching MAC addresses on port1 and \
+                                 port2, which may break functionality",
+                                iface.merged.name()
+                            );
+                        }
+
+                        return None;
+                    }
+
+                    return Some((hsr_iface, hsr_conf, mac));
+                }
+
+                None
+            })
+        {
+            for ifname in
+                [&hsr_iface.base.name, &hsr_conf.port1, &hsr_conf.port2]
+            {
+                pending_changes.push((ifname.clone(), mac.clone()));
+            }
+        }
+
+        for (ifname, mac) in pending_changes {
+            if let Some(iface) = self.kernel_ifaces.get_mut(&ifname) {
+                iface.mark_as_changed();
+                iface.set_copy_from_mac(mac.clone());
+            }
+        }
+
         Ok(())
     }
 }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -904,6 +904,8 @@ impl MergedInterfaces {
     fn process(&mut self) -> Result<(), NmstateError> {
         self.process_allow_extra_ovs_patch_ports_for_apply();
         self.apply_copy_mac_from()?;
+        self.validate_hsr_mac()?;
+        self.copy_hsr_mac()?;
         self.validate_controller_and_port_list_confliction()?;
         self.resolve_port_name_ref()?;
         self.resolve_parent_name_ref()?;

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     unit_tests::testlib::{
-        new_eth_iface, new_ovs_br_iface, new_ovs_iface, new_unknown_iface,
-        new_vlan_iface,
+        get_mac, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
+        new_unknown_iface, new_vlan_iface,
     },
-    BondMode, Interface, InterfaceState, InterfaceType, Interfaces,
+    BondMode, ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
     MergedInterfaces,
 };
 
@@ -424,5 +424,424 @@ fn test_unknown_iface_type() {
         serde_yaml::to_string(&InterfaceType::Other("foo_type".to_string()))
             .unwrap(),
         "foo_type\n"
+    );
+}
+
+#[test]
+fn test_hsr_mac_sync_no_mac_addresses_defined() {
+    let cur_ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: AA:BB:CC:DD:EE:FF
+  - name: eth2
+    type: ethernet
+    state: up
+    ",
+    )
+    .unwrap();
+
+    let des_ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        crate::NetworkStateMode::Apply,
+        false,
+    )
+    .unwrap();
+
+    let hsr_iface =
+        merged_ifaces.get_iface("hsr0", InterfaceType::Hsr).unwrap();
+    assert_eq!(
+        get_mac(&hsr_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+
+    let port2_iface = merged_ifaces
+        .get_iface("eth2", InterfaceType::Ethernet)
+        .unwrap();
+    assert_eq!(
+        get_mac(&port2_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+}
+
+#[test]
+fn test_hsr_mac_sync_mac_address_defined() {
+    let cur_ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: aa:bb:cc:dd:ee:ff
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: bb:cc:dd:ee:ff:00
+    ",
+    )
+    .unwrap();
+
+    let des_ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+  - name: hsr0
+    type: hsr
+    state: up
+    mac-address: bb:cc:ee:ff:00:11
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        crate::NetworkStateMode::Apply,
+        false,
+    )
+    .unwrap();
+
+    let hsr_iface =
+        merged_ifaces.get_iface("hsr0", InterfaceType::Hsr).unwrap();
+    assert_eq!(
+        hsr_iface
+            .for_apply
+            .as_ref()
+            .unwrap()
+            .base_iface()
+            .mac_address,
+        Some("BB:CC:EE:FF:00:11".to_string())
+    );
+
+    let port1_iface = merged_ifaces
+        .get_iface("eth1", InterfaceType::Ethernet)
+        .unwrap();
+    assert_eq!(
+        get_mac(&port1_iface.for_apply),
+        Some("BB:CC:EE:FF:00:11".to_string())
+    );
+
+    let port2_iface = merged_ifaces
+        .get_iface("eth2", InterfaceType::Ethernet)
+        .unwrap();
+    assert_eq!(
+        get_mac(&port2_iface.for_apply),
+        Some("BB:CC:EE:FF:00:11".to_string())
+    );
+}
+
+#[test]
+fn test_hsr_conflicting_desired_port_macs() {
+    let current = Interfaces::new();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1a
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1b
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged_err =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap_err();
+    assert_eq!(merged_err.kind(), ErrorKind::InvalidArgument);
+    assert!(merged_err.msg().contains("ports on interface hsr0"));
+}
+
+#[test]
+fn test_hsr_both_port_desired_macs() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+    ",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1b
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1b
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let port1_iface =
+        merged.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+
+    let hsr_iface = merged.get_iface("hsr0", InterfaceType::Ethernet).unwrap();
+
+    assert_eq!(
+        get_mac(&port1_iface.for_apply),
+        Some("00:23:45:67:89:1B".to_string())
+    );
+    assert_eq!(
+        get_mac(&hsr_iface.for_apply),
+        Some("00:23:45:67:89:1B".to_string())
+    );
+}
+
+#[test]
+fn test_hsr_all_ifaces_desired_macs() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+    ",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1c
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: 00:23:45:67:89:1c
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: hsr0
+    type: hsr
+    state: up
+    mac-address: 00:23:45:67:89:1c
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let port1_iface =
+        merged.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+
+    let hsr_iface = merged.get_iface("hsr0", InterfaceType::Ethernet).unwrap();
+
+    assert_eq!(
+        get_mac(&port1_iface.for_apply),
+        Some("00:23:45:67:89:1C".to_string())
+    );
+    assert_eq!(
+        get_mac(&hsr_iface.for_apply),
+        Some("00:23:45:67:89:1C".to_string())
+    );
+}
+
+#[test]
+fn test_hsr_port2_desired_mac() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    permanent-mac-address: 00:23:45:67:89:1c
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+    ",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: eth2
+    type: ethernet
+    state: up
+    mac-address: aa:bb:cc:dd:ee:ff
+    ipv4:
+      enabled: false
+    ipv6:
+      enabled: false
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let port1_iface =
+        merged.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+
+    let hsr_iface = merged.get_iface("hsr0", InterfaceType::Ethernet).unwrap();
+
+    assert_eq!(
+        get_mac(&port1_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+    assert_eq!(
+        get_mac(&hsr_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+}
+
+#[test]
+fn test_hsr_all_ifaces_only_permanent_mac() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    permanent-mac-address: aa:bb:cc:dd:ee:ff
+    state: up
+  - name: eth2
+    type: ethernet
+    permanent-mac-address: 11:22:33:44:55:66
+    state: up
+    ",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    state: up
+  - name: eth2
+    type: ethernet
+    state: up
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: prp
+",
+    )
+    .unwrap();
+
+    let merged =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let port1_iface =
+        merged.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+    let port2_iface =
+        merged.get_iface("eth2", InterfaceType::Ethernet).unwrap();
+    let hsr_iface = merged.get_iface("hsr0", InterfaceType::Ethernet).unwrap();
+
+    assert_eq!(
+        get_mac(&port1_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+    assert_eq!(
+        get_mac(&port2_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
+    );
+    assert_eq!(
+        get_mac(&hsr_iface.for_apply),
+        Some("AA:BB:CC:DD:EE:FF".to_string())
     );
 }

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -125,6 +125,13 @@ pub(crate) fn bond_with_ports(name: &str, ports: &[&str]) -> Interface {
     iface
 }
 
+pub(crate) fn get_mac(iface: &Option<Interface>) -> Option<String> {
+    iface
+        .as_ref()
+        .map(|i| i.base_iface().mac_address.clone())
+        .flatten()
+}
+
 pub(crate) const TEST_NIC: &str = "eth1";
 pub(crate) const TEST_IPV4_NET1: &str = "192.0.2.0/24";
 pub(crate) const TEST_IPV4_ADDR1: &str = "198.51.100.1";

--- a/tests/integration/hsr_test.py
+++ b/tests/integration/hsr_test.py
@@ -9,11 +9,22 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Hsr
 
 from .testlib import assertlib
+from .testlib.hsrlib import hsr_interface
+from .testlib.ifacelib import get_mac_address
 
 
 ETH1 = "eth1"
 ETH2 = "eth2"
 HSR0 = "hsr0"
+
+
+@pytest.fixture
+def hsr0_with_eths(eth1_up, eth2_up):
+    eth1 = eth1_up[Interface.KEY][0][Interface.NAME]
+    eth2 = eth2_up[Interface.KEY][0][Interface.NAME]
+
+    with hsr_interface(HSR0, eth1, eth2) as state:
+        yield state
 
 
 @pytest.mark.tier1
@@ -41,3 +52,15 @@ def test_add_hsr_and_remove(eth1_up, eth2_up):
             Interface.STATE
         ] = InterfaceState.ABSENT
         libnmstate.apply(desired_state)
+
+
+# https://issues.redhat.com/browse/RHEL-100758
+@pytest.mark.tier1
+def test_hsr_mac_address_sync(hsr0_with_eths):
+    hsr_mac = get_mac_address("hsr0")
+    eth1_mac = get_mac_address("eth1")
+    eth2_mac = get_mac_address("eth2")
+
+    assert hsr_mac is not None
+    assert hsr_mac == eth1_mac
+    assert hsr_mac == eth2_mac

--- a/tests/integration/testlib/hsrlib.py
+++ b/tests/integration/testlib/hsrlib.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from contextlib import contextmanager
+
+import libnmstate
+from libnmstate.schema import Hsr
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+
+
+@contextmanager
+def hsr_interface(
+    name, port1, port2, mcast_spec=40, protocol="prp", create=True
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: name,
+                Interface.TYPE: InterfaceType.HSR,
+                Interface.STATE: InterfaceState.UP,
+                Hsr.CONFIG_SUBTREE: {
+                    Hsr.PORT1: port1,
+                    Hsr.PORT2: port2,
+                    Hsr.MULTICAST_SPEC: mcast_spec,
+                    Hsr.PROTOCOL: protocol,
+                },
+            }
+        ]
+    }
+
+    if create:
+        libnmstate.apply(desired_state)
+
+    try:
+        yield desired_state
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: name,
+                        Interface.TYPE: InterfaceType.HSR,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    }
+                ]
+            },
+        )


### PR DESCRIPTION
Currently, when a PRP interface is configured, the MAC address is not shared among ports, and the interface loses failover ability.

Make it so that the MAC address is shared among the PRP interface and its ports. The MAC address is chosen in order of preference:
- mac-address / copy-mac-from set on hsr interface
- mac-address / copy-mac-from set on port1 interface
- permanent-mac-address of port1 interface

This issue is already handled similarly in kernel: https://lore.kernel.org/netdev/20250409101911.3120-1-ffmancera@riseup.net/

This fix is a (re)implementation of this logic to maintain support for older distributions.

Resolves: https://issues.redhat.com/browse/RHEL-100758