### PR TITLE
WIP: service: Load state file from /run/nmstate folder

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -8,9 +8,13 @@ nmstate\&.service
 .PP
 nmstate\&.service invokes \fBnmstatectl service\fR command which
 apply all network state files ending with \fB.yml\fR in
-\fB/etc/nmstate\fR folder.
+\fB/etc/nmstate\fR folder and \fB/run/nmstate\fR folder.
 
 .PP
+
+For file in `/run/nmstate`, the service will take action to prevent second
+apply because OS reboot will purge that folder. For security reason, only file
+owned by root(0) in `/run/nmstate` folder will be used.
 
 By default, the service renames the network state file to a name with suffix
 \fB.applied\fR after processing the file. This prevents applying the same file

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -4,11 +4,16 @@ use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Read;
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::{apply::apply_state, error::CliError, state::state_from_fd};
+use crate::{
+    apply::apply_state,
+    error::CliError,
+    state::{state_from_fd, state_from_file},
+};
 
 const CONFIG_FILE_EXTENSION: &str = "yml";
 const APPLIED_FILE_EXTENSION: &str = "applied";
@@ -43,6 +48,13 @@ impl FileContent {
 pub(crate) fn ncl_service(
     matches: &clap::ArgMatches,
 ) -> Result<String, CliError> {
+    // We ignore the error on loading
+    if let Err(e) = ncl_service_run_dir() {
+        log::error!(
+            "Failed to load desired state file from /run/nmstate folder: {e}"
+        );
+    }
+
     let folder = matches
         .value_of(crate::CONFIG_FOLDER_KEY)
         .unwrap_or(crate::DEFAULT_SERVICE_FOLDER);
@@ -138,6 +150,10 @@ fn get_unapplied_state_files(
     keep_state_file_after_apply: bool,
 ) -> Result<Vec<FileContent>, CliError> {
     let folder = Path::new(folder);
+    if !folder.exists() {
+        log::info!("Folder {} does not exists", folder.display());
+        return Ok(Vec::new());
+    }
     let mut yml_files = HashSet::<FileContent>::new();
     let mut applied_files = HashSet::<FileContent>::new();
     for entry in folder.read_dir()? {
@@ -216,5 +232,54 @@ fn relocate_file(file_path: &Path) -> Result<(), CliError> {
         file_path.display(),
         new_path.display()
     );
+    Ok(())
+}
+
+// Read state file from `/run/nmstate` folder, since this folder will
+// be purged by OS reboot, nmstate will use `.applied` file to prevent
+// second apply.
+// For security reason, only file own by root will be loaded.
+fn ncl_service_run_dir() -> Result<(), CliError> {
+    let folder = Path::new("/run/nmstate");
+    if !folder.exists() {
+        return Ok(());
+    }
+    let mut file_paths: Vec<String> = Vec::new();
+    for entry in folder.read_dir()? {
+        let file = entry?.path();
+        if file.extension() == Some(OsStr::new(CONFIG_FILE_EXTENSION)) {
+            if let Some(file_path) = folder.join(file).to_str() {
+                let meta = fs::metadata(file_path)?;
+                if meta.uid() == 0 {
+                    file_paths.push(file_path.to_string());
+                } else {
+                    log::warn!(
+                        "Ignoring file {} because it is not own by root",
+                        file_path
+                    );
+                }
+            }
+        }
+    }
+    file_paths.sort_unstable();
+    for file_path in file_paths {
+        let state = match state_from_file(&file_path) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("File {file_path} is not valid nmstate YAML: {e}");
+                continue;
+            }
+        };
+        log::info!("Applying desired state from {file_path}");
+        match apply_state(&state, false) {
+            Ok(_) => {
+                log::info!("File {file_path} applied",);
+            }
+
+            Err(e) => {
+                log::error!("Failed to apply state file {file_path}: {e}",);
+            }
+        }
+    }
     Ok(())
 }

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -76,6 +76,7 @@ desired:
 """
 
 CONFIG_DIR = "/etc/nmstate"
+RUN_CONFIG_DIR = "/run/nmstate"
 NMSTATE_CONF_PATH = f"{CONFIG_DIR}/nmstate.conf"
 TEST_CONFIG1_FILE_PATH = f"{CONFIG_DIR}/01-nmstate-test.yml"
 TEST_CONFIG1_APPLIED_FILE_PATH = f"{CONFIG_DIR}/01-nmstate-test.applied"
@@ -271,3 +272,33 @@ def test_nmstate_service_override(
     iface_state = show_only(("eth1",))[Interface.KEY][0]
     assert not iface_state[Interface.IPV4][InterfaceIPv4.ENABLED]
     assert not iface_state[Interface.IPV6][InterfaceIPv6.ENABLED]
+
+
+@pytest.fixture
+def dummy1_yaml_in_run_folder():
+    file_path = f"{RUN_CONFIG_DIR}/dummy1.yml"
+    with open(file_path, "w") as fd:
+        fd.write(
+            f"""---
+            interfaces:
+            - type: {DUMMY1}
+              name: dummy
+            """
+        )
+    yield
+    shutil.rmtree(RUN_CONFIG_DIR, ignore_errors=True)
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: DUMMY1,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+def test_nmstate_service_using_run_files(dummy1_yaml_in_run_folder):
+    exec_cmd("nmstatectl service".split(), check=True)
+    assert show_only(("dummy1",))[Interface.KEY][0][Interface.STATE] == "up"


### PR DESCRIPTION
With this patch,  `nmstate.service` will apply nmstate YAML file in
`/run/nmstate` folder.

Unlike files in `/etc/nmstate` folder, nmstate will not take any actions
to prevent second apply because OS reboot will purge `/run/` folder.

For security reason, only file own by root(0) will be used.

It is also useful for using `nmstate.service` in initrd environment where
network should be apply again after chroot with /run preserved.

Integration test case included.