### PR TITLE
gen_conf: Use UUID for non-name-ref parent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - rust_version: "stable"
           - rust_version: "nightly"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5
@@ -61,7 +61,7 @@ jobs:
           - rust_version: "nightly"
           - rust_version: "beta"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5
@@ -97,7 +97,7 @@ jobs:
       run: make clib_check
 
   rpm_build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -114,7 +114,7 @@ jobs:
           retention-days: 5
 
   py_lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: quay.io/nmstate/test-env:nmstate-lint
     steps:
       - uses: actions/checkout@v5
@@ -124,7 +124,7 @@ jobs:
 
   integ:
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [rust_lint, py_lint, rpm_build]
     strategy:
       fail-fast: false

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - msrv: "1.77"
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ErrorKind, MergedNetworkState, NmstateError};
+use crate::{
+    ErrorKind, InterfaceIdentifier, MergedInterfaces, MergedNetworkState,
+    NmstateError,
+};
 
 use super::{
     connection::prepare_nm_conns,
     dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
     route::store_route_config,
     route_rule::store_route_rule_config,
+    settings::uuid_from_name_and_type,
     NmConnectionMatcher,
 };
 
@@ -34,6 +38,13 @@ pub(crate) fn nm_gen_conf(
     } else {
         store_dns_config_to_iface(&mut merged_state, &[], &[])?;
     }
+
+    // If parent interface is not referenced by interface name, in `gen_conf`
+    // mode, nmstate cannot tell the real interface name of parent, so child
+    // should refer its parent by UUID.
+    // Since we are using `stable_uuid` in gen_conf mode, we can predict the
+    // UUID via `uuid_from_name_and_type()` of parent.
+    use_uuid_for_non_name_ref_parent(&mut merged_state.interfaces);
 
     let conn_matcher = NmConnectionMatcher::new(
         Vec::new(),
@@ -70,4 +81,43 @@ pub(crate) fn nm_gen_conf(
         }
     }
     Ok(ret)
+}
+
+// If parent interface is not referenced by interface name, in `gen_conf`
+// mode, nmstate cannot tell the real interface name of parent, so child should
+// refer its parent by UUID.
+fn use_uuid_for_non_name_ref_parent(merged_ifaces: &mut MergedInterfaces) {
+    // Pending changes holds Vec of (child_interface_name, parent_uuid).
+    let mut pending_changes: Vec<(String, String)> = Vec::new();
+    for iface in merged_ifaces
+        .kernel_ifaces
+        .values()
+        .filter_map(|i| i.for_apply.as_ref())
+    {
+        if let Some(parent) = iface.parent() {
+            if let Some(parent_iface) = merged_ifaces.kernel_ifaces.get(parent)
+            {
+                if parent_iface.merged.base_iface().identifier
+                    != Some(InterfaceIdentifier::Name)
+                    && parent_iface.merged.base_iface().identifier.is_some()
+                {
+                    let parent_uuid = uuid_from_name_and_type(
+                        parent_iface.merged.name(),
+                        &parent_iface.merged.iface_type(),
+                    );
+                    pending_changes
+                        .push((iface.name().to_string(), parent_uuid));
+                }
+            }
+        }
+    }
+    for (child_name, parent_uuid) in pending_changes {
+        if let Some(child_iface) = merged_ifaces
+            .kernel_ifaces
+            .get_mut(&child_name)
+            .and_then(|i| i.for_apply.as_mut())
+        {
+            child_iface.change_parent_name(&parent_uuid);
+        }
+    }
 }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
@@ -64,6 +64,9 @@ impl NmConnection {
         if let Some(mac_vlan) = &self.mac_vlan {
             sections.push(("macvlan", mac_vlan.to_keyfile()?));
         }
+        if let Some(macsec) = &self.macsec {
+            sections.push(("macsec", macsec.to_keyfile()?));
+        }
         if let Some(vrf) = &self.vrf {
             sections.push(("vrf", vrf.to_keyfile()?));
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/conn.rs
@@ -97,6 +97,9 @@ impl NmConnection {
                 sections.push(("vpn-secrets", s));
             }
         }
+        if let Some(iface_match) = &self.iface_match {
+            sections.push(("match", iface_match.to_keyfile()?));
+        }
 
         keyfile_sections_to_string(&sections)
     }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/macsec.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/macsec.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::{NmSettingMacSec, ToKeyfile};
