### PR TITLE
WIP: CI: Limit memory usage for `make rpm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ srpm: dist
 .PHONY: rpm
 rpm: dist
 	$(eval TMPDIR := $(shell mktemp -d))
-	rpmbuild --define "_rpmdir $(TMPDIR)/" -tb $(TARBALL)
+	env RPM_BUILD_NCPUS=2 \
+		rpmbuild --define "_rpmdir $(TMPDIR)/" -tb $(TARBALL)
 	find $(TMPDIR) -type f -exec mv -v {} $(ROOT_DIR) \;
 	rm -rf $(TMPDIR)
 	rm -f $(TARBALL)


### PR DESCRIPTION
In kubevirt CI, we noticed `cargo build` consumed too many memory (4GiB)
which lead to out of memory kill by linux kernel.

Fixed by limit the parallel compiling job to 2 instead of CPU count.