### PR TITLE
service: Ignore NetworkManager-wait-online.service failure

### DIFF
--- a/packaging/nmstate.service
+++ b/packaging/nmstate.service
@@ -3,7 +3,7 @@ Description=Apply nmstate on-disk state
 Documentation=man:nmstate.service(8) https://www.nmstate.io
 After=NetworkManager-wait-online.service
 Before=network-online.target
-Requires=NetworkManager-wait-online.service
+Wants=NetworkManager-wait-online.service
 Requires=NetworkManager.service
 
 [Service]


### PR DESCRIPTION
The failure of `NetworkManager-wait-online.service` will cause
nmstate.service not been invoked.

Changed to `Wants`, so the `nmstate.service` been invoked regardless
the failure of NM wait online.