### PR TITLE
Add support for the lsc-interrupt option for OVS DPDK interfaces

### DIFF
--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -659,6 +659,16 @@ pub struct OvsDpdkConfig {
     /// Must be power of 2 in the range of 1 to 4096.
     /// Setting to 0 means remove this setting from OVS database.
     pub n_txq_desc: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "lsc-interrupt",
+        alias = "dpdk-lsc-interrupt"
+    )]
+    /// Configures the Link State Change (LSC) detection mode for dpdk ports.
+    /// Setting to true enables interrupt mode; false disables interrupt mode
+    /// and configures the interface in poll mode. You may also use the OVS
+    /// terminology `dpdk-lsc-interrupt` for this property.
+    pub lsc_interrupt: Option<bool>,
 }
 
 const POWER_2_BETWEEN_1_4096: [u32; 13] =

--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -289,6 +289,7 @@ pub struct NmSettingOvsDpdk {
     pub n_rxq: Option<u32>,
     pub n_rxq_desc: Option<u32>,
     pub n_txq_desc: Option<u32>,
+    pub lsc_interrupt: Option<bool>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
 
@@ -300,6 +301,8 @@ impl TryFrom<DbusDictionary> for NmSettingOvsDpdk {
             n_rxq: _from_map!(v, "n-rxq", u32::try_from)?,
             n_rxq_desc: _from_map!(v, "n-rxq-desc", u32::try_from)?,
             n_txq_desc: _from_map!(v, "n-txq-desc", u32::try_from)?,
+            lsc_interrupt: _from_map!(v, "lsc-interrupt", i32::try_from)?
+                .map(|i| i != 0),
             _other: v,
         })
     }
@@ -319,6 +322,9 @@ impl ToDbusValue for NmSettingOvsDpdk {
         }
         if let Some(v) = &self.n_txq_desc {
             ret.insert("n-txq-desc", zvariant::Value::new(v));
+        }
+        if let Some(v) = &self.lsc_interrupt {
+            ret.insert("lsc-interrupt", zvariant::Value::new(*v as i32));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -166,6 +166,7 @@ pub(crate) fn gen_nm_ovs_iface_setting(
             nm_ovs_dpdk.n_rxq = dpdk_iface.rx_queue;
             nm_ovs_dpdk.n_rxq_desc = dpdk_iface.n_rxq_desc;
             nm_ovs_dpdk.n_txq_desc = dpdk_iface.n_txq_desc;
+            nm_ovs_dpdk.lsc_interrupt = dpdk_iface.lsc_interrupt;
             nm_conn.ovs_dpdk = Some(nm_ovs_dpdk);
             nm_conn.ovs_iface = Some(nm_ovs_iface_set);
         }

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -336,6 +336,13 @@ fn parse_ovs_iface_dpdk_conf(
                     conf.n_txq_desc = Some(i)
                 }
             }
+            if let Some(lsc_interrupt) = options.get("dpdk-lsc-interrupt") {
+                conf.lsc_interrupt = match lsc_interrupt.as_str() {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                }
+            }
             return Some(conf);
         }
     }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -391,6 +391,7 @@ class OVSInterface(OvsDB):
         RX_QUEUE = "rx-queue"
         N_RXQ_DESC = "n_rxq_desc"
         N_TXQ_DESC = "n_txq_desc"
+        LSC_INTERRUPT = "lsc-interrupt"
 
 
 class OVSBridge(Bridge, OvsDB):

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -537,6 +537,7 @@ def test_gc_on_ovs_dpdk():
             n_rxq: 100
             n_rxq_desc: 1024
             n_txq_desc: 2048
+            lsc-interrupt: true
         - name: br0
           type: ovs-bridge
           state: up
@@ -556,6 +557,7 @@ def test_gc_on_ovs_dpdk():
     assert "n-rxq-desc=1024" in ovs_iface_conf
     assert "n-txq-desc=2048" in ovs_iface_conf
     assert "n-rxq=100" in ovs_iface_conf
+    assert "lsc-interrupt=1" in ovs_iface_conf
     assert "devargs=0000:af:00.1" in ovs_iface_conf
 
 

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1431,6 +1431,7 @@ class TestOvsDpdk:
             OVSInterface.Dpdk.DEVARGS: _test_pci_path(),
             OVSInterface.Dpdk.N_RXQ_DESC: 1024,
             OVSInterface.Dpdk.N_TXQ_DESC: 2048,
+            OVSInterface.Dpdk.LSC_INTERRUPT: True,
         }
         bridge = Bridge(BRIDGE0)
         bridge.add_internal_port(PORT1, dpdk_state=dpdk0_state)


### PR DESCRIPTION
Add support for configuring the Link State Change (LSC) detection mode for OVS DPDK interfaces.

Resolves: https://issues.redhat.com/browse/RHEL-53956
