### PR TITLE
kernel mode: validate conflicting routes

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use log::warn;
 
 use crate::{
@@ -289,9 +291,56 @@ fn nmstate_to_nispor_route_conf(
 pub(crate) fn gen_nispor_route_confs(
     merged_routes: &MergedRoutes,
 ) -> Result<Vec<nispor::RouteConf>, NmstateError> {
+    validate_routes(merged_routes)?;
     let mut ret = Vec::new();
     for nmstate_rt in merged_routes.changed_routes.as_slice() {
         ret.push(nmstate_to_nispor_route_conf(nmstate_rt)?)
     }
     Ok(ret)
+}
+
+fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
+    for iface in merged_routes.route_changed_ifaces.as_slice() {
+        let iface_routes = if let Some(r) = merged_routes.merged.get(iface) {
+            r
+        } else {
+            continue;
+        };
+        let mut hashed_rts: HashMap<(&str, Option<u32>), &RouteEntry> =
+            HashMap::new();
+        for rt in iface_routes {
+            if rt.weight.is_some() {
+                return Err(NmstateError::new(
+                    ErrorKind::NotSupportedError,
+                    "Kernel mode does not support ECMP routes".to_string(),
+                ));
+            }
+
+            // The `Routes::validate()` already confirmed non-absent routes
+            // always has destination.
+            // The `merged_routes.merged` does not have absent route.
+            let dst = if let Some(dst) = rt.destination.as_deref() {
+                dst
+            } else {
+                continue;
+            };
+
+            if hashed_rts
+                .insert(
+                    (dst, rt.metric.and_then(|m| u32::try_from(m).ok())),
+                    rt,
+                )
+                .is_some()
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Multiple routes to {dst} are sharing the same \
+                         metric, please use `state: absent` to remove others."
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2505,3 +2505,90 @@ def test_apply_ignored_routes_to_iface(eth1_static_ip):
     assert IPV4_ADDRESS2 not in ipv4_routes_output
     ipv6_routes_output = _get_routes_from_iproute(6, 254)
     assert IPV6_ADDRESS2 not in ipv6_routes_output
+
+
+@pytest.mark.parametrize(
+    "routes",
+    [
+        (
+            """
+            - destination: 203.0.113.0/24
+              next-hop-address: 192.0.2.1
+              next-hop-interface: veth1
+            - destination: 203.0.113.0/24
+              next-hop-address: 192.0.2.2
+              next-hop-interface: veth1
+            """
+        ),
+        (
+            """
+            - destination: 203.0.113.0/24
+              next-hop-address: 192.0.2.1
+              next-hop-interface: veth1
+              metric: 109
+            - destination: 203.0.113.0/24
+              next-hop-address: 192.0.2.2
+              next-hop-interface: veth1
+              metric: 109
+            """
+        ),
+        (
+            """
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::2
+              next-hop-interface: veth1
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::3
+              next-hop-interface: veth1
+            """
+        ),
+        (
+            """
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::2
+              next-hop-interface: veth1
+              metric: 102
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::3
+              next-hop-interface: veth1
+              metric: 102
+            """
+        ),
+    ],
+    ids=[
+        "v4_without_metric",
+        "v4_with_metric",
+        "v6_without_metric",
+        "v6_with_metric",
+    ],
+)
+def test_kernel_mode_fail_on_same_dst_metric_routes(
+    routes,
+    cleanup_veth1_kernel_mode,
+):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+        """
+    )
+    desired_state[Route.KEY] = {Route.CONFIG: load_yaml(routes)}
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply(desired_state, kernel_only=True)


### PR DESCRIPTION
Kernel does not allows desired multiple routes with the same destination
and metric.
When user desire so, it is unclear whether user made a fault or want
ECMP routes.

In NM mode, that YAML will generate ECMP routes for IPv6 and append
desired routes before existing for IPv4. This patch does not change that
because it might break working YAMLs.

For kernel mode, this patch raise better error instead of kernel error
code `-22`:

    NmstateError: InvalidArgument: Multiple routes to 2001:db8:2::/64 are
    sharing the same metric without weight, please neither use `state:
    absent` to remove others or define `weight` for ECMP.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-54558