### PR TITLE
Support omit timer from NetworkState

### DIFF
--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -138,6 +138,12 @@ fn main() {
                         .long("show-secrets")
                         .takes_value(false)
                         .help("Show secrets(hide by default)"),
+                )
+                .arg(
+                    clap::Arg::new("PURGE_TIMER")
+                        .long("purge-timer")
+                        .takes_value(false)
+                        .help("Purge count down timer properties"),
                 ),
         )
         .subcommand(

--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -40,6 +40,9 @@ pub(crate) fn show(matches: &clap::ArgMatches) -> Result<String, CliError> {
     }
     net_state.set_include_secrets(matches.is_present("SHOW_SECRETS"));
     net_state.retrieve()?;
+    if matches.is_present("PURGE_TIMER") {
+        net_state.purge_timer();
+    }
     Ok(if let Some(ifname) = matches.value_of("IFNAME") {
         let mut new_net_state = filter_net_state_with_iface(&net_state, ifname);
         new_net_state.set_kernel_only(matches.is_present("KERNEL"));

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -773,6 +773,18 @@ impl Interface {
             iface.change_port_name(org_port_name, new_port_name);
         }
     }
+
+    pub(crate) fn purge_timer(&mut self) {
+        if let Some(ip) = self.base_iface_mut().ipv4.as_mut() {
+            ip.purge_timer()
+        }
+        if let Some(ip) = self.base_iface_mut().ipv6.as_mut() {
+            ip.purge_timer()
+        }
+        if let Interface::LinuxBridge(iface) = self {
+            iface.purge_timer()
+        }
+    }
 }
 
 // The default on enum is experimental, but clippy is suggestion we use

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -721,6 +721,12 @@ impl Interfaces {
             }
         }
     }
+
+    pub(crate) fn purge_timer(&mut self) {
+        for iface in self.kernel_ifaces.values_mut().filter(|i| i.is_up()) {
+            iface.purge_timer()
+        }
+    }
 }
 
 fn is_opt_str_empty(opt_string: &Option<String>) -> bool {

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -124,7 +124,7 @@ impl LinuxBridgeInterface {
         self.use_upper_case_of_mac_address();
         self.flatten_port_vlan_ranges();
         self.sort_port_vlans();
-        self.remove_runtime_only_timers();
+        self.purge_timer();
         if let Some(port_confs) = self
             .bridge
             .as_ref()
@@ -188,7 +188,7 @@ impl LinuxBridgeInterface {
         }
     }
 
-    fn remove_runtime_only_timers(&mut self) {
+    pub(crate) fn purge_timer(&mut self) {
         if let Some(ref mut br_conf) = self.bridge {
             if let Some(ref mut opts) = &mut br_conf.options {
                 opts.gc_timer = None;

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -344,7 +344,8 @@ impl InterfaceIpv4 {
             addrs.retain(|a| !a.is_auto());
             addrs.iter_mut().for_each(|a| {
                 a.valid_life_time = None;
-                a.preferred_life_time = None
+                a.preferred_life_time = None;
+                a.dynamic = None;
             });
         }
 
@@ -390,6 +391,15 @@ impl InterfaceIpv4 {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn purge_timer(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            for addr in addrs.iter_mut() {
+                addr.preferred_life_time = None;
+                addr.valid_life_time = None;
+            }
+        }
     }
 }
 
@@ -782,6 +792,15 @@ impl InterfaceIpv6 {
             }
         }
     }
+
+    pub(crate) fn purge_timer(&mut self) {
+        if let Some(addrs) = self.addresses.as_mut() {
+            for addr in addrs.iter_mut() {
+                addr.preferred_life_time = None;
+                addr.valid_life_time = None;
+            }
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for InterfaceIpv6 {
@@ -908,6 +927,14 @@ pub struct InterfaceIpAddr {
         alias = "preferred-lft"
     )]
     pub preferred_life_time: Option<String>,
+    /// Whether IP address is dynamic allocated by DHCP or IPv6-RA.
+    /// This property is query only, it will be ignored when applying.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub dynamic: Option<bool>,
 }
 
 impl Default for InterfaceIpAddr {
@@ -918,31 +945,32 @@ impl Default for InterfaceIpAddr {
             mptcp_flags: None,
             valid_life_time: None,
             preferred_life_time: None,
+            dynamic: None,
         }
     }
 }
 
 impl std::fmt::Display for InterfaceIpAddr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_auto() {
-            write!(
-                f,
-                "{}/{} valid_life_time {} preferred_lft {}",
-                self.ip,
-                self.prefix_length,
-                self.valid_life_time.as_deref().unwrap_or(FOREVER),
-                self.preferred_life_time.as_deref().unwrap_or(FOREVER)
-            )
-        } else {
-            write!(f, "{}/{}", self.ip, self.prefix_length)
+        write!(f, "{}/{}", self.ip, self.prefix_length,)?;
+        if let Some(life_time) = self.valid_life_time.as_ref() {
+            write!(f, " valid_life_time {life_time}")?;
         }
+        if let Some(life_time) = self.preferred_life_time.as_ref() {
+            write!(f, " preferred_lft {life_time}")?;
+        }
+        if self.dynamic == Some(true) {
+            write!(f, " dynamic")?;
+        }
+        Ok(())
     }
 }
 
 impl InterfaceIpAddr {
     pub(crate) fn is_auto(&self) -> bool {
-        self.valid_life_time.is_some()
-            && self.valid_life_time.as_deref() != Some(FOREVER)
+        self.dynamic == Some(true)
+            || (self.valid_life_time.is_some()
+                && self.valid_life_time.as_deref() != Some(FOREVER))
     }
 }
 
@@ -992,6 +1020,7 @@ impl std::convert::TryFrom<&str> for InterfaceIpAddr {
             mptcp_flags: None,
             valid_life_time: None,
             preferred_life_time: None,
+            dynamic: None,
         })
     }
 }

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -259,6 +259,17 @@ impl NetworkState {
         }
     }
 
