### PR TITLE
bond: Ignore desired MAC when in MAC restricted mode

### DIFF
--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -254,35 +254,34 @@ impl BondInterface {
         Ok(())
     }
 
-    // Fail on
-    // * Desire mac restricted mode with mac defined
+    // Remove desired MAC address with warning message when:
+    // * New bond desired in mac restricted mode with mac defined
     // * Desire mac address with current interface in mac restricted mode with
     //   desired not changing mac restricted mode
-    fn validate_mac_restricted_mode(
-        &self,
-        current: Option<&Interface>,
-    ) -> Result<(), NmstateError> {
-        let e = NmstateError::new(
-            ErrorKind::InvalidArgument,
-            "MAC address cannot be specified in bond interface along with \
-             fail_over_mac active on active backup mode"
-                .to_string(),
+    // The verification process will fail the apply action when desired MAC
+    // address differ from port MAC.
+    fn sanitize_mac_restricted_mode(&mut self, current: Option<&Interface>) {
+        let warn_msg = format!(
+            "The bond interface {} with fail_over_mac:active and \
+             mode:active-backup is determined by its ports, hence ignoring \
+             desired MAC address",
+            self.base.name.as_str()
         );
-        if self.is_mac_restricted_mode() && self.base.mac_address.is_some() {
-            log::error!("{e}");
-            return Err(e);
-        }
 
         if let Some(Interface::Bond(current)) = current {
             if current.is_mac_restricted_mode()
                 && self.base.mac_address.is_some()
                 && !self.is_not_mac_restricted_mode_explicitly()
             {
-                log::error!("{e}");
-                return Err(e);
+                self.base.mac_address = None;
+                log::warn!("{warn_msg}");
             }
+        } else if self.is_mac_restricted_mode()
+            && self.base.mac_address.is_some()
+        {
+            self.base.mac_address = None;
+            log::warn!("{warn_msg}");
         }
-        Ok(())
     }
 
     fn validate_conflict_in_port_and_port_configs(
@@ -1557,10 +1556,10 @@ impl MergedInterface {
         if self.merged.is_absent() {
             return Ok(());
         }
-        if let Some(Interface::Bond(apply_iface)) = self.for_apply.as_ref() {
+        if let Some(Interface::Bond(apply_iface)) = self.for_apply.as_mut() {
             apply_iface
                 .validate_new_iface_with_no_mode(self.current.as_ref())?;
-            apply_iface.validate_mac_restricted_mode(self.current.as_ref())?;
+            apply_iface.sanitize_mac_restricted_mode(self.current.as_ref());
             apply_iface.validate_conflict_in_port_and_port_configs()?;
 
             if let Some(bond_opts) =

--- a/rust/src/lib/unit_tests/bond.rs
+++ b/rust/src/lib/unit_tests/bond.rs
@@ -41,11 +41,7 @@ link-aggregation:
     )
     .unwrap();
     let mut merged_iface = MergedInterface::new(Some(iface), None).unwrap();
-    let result = merged_iface.post_inter_ifaces_process_bond();
-    assert!(result.is_err());
-    if let Err(e) = result {
-        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
-    }
+    merged_iface.post_inter_ifaces_process_bond().unwrap();
 }
 
 #[test]
@@ -73,11 +69,7 @@ link-aggregation:
     .unwrap();
     let mut merged_iface =
         MergedInterface::new(Some(des_iface), Some(cur_iface)).unwrap();
-    let result = merged_iface.post_inter_ifaces_process_bond();
-    assert!(result.is_err());
-    if let Err(e) = result {
-        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
-    }
+    merged_iface.post_inter_ifaces_process_bond().unwrap();
 }
 
 #[test]

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -642,7 +642,7 @@ def test_bond_mac_restriction_with_mac_in_desire(eth1_up, eth2_up):
         },
         create=False,
     ) as state:
-        with pytest.raises(NmstateValueError):
+        with pytest.raises((NmstateVerificationError)):
             libnmstate.apply(state)
 
 
@@ -673,7 +673,7 @@ def test_bond_mac_restriction_in_current_mac_in_desire(eth1_up, eth2_up):
         },
     ) as state:
         assertlib.assert_state_match(state)
-        with pytest.raises(NmstateValueError):
+        with pytest.raises(NmstateVerificationError):
             libnmstate.apply(
                 {
                     Interface.KEY: [


### PR DESCRIPTION
For active-backup bond with `fail_over_mac: active`, the MAC address of
bond is determined by its bond port, previously we raise error when
this bond in desired state has MAC address defined.

This cause problem when user try to apply the state retrieved by
`nmstatectl show`.

Instead of raising error, this patch just discard desired MAC address
and raise an warning message. If user desired invalid MAC address(not
bond port MAC address), verification stage will fail the apply action.

Unit and integration test cases updated.

Resolves: https://issues.redhat.com/browse/RHEL-106135