### PR TITLE
ipsec: Support `rightca` option

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -104,6 +104,7 @@ function create_container {
   CONTAINER_ID="$(${CONTAINER_CMD} run --privileged -d \
       -e CI \
       -e SHIPPABLE \
+      -v /var/lib/containers:/var/lib/containers \
       -v $PROJECT_PATH:$CONTAINER_WORKSPACE \
       -v $EXPORT_DIR:$CONT_EXPORT_DIR $CONTAINER_IMAGE)"
   [ -n "$debug_exit_shell" ] && trap open_shell EXIT || trap run_exit EXIT

--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -155,6 +155,8 @@ pub struct LibreswanConfig {
     pub require_id_on_certificate: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub leftsendcert: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rightca: Option<String>,
 }
 
 impl LibreswanConfig {

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -115,6 +115,7 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.require_id_on_certificate =
             data.get("require-id-on-certificate").map(|s| s == "yes");
         ret.leftsendcert = data.get("leftsendcert").cloned();
+        ret.rightca = data.get("rightca").cloned();
     }
     if let Some(secrets) = nm_set_vpn.secrets.as_ref() {
         ret.psk = secrets.get("pskvalue").cloned();

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -95,6 +95,9 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.leftsendcert.as_ref() {
             vpn_data.insert("leftsendcert".into(), v.to_string());
         }
+        if let Some(v) = conf.rightca.as_ref() {
+            vpn_data.insert("rightca".into(), v.to_string());
+        }
 
         let mut nm_vpn_set = NmSettingVpn::default();
         nm_vpn_set.data = Some(vpn_data);

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -10,11 +10,12 @@ from libnmstate.schema import InterfaceIPv6
 
 
 from .testlib import cmdlib
+from .testlib.env import is_k8s
 from .testlib.env import nm_libreswan_version_int
 from .testlib.env import version_str_to_int
+from .testlib.ipsec import IpsecTestEnv
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import show_only
-from .testlib.ipsec import IpsecTestEnv
 
 
 RETRY_COUNT = 10
@@ -1036,6 +1037,49 @@ def test_ipsec_leftsendcert(ipsec_srv_cert_gw, load_both_keys):
             rightcert: {IpsecTestEnv.SRV_KEY_ID}
             rightsubnet: 0.0.0.0/0
             leftsendcert: always
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec,
+        IpsecTestEnv.CLI_ADDR_V4,
+        IpsecTestEnv.SRV_ADDR_V4,
+    )
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec_ip,
+        IpsecTestEnv.SRV_POOL_PREFIX_V4,
+        IpsecTestEnv.CLI_NIC,
+    )
+
+
+# https://issues.redhat.com/browse/RHEL-114237
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    nm_libreswan_version_int() < version_str_to_int("1.2.27"),
+    reason="Need NetworkManager-libreswan 1.2.27+ to support rightca",
+)
+@pytest.mark.skipif(is_k8s(), reason="K8S CI does not support IPSec yet")
+def test_ipsec_rightca(ipsec_srv_cert_gw):
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: {IPSEC_CONN_NAME}
+          type: ipsec
+          ipv4:
+            enabled: true
+            dhcp: true
+          libreswan:
+            left: {IpsecTestEnv.CLI_ADDR_V4}
+            leftid: '%fromcert'
+            leftcert: {IpsecTestEnv.CLI_KEY_ID}
+            leftmodecfgclient: true
+            right: {IpsecTestEnv.SRV_ADDR_V4}
+            rightid: '%fromcert'
+            rightsubnet: 0.0.0.0/0
+            rightca: '%same'
             ikev2: insist""",
         Loader=yaml.SafeLoader,
     )


### PR DESCRIPTION
Example YAML:

```yml
---
interfaces:
  - name: ipsec_conn4
    type: ipsec
    ipv4:
      enabled: true
      dhcp: true
    libreswan:
      left: 192.0.2.2
      leftid: '%fromcert'
      leftcert: cli-a.example.org
      leftrsasigkey: '%cert'
      right: 192.0.2.1
      rightsubnet: 0.0.0.0/0
      rightid: '%fromcert'
      rightca: '%same'
      ikev2: insist
      leftmodecfgclient: true
```

Integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-114237