### PR TITLE
deps: use time instead of chrono

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,7 +24,7 @@ libc = "0.2.74"
 once_cell = "1.12.0"
 env_logger = "0.11.6"
 clap = { version = "3.1", features = ["cargo"] }
-chrono = "0.4"
+time = { version = "0.3", default-features = false, features = ["std", "formatting", "parsing"] }
 toml = "0.9.4"
 tokio = { version = "1.30", features = ["rt", "net", "time"] }
 

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -26,7 +26,7 @@ log = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, optional = true, features = [ "signal"] }
 uuid = { workspace = true }
-chrono = { workspace = true }
+time = { workspace = true }
 nispor = { workspace = true, optional = true }
 toml = { workspace = true }
 

--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -149,5 +149,161 @@ fn store_capture_states_from_file(
 }
 
 fn get_utc_time_in_rfc3339_format() -> String {
-    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("Failed to format time as RFC3339")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_utc_time_in_rfc3339_format() {
+        let timestamp = get_utc_time_in_rfc3339_format();
+
+        // RFC3339 format: YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS.fffffZ
+        // Example: "2025-11-26T14:30:45Z" or "2025-11-26T14:30:45.123456Z"
+
+        // Verify minimum length (at least "YYYY-MM-DDTHH:MM:SSZ" = 20 chars)
+        assert!(timestamp.len() >= 20, "Timestamp too short: {}", timestamp);
+
+        // Verify it ends with 'Z' (UTC timezone)
+        assert!(
+            timestamp.ends_with('Z'),
+            "Timestamp should end with 'Z' for UTC: {}",
+            timestamp
+        );
+
+        // Verify it contains 'T' separator between date and time
+        assert!(
+            timestamp.contains('T'),
+            "Timestamp should contain 'T' separator: {}",
+            timestamp
+        );
+
+        // Verify date part format (YYYY-MM-DD)
+        let parts: Vec<&str> = timestamp.split('T').collect();
+        assert_eq!(parts.len(), 2, "Should have date and time parts");
+
+        let date_part = parts[0];
+        assert_eq!(
+            date_part.len(),
+            10,
+            "Date part should be 10 chars (YYYY-MM-DD): {}",
+            date_part
+        );
+        assert_eq!(
+            &date_part[4..5],
+            "-",
+            "Date should have dash at position 4"
+        );
+        assert_eq!(
+            &date_part[7..8],
+            "-",
+            "Date should have dash at position 7"
+        );
+
+        // Verify time part starts with HH:MM:SS
+        let time_part = parts[1].trim_end_matches('Z');
+        assert!(
+            time_part.len() >= 8,
+            "Time part should be at least HH:MM:SS (8 chars): {}",
+            time_part
+        );
+
+        // Verify year is reasonable (between 2020 and 2100)
+        let year: u32 = date_part[0..4]
+            .parse()
+            .expect("Year should be a valid number");
+        assert!(
+            year >= 2020 && year <= 2100,
+            "Year should be reasonable: {}",
+            year
+        );
+
+        // Verify month is valid (01-12)
+        let month: u32 = date_part[5..7]
+            .parse()
+            .expect("Month should be a valid number");
+        assert!(
+            month >= 1 && month <= 12,
+            "Month should be between 1 and 12: {}",
+            month
+        );
+
+        // Verify day is valid (01-31)
+        let day: u32 = date_part[8..10]
+            .parse()
+            .expect("Day should be a valid number");
+        assert!(
+            day >= 1 && day <= 31,
+            "Day should be between 1 and 31: {}",
+            day
+        );
+
+        // Verify hour is valid (00-23)
+        let hour: u32 = time_part[0..2]
+            .parse()
+            .expect("Hour should be a valid number");
+        assert!(hour <= 23, "Hour should be between 0 and 23: {}", hour);
+
+        // Verify minute is valid (00-59)
+        let minute: u32 = time_part[3..5]
+            .parse()
+            .expect("Minute should be a valid number");
+        assert!(
+            minute <= 59,
+            "Minute should be between 0 and 59: {}",
+            minute
+        );
+
+        // Verify second is valid (00-59) or is leap second (60)
+        let second: u32 = time_part[6..8]
+            .parse()
+            .expect("Second should be a valid number");
+        assert!(
+            second <= 60,
+            "Second should be between 0 and 60: {}",
+            second
+        );
+    }
+
+    #[test]
+    fn test_rfc3339_format_consistency() {
+        // Call the function multiple times and verify all produce valid RFC3339
+        for _ in 0..5 {
+            let timestamp = get_utc_time_in_rfc3339_format();
+            assert!(timestamp.len() >= 20);
+            assert!(timestamp.ends_with('Z'));
+            assert!(timestamp.contains('T'));
+
+            // Small delay to ensure timestamps are different
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn test_rfc3339_parseable() {
+        // Verify the timestamp can be parsed back using the time crate
+        let timestamp = get_utc_time_in_rfc3339_format();
+
+        let parsed = time::OffsetDateTime::parse(
+            &timestamp,
+            &time::format_description::well_known::Rfc3339,
+        );
+
+        assert!(
+            parsed.is_ok(),
+            "Generated timestamp should be parseable: {}",
+            timestamp
+        );
+
+        let parsed_dt = parsed.unwrap();
+        assert_eq!(
+            parsed_dt.offset(),
+            time::UtcOffset::UTC,
+            "Parsed timestamp should be UTC"
+        );
+    }
 }


### PR DESCRIPTION
This PR changes the `get_utc_time_in_rfc3339_format` function to use `time` instead of `chrono`. This is in order to reduce dependencies of the project to get rid of unwanted Android libraries (namely `android-tzdata` and `android_system_properties`i).

PR includes unit tests for the modified function.