### PR TITLE
nm dns: always save DNS search and options to global-dns

### DIFF
--- a/rust/src/lib/nm/nm_dbus/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/dns.rs
@@ -105,21 +105,26 @@ impl NmGlobalDnsConfig {
         }
         Ok(zvariant::Value::Dict(ret))
     }
-}
 
-impl TryFrom<HashMap<String, zvariant::OwnedValue>> for NmGlobalDnsConfig {
-    type Error = NmError;
-    fn try_from(
+    pub(crate) fn from_value(
         mut v: HashMap<String, zvariant::OwnedValue>,
-    ) -> Result<Self, Self::Error> {
-        Ok(Self {
-            searches: _from_map!(v, "searches", Vec::<String>::try_from)?
-                .unwrap_or_default(),
-            options: _from_map!(v, "options", Vec::<String>::try_from)?
-                .unwrap_or_default(),
-            domains: _from_map!(v, "domains", parse_global_dns_domain_configs)?
-                .unwrap_or_default(),
-        })
+    ) -> Result<Option<NmGlobalDnsConfig>, NmError> {
+        let searches = _from_map!(v, "searches", Vec::<String>::try_from)?;
+        let options = _from_map!(v, "options", Vec::<String>::try_from)?;
+        let domains =
+            _from_map!(v, "domains", parse_global_dns_domain_configs)?
+                .unwrap_or_default();
+        if searches.is_some() || options.is_some() || !domains.is_empty() {
+            Ok(Some(Self {
+                searches: searches.unwrap_or_default(),
+                options: options.unwrap_or_default(),
+                domains,
+            }))
+        } else {
+            // If searches and options are missing, it means that no
+            // [global-dns] section is defined in NM
+            Ok(None)
+        }
     }
 }
 

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -431,10 +431,17 @@ impl NmApi<'_> {
         Ok(())
     }
 
