### PR TITLE
ip: Support configuring per-device IPv4 sysctl forwarding

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "1.2.26"
+nispor = "1.2.27"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.30", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -103,6 +103,8 @@ struct InterfaceIp {
         rename = "dhcp-custom-hostname"
     )]
     pub dhcp_custom_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forwarding: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
@@ -147,6 +149,8 @@ pub struct InterfaceIpv4 {
     /// which result the IP addresses after first one holding the `secondary`
     /// flag.
     pub addresses: Option<Vec<InterfaceIpAddr>>,
+    /// Whether per‐interface IPv4 sysctl forwarding is enabled.
+    pub forwarding: Option<bool>,
     /// Whether to apply DNS resolver information retrieved from DHCP server.
     /// Serialize and deserialize to/from `auto-dns`.
     /// If you want to append static DNS name server before DHCP provided
@@ -299,6 +303,15 @@ impl InterfaceIpv4 {
             }
         }
 
+        if let Some(forwarding) = self.forwarding {
+            if !self.enabled && forwarding && is_desired {
+                log::warn!(
+                    "Ignoring `forwarding: {forwarding}` as IPv4 is disabled",
+                );
+                self.forwarding = None;
+            }
+        }
+
         if let Some(addrs) = self.addresses.as_mut() {
             if is_desired {
                 for addr in addrs.as_slice().iter().filter(|a| a.is_auto()) {
@@ -427,6 +440,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
             auto_route_metric: ip.auto_route_metric,
             dhcp_send_hostname: ip.dhcp_send_hostname,
             dhcp_custom_hostname: ip.dhcp_custom_hostname,
+            forwarding: ip.forwarding,
             ..Default::default()
         }
     }
@@ -452,6 +466,7 @@ impl From<InterfaceIpv4> for InterfaceIp {
             auto_route_metric: ip.auto_route_metric,
             dhcp_send_hostname: ip.dhcp_send_hostname,
             dhcp_custom_hostname: ip.dhcp_custom_hostname,
+            forwarding: ip.forwarding,
             ..Default::default()
         }
     }
@@ -781,6 +796,12 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
                 return Err(serde::de::Error::custom(
                     "dhcp-client-id is not allowed for IPv6",
                 ));
+            }
+            if v_map.contains_key("forwarding") {
+                return Err(serde::de::Error::custom(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "forwarding is not supported for IPv6".to_string(),
+                )));
             }
         }
         let ip: InterfaceIp = match serde_json::from_value(v) {

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -17,6 +17,7 @@ pub(crate) fn np_ipv4_to_nmstate(
             enabled_defined: true,
             ..Default::default()
         };
+        ip.forwarding = np_iface.ipv4.as_ref().and_then(|v| v.forwarding);
         if !ip.enabled {
             return Some(ip);
         }
@@ -64,6 +65,7 @@ pub(crate) fn np_ipv4_to_nmstate(
             }
         }
         ip.addresses = Some(addresses);
