### PR TITLE
nm: use device's Disconnect instead of DeactivateConnection

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    nm_dbus::{NmConnection, NmIfaceType},
+    device::create_index_for_nm_devs,
+    nm_dbus::{NmConnection, NmDevice, NmIfaceType},
     settings::{fix_ip_dhcp_timeout, iface_to_nm_connections},
     NmConnectionMatcher,
 };
@@ -15,12 +16,13 @@ use crate::{
 pub(crate) struct PreparedNmConnections {
     pub(crate) to_store: Vec<NmConnection>,
     pub(crate) to_activate: Vec<NmConnection>,
-    pub(crate) to_deactivate: Vec<NmConnection>,
+    pub(crate) to_deactivate: Vec<NmDevice>,
 }
 
 pub(crate) fn prepare_nm_conns(
     merged_state: &MergedNetworkState,
     conn_matcher: &NmConnectionMatcher,
+    nm_devs: &[NmDevice],
     gen_conf_mode: bool,
     is_retry: bool,
 ) -> Result<PreparedNmConnections, NmstateError> {
@@ -44,11 +46,15 @@ pub(crate) fn prepare_nm_conns(
         }
     });
 
-    let mut nm_conns_to_deactivate: Vec<NmConnection> = ifaces
-        .as_slice()
+    let nm_devs_indexed = create_index_for_nm_devs(nm_devs);
+    let mut nm_devs_to_deactivate: Vec<NmDevice> = ifaces
         .iter()
         .filter(|iface| iface.merged.is_down())
-        .filter_map(|iface| conn_matcher.get_applied(iface.merged.base_iface()))
+        .filter_map(|iface| {
+            nm_devs_indexed
+                .get(&(iface.merged.name(), iface.merged.iface_type()))
+                .copied()
+        })
         .cloned()
         .collect();
 