+    /// Get the global DNS configuration.
+    /// If no global DNS configuration exists, `Ok(None)` is returned. The
+    /// distinction from an empty global DNS configuration is important,
+    /// because an empty global config overwrites connections' DNS configs.
+    /// If no global DNS config exists, then connections' DNS configs matter.
     pub async fn get_global_dns_configuration(
         &self,
-    ) -> Result<NmGlobalDnsConfig, NmError> {
-        NmGlobalDnsConfig::try_from(self.dbus.global_dns_configuration().await?)
+    ) -> Result<Option<NmGlobalDnsConfig>, NmError> {
+        NmGlobalDnsConfig::from_value(
+            self.dbus.global_dns_configuration().await?,
+        )
     }
 
     pub async fn set_global_dns_configuration(

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -5,22 +5,13 @@ use std::collections::HashSet;
 use super::super::{
     connection::{prepare_nm_conns, PreparedNmConnections},
     device::create_index_for_nm_devs,
-    dns::{
-        store_dns_config_to_desired_iface, store_dns_config_to_iface,
-        store_dns_search_or_option_to_iface,
-    },
     error::nm_error_to_nmstate,
     nm_dbus::{NmApi, NmConnection, NmIfaceType, NmVersion, NmVersionInfo},
     query_apply::{
-        activate_nm_connections,
-        connection::is_uuid,
+        activate_nm_connections, connection::is_uuid,
         deactivate_nm_connections, deactivate_nm_devices,
         delete_exist_connections, delete_orphan_ovs_ports,
-        dispatch::apply_dispatch_script,
-        dns::{
-            cur_dns_ifaces_still_valid_for_dns, is_iface_dns_desired,
-            purge_global_dns_config, store_dns_config_via_global_api,
-        },
+        dispatch::apply_dispatch_script, dns::store_dns_config,
         is_ipvlan_changed, is_mptcp_flags_changed, is_route_removed,
         is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
         is_vxlan_changed, save_nm_connections,
@@ -104,58 +95,7 @@ pub(crate) async fn nm_apply(
 
     store_route_rule_config(&mut merged_state)?;
 
-    if merged_state.dns.is_changed()
-        || merged_state.dns.is_desired()
-        || !cur_dns_ifaces_still_valid_for_dns(&merged_state.interfaces)
-    {
-        purge_global_dns_config(&mut nm_api).await?;
-
-        if merged_state.dns.is_search_or_option_only() {
-            log::info!(
-                "Using interface level DNS for special use case: only static \
-                 DNS search and/or DNS option desired"
-            );
-            // we cannot use global DNS in this case because global DNS suppress
-            // DNS nameserver learn from DHCP/autoconf.
-            store_dns_search_or_option_to_iface(
-                &mut merged_state,
-                &nm_acs,
-                &nm_devs,
-            )?;
-        } else if is_iface_dns_desired(&merged_state) {
-            if let Err(e) =
-                store_dns_config_to_iface(&mut merged_state, &nm_acs, &nm_devs)
-            {
-                log::info!(
-                    "Cannot store DNS to interface profile: {e}, will try to \
-                     set via global DNS"
-                );
-                store_dns_config_via_global_api(
-                    &mut nm_api,
-                    merged_state.dns.servers.as_slice(),
-                    merged_state.dns.searches.as_slice(),
-                    merged_state.dns.options.as_slice(),
-                )
-                .await?;
-            }
-        } else if merged_state.dns.is_purge() {
-            // Also need to purge interface level DNS
-            store_dns_config_to_iface(&mut merged_state, &nm_acs, &nm_devs)
-                .ok();
-        } else {
-            store_dns_config_via_global_api(
-                &mut nm_api,
-                merged_state.dns.servers.as_slice(),
-                merged_state.dns.searches.as_slice(),
-                merged_state.dns.options.as_slice(),
-            )
-            .await?;
-            // Still store DNS into desired interface to provides backwards
-            // compatibility for user who uses NM keyfiles only:
-            // https://github.com/coreos/fedora-coreos-tracker/issues/1947
-            store_dns_config_to_desired_iface(&mut merged_state);
-        }
-    }
+    store_dns_config(&mut merged_state, &mut nm_api, &nm_acs, &nm_devs).await?;
 
     let PreparedNmConnections {
         to_store: nm_conns_to_store,

--- a/rust/src/lib/nm/query_apply/dns.rs
+++ b/rust/src/lib/nm/query_apply/dns.rs
@@ -264,7 +264,7 @@ async fn purge_global_dns_config(
         .get_global_dns_configuration()
         .await
         .map_err(nm_error_to_nmstate)?;
-    if !cur_dns.is_empty() {
+    if cur_dns.is_none() || cur_dns.is_some_and(|cur_dns| !cur_dns.is_empty()) {
         log::debug!("Purging NM Global DNS config");
         nm_api
             .set_global_dns_configuration(&NmGlobalDnsConfig::default())

--- a/rust/src/lib/nm/query_apply/dns.rs
+++ b/rust/src/lib/nm/query_apply/dns.rs
@@ -3,9 +3,16 @@
 use std::str::FromStr;
 
 use super::super::{
-    dns::{extract_ipv6_link_local_iface_from_dns_srv, get_cur_dns_ifaces},
+    dns::{
+        extract_ipv6_link_local_iface_from_dns_srv, get_cur_dns_ifaces,
+        store_dns_config_to_desired_iface, store_dns_config_to_iface,
+        store_dns_search_or_option_to_iface,
+    },
     error::nm_error_to_nmstate,
-    nm_dbus::{NmApi, NmDnsEntry, NmGlobalDnsConfig, NmSettingIp},
+    nm_dbus::{
+        NmActiveConnection, NmApi, NmDevice, NmDnsEntry, NmGlobalDnsConfig,
+        NmSettingIp,
+    },
 };
 
 use crate::{
@@ -170,7 +177,63 @@ fn nm_dns_srvs_to_nmstate(nm_dns_entry: &NmDnsEntry) -> Vec<String> {
     srvs
 }
 
-pub(crate) async fn store_dns_config_via_global_api(
+pub(crate) async fn store_dns_config(
+    merged_state: &mut MergedNetworkState,
+    nm_api: &mut NmApi<'_>,
+    nm_acs: &[NmActiveConnection],
+    nm_devs: &[NmDevice],
+) -> Result<(), NmstateError> {
+    if merged_state.dns.is_changed()
+        || merged_state.dns.is_desired()
+        || !cur_dns_ifaces_still_valid_for_dns(&merged_state.interfaces)
+    {
+        purge_global_dns_config(nm_api).await?;
+
+        if merged_state.dns.is_search_or_option_only() {
+            log::info!(
+                "Using interface level DNS for special use case: only static \
+                 DNS search and/or DNS option desired"
+            );
+            // we cannot use global DNS in this case because global DNS suppress
+            // DNS nameserver learn from DHCP/autoconf.
+            store_dns_search_or_option_to_iface(merged_state, nm_acs, nm_devs)?;
+        } else if is_iface_dns_desired(merged_state) {
+            if let Err(e) =
+                store_dns_config_to_iface(merged_state, nm_acs, nm_devs)
+            {
+                log::info!(
+                    "Cannot store DNS to interface profile: {e}, will try to \
+                     set via global DNS"
+                );
+                store_dns_config_via_global_api(
+                    nm_api,
+                    merged_state.dns.servers.as_slice(),
+                    merged_state.dns.searches.as_slice(),
+                    merged_state.dns.options.as_slice(),
+                )
+                .await?;
+            }
+        } else if merged_state.dns.is_purge() {
+            // Also need to purge interface level DNS
+            store_dns_config_to_iface(merged_state, nm_acs, nm_devs).ok();
+        } else {
+            store_dns_config_via_global_api(
+                nm_api,
+                merged_state.dns.servers.as_slice(),
+                merged_state.dns.searches.as_slice(),
+                merged_state.dns.options.as_slice(),
+            )
+            .await?;
+            // Still store DNS into desired interface to provides backwards
+            // compatibility for user who uses NM keyfiles only:
+            // https://github.com/coreos/fedora-coreos-tracker/issues/1947
+            store_dns_config_to_desired_iface(merged_state);
+        }
+    }
+    Ok(())
+}
+
+async fn store_dns_config_via_global_api(
     nm_api: &mut NmApi<'_>,
     servers: &[String],
     searches: &[String],
@@ -194,7 +257,7 @@ pub(crate) async fn store_dns_config_via_global_api(
     Ok(())
 }
 
-pub(crate) async fn purge_global_dns_config(
+async fn purge_global_dns_config(
     nm_api: &mut NmApi<'_>,
 ) -> Result<(), NmstateError> {
     let cur_dns = nm_api
@@ -243,7 +306,7 @@ pub(crate) fn nm_global_dns_to_nmstate(
 //  3. User want to force DNS server stored in interface for static IP
 //     interface. This case, user need to state static DNS config along with
 //     static IP config.
-pub(crate) fn is_iface_dns_desired(merged_state: &MergedNetworkState) -> bool {
+fn is_iface_dns_desired(merged_state: &MergedNetworkState) -> bool {
     if extract_ipv6_link_local_iface_from_dns_srv(
         merged_state.dns.servers.as_slice(),
     )
@@ -296,7 +359,7 @@ pub(crate) fn is_iface_dns_desired(merged_state: &MergedNetworkState) -> bool {
     false
 }
 
-pub(crate) fn cur_dns_ifaces_still_valid_for_dns(
+fn cur_dns_ifaces_still_valid_for_dns(
     merged_ifaces: &MergedInterfaces,
 ) -> bool {
     let (cur_v4_ifaces, cur_v6_ifaces) = get_cur_dns_ifaces(merged_ifaces);

--- a/rust/src/lib/nm/query_apply/dns.rs
+++ b/rust/src/lib/nm/query_apply/dns.rs
@@ -51,110 +51,161 @@ pub(crate) fn nm_dns_to_nmstate(
     }
 }
 
-pub(crate) async fn retrieve_dns_info(
+pub(crate) async fn retrieve_dns_state(
     nm_api: &mut NmApi<'_>,
     ifaces: &Interfaces,
 ) -> Result<DnsState, NmstateError> {
-    let mut nm_dns_entires = nm_api
+    let config_dns_info = retrieve_configured_dns_info(nm_api, ifaces).await?;
+    let running_dns_servers = retrieve_running_dns_servers(nm_api).await?;
+    let running_dns_info = DnsClientState {
+        server: Some(running_dns_servers),
+        search: config_dns_info.search.clone(),
+        options: config_dns_info.options.clone(),
+        ..Default::default()
+    };
+
+    Ok(DnsState {
+        running: Some(running_dns_info),
+        config: Some(config_dns_info),
+    })
+}
+
+async fn retrieve_running_dns_servers(
+    nm_api: &mut NmApi<'_>,
+) -> Result<Vec<String>, NmstateError> {
+    let mut servers: Vec<String> = Vec::new();
+    let mut has_split_dns = false;
+
+    let mut nm_dns_entries = nm_api
         .get_dns_configuration()
         .await
         .map_err(nm_error_to_nmstate)?;
-    nm_dns_entires.sort_unstable_by_key(|d| d.priority);
-    let mut running_srvs: Vec<String> = Vec::new();
-    let mut running_schs: Vec<String> = Vec::new();
-    for nm_dns_entry in nm_dns_entires {
-        running_srvs.extend(nm_dns_srvs_to_nmstate(&nm_dns_entry));
-        running_schs.extend_from_slice(nm_dns_entry.domains.as_slice());
+    nm_dns_entries.sort_unstable_by_key(|d| d.priority);
+
+    // If there are global nameservers, only those are used
+    for nm_dns_entry in nm_dns_entries
+        .iter()
+        .filter(|entry| entry.interface.is_empty())
+    {
+        if !nm_dns_entry.domains.is_empty() {
+            has_split_dns = true;
+        }
+        servers.extend(nm_dns_srvs_to_nmstate(nm_dns_entry));
     }
 
-    let mut dns_confs: Vec<&DnsClientState> = Vec::new();
-    for iface in ifaces.kernel_ifaces.values() {
-        if let Some(ip_conf) = iface.base_iface().ipv6.as_ref() {
-            if let Some(dns_conf) = ip_conf.dns.as_ref() {
-                dns_confs.push(dns_conf);
-            }
-        }
-        if let Some(ip_conf) = iface.base_iface().ipv4.as_ref() {
-            if let Some(dns_conf) = ip_conf.dns.as_ref() {
-                dns_confs.push(dns_conf);
-            }
-        }
+    if has_split_dns {
+        log::warn!(
+            "Running DNS config has split-DNS, but nmstate doesn't support \
+             it. Its info may be inaccurate."
+        );
     }
-    dns_confs.sort_unstable_by_key(|d| d.priority.unwrap_or_default());
-    let mut config_srvs: Vec<String> = Vec::new();
-    let mut config_schs: Vec<String> = Vec::new();
-    for dns_conf in dns_confs {
-        if let Some(srvs) = dns_conf.server.as_ref() {
-            config_srvs.extend_from_slice(srvs);
-        }
-        if let Some(schs) = dns_conf.search.as_ref() {
-            config_schs.extend_from_slice(schs);
+
+    if !servers.is_empty() {
+        return Ok(servers);
+    }
+
+    // If there are no global nameservers, those from connections are used
+    for nm_dns_entry in nm_dns_entries {
+        servers.extend(nm_dns_srvs_to_nmstate(&nm_dns_entry));
+        if nm_dns_entry.priority < 0 {
+            // Per NM's doc, ignore remaining entries if priority<0
+            break;
         }
     }
 
-    // The DNS options is not provided via `NmApi.get_dns_configuration()`,
-    // The data stored in active connections will not be refreshed after
-    // reapply.
-    // The data stored in applied connection will not do validation.
-    let mut dns_options: Vec<String> = Vec::new();
+    Ok(servers)
+}
 
-    let nm_conns = nm_api
-        .applied_connections_get()
+async fn retrieve_configured_dns_info(
+    nm_api: &mut NmApi<'_>,
+    ifaces: &Interfaces,
+) -> Result<DnsClientState, NmstateError> {
+    let mut use_global_servers = false;
+    let mut use_global_searches_and_options = false;
+    let mut servers: Vec<String> = Vec::new();
+    let mut searches: Vec<String> = Vec::new();
+    let mut options: Vec<String> = Vec::new();
+
+    // First fill from global config
+    let nm_global_dns_conf = nm_api
+        .get_global_dns_configuration()
         .await
         .map_err(nm_error_to_nmstate)?;
-    for nm_conn in &nm_conns {
-        if let Some(opts) =
-            nm_conn.ipv4.as_ref().and_then(|i| i.dns_options.as_deref())
-        {
-            for opt in opts {
-                if !dns_options.contains(opt) {
-                    dns_options.push(opt.clone());
+
+    if let Some(nm_global_dns_conf) = nm_global_dns_conf {
+        use_global_searches_and_options = true;
+        searches.extend_from_slice(&nm_global_dns_conf.searches);
+        options.extend_from_slice(&nm_global_dns_conf.options);
+
+        if let Some(nm_domain_conf) = nm_global_dns_conf.domains.get("*") {
+            use_global_servers = true;
+            servers.extend_from_slice(&nm_domain_conf.servers)
+        }
+
+        if nm_global_dns_conf.domains.len() > 1 {
+            log::warn!("Ignoring split-DNS nameservers (not supported)");
+        }
+    }
+
+    // Fill servers from ifaces only if they are not defined in global config.
+    // Fill searches and options from ifaces only if neither them nor servers
+    // are defined in global config.
+    if !use_global_servers {
+        let mut nm_ifaces_dns_confs: Vec<&DnsClientState> = Vec::new();
+        for iface in ifaces.kernel_ifaces.values() {
+            if let Some(ip_conf) = iface.base_iface().ipv6.as_ref() {
+                if let Some(dns_conf) = ip_conf.dns.as_ref() {
+                    nm_ifaces_dns_confs.push(dns_conf);
+                }
+            }
+            if let Some(ip_conf) = iface.base_iface().ipv4.as_ref() {
+                if let Some(dns_conf) = ip_conf.dns.as_ref() {
+                    nm_ifaces_dns_confs.push(dns_conf);
                 }
             }
         }
-        if let Some(opts) =
-            nm_conn.ipv6.as_ref().and_then(|i| i.dns_options.as_deref())
-        {
-            for opt in opts {
-                if !dns_options.contains(opt) {
-                    dns_options.push(opt.clone());
+        nm_ifaces_dns_confs
+            .sort_unstable_by_key(|d| d.priority.unwrap_or_default());
+
+        for dns_conf in nm_ifaces_dns_confs {
+            if let Some(srvs) = dns_conf.server.as_ref() {
+                servers.extend_from_slice(srvs);
+            }
+
+            if !use_global_searches_and_options {
+                if let Some(schs) = dns_conf.search.as_ref() {
+                    for sch in schs {
+                        if sch.starts_with("~") {
+                            // Ignore routing only domains
+                            continue;
+                        }
+                        if !searches.contains(sch) {
+                            searches.push(sch.clone())
+                        }
+                    }
                 }
+                if let Some(opts) = dns_conf.options.as_ref() {
+                    for opt in opts {
+                        if !options.contains(opt) {
+                            options.push(opt.clone());
+                        }
+                    }
+                }
+            }
+
+            if dns_conf.priority.unwrap_or(0) < 0 {
+                // Per NM's doc, ignore remaining entries if priority<0
+                break;
             }
         }
     }
-    // The order of DNS options does not matters, hence no need to sort the
-    // DNS option using DNS priority.
-    dns_options.sort_unstable();
 
-    Ok(DnsState {
-        running: Some(DnsClientState {
-            server: Some(running_srvs),
-            search: Some(running_schs),
-            options: if dns_options.is_empty() {
-                None
-            } else {
-                Some(dns_options.clone())
-            },
-            ..Default::default()
-        }),
-        config: Some(DnsClientState {
-            server: if config_srvs.is_empty() && config_schs.is_empty() {
-                None
-            } else {
-                Some(config_srvs.clone())
-            },
-            search: if config_srvs.is_empty() && config_schs.is_empty() {
-                None
-            } else {
-                Some(config_schs)
-            },
-            options: if dns_options.is_empty() {
-                None
-            } else {
-                Some(dns_options)
-            },
-            ..Default::default()
-        }),
+    let servers_or_searches_set = !servers.is_empty() || !searches.is_empty();
+    Ok(DnsClientState {
+        server: servers_or_searches_set.then_some(servers),
+        search: servers_or_searches_set.then_some(searches),
+        options: (!options.is_empty()).then_some(options),
+        ..Default::default()
     })
 }
 
@@ -272,30 +323,6 @@ async fn purge_global_dns_config(
             .map_err(nm_error_to_nmstate)?;
     }
     Ok(())
-}
-
-pub(crate) fn nm_global_dns_to_nmstate(
-    nm_global_dns_conf: &NmGlobalDnsConfig,
-) -> DnsState {
-    let mut config = DnsClientState::new();
-
-    config.options = if nm_global_dns_conf.options.is_empty() {
-        None
-    } else {
-        Some(nm_global_dns_conf.options.clone())
-    };
-    config.search = Some(nm_global_dns_conf.searches.clone());
-    config.server =
-        if let Some(nm_domain_conf) = nm_global_dns_conf.domains.get("*") {
-            Some(nm_domain_conf.servers.clone())
-        } else {
-            Some(Vec::new())
-        };
-
-    DnsState {
-        running: Some(config.clone()),
-        config: Some(config),
-    }
 }
 
 // To save us from NM iface-DNS mess, we prefer global DNS over iface DNS,

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use self::connection::{
     delete_exist_connections, save_nm_connections,
 };
 pub(crate) use self::device::deactivate_nm_devices;
-pub(crate) use self::dns::retrieve_dns_info;
+pub(crate) use self::dns::retrieve_dns_state;
 pub(crate) use self::ieee8021x::nm_802_1x_to_nmstate;
 pub(crate) use self::ip::{
     nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6, query_nmstate_wait_ip,

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -174,7 +174,7 @@ pub(crate) async fn nm_retrieve(
         }
     }
 
-    let mut dns_config = if let Ok(nm_global_dns_conf) = nm_api
+    let mut dns_config = if let Ok(Some(nm_global_dns_conf)) = nm_api
         .get_global_dns_configuration()
         .await
         .map_err(nm_error_to_nmstate)

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -9,11 +9,10 @@ use super::{
     error::nm_error_to_nmstate,
     query_apply::{
         device::nm_dev_iface_type_to_nmstate, dispatch::get_dispatches,
-        dns::nm_global_dns_to_nmstate, get_description, get_lldp,
-        is_lldp_enabled, nm_802_1x_to_nmstate, nm_ip_setting_to_nmstate4,
-        nm_ip_setting_to_nmstate6, ovs::merge_ovs_netdev_tun_iface,
-        query_nmstate_wait_ip, retrieve_dns_info,
-        vpn::get_supported_vpn_ifaces,
+        get_description, get_lldp, is_lldp_enabled, nm_802_1x_to_nmstate,
+        nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6,
+        ovs::merge_ovs_netdev_tun_iface, query_nmstate_wait_ip,
+        retrieve_dns_state, vpn::get_supported_vpn_ifaces,
     },
     settings::get_bond_balance_slb,
     NmConnectionMatcher,
@@ -174,19 +173,8 @@ pub(crate) async fn nm_retrieve(
         }
     }
 
-    let mut dns_config = if let Ok(Some(nm_global_dns_conf)) = nm_api
-        .get_global_dns_configuration()
-        .await
-        .map_err(nm_error_to_nmstate)
-    {
-        if nm_global_dns_conf.is_empty() {
-            retrieve_dns_info(&mut nm_api, &net_state.interfaces).await?
-        } else {
-            nm_global_dns_to_nmstate(&nm_global_dns_conf)
-        }
-    } else {
-        retrieve_dns_info(&mut nm_api, &net_state.interfaces).await?
-    };
+    let mut dns_config =
+        retrieve_dns_state(&mut nm_api, &net_state.interfaces).await?;
     dns_config.sanitize().ok();
     if running_config_only {
         dns_config.running = None;


### PR DESCRIPTION
Since NM 1.44 it is allowed to have a global-dns section without any global-dns-domain-* section. In that same version, and later in NM 1.56, it was changed how the settings in global-dns interacts with those defined in connections (see full explanation in the last commit of the PR). Let's adapt to those changes, so we interpret correctly a global-dns section but with nameservers defined in the connections.

Resolves: https://issues.redhat.com/browse/NMT-1795