### PR TITLE
ipsec: Support leftsendcert option

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -153,6 +153,8 @@ pub struct LibreswanConfig {
         rename = "require-id-on-certificate"
     )]
     pub require_id_on_certificate: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leftsendcert: Option<String>,
 }
 
 impl LibreswanConfig {
@@ -193,6 +195,7 @@ impl std::fmt::Debug for LibreswanConfig {
             .field("hostaddrfamily", &self.hostaddrfamily)
             .field("clientaddrfamily", &self.clientaddrfamily)
             .field("require_id_on_certificate", &self.require_id_on_certificate)
+            .field("leftsendcert", &self.leftsendcert)
             .finish()
     }
 }

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -114,6 +114,7 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
             .and_then(|s| nm_libreswan_addr_family_to_nmstate(s));
         ret.require_id_on_certificate =
             data.get("require-id-on-certificate").map(|s| s == "yes");
+        ret.leftsendcert = data.get("leftsendcert").cloned();
     }
     if let Some(secrets) = nm_set_vpn.secrets.as_ref() {
         ret.psk = secrets.get("pskvalue").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -92,6 +92,9 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
             let v = if v { "yes" } else { "no" };
             vpn_data.insert("require-id-on-certificate".into(), v.to_string());
         }
+        if let Some(v) = conf.leftsendcert.as_ref() {
+            vpn_data.insert("leftsendcert".into(), v.to_string());
+        }
 
         let mut nm_vpn_set = NmSettingVpn::default();
         nm_vpn_set.data = Some(vpn_data);

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -1011,3 +1011,44 @@ def _is_ipsec_nic_ipv6_no_auto(nic_name):
         iface_state[Interface.IPV6].get(InterfaceIPv6.DHCP)
         or iface_state[Interface.IPV6].get(InterfaceIPv6.AUTOCONF)
     )
+
+
+@pytest.mark.xfail(
+    nm_libreswan_version_int() < version_str_to_int("1.2.26"),
+    reason="Need NetworkManager-libreswan 1.2.26+ to support leftsendcert",
+)
+def test_ipsec_leftsendcert(ipsec_srv_cert_gw, load_both_keys):
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: {IPSEC_CONN_NAME}
+          type: ipsec
+          ipv4:
+            enabled: true
+            dhcp: true
+          libreswan:
+            left: {IpsecTestEnv.CLI_ADDR_V4}
+            leftid: '%fromcert'
+            leftcert: {IpsecTestEnv.CLI_KEY_ID}
+            leftmodecfgclient: true
+            right: {IpsecTestEnv.SRV_ADDR_V4}
+            rightid: '%fromcert'
+            rightcert: {IpsecTestEnv.SRV_KEY_ID}
+            rightsubnet: 0.0.0.0/0
+            leftsendcert: always
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec,
+        IpsecTestEnv.CLI_ADDR_V4,
+        IpsecTestEnv.SRV_ADDR_V4,
+    )
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec_ip,
+        IpsecTestEnv.SRV_POOL_PREFIX_V4,
+        IpsecTestEnv.CLI_NIC,
+    )


### PR DESCRIPTION
Example YAML:

```yml
interfaces:
- name: ipsec-cli
  type: ipsec
  state: up
  ipv4:
    enabled: true
    dhcp: true
  libreswan:
    right: 192.0.2.252
    rightid: '@hostb.example.org'
    rightrsasigkey: '%cert'
    left: 192.0.2.251
    leftid: '%fromcert'
    leftrsasigkey: '%cert'
    leftcert: hosta.example.org
    ikev2: insist
    leftsendcert: always
```

Require NetworkManager-libreswan 1.2.26+.

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-104439