### PR TITLE
New release 2.2.53

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [2.2.53] - 2025-10-20
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - ovsdb: Extend maximum JSON string length from 2KiB to 4GiB. (41a9a01c)
+ - policy route: Fix problem when removing routes via policy. (3111eac9)
+ - package: Fix `%cargo_install` option. (158cb534)
+
 ## [2.2.52] - 2025-09-16
 ### Breaking changes
  - N/A


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - ovsdb: Extend maximum JSON string length from 2KiB to 4GiB. (41a9a01c)
 - policy route: Fix problem when removing routes via policy. (3111eac9)
 - package: Fix `%cargo_install` option. (158cb534)

Signed-off-by: Gris Ge <fge@redhat.com>