### PR TITLE
policy route: Fix problem when removing routes via policy

### DIFF
--- a/examples/policy/capture_all/expected.yml
+++ b/examples/policy/capture_all/expected.yml
@@ -2,6 +2,10 @@
 routes:
   config:
     - destination: 0.0.0.0/0
+      next-hop-interface: eth1
+      next-hop-address: 192.0.2.1
+      state: absent
+    - destination: 0.0.0.0/0
       next-hop-interface: br1
       next-hop-address: 192.0.2.1
 interfaces:

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -9,30 +9,18 @@ use crate::{
 
 impl MergedRoutes {
     pub(crate) fn gen_diff(&self) -> Routes {
-        let mut changed_routes: Vec<RouteEntry> = Vec::new();
-        let mut current_routes: HashSet<&RouteEntry> = HashSet::new();
-
-        if let Some(rts) = self.current.config.as_ref() {
-            for rt in rts {
-                current_routes.insert(rt);
+        if self.changed_routes.is_empty() {
+            Routes {
+                config: None,
+                ..Default::default()
             }
-        }
-
-        for rts in self.merged.values() {
-            for rt in rts {
-                if rt.is_absent() || !current_routes.contains(rt) {
-                    changed_routes.push(rt.clone());
-                }
+        } else {
+            let mut changed_routes = self.changed_routes.clone();
+            changed_routes.sort_unstable();
+            Routes {
+                config: Some(changed_routes),
+                ..Default::default()
             }
-        }
-
-        Routes {
-            config: if !changed_routes.is_empty() {
-                Some(changed_routes)
-            } else {
-                None
-            },
-            ..Default::default()
         }
     }
 

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -789,6 +789,8 @@ impl MergedRoutes {
                 {
                     changed_routes.insert(rt.clone());
                 }
+            } else {
+                changed_routes.insert(rt.clone());
             }
             merged_routes.push(rt.clone());
         }

--- a/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/current.yml
@@ -1,0 +1,29 @@
+---
+interfaces:
+  - name: eth2
+    type: ethernet
+    state: up
+  - name: eth1
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.251
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::1
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1

--- a/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/desired.yml
@@ -1,0 +1,30 @@
+---
+interfaces:
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::2
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: 0.0.0.0/0
+    state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.2
+    next-hop-interface: eth2
+  - destination: ::/0
+    state: absent
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::4
+    next-hop-interface: eth2

--- a/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/route_absent/diff.yml
@@ -1,0 +1,34 @@
+---
+interfaces:
+  - name: eth2
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+      - ip: 192.0.2.252
+        prefix-length: 24
+      dhcp: false
+      enabled: true
+    ipv6:
+      address:
+      - ip: 2001:db8:1::2
+        prefix-length: 64
+      dhcp: false
+      enabled: true
+      autoconf: false
+routes:
+  config:
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::3
+    next-hop-interface: eth1
+    state: absent
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.1
+    next-hop-interface: eth1
+    state: absent
+  - destination: ::/0
+    next-hop-address: 2001:db8:1::4
+    next-hop-interface: eth2
+  - destination: 0.0.0.0/0
+    next-hop-address: 192.0.2.2
+    next-hop-interface: eth2

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 
-use crate::{NetworkPolicy, NetworkState};
+use crate::{NetworkPolicy, NetworkState, RouteState};
 
 #[test]
 fn test_policy_move_dhcp_gw_eth_to_bridge() {
@@ -150,11 +150,17 @@ desiredState:
         std::net::IpAddr::from_str("192.0.2.251").unwrap()
     );
     let routes = state.routes.config.as_ref().unwrap();
-    assert_eq!(routes.len(), 2);
+    assert_eq!(routes.len(), 4);
     assert_eq!(routes[0].destination, Some("0.0.0.0/0".to_string()));
-    assert_eq!(routes[0].next_hop_iface, Some("br1".to_string()));
+    assert_eq!(routes[0].next_hop_iface, Some("eth1".to_string()));
+    assert_eq!(routes[0].state, Some(RouteState::Absent));
     assert_eq!(routes[1].destination, Some("192.51.100.0/24".to_string()));
-    assert_eq!(routes[1].next_hop_iface, Some("br1".to_string()));
+    assert_eq!(routes[1].next_hop_iface, Some("eth1".to_string()));
+    assert_eq!(routes[1].state, Some(RouteState::Absent));
+    assert_eq!(routes[2].destination, Some("0.0.0.0/0".to_string()));
+    assert_eq!(routes[2].next_hop_iface, Some("br1".to_string()));
+    assert_eq!(routes[3].destination, Some("192.51.100.0/24".to_string()));
+    assert_eq!(routes[3].next_hop_iface, Some("br1".to_string()));
 }
 
 #[test]

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -508,3 +508,70 @@ def test_cli_apply_with_override_iface(eth1_with_static_route_and_rule):
     iface_state = show_only(("eth1",))[Interface.KEY][0]
     assert not iface_state[Interface.IPV4][InterfaceIPv4.ENABLED]
     assert not iface_state[Interface.IPV6][InterfaceIPv6.ENABLED]
+
+
+@pytest.fixture
+def eth1_with_static_route(eth1_up):
+    desired_state = yaml.load(
+        """---
+        routes:
+          config:
+          - destination: 203.0.113.0/24
+            next-hop-address: 192.0.2.1
+            next-hop-interface: eth1
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: 192.0.2.252
+                prefix-length: 24
+        """,
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    yield
+
+
+def test_cli_apply_policy_change_routes(eth1_with_static_route, eth2_up):
+    with NamedTemporaryFile() as fd:
+        fd.write(
+            """---
+            capture:
+              nic: interfaces.name == "eth2"
+            desired:
+              routes:
+                config:
+                  - destination: 203.0.113.0/24
+                    state: absent
+                  - destination: 203.0.113.0/24
+                    next-hop-interface: "{{ capture.nic.interfaces.0.name }}"
+                    next-hop-address: 192.0.2.1
+              interfaces:
+                - name: "{{ capture.nic.interfaces.0.name }}"
+                  state: up
+                  type: ethernet
+                  ipv4:
+                    address:
+                    - ip: 192.0.2.253
+                      prefix-length: 24
+                    enabled: true
+            """.encode(
+                "utf-8"
+            )
+        )
+        fd.flush()
+        cmdlib.exec_cmd(f"nmstatectl apply {fd.name}".split(), check=True)
+
+    cur_state = libnmstate.show()
+
+    eth1_routes = [
+        route
+        for route in cur_state[Route.KEY][Route.CONFIG]
+        if route[Route.NEXT_HOP_INTERFACE] == "eth1"
+    ]
+
+    assert not eth1_routes


### PR DESCRIPTION
Nmstate ignore policy to remove routes using not-interface matching, for
example:

```yml
desired:
  routes:
    config:
      - destination: 203.0.113.0/24
        state: absent
```

This is because `NetworkPolicy` use `MergedRoutes.get_diff()` to
generate `NetworkState`, and it has it own implementation of applying
absent routes which does not handle route match correctly.

To fix the issue, instead of re-calculate the changed routes, we use
`MergedRoutes.changed_routes` which is well tested by apply action.

Unit test and integration test case included.