### PR TITLE
nm: deactivate hsr interface before reactivating when changed

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -11,7 +11,7 @@ use super::super::{
         activate_nm_connections, connection::is_uuid,
         deactivate_nm_connections, deactivate_nm_devices,
         delete_exist_connections, delete_orphan_ovs_ports,
-        dispatch::apply_dispatch_script, dns::store_dns_config,
+        dispatch::apply_dispatch_script, dns::store_dns_config, is_hsr_changed,
         is_ipvlan_changed, is_mptcp_flags_changed, is_route_removed,
         is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
         is_vxlan_changed, save_nm_connections,
@@ -343,6 +343,7 @@ async fn delete_orphan_ports(
 // * NM cannot change VRF table ID, so we deactivate first
 // * VLAN config changed.
 // * Veth peer changed.
+// * HSR config changed.
 // * NM cannot reapply changes to MPTCP flags.
 // * All VPN connection
 // * All linux bridge ports should be deactivate if its controller has
@@ -375,6 +376,7 @@ fn gen_nm_conn_need_to_deactivate_first(
                     && is_route_removed(nm_conn, nm_applied_conn))
                     || is_vrf_table_id_changed(nm_conn, nm_applied_conn)
                     || is_vlan_changed(nm_conn, nm_applied_conn)
+                    || is_hsr_changed(nm_conn, nm_applied_conn)
                     || is_vxlan_changed(nm_conn, nm_applied_conn)
                     || is_veth_peer_changed(nm_conn, nm_applied_conn)
                     || is_mptcp_flags_changed(nm_conn, nm_applied_conn)

--- a/rust/src/lib/nm/query_apply/hsr.rs
+++ b/rust/src/lib/nm/query_apply/hsr.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::nm_dbus::NmConnection;
+
+pub(crate) fn is_hsr_changed(
+    new_nm_conn: &NmConnection,
+    cur_nm_conn: &NmConnection,
+) -> bool {
+    if let (Some(new_hsr_conf), Some(cur_hsr_conf)) =
+        (new_nm_conn.hsr.as_ref(), cur_nm_conn.hsr.as_ref())
+    {
+        new_hsr_conf.port1 != cur_hsr_conf.port1
+            || new_hsr_conf.port2 != cur_hsr_conf.port2
+            || new_hsr_conf.multicast_spec != cur_hsr_conf.multicast_spec
+            || new_hsr_conf.prp != cur_hsr_conf.prp
+    } else {
+        false
+    }
+}

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -5,6 +5,7 @@ mod connection;
 pub(crate) mod device;
 pub(crate) mod dispatch;
 pub(crate) mod dns;
+mod hsr;
 mod ieee8021x;
 mod ip;
 mod ipvlan;
@@ -26,6 +27,7 @@ pub(crate) use self::connection::{
 };
 pub(crate) use self::device::deactivate_nm_devices;
 pub(crate) use self::dns::retrieve_dns_state;
+pub(crate) use self::hsr::is_hsr_changed;
 pub(crate) use self::ieee8021x::nm_802_1x_to_nmstate;
 pub(crate) use self::ip::{
     nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6, query_nmstate_wait_ip,

--- a/tests/integration/hsr_test.py
+++ b/tests/integration/hsr_test.py
@@ -64,3 +64,17 @@ def test_hsr_mac_address_sync(hsr0_with_eths):
     assert hsr_mac is not None
     assert hsr_mac == eth1_mac
     assert hsr_mac == eth2_mac
+
+
+# https://issues.redhat.com/browse/RHEL-100773
+@pytest.mark.tier1
+def test_hsr_update_protocol(hsr0_with_eths):
+    # Break if the default protocol in fixture is changed,
+    # since it may render this test otherwise useless.
+    assert (
+        "prp"
+        == hsr0_with_eths[Interface.KEY][0][Hsr.CONFIG_SUBTREE][Hsr.PROTOCOL]
+    )
+    hsr0_with_eths[Interface.KEY][0][Hsr.CONFIG_SUBTREE][Hsr.PROTOCOL] = "hsr"
+    libnmstate.apply(hsr0_with_eths)
+    assertlib.assert_state_match(hsr0_with_eths)


### PR DESCRIPTION
NM has special handling for "virtual" interfaces, and does not remove them from kernel when connections are changed. This is a problem because now-modified properties are not properly applied to such interfaces.

HSR is one of such virtual interfaces, and since it does not have a `changelink` handler in kernel, implementing reapply is out of the question. Thus, we have no other option but to deactivate the interface, to force NM into recreating it from scratch.

Resolves: https://issues.redhat.com/browse/RHEL-100773