### PR TITLE
package: Fix `%cargo_install` option

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -190,13 +190,7 @@ popd
 
 %build
 pushd rust
-%if 0%{?rhel} == 9
-# It is safe to ignore minimum rust version. The main blocker on MSRV is
-# toml which just increase their MSRV by a robot for no hard reason.
-%cargo_build --ignore-rust-version
-%else
 %cargo_build
-%endif
 popd
 
 pushd rust/src/python


### PR DESCRIPTION
With `rust-toolset-1.89.0-1.el9.noarch`, the `%cargo_install` does not
accept any cargo options anymore.

Instead of waiting RHEL fix the issue, this patch remove the use of
`--ignore-rust-version` build option, because this is for CentOS stream
9 build only where new rust compiler exists.