### PR TITLE
nispor: consider re-ordering when assigning static ip

### DIFF
--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -155,45 +155,50 @@ pub(crate) fn nmstate_ipv4_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
 
-    // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
-        if let (Some(nms_cur_ipv4), Some(nms_des_ipv4)) = (
-            &nms_cur_iface.base_iface().ipv4,
-            &nms_merged_iface.merged.base_iface().ipv4,
-        ) {
-            let des_ips: Vec<_> = nms_des_ipv4
-                .addresses
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .collect();
+    let des_ips = nms_merged_iface
+        .merged
+        .base_iface()
+        .ipv4
+        .as_ref()
+        .and_then(|ipv4| ipv4.addresses.as_deref())
+        .unwrap_or_default();
 
-            for nms_addr in
-                nms_cur_ipv4.addresses.as_deref().unwrap_or_default()
-            {
-                if !des_ips.contains(&nms_addr) {
-                    np_ip_conf.addresses.push({
-                        let mut ip_conf = nispor::IpAddrConf::default();
-                        ip_conf.address = nms_addr.ip.to_string();
-                        ip_conf.prefix_len = nms_addr.prefix_length;
-                        ip_conf.remove = true;
-                        ip_conf
-                    });
-                }
-            }
-        }
-    }
+    let cur_ips = nms_merged_iface
+        .current
+        .as_ref()
+        .and_then(|cur_iface| {
+            cur_iface
+                .base_iface()
+                .ipv4
+                .as_ref()
+                .and_then(|ipv4| ipv4.addresses.as_deref())
+        })
+        .unwrap_or_default();
 
-    // Add new ip address entries before deleting
-    if let Some(nms_des_ipv4) = &nms_merged_iface.merged.base_iface().ipv4 {
-        for nms_addr in nms_des_ipv4.addresses.as_deref().unwrap_or_default() {
+    for (idx, nms_cur_addr) in cur_ips.iter().enumerate() {
+        let delete = match des_ips.get(idx) {
+            Some(nms_des_addr) => nms_des_addr != nms_cur_addr,
+            None => true,
+        };
+
+        if delete {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
-                ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length;
+                ip_conf.address = nms_cur_addr.ip.to_string();
+                ip_conf.prefix_len = nms_cur_addr.prefix_length;
+                ip_conf.remove = true;
                 ip_conf
             });
         }
+    }
+
+    for nms_cur_addr in des_ips {
+        np_ip_conf.addresses.push({
+            let mut ip_conf = nispor::IpAddrConf::default();
+            ip_conf.address = nms_cur_addr.ip.to_string();
+            ip_conf.prefix_len = nms_cur_addr.prefix_length;
+            ip_conf
+        });
     }
     np_ip_conf
 }
@@ -203,45 +208,50 @@ pub(crate) fn nmstate_ipv6_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
 
-    // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
-        if let (Some(nms_cur_ipv6), Some(nms_des_ipv6)) = (
-            &nms_cur_iface.base_iface().ipv6,
-            &nms_merged_iface.merged.base_iface().ipv6,
-        ) {
-            let des_ips: Vec<_> = nms_des_ipv6
-                .addresses
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .collect();
+    let des_ips = nms_merged_iface
+        .merged
+        .base_iface()
+        .ipv6
+        .as_ref()
+        .and_then(|ipv6| ipv6.addresses.as_deref())
+        .unwrap_or_default();
 
-            for nms_addr in
-                nms_cur_ipv6.addresses.as_deref().unwrap_or_default()
-            {
-                if !des_ips.contains(&nms_addr) {
-                    np_ip_conf.addresses.push({
-                        let mut ip_conf = nispor::IpAddrConf::default();
-                        ip_conf.address = nms_addr.ip.to_string();
-                        ip_conf.prefix_len = nms_addr.prefix_length;
-                        ip_conf.remove = true;
-                        ip_conf
-                    });
-                }
-            }
-        }
-    }
+    let cur_ips = nms_merged_iface
+        .current
+        .as_ref()
+        .and_then(|cur_iface| {
+            cur_iface
+                .base_iface()
+                .ipv6
+                .as_ref()
+                .and_then(|ipv6| ipv6.addresses.as_deref())
+        })
+        .unwrap_or_default();
 
