### PR TITLE
iface: Consistent order on serialization

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -88,7 +88,7 @@ impl Interfaces {
         for iface in self.user_ifaces.values() {
             ifaces.push(iface);
         }
-        ifaces.sort_unstable_by_key(|iface| iface.name());
+        ifaces.sort_unstable_by_key(|iface| (iface.name(), iface.iface_type()));
         // Use sort_by_key() instead of unstable one, do we can alphabet
         // activation order which is required to simulate the OS boot-up.
         ifaces.sort_by_key(|iface| iface.base_iface().up_priority);

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -911,3 +911,36 @@ fn test_hsr_v1_protocol() {
         panic!("Should be resolved to hsr interface, but got {merged_if:?}");
     }
 }
+
+#[test]
+fn test_sort_ovs_bridge_with_same_name() {
+    let ifaces_1 = serde_yaml::from_str::<Interfaces>(
+        r"---
+          - name: br-ex
+            type: ovs-bridge
+            state: up
+          - name: br-ex
+            type: ovs-interface
+            state: up",
+    )
+    .unwrap();
+    let ifaces_2 = serde_yaml::from_str::<Interfaces>(
+        r"---
+          - name: br-ex
+            type: ovs-interface
+            state: up
+          - name: br-ex
+            type: ovs-bridge
+            state: up",
+    )
+    .unwrap();
+
+    let sorted_ifaces_1 = ifaces_1.to_vec();
+    let sorted_ifaces_2 = ifaces_2.to_vec();
+    assert_eq!(sorted_ifaces_1, sorted_ifaces_2);
+
+    assert_eq!(sorted_ifaces_1[0].name(), "br-ex");
+    assert_eq!(sorted_ifaces_1[0].iface_type(), InterfaceType::OvsBridge);
+    assert_eq!(sorted_ifaces_1[1].name(), "br-ex");
+    assert_eq!(sorted_ifaces_1[1].iface_type(), InterfaceType::OvsInterface);
+}


### PR DESCRIPTION
When state contains OVS interface and OVS bridge sharing the same name,
the JSON/YAML serialization produces random ordering on these two
interfaces.

To produce consistent interface ordering, the `Interfaces::to_vec()`
function will sort with `InterfaceType` as second sort consideration.

Unit test case included.

Resolves: https://issues.redhat.com/browse/RHEL-130157