### PR TITLE
ovs: Fix build on i686

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -17,11 +17,17 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - name: Install Rust i686 target
+      run: rustup target add i686-unknown-linux-gnu
+
     - name: Install Rust 1.82
-      run: rustup install 1.82
+      run: rustup install 1.82 && rustup install 1.82 --target i686-unknown-linux-gnu
 
     - name: Build test
       run: cd rust && cargo +1.82 build --ignore-rust-version
+
+    - name: Build test (i686)
+      run: cd rust/src/lib && cargo +1.82 build --ignore-rust-version --target i686-unknown-linux-gnu
 
     - name: Unit tests
       run: cd rust && cargo +1.82 test --ignore-rust-version

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -13,7 +13,7 @@ const BUFFER_SIZE: usize = 4096;
 // The `lib/jsonrpc.c` is using infinite retry on OVS, we cannot do that
 // risking nmstate stuck for ever. We assume the OVSDB returns at most
 // 4 GiB data for a single JSON string.
-const MAX_RECV_RETRY_COUNT: usize = 4 * 1024 * 1024 * 1024 / BUFFER_SIZE;
+const MAX_RECV_RETRY_COUNT: usize = 1048576;
 
 #[derive(Debug)]
 pub(crate) struct OvsDbJsonRpc {


### PR DESCRIPTION
Got error when compiling in i686 system:

```
16 | const MAX_RECV_RETRY_COUNT: usize = 4 * 1024 * 1024 * 1024 / BUFFER_SIZE;
   |                                     ^^^^^^^^^^^^^^^^^^^^^^
   evaluation of `ovsdb::json_rpc::MAX_RECV_RETRY_COUNT` failed here
```

Fixed by change it to magic number.

CI test enabled to ensure it never happens again.