### PR TITLE
Increase minimum supported rust version to 1.82

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -12,22 +12,16 @@ on:
 
 jobs:
   build_on_msrv:
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - msrv: "1.77"
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v5
 
-    - name: Install Rust ${{ matrix.msrv }}
-      run: rustup install ${{ matrix.msrv }}
+    - name: Install Rust 1.82
+      run: rustup install 1.82
 
     - name: Build test
-      run: cd rust && cargo +${{ matrix.msrv }} build --ignore-rust-version
+      run: cd rust && cargo +1.82 build --ignore-rust-version
 
     - name: Unit tests
-      run: cd rust && cargo +${{ matrix.msrv }} test --ignore-rust-version
+      run: cd rust && cargo +1.82 test --ignore-rust-version

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.77"
+rust-version = "1.82"
 
 [workspace.dependencies]
 log = "0.4.17"

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -1385,7 +1385,7 @@ fn sanitize_ipv6_token_to_string(
 }
 
 fn is_ip_addrs_none_or_all_auto(addrs: Option<&[InterfaceIpAddr]>) -> bool {
-    addrs.map_or(true, |addrs| {
+    addrs.is_none_or(|addrs| {
         addrs.iter().all(|a| {
             if let IpAddr::V6(ip_addr) = a.ip {
                 is_ipv6_unicast_link_local(&ip_addr) || a.is_auto()


### PR DESCRIPTION
The zbus_macros -> proc-macro-crate -> indexmap dependency chain has
indexmap 2.12 which require 1.82 to compile.

It is not a dependency we can bypass. Have to bump MSRV to 1.82.

CI test updated.