+
+impl ToKeyfile for NmSettingMacSec {}

--- a/rust/src/lib/nm/nm_dbus/gen_conf/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/mod.rs
@@ -11,6 +11,7 @@ mod ip;
 mod ipvlan;
 mod keyfile;
 mod mac_vlan;
+mod macsec;
 mod ovs;
 mod route;
 mod route_rule;

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -427,7 +427,7 @@ pub(crate) fn gen_nm_conn_setting(
     Ok(())
 }
 
-fn uuid_from_name_and_type(
+pub(crate) fn uuid_from_name_and_type(
     iface_name: &str,
     iface_type: &InterfaceType,
 ) -> String {

--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -30,6 +30,9 @@ mod wired;
 pub(crate) use self::connection::iface_to_nm_connections;
 pub(crate) use self::ip::fix_ip_dhcp_timeout;
 
+#[cfg(feature = "gen_conf")]
+pub(crate) use self::connection::uuid_from_name_and_type;
+
 #[cfg(feature = "query_apply")]
 pub(crate) use self::bond::get_bond_balance_slb;
 #[cfg(feature = "query_apply")]

--- a/rust/src/lib/unit_tests/ethernet.rs
+++ b/rust/src/lib/unit_tests/ethernet.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ErrorKind, EthernetConfig, EthernetDuplex, EthernetInterface, Interface,
-    InterfaceIdentifier, InterfaceType, Interfaces, MergedInterfaces,
+    ErrorKind, EthernetInterface, InterfaceIdentifier, InterfaceType,
+    Interfaces, MergedInterfaces,
 };
 
 #[test]

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -588,3 +588,181 @@ def test_gen_conf_ovs_bridge_port_ref_by_mac(eth1_eth2_up_with_no_config):
                 - name: eth2"""
         )
         assertlib.assert_state_match(expected_state)
+
+
+def test_gen_conf_vlan_parent_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {port1_mac}
+        - name: vlan100
+          type: vlan
+          state: up
+          vlan:
+            id: 100
+            base-iface: port1
+            """
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: vlan100
+              type: vlan
+              state: up
+              vlan:
+                id: 100
+                base-iface: eth1"""
+        )
+        assertlib.assert_state_match(expected_state)
+
+
+def test_gen_conf_vxlan_parent_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {port1_mac}
+        - name: vxlan100
+          type: vxlan
+          state: up
+          vxlan:
+            id: 100
+            base-iface: port1
+            """
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: vxlan100
+              type: vxlan
+              state: up
+              vxlan:
+                id: 100
+                base-iface: eth1"""
+        )
+        assertlib.assert_state_match(expected_state)
+
+
+def test_gen_conf_macvlan_parent_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {port1_mac}
+        - name: macvlan100
+          type: mac-vlan
+          state: up
+          mac-vlan:
+            base-iface: port1
+            mode: passthru
+            promiscuous: true
+            """
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: macvlan100
+              type: mac-vlan
+              state: up
+              mac-vlan:
+                base-iface: eth1
+                mode: passthru
+                promiscuous: true"""
+        )
+        assertlib.assert_state_match(expected_state)
+
+
+def test_gen_conf_macvtap_parent_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {port1_mac}
+        - name: macvtap100
+          type: mac-vtap
+          state: up
+          mac-vtap:
+            base-iface: port1
+            mode: passthru
+            promiscuous: true
+            """
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: macvtap100
+              type: mac-vtap
+              state: up
+              mac-vtap:
+                base-iface: eth1
+                mode: passthru
+                promiscuous: true"""
+        )
+        assertlib.assert_state_match(expected_state)
+
+
+def test_gen_conf_macsec_parent_ref_by_mac(eth1_eth2_up_with_no_config):
+    port1_mac = get_mac_address("eth1")
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: mac-address
+          mac-address: {port1_mac}
+        - name: macsec100
+          type: macsec
+          state: up
+          macsec:
+            encrypt: true
+            base-iface: port1
+            mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
+            mka-ckn: f2b4297d39da7330910a74abc0449feb
+            port: 0
+            validation: strict
+            send-sci: true"""
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            """---
+            interfaces:
+            - name: macsec100
+              type: macsec
+              state: up
+              macsec:
+                encrypt: true
+                base-iface: eth1
+                mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
+                mka-ckn: f2b4297d39da7330910a74abc0449feb
+                port: 0
+                validation: strict
+                send-sci: true"""
+        )
+        assertlib.assert_state_match(expected_state)

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -105,6 +105,29 @@ interfaces:
         assertlib.assert_state_match(desired_state)
 
 
