### PR TITLE
service: Support `.yaml` extension

### DIFF
--- a/doc/nmstate.service.8.in
+++ b/doc/nmstate.service.8.in
@@ -7,8 +7,10 @@ nmstate\&.service
 .SH "DESCRIPTION"
 .PP
 nmstate\&.service invokes \fBnmstatectl service\fR command which
-apply all network state files ending with \fB.yml\fR in
-\fB/etc/nmstate\fR folder.
+apply all network state files ending with \fB.yml\fR or \fB.yaml\fR in
+\fB/etc/nmstate\fR folder. When two files holding the same name but one with
+`.yml` and another with `.yaml`, nmstate will not apply any but fail the
+service.
 
 .PP
 

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use crate::{apply::apply_state, error::CliError, state::state_from_fd};
 
 const CONFIG_FILE_EXTENSION: &str = "yml";
+const CONFIG_FILE_EXTENSION2: &str = "yaml";
 const APPLIED_FILE_EXTENSION: &str = "applied";
 const CONFIG_FILE_NAME: &str = "nmstate.conf";
 
@@ -49,23 +50,19 @@ pub(crate) fn ncl_service(
 
     let config = load_config(folder)?;
 
-    let state_files = match get_unapplied_state_files(
+    if !Path::new(&folder).exists() {
+        log::info!("{folder} does not exist, skipping");
+        return Ok(String::new());
+    }
+
+    let state_files = get_unapplied_state_files(
         folder,
         config.service.keep_state_file_after_apply,
-    ) {
-        Ok(f) => f,
-        Err(e) => {
-            log::info!(
-                "Failed to read config folder {folder} due to error {e}, \
-                 ignoring"
-            );
-            return Ok(String::new());
-        }
-    };
+    )?;
     if state_files.is_empty() {
         log::info!(
-            "No new nmstate config(end with .{CONFIG_FILE_EXTENSION}) found \
-             in config folder {folder}"
+            "No new nmstate config(end with .{CONFIG_FILE_EXTENSION} or \
+             .{CONFIG_FILE_EXTENSION2}) found in config folder {folder}"
         );
         return Ok(String::new());
     }
@@ -142,12 +139,21 @@ fn get_unapplied_state_files(
     let mut applied_files = HashSet::<FileContent>::new();
     for entry in folder.read_dir()? {
         let file = entry?.path();
-        if file.extension() == Some(OsStr::new(CONFIG_FILE_EXTENSION)) {
+        if file.extension() == Some(OsStr::new(CONFIG_FILE_EXTENSION))
+            || file.extension() == Some(OsStr::new(CONFIG_FILE_EXTENSION2))
+        {
             let content = fs::read_to_string(&file)?;
-            yml_files.insert(FileContent::new(
-                folder.join(file).with_extension(""),
+            let file_name_no_extention = folder.join(&file).with_extension("");
+            if !yml_files.insert(FileContent::new(
+                file_name_no_extention.clone(),
                 content,
-            ));
+            )) {
+                return Err(CliError::from(format!(
+                    "Conflict YAML file {}.yml and {}.yaml",
+                    file_name_no_extention.display(),
+                    file_name_no_extention.display(),
+                )));
+            }
         } else if keep_state_file_after_apply
             && file.extension() == Some(OsStr::new(APPLIED_FILE_EXTENSION))
         {
@@ -158,16 +164,26 @@ fn get_unapplied_state_files(
             ));
         }
     }
-    let mut ret: Vec<_> = yml_files
-        .difference(&applied_files)
-        .cloned()
-        .map(|f| {
-            FileContent::new(
-                f.path.with_extension(CONFIG_FILE_EXTENSION),
-                f.content,
-            )
-        })
-        .collect();
+
+    let mut ret: Vec<FileContent> = Vec::new();
+    for fc in yml_files.difference(&applied_files) {
+        let file_path =
+            if fc.path.with_extension(CONFIG_FILE_EXTENSION).exists() {
+                fc.path.with_extension(CONFIG_FILE_EXTENSION)
+            } else if fc.path.with_extension(CONFIG_FILE_EXTENSION2).exists() {
+                fc.path.with_extension(CONFIG_FILE_EXTENSION2)
+            } else {
+                log::error!(
+                    "Bug: {}.yml or {}.yaml not exists",
+                    fc.path.display(),
+                    fc.path.display()
+                );
+                continue;
+            };
+
+        ret.push(FileContent::new(file_path, fc.content.clone()));
+    }
+
     ret.sort_by_key(|f| f.path.clone());
     Ok(ret)
 }

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+from pathlib import Path
+from subprocess import SubprocessError
 import os
 import shutil
-from pathlib import Path
 
 import yaml
 import pytest
@@ -271,3 +272,45 @@ def test_nmstate_service_override(
     iface_state = show_only(("eth1",))[Interface.KEY][0]
     assert not iface_state[Interface.IPV4][InterfaceIPv4.ENABLED]
     assert not iface_state[Interface.IPV6][InterfaceIPv6.ENABLED]
+
+
+@pytest.fixture
+def dummy0_conf_with_yaml_extention():
+    if not os.path.isdir(CONFIG_DIR):
+        os.mkdir(CONFIG_DIR)
+    with open(f"{CONFIG_DIR}/01-nmstate-test.yaml", "w") as fd:
+        fd.write(TEST_YAML1_CONTENT)
+    yield
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "dummy0",
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        }
+    )
+
+
+def test_nmstate_serice_with_yaml_extention(dummy0_conf_with_yaml_extention):
+    exec_cmd("nmstatectl service".split(), check=True)
+    current_state = show_only(("dummy0",))
+    assert current_state[Interface.KEY][0][Interface.NAME] == "dummy0"
+
+
+@pytest.fixture
+def conflict_yamls():
+    if not os.path.isdir(CONFIG_DIR):
+        os.mkdir(CONFIG_DIR)
+    with open(f"{CONFIG_DIR}/01-nmstate-test.yaml", "w") as fd:
+        fd.write(TEST_YAML1_CONTENT)
+    with open(f"{CONFIG_DIR}/01-nmstate-test.yml", "w") as fd:
+        fd.write(TEST_YAML1_CONTENT)
+    yield
+
+
+def test_nmstate_service_with_conflict_yamls(conflict_yamls):
+    with pytest.raises(SubprocessError):
+        exec_cmd("nmstatectl service".split(), check=True)
+    assert_absent("dummy0")


### PR DESCRIPTION
Introduce the support of file named with `.yaml` extension for desired
state file in `/etc/nmstate` folder.

When two files holding the same name but one with `.yml` and another
with `.yaml`, nmstate.service will fail with error message indicating
the confliction. The reason of raising error for this use case is
because both files will be renamed to `foo.applied`. Changing the
renamed file to `foo.yaml.applied` will be change of behavior which is
too risky comparing the corner case of having two YAMLs holding the same
name with different extensions..

Integration test case included.