### PR TITLE
route: Support referring route table ID by VRF interface name

### DIFF
--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::collections::HashSet;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
     BaseInterface, ErrorKind, Interface, InterfaceType, MergedInterface,
-    NmstateError,
+    MergedInterfaces, NmstateError, Routes,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,6 +182,104 @@ impl MergedInterface {
             if let Some(Interface::Vrf(verify_iface)) = self.for_verify.as_mut()
             {
                 verify_iface.merge_table_id(self.current.as_ref())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Routes {
+    pub(crate) fn resolve_vrf_name(
+        &mut self,
+        merged_ifaces: &MergedInterfaces,
+    ) -> Result<(), NmstateError> {
+        let vrf_names_down: HashSet<&str> = merged_ifaces
+            .kernel_ifaces
+            .values()
+            .filter(|merged_iface| merged_iface.merged.is_down())
+            .filter_map(|merged_iface| {
+                if merged_iface.merged.iface_type() == InterfaceType::Vrf {
+                    Some(merged_iface.merged.name())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let vrf_names_absent: HashSet<&str> = merged_ifaces
+            .kernel_ifaces
+            .values()
+            .filter(|merged_iface| merged_iface.merged.is_absent())
+            .filter_map(|merged_iface| {
+                if merged_iface.merged.iface_type() == InterfaceType::Vrf {
+                    Some(merged_iface.merged.name())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let vrf_name_to_table_id: HashMap<&str, u32> = merged_ifaces
+            .kernel_ifaces
+            .values()
+            .filter(|merged_iface| merged_iface.merged.is_up())
+            .filter_map(|merged_iface| {
+                if let Interface::Vrf(vrf_iface) = &merged_iface.merged {
+                    vrf_iface.vrf.as_ref().and_then(|v| v.table_id).map(
+                        |table_id| (vrf_iface.base.name.as_str(), table_id),
+                    )
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if let Some(config_routes) = self.config.as_mut() {
+            for rt in config_routes.iter_mut() {
+                let vrf_name = if let Some(n) = rt.vrf_name.as_deref() {
+                    n
+                } else {
+                    continue;
+                };
+                if vrf_names_down.contains(vrf_name) {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "VRF defined in Route '{rt}' is marked as 'state: \
+                             down'"
+                        ),
+                    ));
+                }
+                if vrf_names_absent.contains(vrf_name) {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "VRF defined in Route '{rt}' is marked as 'state: \
+                             absent'"
+                        ),
+                    ));
+                }
+                let table_id = if let Some(t) =
+                    vrf_name_to_table_id.get(vrf_name)
+                {
+                    *t
+                } else {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!("VRF defined in Route '{rt}' does not exist"),
+                    ));
+                };
+                if let Some(des_table_id) = rt.table_id {
+                    if des_table_id != table_id {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Route '{rt}' has both table id and VRF name \
+                                 defined, but desired table ID is {} while \
+                                 table ID for VRF {} is {}",
+                                des_table_id, vrf_name, table_id
+                            ),
+                        ));
+                    }
+                }
+                rt.table_id = Some(table_id);
             }
         }
         Ok(())

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 use log::warn;
 
 use crate::{
-    ErrorKind, MergedRoutes, NmstateError, RouteEntry, RouteType, Routes,
+    ErrorKind, Interface, Interfaces, MergedRoutes, NmstateError, RouteEntry,
+    RouteType, Routes,
 };
 
 const SUPPORTED_ROUTE_SCOPE: [nispor::RouteScope; 2] =
@@ -32,7 +33,10 @@ const IPV6_EMPTY_NEXT_HOP_ADDRESS: &str = "::";
 // kernel values
 const RTAX_CWND: u32 = 7;
 
-pub(crate) async fn get_routes(running_config_only: bool) -> Routes {
+pub(crate) async fn get_routes(
+    running_config_only: bool,
+    ifaces: &Interfaces,
+) -> Routes {
     let mut ret = Routes::new();
     let mut np_routes: Vec<nispor::Route> = Vec::new();
     let route_type = [
@@ -65,6 +69,22 @@ pub(crate) async fn get_routes(running_config_only: bool) -> Routes {
         }
     }
 
+    let table_id_to_vrf_names: HashMap<u32, &str> =
+        ifaces
+            .kernel_ifaces
+            .values()
+            .filter(|i| i.is_up())
+            .filter_map(|iface| {
+                if let Interface::Vrf(vrf_iface) = iface {
+                    vrf_iface.vrf.as_ref().and_then(|v| v.table_id).map(
+                        |table_id| (table_id, vrf_iface.base.name.as_str()),
+                    )
+                } else {
+                    None
+                }
+            })
+            .collect();
+
     if !running_config_only {
         let mut running_routes = Vec::new();
         for np_route in np_routes
@@ -72,13 +92,21 @@ pub(crate) async fn get_routes(running_config_only: bool) -> Routes {
             .filter(|np_route| SUPPORTED_ROUTE_SCOPE.contains(&np_route.scope))
         {
             if is_multipath(np_route) {
-                for route in flat_multipath_route(np_route) {
+                for route in
+                    flat_multipath_route(np_route, &table_id_to_vrf_names)
+                {
                     running_routes.push(route);
                 }
             } else if route_type.contains(&np_route.route_type) {
-                running_routes.push(np_routetype_to_nmstate(np_route));
+                running_routes.push(np_routetype_to_nmstate(
+                    np_route,
+                    &table_id_to_vrf_names,
+                ));
             } else if np_route.oif.is_some() {
-                running_routes.push(np_route_to_nmstate(np_route));
+                running_routes.push(np_route_to_nmstate(
+                    np_route,
+                    &table_id_to_vrf_names,
+                ));
             }
         }
         ret.running = Some(running_routes);
@@ -90,20 +118,28 @@ pub(crate) async fn get_routes(running_config_only: bool) -> Routes {
             && SUPPORTED_STATIC_ROUTE_PROTOCOL.contains(&np_route.protocol)
     }) {
         if is_multipath(np_route) {
-            for route in flat_multipath_route(np_route) {
+            for route in flat_multipath_route(np_route, &table_id_to_vrf_names)
+            {
                 config_routes.push(route);
             }
         } else if route_type.contains(&np_route.route_type) {
-            config_routes.push(np_routetype_to_nmstate(np_route));
+            config_routes.push(np_routetype_to_nmstate(
+                np_route,
+                &table_id_to_vrf_names,
+            ));
         } else if np_route.oif.is_some() {
-            config_routes.push(np_route_to_nmstate(np_route));
+            config_routes
+                .push(np_route_to_nmstate(np_route, &table_id_to_vrf_names));
         }
     }
     ret.config = Some(config_routes);
     ret
 }
 
-fn np_routetype_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
+fn np_routetype_to_nmstate(
+    np_route: &nispor::Route,
+    table_id_to_vrf_names: &HashMap<u32, &str>,
+) -> RouteEntry {
     let destination = match &np_route.dst {
         Some(dst) => Some(dst.to_string()),
         None => match np_route.address_family {
@@ -130,6 +166,9 @@ fn np_routetype_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     }
     route_entry.metric = np_route.metric.map(i64::from);
     route_entry.table_id = Some(np_route.table);
+    route_entry.vrf_name = table_id_to_vrf_names
+        .get(&np_route.table)
+        .map(|n| n.to_string());
     match np_route.route_type {
         nispor::RouteType::BlackHole => {
             route_entry.route_type = Some(RouteType::Blackhole)
@@ -152,7 +191,10 @@ fn np_routetype_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry
 }
 
-fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
+fn np_route_to_nmstate(
+    np_route: &nispor::Route,
+    table_id_to_vrf_names: &HashMap<u32, &str>,
+) -> RouteEntry {
     let destination = match &np_route.dst {
         Some(dst) => Some(dst.to_string()),
         None => match np_route.address_family {
@@ -202,6 +244,9 @@ fn np_route_to_nmstate(np_route: &nispor::Route) -> RouteEntry {
     route_entry.source = source;
     route_entry.metric = np_route.metric.map(i64::from);
     route_entry.table_id = Some(np_route.table);
+    route_entry.vrf_name = table_id_to_vrf_names
+        .get(&np_route.table)
+        .map(|n| n.to_string());
     // according to `man ip-route`, cwnd is useless without the lock flag, so
     // we require both cwnd and its lock flag to consider cwnd as set.
     let cwnd_lock = np_route.lock.unwrap_or(0) & (1 << RTAX_CWND) != 0;
@@ -223,14 +268,18 @@ fn is_multipath(np_route: &nispor::Route) -> bool {
         .unwrap_or_default()
 }
 
-fn flat_multipath_route(np_route: &nispor::Route) -> Vec<RouteEntry> {
+fn flat_multipath_route(
+    np_route: &nispor::Route,
+    table_id_to_vrf_names: &HashMap<u32, &str>,
+) -> Vec<RouteEntry> {
     let mut ret: Vec<RouteEntry> = Vec::new();
     if let Some(mpath_routes) = np_route.multipath.as_ref() {
         for mp_route in mpath_routes {
             let mut new_np_route = np_route.clone();
             new_np_route.via = Some(mp_route.via.to_string());
             new_np_route.oif = Some(mp_route.iface.to_string());
-            let mut route = np_route_to_nmstate(&new_np_route);
+            let mut route =
+                np_route_to_nmstate(&new_np_route, table_id_to_vrf_names);
             if np_route.address_family == nispor::AddressFamily::IPv4 {
                 route.weight = Some(mp_route.weight);
             }

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -166,7 +166,8 @@ pub(crate) async fn nispor_retrieve(
         net_state.append_interface_data(iface);
     }
     set_controller_type(&mut net_state.interfaces);
-    net_state.routes = get_routes(running_config_only).await;
+    net_state.routes =
+        get_routes(running_config_only, &net_state.interfaces).await;
     net_state.rules = get_route_rules(&np_state.rules, running_config_only);
     if kernel_only {
         net_state.dns = get_dns();

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -302,6 +302,9 @@ pub struct RouteEntry {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub advmss: Option<u32>,
+    /// Store the routes to the route table specified VRF bind to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vrf_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -412,6 +415,9 @@ impl RouteEntry {
         if self.advmss.is_some() && self.advmss != other.advmss {
             return false;
         }
+        if self.vrf_name.is_some() && self.vrf_name != other.vrf_name {
+            return false;
+        }
         true
     }
 
@@ -437,6 +443,7 @@ impl RouteEntry {
                 self.destination.as_deref().unwrap_or(""),
                 self.next_hop_addr.as_deref().unwrap_or(""),
                 self.source.as_deref().unwrap_or(""),
+                self.vrf_name.as_deref().unwrap_or(""),
             ],
             vec![
                 self.table_id.unwrap_or(DEFAULT_TABLE_ID),
@@ -622,6 +629,9 @@ impl std::fmt::Display for RouteEntry {
         if let Some(v) = self.advmss {
             props.push(format!("advmss: {v}"));
         }
+        if let Some(v) = self.vrf_name.as_ref() {
+            props.push(format!("vrf-name: {v}"));
+        }
 
         write!(f, "{}", props.join(" "))
     }
@@ -652,6 +662,7 @@ impl MergedRoutes {
         desired.remove_ignored_routes();
         desired.validate()?;
         desired.resolve_next_hop_iface_ref(merged_ifaces)?;
+        desired.resolve_vrf_name(merged_ifaces)?;
 
         let mut desired_routes = Vec::new();
         if let Some(rts) = desired.config.as_ref() {

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{InterfaceType, Interfaces, MergedInterfaces, VrfInterface};
+use crate::{
+    ErrorKind, InterfaceType, Interfaces, MergedInterfaces, Routes,
+    VrfInterface,
+};
 
 #[test]
 fn test_vrf_stringlized_attributes() {
@@ -107,4 +110,180 @@ fn test_vrf_skip_port_if_null() {
     let iface_yaml = serde_yaml::to_string(&iface).unwrap();
 
     assert!(!iface_yaml.contains("port"))
+}
+
+#[test]
+fn test_route_vrf_name() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces = Interfaces::default();
+
+    let mut des_routes: Routes = serde_yaml::from_str(
+        r"---
+        config:
+          - destination: 198.51.200.0/24
+            route-type: blackhole
+            vrf-name: vrf0
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    des_routes.resolve_vrf_name(&merged_ifaces).unwrap();
+
+    assert_eq!(des_routes.config.as_ref().unwrap()[0].table_id, Some(100));
+}
+
+#[test]
+fn test_route_vrf_name_down() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: down
+        ",
+    )
+    .unwrap();
+
+    let mut des_routes: Routes = serde_yaml::from_str(
+        r"---
+        config:
+          - destination: 198.51.200.0/24
+            route-type: blackhole
+            vrf-name: vrf0
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let result = des_routes.resolve_vrf_name(&merged_ifaces);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_route_vrf_name_absent() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: absent
+        ",
+    )
+    .unwrap();
+
+    let mut des_routes: Routes = serde_yaml::from_str(
+        r"---
+        config:
+          - destination: 198.51.200.0/24
+            route-type: blackhole
+            vrf-name: vrf0
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let result = des_routes.resolve_vrf_name(&merged_ifaces);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
+}
+
+#[test]
+fn test_route_vrf_name_table_id_conflict() {
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces = Interfaces::default();
+
+    let mut des_routes: Routes = serde_yaml::from_str(
+        r"---
+        config:
+          - destination: 198.51.200.0/24
+            route-type: blackhole
+            table-id: 101
+            vrf-name: vrf0
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let result = des_routes.resolve_vrf_name(&merged_ifaces);
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -56,6 +56,7 @@ class Route:
     MTU = "mtu"
     QUICKACK = "quickack"
     ADVMSS = "advmss"
+    VRF_NAME = "vrf-name"
 
 
 class RouteRule:

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -9,8 +9,9 @@ from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
-from libnmstate.schema import InterfaceType
 from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
+from libnmstate.schema import Route
 from libnmstate.schema import VRF
 
 from .testlib import assertlib
@@ -491,3 +492,38 @@ class TestVrf:
         assertlib.assert_absent(TEST_VRF0)
         assertlib.assert_absent(TEST_BOND0)
         assertlib.assert_absent(TEST_BOND0_VLAN)
+
+    # https://issues.redhat.com/browse/RHEL-119046
+    @pytest.mark.tier1
+    def test_route_to_vrf_name(self, vrf0_with_port0):
+        desired = yaml.load(
+            f"""---
+            routes:
+              config:
+              - destination: 198.51.200.0/24
+                route-type: blackhole
+                vrf-name: {TEST_VRF0}
+            """,
+            Loader=yaml.SafeLoader,
+        )
+        libnmstate.apply(desired)
+
+        cur_routes = libnmstate.show()[Route.KEY]
+        for routes in (cur_routes[Route.RUNNING], cur_routes[Route.CONFIG]):
+            assert any(
+                route[Route.VRF_NAME] == TEST_VRF0
+                and route[Route.TABLE_ID] == TEST_ROUTE_TABLE_ID0
+                for route in routes
+            )
+        desired = yaml.load(
+            f"""---
+            routes:
+              config:
+              - destination: 198.51.200.0/24
+                state: absent
+                route-type: blackhole
+                vrf-name: {TEST_VRF0}
+            """,
+            Loader=yaml.SafeLoader,
+        )
+        libnmstate.apply(desired)


### PR DESCRIPTION
Given the VRF interface always bind to a route table ID, this patch
introducing `vrf-name` to route entry, allowing user to refer a route
table ID by VRF interface name. For example:

```yml
---
routes:
  config:
    - destination: 198.51.200.0/24
      route-type: blackhole
      vrf-name: vrf0
interfaces:
- name: vrf0
  type: vrf
  vrf:
    route-table-id: "100"
    port:
      - eth1
      - eth2
```

Tier 1 integration test case and unit test cases are included.

Resolves: https://issues.redhat.com/browse/RHEL-119046