### PR TITLE
route: Better error message for routes to ignored interface

### DIFF
--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -94,8 +94,12 @@ fn nmstate_iface_to_np(
     let nms_iface = match nms_merged_iface.for_apply.as_ref() {
         Some(iface) => iface,
         None => {
-            let error =
-                NmstateError::new(ErrorKind::Bug, "BUG: merged_interface.for_apply was assumed to be Some but None was found".to_string());
+            let error = NmstateError::new(
+                ErrorKind::Bug,
+                "BUG: merged_interface.for_apply was assumed to be Some but \
+                 None was found"
+                    .to_string(),
+            );
             return Err(error);
         }
     };

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -132,14 +132,32 @@ impl Routes {
                         continue;
                     }
                     if kernel_names.is_empty() && !route.is_absent() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Route '{}': next hop interface {} not found",
-                                route,
-                                next_hop_iface.as_str()
-                            ),
-                        ));
+                        if merged_ifaces.ignored_ifaces.iter().any(
+                            |(name, iface_type)| {
+                                name == next_hop_iface
+                                    && !iface_type.is_userspace()
+                            },
+                        ) {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Route '{}': next hop interface {} is \
+                                     marked as ignored",
+                                    route,
+                                    next_hop_iface.as_str()
+                                ),
+                            ));
+                        } else {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Route '{}': next hop interface {} not \
+                                     found",
+                                    route,
+                                    next_hop_iface.as_str()
+                                ),
+                            ));
+                        }
                     } else if kernel_names.len() > 1 {
                         return Err(NmstateError::new(
                             ErrorKind::InvalidArgument,


### PR DESCRIPTION
Current error message for routes to ignored interface is:

```
   Route 'destination: 198.51.100.0/24 next-hop-interface: dummy1
   next-hop-address: 192.0.2.1 metric: 150 table-id: 254': next hop
   interface dummy1 not found
```

Changed to:

```
   Route 'destination: 198.51.100.0/24 next-hop-interface: dummy1
   next-hop-address: 192.0.2.1 metric: 150 table-id: 254': next hop
   interface dummy1 is marked as ignored
```