### PR TITLE
route: Introduce `state: ignore` for route

### DIFF
--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -132,6 +132,9 @@ impl NetworkState {
             .user_ifaces
             .retain(|_, iface| !iface.is_ignore());
 
+        // Mark routes next hop to ignored interface as ignored
+        self.routes.apply_ignored_ifaces(&self.interfaces);
+
         Ok(self)
     }
 

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use crate::{
     ErrorKind, InterfaceType, Interfaces, MergedRoutes, NmstateError,
-    RouteEntry, Routes,
+    RouteEntry, RouteState, Routes,
 };
 
 impl MergedRoutes {
@@ -210,6 +210,38 @@ impl RouteEntry {
     fn sanitize_current_route_for_verify(&mut self) {
         if self.quickack.is_none() {
             self.quickack = Some(false);
+        }
+    }
+}
+
+impl Routes {
+    pub(crate) fn apply_ignored_ifaces(&mut self, ifaces: &Interfaces) {
+        let ignored_ifaces: HashSet<&str> = ifaces
+            .kernel_ifaces
+            .iter()
+            .filter_map(|(name, iface)| {
+                if iface.is_ignore() {
+                    Some(name.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for rts in [self.running.as_mut(), self.config.as_mut()]
+            .into_iter()
+            .flatten()
+        {
+            for rt in rts {
+                if Some(true)
+                    == rt
+                        .next_hop_iface
+                        .as_deref()
+                        .map(|iface| ignored_ifaces.contains(&iface))
+                {
+                    rt.state = Some(RouteState::Ignore);
+                }
+            }
         }
     }
 }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -106,6 +106,15 @@ impl Routes {
         Ok(())
     }
 
+    pub(crate) fn remove_ignored_routes(&mut self) {
+        for rts in [self.running.as_mut(), self.config.as_mut()]
+            .into_iter()
+            .flatten()
+        {
+            rts.retain(|rt| !rt.is_ignore());
+        }
+    }
+
     pub(crate) fn resolve_next_hop_iface_ref(
         &mut self,
         merged_ifaces: &MergedInterfaces,
@@ -163,6 +172,8 @@ impl Routes {
 pub enum RouteState {
     /// Mark a route entry as absent to remove it.
     Absent,
+    /// Mark a route as ignored
+    Ignore,
 }
 
 impl Default for RouteState {
@@ -328,6 +339,10 @@ impl RouteEntry {
 
     pub(crate) fn is_absent(&self) -> bool {
         matches!(self.state, Some(RouteState::Absent))
+    }
+
+    pub(crate) fn is_ignore(&self) -> bool {
+        matches!(self.state, Some(RouteState::Ignore))
     }
 
     /// Whether the desired route (self) matches with another
@@ -620,6 +635,7 @@ impl MergedRoutes {
         current: Routes,
         merged_ifaces: &MergedInterfaces,
     ) -> Result<Self, NmstateError> {
+        desired.remove_ignored_routes();
         desired.validate()?;
         desired.resolve_next_hop_iface_ref(merged_ifaces)?;
 

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -36,6 +36,7 @@ class Route:
     CONFIG = "config"
     STATE = "state"
     STATE_ABSENT = "absent"
+    STATE_IGNORE = "ignore"
     TABLE_ID = "table-id"
     DESTINATION = "destination"
     NEXT_HOP_INTERFACE = "next-hop-interface"

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -2,8 +2,9 @@
 
 from subprocess import SubprocessError
 
-from libnmstate.schema import InterfaceState
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
 from libnmstate.schema import Route
 import libnmstate
 import pytest
@@ -14,18 +15,22 @@ from ..testlib.dummy import dummy_interface
 from ..testlib.ifacelib import get_mac_address
 from ..testlib.iproutelib import ip_monitor_assert_stable_link_up
 from ..testlib.route import assert_routes
+from ..testlib.dummy import nm_unmanaged_dummy
 
 
 from libnmstate.error import NmstateVerificationError
 
 IPV4_ADDRESS1 = "192.0.2.251"
+IPV4_ADDRESS2 = "192.0.2.252"
 IPV4_TEST_NET1 = "203.0.113.0/24"
 IPV4_GATEWAY1 = "192.0.2.1"
 IPV6_ADDRESS1 = "2001:db8:1::1"
+IPV6_ADDRESS2 = "2001:db8:1::2"
 IPV6_TEST_NET1 = "2001:db8:e::/64"
 IPV6_GATEWAY1 = "2001:db8:1::f"
 TEST_GATEAY4 = "192.0.2.1"
 TEST_GATEAY6 = "2001:db8:2::"
+DUMMY1 = "dummy1"
 
 
 @pytest.fixture
@@ -384,3 +389,102 @@ def test_route_delete_next_hop_iface_by_profile_name_no_leftover(
     )
     with pytest.raises(SubprocessError):
         exec_cmd("nmcli c show port1".split(), check=True)
+
+
+@pytest.fixture
+def unmanged_dummy1_with_static_routes():
+    with nm_unmanaged_dummy(DUMMY1):
+        exec_cmd(
+            f"ip addr add {IPV4_ADDRESS1}/24 dev {DUMMY1}".split(), check=True
+        )
+        exec_cmd(
+            f"ip addr add {IPV6_ADDRESS1}/64 dev {DUMMY1}".split(), check=True
+        )
+        exec_cmd(
+            f"ip -6 route add {IPV6_TEST_NET1} via {IPV6_ADDRESS2} "
+            f"dev {DUMMY1}".split(),
+            check=True,
+        )
+        exec_cmd(
+            f"ip route add {IPV4_TEST_NET1} via {IPV4_ADDRESS2} dev {DUMMY1} "
+            "metric 101".split(),
+            check=True,
+        )
+        yield
+
+
+# https://issues.redhat.com/browse/RHEL-107130
+@pytest.mark.tier1
+def test_show_route_as_ignored(unmanged_dummy1_with_static_routes):
+    cur_state = libnmstate.show()
+    for routes in (
+        cur_state[Route.KEY][Route.RUNNING],
+        cur_state[Route.KEY][Route.CONFIG],
+    ):
+        found = False
+        for route in routes:
+            if route[Route.NEXT_HOP_INTERFACE] == DUMMY1:
+                found = True
+                assert route[Route.STATE] == Route.STATE_IGNORE
+        assert found
+
+
+def test_apply_static_routes_to_ignored_iface(
+    unmanged_dummy1_with_static_routes,
+):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+    ]
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(
+            {
+                Route.KEY: {Route.CONFIG: routes},
+            },
+        )
+
+
+def test_apply_absent_routes_to_ignored_iface(
+    unmanged_dummy1_with_static_routes,
+):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.STATE: Route.STATE_ABSENT,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.STATE: Route.STATE_ABSENT,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Route.KEY: {Route.CONFIG: routes},
+        },
+    )
+
+    cur_state = libnmstate.show()
+    for routes in (
+        cur_state[Route.KEY][Route.RUNNING],
+        cur_state[Route.KEY][Route.CONFIG],
+    ):
+        assert any(
+            route[Route.NEXT_HOP_INTERFACE] == DUMMY1
+            and route[Route.DESTINATION] == IPV4_TEST_NET1
+            for route in routes
+        )
+        assert any(
+            route[Route.NEXT_HOP_INTERFACE] == DUMMY1
+            and route[Route.DESTINATION] == IPV6_TEST_NET1
+            for route in routes
+        )

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2437,3 +2437,71 @@ def test_add_route_with_advmss(eth1_up):
     )
     cur_state = libnmstate.show()
     assert_routes(routes, cur_state)
+
+
+# https://issues.redhat.com/browse/RHEL-107130
+@pytest.mark.tier1
+def test_apply_ignored_routes_to_ignored_iface(eth1_static_ip):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.STATE: Route.STATE_IGNORE,
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.STATE: Route.STATE_IGNORE,
+            Route.TABLE_ID: 254,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth1",
+                    Interface.STATE: InterfaceState.IGNORE,
+                }
+            ],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+
+    ipv4_routes_output = _get_routes_from_iproute(4, 254)
+    assert IPV4_ADDRESS2 not in ipv4_routes_output
+    ipv6_routes_output = _get_routes_from_iproute(6, 254)
+    assert IPV6_ADDRESS2 not in ipv6_routes_output
+
+
+# https://issues.redhat.com/browse/RHEL-107130
+@pytest.mark.tier1
+def test_apply_ignored_routes_to_iface(eth1_static_ip):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.STATE: Route.STATE_IGNORE,
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.STATE: Route.STATE_IGNORE,
+            Route.TABLE_ID: 254,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+
+    ipv4_routes_output = _get_routes_from_iproute(4, 254)
+    assert IPV4_ADDRESS2 not in ipv4_routes_output
+    ipv6_routes_output = _get_routes_from_iproute(6, 254)
+    assert IPV6_ADDRESS2 not in ipv6_routes_output


### PR DESCRIPTION
Given a system with ignored interface holding static routes,
When applying desire state retrieved by `nmstatectl show` or
`libnmstate.show()`,
The nmstate will fail with error:

```
    Desired route destination: 2001:db8:e::/64 next-hop-interface: eth1
    next-hop-address: 2001:db8:1::2 table-id: 254 not found after applyVg
```

This is caused by nmstate removed ignored interface during merging
desired state with current.

To fix this issue, this patch introduced `state: ignore` to route entry,
for `libnmstate.show()` and `nmstatectl show`, routes next hop to
ignored interface is now marked with `state: ignore` which will be
ignored during apply action.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-107130