### PR TITLE
hsr: add support for HSRv1/2012 protocol

### DIFF
--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -256,6 +256,9 @@ impl HsrConfig {
 #[derive(Default)]
 pub enum HsrProtocol {
     #[default]
+    #[serde(alias = "hsr-2010")]
     Hsr,
+    #[serde(rename = "hsr-2012")]
+    Hsr2012,
     Prp,
 }

--- a/rust/src/lib/nispor/hsr.rs
+++ b/rust/src/lib/nispor/hsr.rs
@@ -2,15 +2,19 @@
 
 use crate::{BaseInterface, HsrConfig, HsrInterface, HsrProtocol};
 
-impl From<nispor::HsrProtocol> for HsrProtocol {
-    fn from(v: nispor::HsrProtocol) -> Self {
-        match v {
-            nispor::HsrProtocol::Hsr => Self::Hsr,
-            nispor::HsrProtocol::Prp => Self::Prp,
-            _ => {
-                log::warn!("Unknown HSR protocol {v:?}");
-                Self::default()
-            }
+fn protocol_from_np(
+    np_protocol: nispor::HsrProtocol,
+    version: u8,
+) -> HsrProtocol {
+    match (np_protocol, version) {
+        (nispor::HsrProtocol::Hsr, 0) => HsrProtocol::Hsr,
+        (nispor::HsrProtocol::Hsr, 1) => HsrProtocol::Hsr2012,
+        (nispor::HsrProtocol::Prp, _) => HsrProtocol::Prp,
+        _ => {
+            log::warn!(
+                "Unknown HSR protocol {np_protocol:?} with version {version}"
+            );
+            HsrProtocol::default()
         }
     }
 }
@@ -42,7 +46,7 @@ pub(crate) fn np_hsr_to_nmstate(
         // Due to a kernel bug multicast_spec is always zero. Until it is fixed,
         // use the last byte of supervision_address instead.
         multicast_spec: mutlicast_value,
-        protocol: np_hsr_info.protocol.into(),
+        protocol: protocol_from_np(np_hsr_info.protocol, np_hsr_info.version),
     });
 
     HsrInterface {

--- a/rust/src/lib/nm/nm_dbus/connection/hsr.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/hsr.rs
@@ -14,6 +14,7 @@ pub struct NmSettingHsr {
     pub port1: Option<String>,
     pub port2: Option<String>,
     pub multicast_spec: Option<u32>,
+    pub protocol_version: Option<i32>,
     pub prp: Option<bool>,
     _other: HashMap<String, zvariant::OwnedValue>,
 }
@@ -25,6 +26,7 @@ impl TryFrom<DbusDictionary> for NmSettingHsr {
             port1: _from_map!(v, "port1", String::try_from)?,
             port2: _from_map!(v, "port2", String::try_from)?,
             multicast_spec: _from_map!(v, "multicast-spec", u32::try_from)?,
+            protocol_version: _from_map!(v, "protocol-version", i32::try_from)?,
             prp: _from_map!(v, "prp", bool::try_from)?,
             _other: v,
         })
@@ -47,6 +49,9 @@ impl ToDbusValue for NmSettingHsr {
         }
         if let Some(v) = &self.prp {
             ret.insert("prp", zvariant::Value::new(*v));
+        }
+        if let Some(v) = &self.protocol_version {
+            ret.insert("protocol-version", zvariant::Value::new(*v));
         }
         ret.extend(self._other.iter().map(|(key, value)| {
             (key.as_str(), zvariant::Value::from(value.clone()))

--- a/rust/src/lib/nm/query_apply/hsr.rs
+++ b/rust/src/lib/nm/query_apply/hsr.rs
@@ -13,6 +13,7 @@ pub(crate) fn is_hsr_changed(
             || new_hsr_conf.port2 != cur_hsr_conf.port2
             || new_hsr_conf.multicast_spec != cur_hsr_conf.multicast_spec
             || new_hsr_conf.prp != cur_hsr_conf.prp
+            || new_hsr_conf.protocol_version != cur_hsr_conf.protocol_version
     } else {
         false
     }

--- a/rust/src/lib/nm/settings/hsr.rs
+++ b/rust/src/lib/nm/settings/hsr.rs
@@ -15,7 +15,15 @@ pub(crate) fn gen_nm_hsr_setting(
         nm_hsr_set.multicast_spec = Some(hsr_conf.multicast_spec as u32);
         nm_hsr_set.prp = match hsr_conf.protocol {
             HsrProtocol::Prp => Some(true),
-            HsrProtocol::Hsr => Some(false),
+            HsrProtocol::Hsr | HsrProtocol::Hsr2012 => Some(false),
+        };
+        nm_hsr_set.protocol_version = match hsr_conf.protocol {
+            // TODO: If protocol is hsr-2010, don't set protocol version
+            // for backwards compatibility. This can be updated when the
+            // minimum required version of NetworkManager is 1.56.
+            HsrProtocol::Hsr => None,
+            HsrProtocol::Hsr2012 => Some(1),
+            HsrProtocol::Prp => None,
         };
     }
     nm_conn.hsr = Some(nm_hsr_set);

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -5,8 +5,8 @@ use crate::{
         get_mac, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
         new_unknown_iface, new_vlan_iface,
     },
-    BondMode, ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
-    MergedInterfaces,
+    BondMode, ErrorKind, HsrProtocol, Interface, InterfaceState, InterfaceType,
+    Interfaces, MergedInterfaces,
 };
 
 #[test]
@@ -844,4 +844,70 @@ fn test_hsr_all_ifaces_only_permanent_mac() {
         get_mac(&hsr_iface.for_apply),
         Some("AA:BB:CC:DD:EE:FF".to_string())
     );
+}
+
+#[test]
+fn test_hsr_v1_protocol() {
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: eth1
+    type: ethernet
+    permanent-mac-address: aa:bb:cc:dd:ee:ff
+    state: up
+  - name: eth2
+    type: ethernet
+    permanent-mac-address: 11:22:33:44:55:66
+    state: up
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: hsr
+    ",
+    )
+    .unwrap();
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+  - name: hsr0
+    type: hsr
+    state: up
+    hsr:
+      port1: eth1
+      port2: eth2
+      multicast-spec: 40
+      protocol: hsr-2012
+",
+    )
+    .unwrap();
+
+    let merged =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let current_if = merged
+        .get_iface("hsr0", InterfaceType::Hsr)
+        .unwrap()
+        .current
+        .as_ref()
+        .unwrap();
+    if let Interface::Hsr(iface) = current_if {
+        assert_eq!(iface.hsr.as_ref().unwrap().protocol, HsrProtocol::Hsr);
+    } else {
+        panic!("Should be resolved to hsr interface, but got {current_if:?}");
+    }
+
+    let merged_if = merged
+        .get_iface("hsr0", InterfaceType::Hsr)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+    if let Interface::Hsr(iface) = merged_if {
+        assert_eq!(iface.hsr.as_ref().unwrap().protocol, HsrProtocol::Hsr2012);
+    } else {
+        panic!("Should be resolved to hsr interface, but got {merged_if:?}");
+    }
 }

--- a/tests/integration/hsr_test.py
+++ b/tests/integration/hsr_test.py
@@ -9,6 +9,8 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Hsr
 
 from .testlib import assertlib
+from .testlib.env import kernel_newer_than
+from .testlib.env import nm_minor_version
 from .testlib.hsrlib import hsr_interface
 from .testlib.ifacelib import get_mac_address
 
@@ -78,3 +80,24 @@ def test_hsr_update_protocol(hsr0_with_eths):
     hsr0_with_eths[Interface.KEY][0][Hsr.CONFIG_SUBTREE][Hsr.PROTOCOL] = "hsr"
     libnmstate.apply(hsr0_with_eths)
     assertlib.assert_state_match(hsr0_with_eths)
+
+
+# https://issues.redhat.com/browse/RHEL-100763
+@pytest.mark.tier1
+@pytest.mark.skipif(
+    not kernel_newer_than(6, 18) or nm_minor_version() < 56,
+    reason=(
+        "HSR protocol version is only supported by NetworkManager 1.56+, "
+        "and kernel exposes this attribute only since 6.19+"
+    ),
+)
+@pytest.mark.parametrize("protocol", ("hsr", "hsr-2010", "hsr-2012"))
+def test_add_hsr_with_protocol_version(eth1_up, eth2_up, protocol):
+    with hsr_interface(HSR0, ETH1, ETH2, protocol=protocol) as state:
+        # hsr-2010 maps to hsr for backwards compatibility, so we expect to see
+        # only `hsr` protocol in the state.
+        state[Interface.KEY][0][Hsr.CONFIG_SUBTREE][Hsr.PROTOCOL] = (
+            "hsr" if "hsr-2010" == protocol else protocol
+        )
+        assertlib.assert_state(state)
+    assertlib.assert_absent(HSR0)


### PR DESCRIPTION
Introduces a new protocol enum value called Hsr2012.

Protocol version is included as part of protocol property, because they are directly tied together, and configuring them separately would be error prone.

Test case included.

Resolves: https://issues.redhat.com/browse/RHEL-100763