+def test_gen_conf_mac_sec(eth1_eth2_up_with_no_config):
+    desired_state = load_yaml(
+        """
+interfaces:
+- name: eth1
+  type: ethernet
+- name: macsec0
+  type: macsec
+  state: up
+  macsec:
+    encrypt: true
+    base-iface: eth1
+    mka-cak: 50b71a8ef0bd5751ea76de6d6c98c03a
+    mka-ckn: f2b4297d39da7330910a74abc0449feb45b5c0b9fc23df1430e1898fcf1c4550
+    port: 0
+    validation: strict
+    send-sci: true"""
+    )
+
+    with gen_conf_apply(desired_state):
+        assertlib.assert_state_match(desired_state)
+
+
 @pytest.mark.tier1
 def test_gen_conf_routes_rules():
     desired_state = load_yaml(

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import time
+import os
 
 import pytest
 import yaml
@@ -764,5 +765,67 @@ def test_gen_conf_macsec_parent_ref_by_mac(eth1_eth2_up_with_no_config):
                 port: 0
                 validation: strict
                 send-sci: true"""
+        )
+        assertlib.assert_state_match(expected_state)
+
+
+def _test_nic_name():
+    return os.environ["TEST_REAL_NIC"]
+
+
+def _test_nic_pci():
+    iface_name = _test_nic_name()
+    iface_state = show_only((iface_name,))[Interface.KEY][0]
+    return iface_state[Interface.PCI]
+
+
+@pytest.fixture
+def real_nic_without_nm_connection():
+    libnmstate.apply(
+        load_yaml(
+            f"""
+            interfaces:
+            - name: {_test_nic_name()}
+              type: ethernet
+              state: absent
+            """
+        )
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_REAL_NIC"),
+    reason="Need to define TEST_REAL_NIC for PCI identifier test",
+)
+def test_ref_vlan_parent_via_pci_address(real_nic_without_nm_connection):
+    iface_name = _test_nic_name()
+    pci_address = _test_nic_pci()
+
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: port1
+          type: ethernet
+          identifier: pci-address
+          pci-address: "{pci_address}"
+        - name: vlan100
+          type: vlan
+          state: up
+          vlan:
+            id: 100
+            base-iface: port1
+            """
+    )
+
+    with gen_conf_apply(desired_state):
+        expected_state = load_yaml(
+            f"""---
+            interfaces:
+            - name: vlan100
+              type: vlan
+              state: up
+              vlan:
+                id: 100
+                base-iface: {iface_name}"""
         )
         assertlib.assert_state_match(expected_state)

--- a/tests/integration/vlan_test.py
+++ b/tests/integration/vlan_test.py
@@ -714,11 +714,27 @@ def test_vlan_add_qos_map_to_existing(vlan_on_eth1):
     assertlib.assert_state_match(desired_state)
 
 
+@pytest.fixture
+def clean_up_test_vlan():
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: VLAN_IFNAME,
+                    Interface.TYPE: InterfaceType.VLAN,
+                    Interface.STATE: InterfaceState.ABSENT,
+                },
+            ]
+        }
+    )
+
+
 @pytest.mark.skipif(
     nm_minor_version() < 51,
     reason=("VLAN QoS map is only fixed by NetworkManager 1.51+"),
 )
-def test_vlan_add_multiple_qos_map_in_mixed_order(eth1_up):
+def test_vlan_add_multiple_qos_map_in_mixed_order(eth1_up, clean_up_test_vlan):
     state = {
         Interface.KEY: [
             {


### PR DESCRIPTION
If parent interface is not referenced by interface name, in `gen_conf`
mode, nmstate cannot tell the real interface name of parent, so child
should refer its parent by UUID.

Implementation detail:

```
   In `gen_conf` mode, the UUID of certain interface can be predict by
   its name and type, so instead of modify the generated NmConnection
   afterwards, this patch invoke `Interface.change_parent_name()` to
   change the parent name into `UUID` of its parent when its parent is
   non-name identifier.
```

Integration test cases included for all child interface types:
* VLAN
* VxLAN
* MAC VTAP
* MAC VLAN
* MAC Sec

Resolves: https://issues.redhat.com/browse/RHEL-94783