### PR TITLE
test: Fix `test_route_to_vrf_name`

### DIFF
--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -5,7 +5,7 @@ RUN echo "2025-03-12" > /build_time
 RUN dnf update -y && \
     dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust cargo NetworkManager NetworkManager-ovs \
-        openvswitch systemd-udev python3-devel python3-pyyaml \
+        openvswitch systemd-udev python3-devel python3-pyyaml python3-pip \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
         libndp procps-ng dpdk rust-packaging \

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -4,7 +4,7 @@ RUN echo "2025-03-12" > /build_time
 
 RUN dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust cargo NetworkManager NetworkManager-ovs \
-        openvswitch systemd-udev python3-devel python3-pyyaml \
+        openvswitch systemd-udev python3-devel python3-pyyaml python3-pip \
         python3-setuptools dnsmasq git iproute rpm-build python3-pytest \
         python3-virtualenv python3-tox tcpreplay wpa_supplicant hostapd \
         libndp procps-ng dpdk rust-packaging \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+license = "LGPL-2.1-or-later"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/rust/src/python/setup.py
+++ b/rust/src/python/setup.py
@@ -27,7 +27,6 @@ setuptools.setup(
     python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
     ],
 )

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -511,7 +511,7 @@ class TestVrf:
         cur_routes = libnmstate.show()[Route.KEY]
         for routes in (cur_routes[Route.RUNNING], cur_routes[Route.CONFIG]):
             assert any(
-                route[Route.VRF_NAME] == TEST_VRF0
+                route.get(Route.VRF_NAME) == TEST_VRF0
                 and route[Route.TABLE_ID] == TEST_ROUTE_TABLE_ID0
                 for route in routes
             )


### PR DESCRIPTION
Some routes does not have `Route.VRF_NAME` property, we will get
exception when access it by `route[Route.VRF_NAME]`.

Fixed by using `route.get(Route.VRF_NAME)`.