### PR TITLE
test: Skip `test_use_global_dns_even_for_with_static_ip` in k8s CI

### DIFF
--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -380,6 +380,7 @@ def eth1_static_iface_dns(eth1_up):
 
 # https://issues.redhat.com/browse/RHEL-125548
 @pytest.mark.tier1
+@pytest.mark.skipif(is_k8s(), reason="K8S cannot check global DNS file")
 def test_use_global_dns_even_for_with_static_ip(
     eth1_static_iface_dns, eth2_up
 ):


### PR DESCRIPTION
In K8S, nmstate is running in a container without access to
`/etc/NetworkManager` folder of host. Hence we should skip the
`test_use_global_dns_even_for_with_static_ip` test case.