@@ -85,7 +91,11 @@ pub(crate) fn prepare_nm_conns(
                     == Some(true)
             {
                 nm_conns_to_activate.push(nm_conn.clone());
-                nm_conns_to_deactivate.push(nm_conn.clone());
+                if let Some(&nm_dev) =
+                    nm_devs_indexed.get(&(iface.name(), iface.iface_type()))
+                {
+                    nm_devs_to_deactivate.push(nm_dev.clone());
+                }
             }
             if iface.is_down() && gen_conf_mode {
                 if let Some(nm_conn_set) = nm_conn.connection.as_mut() {
@@ -101,7 +111,7 @@ pub(crate) fn prepare_nm_conns(
     Ok(PreparedNmConnections {
         to_store: nm_conns_to_update,
         to_activate: nm_conns_to_activate,
-        to_deactivate: nm_conns_to_deactivate,
+        to_deactivate: nm_devs_to_deactivate,
     })
 }
 

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -12,18 +12,18 @@ use crate::{
 };
 
 #[cfg_attr(not(feature = "query_apply"), allow(dead_code))]
-pub(crate) struct PerparedNmConnections {
+pub(crate) struct PreparedNmConnections {
     pub(crate) to_store: Vec<NmConnection>,
     pub(crate) to_activate: Vec<NmConnection>,
     pub(crate) to_deactivate: Vec<NmConnection>,
 }
 
-pub(crate) fn perpare_nm_conns(
+pub(crate) fn prepare_nm_conns(
     merged_state: &MergedNetworkState,
     conn_matcher: &NmConnectionMatcher,
     gen_conf_mode: bool,
     is_retry: bool,
-) -> Result<PerparedNmConnections, NmstateError> {
+) -> Result<PreparedNmConnections, NmstateError> {
     let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
 
@@ -98,7 +98,7 @@ pub(crate) fn perpare_nm_conns(
 
     fix_ip_dhcp_timeout(&mut nm_conns_to_update);
 
-    Ok(PerparedNmConnections {
+    Ok(PreparedNmConnections {
         to_store: nm_conns_to_update,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_conns_to_deactivate,

--- a/rust/src/lib/nm/device.rs
+++ b/rust/src/lib/nm/device.rs
@@ -2,14 +2,21 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::{NmDevice, NmIfaceType};
+use crate::nm::nm_dbus::NmDevice;
+use crate::InterfaceType;
 
 pub(crate) fn create_index_for_nm_devs(
     nm_devs: &[NmDevice],
-) -> HashMap<(String, NmIfaceType), &NmDevice> {
-    let mut ret: HashMap<(String, NmIfaceType), &NmDevice> = HashMap::new();
+) -> HashMap<(&str, InterfaceType), &NmDevice> {
+    let mut ret = HashMap::new();
     for nm_dev in nm_devs {
-        ret.insert((nm_dev.name.to_string(), nm_dev.iface_type), nm_dev);
+        ret.insert(
+            (
+                nm_dev.name.as_str(),
+                InterfaceType::from(&nm_dev.iface_type),
+            ),
+            nm_dev,
+        );
     }
     ret
 }

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -3,7 +3,7 @@
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
 use super::{
-    connection::perpare_nm_conns,
+    connection::prepare_nm_conns,
     dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
     route::store_route_config,
     route_rule::store_route_rule_config,
@@ -42,7 +42,7 @@ pub(crate) fn nm_gen_conf(
         &merged_state.interfaces,
     );
 
-    let nm_conns = perpare_nm_conns(
+    let nm_conns = prepare_nm_conns(
         &merged_state,
         &conn_matcher,
         true,  // gen_conf mode

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -45,6 +45,7 @@ pub(crate) fn nm_gen_conf(
     let nm_conns = prepare_nm_conns(
         &merged_state,
         &conn_matcher,
+        &[],
         true,  // gen_conf mode
         false, // is_retry
     )?

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -4,7 +4,6 @@
 mod checkpoint;
 mod conn_matcher;
 mod connection;
-#[cfg(feature = "query_apply")]
 mod device;
 pub(crate) mod dns;
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -17,7 +17,7 @@ use super::{
     error::{ErrorKind, NmError},
     lldp::NmLldpNeighbor,
     query_apply::device::{
-        nm_dev_delete, nm_dev_from_obj_path, nm_dev_get_llpd,
+        nm_dev_delete, nm_dev_disconnect, nm_dev_from_obj_path, nm_dev_get_llpd,
     },
     NmIfaceType,
 };
@@ -323,6 +323,14 @@ impl NmApi<'_> {
             }
         }
         Ok(ret)
+    }
+
+    pub async fn device_disconnect(
+        &mut self,
+        nm_dev_obj_path: &str,
+    ) -> Result<(), NmError> {
+        self.extend_timeout_if_required().await?;
+        nm_dev_disconnect(&self.dbus.connection, nm_dev_obj_path).await
     }
 
     pub async fn device_delete(

--- a/rust/src/lib/nm/nm_dbus/query_apply/device.rs
+++ b/rust/src/lib/nm/nm_dbus/query_apply/device.rs
@@ -215,6 +215,32 @@ pub(crate) async fn nm_dev_from_obj_path(
     Ok(dev)
 }
 
+pub(crate) async fn nm_dev_disconnect(
+    dbus_conn: &zbus::Connection,
+    obj_path: &str,
+) -> Result<(), NmError> {
+    let proxy = zbus::Proxy::new(
+        dbus_conn,
+        NM_DBUS_INTERFACE_ROOT,
+        obj_path,
+        NM_DBUS_INTERFACE_DEV,
+    )
+    .await?;
+    match proxy.call::<&str, (), ()>("Disconnect", &()).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let nm_err: NmError = e.into();
+            Err(NmError::new(
+                nm_err.kind,
+                format!(
+                    "Failed to disconnect device {obj_path}: {}",
+                    nm_err.msg
+                ),
+            ))
+        }
+    }
+}
+
 pub(crate) async fn nm_dev_delete(
     dbus_conn: &zbus::Connection,
     obj_path: &str,

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use super::super::{
-    connection::{perpare_nm_conns, PerparedNmConnections},
+    connection::{prepare_nm_conns, PreparedNmConnections},
     device::create_index_for_nm_devs,
     dns::{
         store_dns_config_to_desired_iface, store_dns_config_to_iface,
@@ -156,11 +156,12 @@ pub(crate) async fn nm_apply(
             store_dns_config_to_desired_iface(&mut merged_state);
         }
     }
-    let PerparedNmConnections {
+
+    let PreparedNmConnections {
         to_store: nm_conns_to_store,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_conns_to_deactivate,
-    } = perpare_nm_conns(&merged_state, &conn_matcher, false, is_retry)?;
+    } = prepare_nm_conns(&merged_state, &conn_matcher, false, is_retry)?;
 
     let nm_conns_to_deactivate_first = gen_nm_conn_need_to_deactivate_first(
         &merged_state.interfaces,

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -14,8 +14,8 @@ use super::super::{
     query_apply::{
         activate_nm_connections,
         connection::is_uuid,
-        deactivate_nm_connections, delete_exist_connections,
-        delete_orphan_ovs_ports,
+        deactivate_nm_connections, deactivate_nm_devices,
+        delete_exist_connections, delete_orphan_ovs_ports,
         dispatch::apply_dispatch_script,
         dns::{
             cur_dns_ifaces_still_valid_for_dns, is_iface_dns_desired,
@@ -160,8 +160,14 @@ pub(crate) async fn nm_apply(
     let PreparedNmConnections {
         to_store: nm_conns_to_store,
         to_activate: nm_conns_to_activate,
-        to_deactivate: nm_conns_to_deactivate,
-    } = prepare_nm_conns(&merged_state, &conn_matcher, false, is_retry)?;
+        to_deactivate: nm_devs_to_deactivate,
+    } = prepare_nm_conns(
+        &merged_state,
+        &conn_matcher,
+        &nm_devs,
+        false,
+        is_retry,
+    )?;
 
     let nm_conns_to_deactivate_first = gen_nm_conn_need_to_deactivate_first(
         &merged_state.interfaces,
@@ -205,8 +211,12 @@ pub(crate) async fn nm_apply(
     )
     .await?;
 
-    deactivate_nm_connections(&mut nm_api, nm_conns_to_deactivate.as_slice())
-        .await?;
+    // Deactivate the devices, not their connections. According to NM's
+    // documentation, this prevents automatic connection activations.
+    // We have deleted most of the other matching connections, but we cannot
+    // delete some connections with "multiconnect". This would lead to unwanted
+    // connection activations if we use deactivate_nm_connections.
+    deactivate_nm_devices(&mut nm_api, &nm_devs_to_deactivate).await?;
 
     Ok(())
 }

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -321,10 +321,9 @@ async fn delete_remain_virtual_interface_as_desired(
         .map(|i| &i.merged)
     {
         if iface.is_virtual() {
-            if let Some(nm_dev) = nm_devs_indexed.get(&(
-                iface.name().to_string(),
-                NmIfaceType::from(&iface.iface_type()),
-            )) {
+            if let Some(nm_dev) =
+                nm_devs_indexed.get(&(iface.name(), iface.iface_type()))
+            {
                 log::info!(
                     "Deleting interface {}/{}: {}",
                     &iface.name(),

--- a/rust/src/lib/nm/query_apply/device.rs
+++ b/rust/src/lib/nm/query_apply/device.rs
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::nm_dbus::{NmDevice, NmIfaceType},
-    InterfaceType,
+    nm::{
+        error::nm_error_to_nmstate,
+        nm_dbus::{ErrorKind, NmApi, NmDevice, NmDeviceError, NmIfaceType},
+    },
+    InterfaceType, NmstateError,
 };
 
 fn nm_iface_type_to_nmstate(nm_iface_type: &NmIfaceType) -> InterfaceType {
@@ -37,4 +40,19 @@ pub(crate) fn nm_dev_iface_type_to_nmstate(nm_dev: &NmDevice) -> InterfaceType {
     } else {
         iface_type
     }
+}
+
+pub(crate) async fn deactivate_nm_devices(
+    nm_api: &mut NmApi<'_>,
+    nm_devs: &[NmDevice],
+) -> Result<(), NmstateError> {
+    for nm_dev in nm_devs {
+        log::info!("Deactivating device {}", &nm_dev.name);
+        if let Err(e) = nm_api.device_disconnect(&nm_dev.obj_path).await {
+            if e.kind != ErrorKind::Device(NmDeviceError::NotActive) {
+                return Err(nm_error_to_nmstate(e));
+            }
+        }
+    }
+    Ok(())
 }

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use self::connection::{
     activate_nm_connections, deactivate_nm_connections,
     delete_exist_connections, save_nm_connections,
 };
+pub(crate) use self::device::deactivate_nm_devices;
 pub(crate) use self::dns::retrieve_dns_info;
 pub(crate) use self::ieee8021x::nm_802_1x_to_nmstate;
 pub(crate) use self::ip::{

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -5,6 +5,8 @@ from subprocess import SubprocessError
 
 import pytest
 
+import time
+
 import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
@@ -421,7 +423,7 @@ def test_ovs_profile_been_delete_by_state_absent(
 
 
 @pytest.fixture
-def multiconnect_profile_with_ip_disabled():
+def multiconnect_profile_with_ip_disabled(eth1_up):
     cmdlib.exec_cmd("nmcli c del eth1".split(), check=True)
     cmdlib.exec_cmd(
         "nmcli c add type ethernet connection.id nmstate-test-default "
@@ -436,7 +438,6 @@ def multiconnect_profile_with_ip_disabled():
 # We cannot use eth1_up which create a dedicate profile for eth1.
 # In order to test the multiconnect feature, we should do it manually.
 def test_set_static_ip_with_multiconnect_profile(
-    eth1_up,
     multiconnect_profile_with_ip_disabled,
 ):
     desired_state = {
@@ -788,3 +789,37 @@ def test_remove_non_exist_down_profile_with_both_mac_and_name(
         cmdlib.exec_cmd(
             "nmcli -g connection.id c show wan0".split(), check=True
         )
+
+
+@pytest.fixture
+def multiconnect_profile_matchall():
+    cmdlib.exec_cmd(
+        "nmcli c add type ethernet connection.id nmstate-test-default "
+        "connection.multi-connect multiple "
+        "ipv4.method disabled ipv6.method disabled".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd("nmcli c del nmstate-test-default".split(), check=False)
+
+
+def test_down_iface_with_multiconnect_profile(
+    eth1_up, multiconnect_profile_matchall
+):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.STATE: InterfaceState.DOWN,
+            }
+        ]
+    }
+    libnmstate.apply(desired_state)
+    assertlib.assert_state_match(desired_state)
+    time.sleep(1)  # Give some time to NetworkManager to auto-activate profiles
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g GENERAL.CONNECTION d show eth1".split(), check=True
+        )[1]
+        == "\n"
+    )


### PR DESCRIPTION
According to NM's documentation:
- connection down: Deactivate a connection from a device without
  preventing the device from further auto-activation.
- device down: Disconnect a device and prevent the device from
  automatically activating further connections without user/manual
  intervention.

The documentation about the D-Bus Device.Disconnect method says the
same.

Use Device.Disconnect to prevent from unwanted connection activations
on devices whose desired state is `down`.

Previously, to avoid uwnanted activations we just deleted any other
connection that matches the device. However, we didn't delete connections
with "multiconnect" that also match other devices to avoid affecting to
other devices. In this case, the multiconnect connection may auto-
activate on the device after doing connection down on the previous
active connection. Using Device.Disconnect it won't happen.

Note that this problem still exists when using `state: absent`. In that
case the multiconnect connection will auto-activate after a reboot. This
needs to be fixed separately.

Resolves: https://issues.redhat.com/browse/RHEL-102340