+
         Some(ip)
     } else {
         // IP might just disabled

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -25,6 +25,7 @@ pub(crate) fn prepare_nm_conns(
     nm_devs: &[NmDevice],
     gen_conf_mode: bool,
     is_retry: bool,
+    forwarding_supported: bool,
 ) -> Result<PreparedNmConnections, NmstateError> {
     let mut nm_conns_to_update: Vec<NmConnection> = Vec::new();
     let mut nm_conns_to_activate: Vec<NmConnection> = Vec::new();
@@ -73,6 +74,32 @@ pub(crate) fn prepare_nm_conns(
             conn_matcher,
             gen_conf_mode,
         )? {
+            // Clear forwarding when not supported by NetworkManager to prevent
+            // failures. TODO: Remove this code once the minimum
+            // supported NetworkManager version is >= 1.54
+            if !forwarding_supported {
+                if let Some(ipv4) = nm_conn.ipv4.as_mut() {
+                    ipv4.forwarding = None;
+                }
+
+                if let Some(desired_iface) = merged_iface.desired.as_ref() {
+                    let forwarding_desired = desired_iface
+                        .base_iface()
+                        .ipv4
+                        .as_ref()
+                        .and_then(|ip4| ip4.forwarding)
+                        .is_some();
+
+                    if forwarding_desired {
+                        log::warn!(
+                            "Clearing unsupported ipv4.forwarding for \
+                             interface '{}'",
+                            desired_iface.name()
+                        );
+                    }
+                }
+            }
+
             if iface.is_up()
                 && (is_retry
                     || !can_skip_activation(

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -59,6 +59,7 @@ pub(crate) fn nm_gen_conf(
         &[],
         true,  // gen_conf mode
         false, // is_retry
+        true,  // forwarding supported
     )?
     .to_store;
 

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -110,6 +110,7 @@ pub struct NmSettingIp {
     pub dhcp_send_hostname: Option<bool>,
     pub dhcp_fqdn: Option<String>,
     pub dhcp_hostname: Option<String>,
+    pub forwarding: Option<i32>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -152,6 +153,7 @@ impl TryFrom<DbusDictionary> for NmSettingIp {
             )?,
             dhcp_fqdn: _from_map!(v, "dhcp-fqdn", String::try_from)?,
             dhcp_hostname: _from_map!(v, "dhcp-hostname", String::try_from)?,
+            forwarding: _from_map!(v, "forwarding", i32::try_from)?,
             ..Default::default()
         };
 
@@ -232,6 +234,9 @@ impl ToDbusValue for NmSettingIp {
         }
         if let Some(dns_priority) = self.dns_priority {
             ret.insert("dns-priority", zvariant::Value::new(dns_priority));
+        }
+        if let Some(forwarding) = self.forwarding {
+            ret.insert("forwarding", zvariant::Value::new(forwarding));
         }
         if let Some(v) = self.ignore_auto_dns {
             ret.insert("ignore-auto-dns", zvariant::Value::new(v));

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -457,6 +457,7 @@ impl NmApi<'_> {
 
 impl NmVersionInfo {
     pub const CAPABILITY_SYNC_ROUTE_WITH_TABLE: usize = 0;
+    pub(crate) const CAPABILITY_IP4_FORWARDING: usize = 1;
 
     fn from(ver_info_arr: &[u32]) -> Self {
         Self {

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -36,8 +36,14 @@ pub(crate) async fn nm_apply(
 ) -> Result<(), NmstateError> {
     let mut nm_api = NmApi::new().await.map_err(nm_error_to_nmstate)?;
     let mut nm_route_remove_needs_deactivate = true;
+    let mut ipv4_forward_support = false;
 
-    check_nm_version(&nm_api, &mut nm_route_remove_needs_deactivate).await;
+    check_nm_version(
+        &nm_api,
+        &mut nm_route_remove_needs_deactivate,
+        &mut ipv4_forward_support,
+    )
+    .await;
 
     nm_api.set_checkpoint(checkpoint, timeout);
     nm_api.set_checkpoint_auto_refresh(true);
@@ -107,6 +113,7 @@ pub(crate) async fn nm_apply(
         &nm_devs,
         false,
         is_retry,
+        ipv4_forward_support,
     )?;
 
     let nm_conns_to_deactivate_first = gen_nm_conn_need_to_deactivate_first(
@@ -392,15 +399,19 @@ fn gen_nm_conn_need_to_deactivate_first(
 async fn check_nm_version(
     nm_api: &NmApi<'_>,
     route_remove_needs_deactivate: &mut bool,
+    ipv4_forward_support: &mut bool,
 ) {
     let version = if let Ok(ver_info) = nm_api.version_info().await {
         *route_remove_needs_deactivate = !ver_info
             .has_capability(NmVersionInfo::CAPABILITY_SYNC_ROUTE_WITH_TABLE);
+        *ipv4_forward_support =
+            ver_info.has_capability(NmVersionInfo::CAPABILITY_IP4_FORWARDING);
         Ok(ver_info.version())
     } else {
         // VersionInfo was added to NM 1.42. For older version we fallback to
         // parsing from Version string if VersionInfo is not available.
         *route_remove_needs_deactivate = true;
+        *ipv4_forward_support = false;
         nm_api.version().await
     };
 

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -64,6 +64,7 @@ fn gen_nm_ipv4_setting(
     }
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
+    nm_setting.forwarding = iface_ip.forwarding.map(i32::from);
     if iface_ip.is_auto() {
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -82,6 +82,9 @@ impl InterfaceIpv4 {
             self.dhcp_custom_hostname
                 .clone_from(&other.dhcp_custom_hostname);
         }
+        if other.forwarding.is_some() {
+            self.forwarding = other.forwarding;
+        }
     }
 }
 

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -598,3 +598,33 @@ fn test_ip_serlize_allow_extra_address() {
 
     assert_eq!(desired, new);
 }
+
+#[test]
+fn test_forwarding_ipv6_deserialize_error() {
+    let desired = r#"---
+name: eth1
+type: ethernet
+state: up
+ipv6:
+  enabled: true
+  dhcp: false
+  autoconf: false
+  forwarding: true
+  address:
+  - ip: 2001:db8:1::1
+    prefix-length: 64
+"#;
+
+    let value = serde_yaml::from_str::<serde_yaml::Value>(desired).unwrap();
+
+    let result = serde_json::from_value::<Interface>(
+        serde_json::to_value(value).unwrap(),
+    );
+
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    let err_str = err.to_string();
+
+    assert!(err_str.starts_with("InvalidArgument:"));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -173,6 +173,7 @@ class InterfaceIP:
 
 class InterfaceIPv4(InterfaceIP):
     DHCP_CLIENT_ID = "dhcp-client-id"
+    FORWARDING = "forwarding"
 
 
 class InterfaceIPv6(InterfaceIP):

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -27,20 +27,23 @@ from libnmstate.error import NmstateValueError
 from libnmstate.iplib import is_ipv6_link_local_addr
 
 from .testlib import assertlib
-from .testlib import cmdlib
 from .testlib import bondlib
+from .testlib import cmdlib
 from .testlib import ifacelib
 from .testlib import statelib
-from .testlib.env import is_k8s
 from .testlib.apply import apply_with_description
-from .testlib.ifacelib import get_mac_address
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
-from .testlib.retry import retry_till_true_or_timeout
+from .testlib.dummy import dummy_interface
+from .testlib.env import is_k8s
+from .testlib.env import nm_minor_version
+from .testlib.ifacelib import get_mac_address
 from .testlib.retry import retry_till_false_or_timeout
+from .testlib.retry import retry_till_true_or_timeout
 from .testlib.veth import create_veth_pair
 from .testlib.veth import remove_veth_pair
+from .testlib.yaml import load_yaml
 
 ETH1 = "eth1"
 
@@ -2371,3 +2374,26 @@ def get_dhcp_addr(iface_state):
         and addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH] == 128
     ]
     return (DHCPV4_ADDRS, DHCPV6_ADDRS)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 54,
+    reason="NetworkManager 1.54- does not support configuring per-device "
+    "IPv4 sysctl forwarding",
+)
+def test_enable_ipv4_forwarding_on_auto_iface_without_dhcp_srv():
+    with dummy_interface("dummy1"):
+        desired_state = load_yaml(
+            """---
+            interfaces:
+            - name: dummy1
+              type: dummy
+              state: up
+              ipv4:
+                enabled: true
+                dhcp: true
+                forwarding: true
+            """
+        )
+        libnmstate.apply(desired_state)
+        assertlib.assert_state_match(desired_state)

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1084,12 +1084,8 @@ def test_linux_bridge_multicast_router(bridge0_with_port0, mcast_router_value):
 def test_linux_bridge_show_port_ip_as_disabled(bridge0_with_port0):
     state = show_only(("eth1",))
 
-    assert state[Interface.KEY][0][Interface.IPV4] == {
-        InterfaceIPv4.ENABLED: False
-    }
-    assert state[Interface.KEY][0][Interface.IPV6] == {
-        InterfaceIPv6.ENABLED: False
-    }
+    assert not state[Interface.KEY][0][Interface.IPV4][InterfaceIPv4.ENABLED]
+    assert not state[Interface.KEY][0][Interface.IPV6][InterfaceIPv6.ENABLED]
 
 
 @pytest.mark.tier1

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -16,6 +16,7 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
 from .testlib.dummy import nm_unmanaged_dummy
+from .testlib.env import nm_minor_version
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.iproutelib import iproute_get_ip_addrs_with_order
@@ -764,25 +765,31 @@ def test_get_ip_address_from_unmanaged_dummy():
             )
         ]
 
-        assert iface_state[Interface.IPV4] == {
-            InterfaceIPv4.ENABLED: True,
-            InterfaceIPv4.ADDRESS: [
-                {
-                    InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
-                    InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
-                }
-            ],
-        }
+        assert statelib.state_match(
+            {
+                InterfaceIPv4.ENABLED: True,
+                InterfaceIPv4.ADDRESS: [
+                    {
+                        InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                        InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                    }
+                ],
+            },
+            iface_state[Interface.IPV4],
+        )
 
-        assert iface_state[Interface.IPV6] == {
-            InterfaceIPv6.ENABLED: True,
-            InterfaceIPv6.ADDRESS: [
-                {
-                    InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
-                    InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
-                }
-            ],
-        }
+        assert statelib.state_match(
+            {
+                InterfaceIPv6.ENABLED: True,
+                InterfaceIPv6.ADDRESS: [
+                    {
+                        InterfaceIPv6.ADDRESS_IP: IPV6_ADDRESS2,
+                        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+                    }
+                ],
+            },
+            iface_state[Interface.IPV6],
+        )
 
 
 def test_ignore_invalid_ip_on_absent_interface(eth1_up):
@@ -915,6 +922,78 @@ def test_merge_ip_enabled_property_from_current(setup_eth1_static_ip):
         InterfaceIPv6.ENABLED
     ] = True
     assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() < 54,
+    reason="NetworkManager 1.54- does not support configuring per-device "
+    "IPv4 sysctl forwarding",
+)
+def test_ipv4_sysctl_forwarding(setup_eth1_static_ip):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                    InterfaceIPv4.FORWARDING: True,
+                },
+            }
+        ]
+    }
+    apply_with_description(
+        "Enable IPv4 forwarding on eth1",
+        desired_state,
+    )
+    assertlib.assert_state_match(desired_state)
+    desired_state[Interface.KEY][0][Interface.IPV4][
+        InterfaceIPv4.FORWARDING
+    ] = False
+    apply_with_description(
+        "Disable IPv4 forwarding on eth1",
+        desired_state,
+    )
+    assertlib.assert_state_match(desired_state)
+
+
+@pytest.mark.skipif(
+    nm_minor_version() >= 53,
+    reason="On NM < 1.53, attempting to set per-interface IPv4 forwarding "
+    "should raise an error",
+)
+def test_ipv4_sysctl_forwarding_unsupported_error(setup_eth1_static_ip):
+    cmdlib.exec_cmd(
+        "sysctl -w net.ipv4.conf.eth1.forwarding=1".split(), check=True
+    )
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                    InterfaceIPv4.FORWARDING: False,
+                },
+            }
+        ]
+    }
+    with pytest.raises(libnmstate.error.NmstateVerificationError):
+        apply_with_description(
+            "Configure the ethernet device eth1 with IPv4 sysctl forwarding "
+            "disabled",
+            desired_state,
+        )
 
 
 def test_preserve_ipv4_addresses_order(eth1_up):


### PR DESCRIPTION
This feature introduces the ability to configure
`net.ipv4.conf.<interface>.forwarding` through nmstate.

Example YAML:

```yml
---
interfaces:
  - name: eth1
    type: ethernet
    state: up
    ipv4:
      address:
        - ip: 192.0.2.251
          prefix-length: 24
      dhcp: false
      enabled: true
      forwarding: true
```

Unit and integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-36429

Changes by Gris Ge:
 * Use `version-info` D-BUS API for checking support status of IPv4
   forwarding in NetworkManager instead of comparing version number.
 * Add integration test case for enabled ipv4 forwarding on auto
   interface without DHCP server.