### PR TITLE
RPM: Fix spec file for time crate dependency

### DIFF
--- a/packaging/nmstate.spec.in
+++ b/packaging/nmstate.spec.in
@@ -44,7 +44,9 @@ BuildRequires:  rust-packaging
 %if ! %{is_snapshot}
 BuildRequires:  (crate(clap/cargo) >= 3.1 with crate(clap/cargo) < 4.0)
 BuildRequires:  (crate(clap/default) >= 3.1 with crate(clap/default) < 4.0)
-BuildRequires:  (crate(chrono/default) >= 0.4 with crate(chrono/default) < 0.5)
+BuildRequires:  (crate(time/std) >= 0.3 with crate(time/std) < 0.4)
+BuildRequires:  (crate(time/formatting) >= 0.3 with crate(time/formatting) < 0.4)
+BuildRequires:  (crate(time/parsing) >= 0.3 with crate(time/parsing) < 0.4)
 BuildRequires:  (crate(env_logger/default) >= 0.11 with crate(env_logger/default) < 0.12)
 BuildRequires:  (crate(libc/default) >= 0.2 with crate(libc/default) < 0.3)
 BuildRequires:  (crate(log/default) >= 0.4 with crate(log/default) < 0.5)


### PR DESCRIPTION
Commit 742c6911 has changed `chrono` to `time`, we should update rpm
SPEC also.