### PR TITLE
CI: Use openvswitch from centos-release-nfv-openvswitch in c10s

### DIFF
--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream10-development
 
-RUN echo "2025-03-12" > /build_time
+RUN echo "2025-10-22" > /build_time
 
 # Add alter-baseos and alter-appstream repositories with lower priority
 COPY c10s-alter-baseos.repo \
@@ -13,15 +13,14 @@ RUN grep -q "^skip_if_unavailable=" /etc/dnf/dnf.conf && \
     echo "skip_if_unavailable=True" >> /etc/dnf/dnf.conf
 
 RUN dnf update -y && \
-    dnf -y install dnf-plugins-core  && \
-    dnf -y copr enable nmstate/ovs-el10 centos-stream-10-x86_64 && \
+    dnf -y install centos-release-nfv-openvswitch && \
     dnf config-manager --set-enabled crb && \
     dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust-toolset NetworkManager NetworkManager-ovs \
         systemd-udev python3-devel python3-pyyaml python3-setuptools dnsmasq \
         git iproute rpm-build python3-pytest wpa_supplicant hostapd libndp \
         python3-pip procps-ng dpdk libreswan NetworkManager-libreswan podman \
-        openvswitch3.3 && \
+        openvswitch3.4 && \
     dnf clean all
 
 RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"


### PR DESCRIPTION
Instead of using OVS from self-build copr repo, this patch changed
the CentOS stream 10 testing container to use openvswitch3.4 from
official centos-release-nfv-openvswitch repo.