### PR TITLE
kernel mode: Mark new veth peer as up

### DIFF
--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -6,7 +6,7 @@ use crate::{
         hostname::set_running_hostname,
         ip::{nmstate_ipv4_to_np, nmstate_ipv6_to_np},
         route::gen_nispor_route_confs,
-        veth::nms_veth_conf_to_np,
+        veth::{nms_veth_conf_to_np, process_new_veth_peer},
         vlan::nms_vlan_conf_to_np,
     },
     ErrorKind, Interface, InterfaceType, MergedInterface, MergedInterfaces,
@@ -42,6 +42,11 @@ pub(crate) async fn nispor_apply(
             && i.for_apply.as_ref().is_some()
     }) {
         np_ifaces.push(nmstate_iface_to_np(merged_iface)?);
+        if let Some(np_iface) =
+            process_new_veth_peer(merged_iface, &merged_state.interfaces)
+        {
+            np_ifaces.push(np_iface);
+        }
     }
 
     let mut net_conf = nispor::NetConf::default();

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BaseInterface, EthernetInterface, VethConfig};
+use crate::{
+    BaseInterface, EthernetInterface, Interface, MergedInterface,
+    MergedInterfaces, VethConfig,
+};
 
 pub(crate) fn np_veth_to_nmstate(
     np_iface: &nispor::Iface,
@@ -34,4 +37,34 @@ pub(crate) fn nms_veth_conf_to_np(
         veth_conf.peer = nms_veth_conf.peer.to_string();
         veth_conf
     })
+}
+
+pub(crate) fn process_new_veth_peer(
+    merged_iface: &MergedInterface,
+    merged_ifaces: &MergedInterfaces,
+) -> Option<nispor::IfaceConf> {
+    if merged_iface.current.is_none() && merged_iface.merged.is_up() {
+        if let Some(Interface::Ethernet(apply_iface)) =
+            merged_iface.for_apply.as_ref()
+        {
+            if let Some(peer) =
+                apply_iface.veth.as_ref().map(|v| v.peer.as_str())
+            {
+                // Mark new veth peer as up if not mentioned in desired state.
+                if merged_ifaces
+                    .kernel_ifaces
+                    .get(peer)
+                    .map(|i| i.for_apply.is_some())
+                    != Some(true)
+                {
+                    let mut np_iface = nispor::IfaceConf::default();
+                    np_iface.name = peer.to_string();
+                    np_iface.iface_type = Some(nispor::IfaceType::Veth);
+                    np_iface.state = nispor::IfaceState::Up;
+                    return Some(np_iface);
+                }
+            }
+        }
+    }
+    None
 }


### PR DESCRIPTION
The nispor 1.2.28 will not automatically mark new veth peer up now.
We should do it in nmstate kernel mode.

The test case `test_add_and_remove_veth_kernel_mode` is enough to
reproduce the issue and confirm the fix.