-    // Add new ip address entries after deleting
-    if let Some(nms_des_ipv6) = &nms_merged_iface.merged.base_iface().ipv6 {
-        for nms_addr in nms_des_ipv6.addresses.as_deref().unwrap_or_default() {
+    for (idx, nms_cur_addr) in cur_ips.iter().enumerate() {
+        let delete = match des_ips.get(idx) {
+            Some(nms_des_addr) => nms_des_addr != nms_cur_addr,
+            None => true,
+        };
+
+        if delete {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
-                ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length;
+                ip_conf.address = nms_cur_addr.ip.to_string();
+                ip_conf.prefix_len = nms_cur_addr.prefix_length;
+                ip_conf.remove = true;
                 ip_conf
             });
         }
+    }
+
+    for nms_des_addr in des_ips {
+        np_ip_conf.addresses.push({
+            let mut ip_conf = nispor::IpAddrConf::default();
+            ip_conf.address = nms_des_addr.ip.to_string();
+            ip_conf.prefix_len = nms_des_addr.prefix_length;
+            ip_conf
+        });
     }
     np_ip_conf
 }

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1219,6 +1219,8 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
             - ip: 192.0.2.251
               prefix-length: 24
+            - ip: 192.0.3.251
+              prefix-length: 24
             dhcp: false
             enabled: true
           ipv6:
@@ -1228,11 +1230,14 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
               - ip: 2001:db8:1::1
                 prefix-length: 64
+              - ip: 2001:db7:1::1
+                prefix-length: 64
         """
     )
     apply_with_description(
-        "Configure the veth device veth1 with the peer veth1_peer and "
-        "address 192.0.2.251/24 and 2001:db8:1::1/64",
+        "Configure the veth device veth1 with the peer veth1_peer and"
+        "address 192.0.2.251/24, 192.0.3.251/24, 2001:db8:1::1/64, and"
+        "2001:db7:1::1/64",
         desired_state,
         kernel_only=True,
     )
@@ -1250,6 +1255,8 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
             - ip: 192.0.2.252
               prefix-length: 24
+            - ip: 192.0.3.252
+              prefix-length: 24
             dhcp: false
             enabled: true
           ipv6:
@@ -1259,11 +1266,14 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
               - ip: 2001:db8:1::2
                 prefix-length: 64
+              - ip: 2001:db7:1::2
+                prefix-length: 64
         """
     )
     apply_with_description(
-        "Configure the veth device veth1 with the peer veth1_peer and "
-        "address 192.0.2.252/24 and 2001:db8:1::2/64",
+        "Configure the veth device veth1 with the peer veth1_peer and"
+        "address 192.0.2.252/24, 192.0.3.252/24, 2001:db8:1::2/64, and"
+        "2001:db7:1::2/64",
         new_desired_state,
         kernel_only=True,
     )
@@ -1281,6 +1291,8 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
             - ip: 192.0.2.252
               prefix-length: 12
+            - ip: 192.0.3.252
+              prefix-length: 24
             dhcp: false
             enabled: true
           ipv6:
@@ -1290,11 +1302,50 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
             address:
               - ip: 2001:db8:1::2
                 prefix-length: 32
+              - ip: 2001:db7:1::2
+                prefix-length: 64
         """
     )
     apply_with_description(
-        "Configure the veth device veth1 with the peer veth1_peer and "
-        "address 192.0.2.252/12 and 2001:db8:1::2/32",
+        "Configure the veth device veth1 with the peer veth1_peer and"
+        "address 192.0.2.252/12, 192.0.3.252/24, 2001:db8:1::2/32, and"
+        "2001:db7:1::2/64",
+        new_desired_state,
+        kernel_only=True,
+    )
+    assertlib.assert_state_match(new_desired_state, kernel_only=True)
+
+    new_desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.3.252
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 12
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db7:1::2
+                prefix-length: 64
+              - ip: 2001:db8:1::2
+                prefix-length: 32
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and"
+        "address 192.0.3.252/24, 192.0.2.252/12, 2001:db7:1::2/64, and"
+        "2001:db8:1::2/32",
         new_desired_state,
         kernel_only=True,
     )


### PR DESCRIPTION
Fixes Pull Request #2953

The original pull request fixed the problem of new ip address appending instead of updating. This was done by removing ip address in current state that are *not* in the desired state and adding new ip addresses.

However, if the ip addresses are re-ordered in the new state, the previous logic will not update the ordering. The new logic will ~instead purge all previous ip addresses and add the new ip addresses in their correct ordering.~ also consider the ordering of the ip addresses. It will delete ip address in current state if it does not exist in desired state or it is in a different index.

Example case:

Old state
```
        name: lo
        type: loopback
        ipv4:
          enabled: true
          address:
          - ip: 127.0.0.1
            prefix-length: 8
          - ip: 127.0.0.2
            prefix-length: 32
        ipv6:
          enabled: true
          address:
          - ip: ::1
            prefix-length: 128
          - ip: ::2
            prefix-length: 128
```
New state
```
        name: lo
        type: loopback
        ipv4:
          enabled: true
          address:
          - ip: 127.0.0.2
            prefix-length: 32
          - ip: 127.0.0.1
            prefix-length: 8
        ipv6:
          enabled: true
          address:
          - ip: ::2
            prefix-length: 128
          - ip: ::1
            prefix-length: 128
```