+    /// Purge lifetime properties like:
+    /// * `ipv4.valid-life-time`
+    /// * `ipv4.preferred-life-time`
+    /// * `ipv6.valid-life-time`
+    /// * `ipv6.preferred-life-time`
+    /// * `bridge.gc-timer`
+    /// * `bridge.hello-timer`
+    pub fn purge_timer(&mut self) {
+        self.interfaces.purge_timer();
+    }
+
     /// Append [Interface] into [NetworkState]
     pub fn append_interface_data(&mut self, iface: Interface) {
         self.interfaces.push(iface);

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -53,6 +53,11 @@ pub(crate) fn np_ipv4_to_nmstate(
                     } else {
                         None
                     },
+                    dynamic: if np_addr.valid_lft != "forever" {
+                        Some(true)
+                    } else {
+                        None
+                    },
                     ..Default::default()
                 }),
                 Err(e) => {
@@ -124,6 +129,14 @@ pub(crate) fn np_ipv6_to_nmstate(
                     },
                     preferred_life_time: if np_addr.preferred_lft != "forever" {
                         Some(np_addr.preferred_lft.clone())
+                    } else {
+                        None
+                    },
+                    dynamic: if !np_addr
+                        .flags
+                        .contains(&nispor::Ipv6AddrFlag::Permanent)
+                    {
+                        Some(true)
                     } else {
                         None
                     },

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Interface, InterfaceIpv4, InterfaceIpv6};
+use crate::{Interface, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6};
 
 impl InterfaceIpv4 {
     // Sort addresses and dedup
@@ -8,6 +8,9 @@ impl InterfaceIpv4 {
         if let Some(addrs) = self.addresses.as_mut() {
             addrs.sort_unstable();
             addrs.dedup();
+            for addr in addrs.iter_mut() {
+                addr.sanitize_current_for_verify();
+            }
         }
         if self.dhcp_custom_hostname.is_none() {
             self.dhcp_custom_hostname = Some(String::new());
@@ -32,6 +35,9 @@ impl InterfaceIpv4 {
                 // false as it might varied depend on whether have route on it
                 self.enabled_defined = false;
             } else {
+                for addr in addrs.iter_mut() {
+                    addr.sanitize_desired_for_verify();
+                }
                 addrs.sort_unstable();
                 addrs.dedup();
             }
@@ -92,6 +98,9 @@ impl InterfaceIpv6 {
     // Sort addresses and dedup
     pub(crate) fn sanitize_current_for_verify(&mut self) {
         if let Some(addrs) = self.addresses.as_mut() {
+            for addr in addrs.iter_mut() {
+                addr.sanitize_current_for_verify();
+            }
             addrs.sort_unstable();
             addrs.dedup();
         }
@@ -123,6 +132,9 @@ impl InterfaceIpv6 {
     // Sort addresses and dedup
     pub(crate) fn sanitize_desired_for_verify(&mut self) {
         if let Some(addrs) = self.addresses.as_mut() {
+            for addr in addrs.iter_mut() {
+                addr.sanitize_desired_for_verify();
+            }
             addrs.sort_unstable();
             addrs.dedup();
         }
@@ -195,7 +207,11 @@ impl Interface {
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
                 if des_ip.allow_extra_address != Some(false) {
-                    cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
+                    cur_ip_addrs.retain(|c| {
+                        des_ip_addrs.iter().any(|d| {
+                            d.ip == c.ip && d.prefix_length == c.prefix_length
+                        })
+                    })
                 }
                 // Remove allow_extra_address as current does not have it
                 des_ip.allow_extra_address = None
@@ -209,11 +225,29 @@ impl Interface {
                 (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
             {
                 if des_ip.allow_extra_address != Some(false) {
-                    cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
+                    cur_ip_addrs.retain(|c| {
+                        des_ip_addrs.iter().any(|d| {
+                            d.ip == c.ip && d.prefix_length == c.prefix_length
+                        })
+                    })
                 }
                 // Remove allow_extra_address as current does not have it
                 des_ip.allow_extra_address = None
             }
+        }
+    }
+}
+
+impl InterfaceIpAddr {
+    pub(crate) fn sanitize_current_for_verify(&mut self) {
+        if self.dynamic != Some(true) {
+            self.dynamic = None;
+        }
+    }
+
+    pub(crate) fn sanitize_desired_for_verify(&mut self) {
+        if self.dynamic != Some(true) {
+            self.dynamic = None;
         }
     }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -170,6 +170,7 @@ class InterfaceIP:
     ALLOW_EXTRA_ADDRESS = "allow-extra-address"
     DHCP_SEND_HOSTNAME = "dhcp-send-hostname"
     DHCP_CUSTOM_HOSTNAME = "dhcp-custom-hostname"
+    DYNAMIC = "dynamic"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -24,6 +24,7 @@ from libnmstate.schema import Route
 
 from libnmstate.error import NmstateNotImplementedError
 from libnmstate.error import NmstateValueError
+from libnmstate.iplib import is_ipv6_address
 from libnmstate.iplib import is_ipv6_link_local_addr
 
 from .testlib import assertlib
@@ -626,6 +627,7 @@ def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
     desired_state = statelib.show_only((DHCP_CLI_NIC,))
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
     dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
+    dhcp_cli_desired_state.pop(Interface.MPTCP, None)
     dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
         enabled=True, dhcp=False
     )
@@ -1059,23 +1061,29 @@ def _create_ipv6_state(
 def create_ipv4_address_state(
     address, prefix_length, valid_lft=None, prefferred_lft=None
 ):
-    return {
+    ret = {
         InterfaceIPv4.ADDRESS_IP: address,
         InterfaceIPv4.ADDRESS_PREFIX_LENGTH: prefix_length,
         InterfaceIPv4.ADDRESS_VALID_LIFE_TIME: valid_lft,
         InterfaceIPv4.ADDRESS_PREFERRED_LIFE_TIME: prefferred_lft,
     }
+    if valid_lft is not None and valid_lft != "forever":
+        ret[InterfaceIPv4.DYNAMIC] = True
+    return ret
 
 
 def create_ipv6_address_state(
     address, prefix_length, valid_lft=None, prefferred_lft=None
 ):
-    return {
+    ret = {
         InterfaceIPv6.ADDRESS_IP: address,
         InterfaceIPv6.ADDRESS_PREFIX_LENGTH: prefix_length,
         InterfaceIPv6.ADDRESS_VALID_LIFE_TIME: valid_lft,
         InterfaceIPv6.ADDRESS_PREFERRED_LIFE_TIME: prefferred_lft,
     }
+    if valid_lft is not None and valid_lft != "forever":
+        ret[InterfaceIPv6.DYNAMIC] = True
+    return ret
 
 
 @pytest.fixture(scope="function")
@@ -1542,6 +1550,7 @@ def _remove_ip_lifetime(addresses):
     for addr in addresses:
         addr.pop(InterfaceIP.ADDRESS_VALID_LIFE_TIME, None)
         addr.pop(InterfaceIP.ADDRESS_PREFERRED_LIFE_TIME, None)
+        addr.pop(InterfaceIP.DYNAMIC, None)
 
 
 def _remove_ip_mptcp_flags(addresses):
@@ -2403,3 +2412,39 @@ def test_enable_ipv4_forwarding_on_auto_iface_without_dhcp_srv():
         )
         libnmstate.apply(desired_state)
         assertlib.assert_state_match(desired_state)
+
+
+def test_show_auto_ip_with_dynamic_property(dhcpcli_up_with_dynamic_ip):
+    iface_state = statelib.show_only((DHCP_CLI_NIC,))[Interface.KEY][0]
+
+    for addrs in (
+        iface_state[Interface.IPV4][InterfaceIPv4.ADDRESS],
+        iface_state[Interface.IPV6][InterfaceIPv6.ADDRESS],
+    ):
+        for addr in addrs:
+            if is_ipv6_address(
+                addr[InterfaceIP.ADDRESS_IP]
+            ) and is_ipv6_link_local_addr(
+                addr[InterfaceIPv6.ADDRESS_IP],
+                addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
+            ):
+                continue
+            assert addr[InterfaceIP.DYNAMIC]
+
+
+def test_nmstatectl_purge_ip_timer(dhcpcli_up_with_dynamic_ip):
+    output = cmdlib.exec_cmd(
+        f"nmstatectl show {DHCP_CLI_NIC}".split(),
+        check=True,
+    )[1]
+    assert "valid-life-time" in output
+    assert "preferred-life-time" in output
+    assert "dynamic: true" in output
+
+    output = cmdlib.exec_cmd(
+        f"nmstatectl show --purge-timer {DHCP_CLI_NIC}".split(),
+        check=True,
+    )[1]
+    assert "valid-life-time" not in output
+    assert "preferred-life-time" not in output
+    assert "dynamic: true" in output

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -629,6 +629,12 @@ def test_ipv4_dhcp_switch_on_to_off(dhcpcli_up):
     dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
         enabled=True, dhcp=False
     )
+    dhcp_cli_desired_state[Interface.IPV4][InterfaceIPv4.ADDRESS] = [
+        {
+            InterfaceIPv4.ADDRESS_IP: "192.0.2.249",
+            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+        }
+    ]
 
     apply_with_description(
         "Configure the ethernet device dhcpcli with the address "

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1382,3 +1382,19 @@ def test_change_mtu_with_stable_link_up(bridge0_with_port0):
     )
 
     assertlib.assert_state(desired_state)
+
+
+def test_nmstatectl_purge_linux_bridge_timer(bridge0_with_port0):
+    output = exec_cmd(
+        f"nmstatectl show {TEST_BRIDGE0}".split(),
+        check=True,
+    )[1]
+    assert "gc-timer" in output
+    assert "hello-timer" in output
+
+    output = exec_cmd(
+        f"nmstatectl show --purge-timer {TEST_BRIDGE0}".split(),
+        check=True,
+    )[1]
+    assert "gc-timer" not in output
+    assert "hello-timer" not in output


### PR DESCRIPTION
In kubernetes-nmstate, the output of `nmstatectl show` will be used to
track the changes of network. The changes of DHCP lift-time (e.g.
`preferred-life-time` and `valid-life-time`) generates false
notification on network changes.

Introduced `NetworkState.omit_timer()` and `nmstatectl show
--omit-timer` to remove these count down timer from output.

With `preferred-life-time` and `valid-life-time` properties omitted,
this patch also introduced `dynamic` property to ip address section
helping nmstate and user determine which IP address is coming from
DHCP/IPv6-RA.

The linux bridge `gc-timer` and `hello-timer` will also be purged by
`NetworkState.omit_timer()`. call.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-131158