### PR TITLE
[Test] Fix: Move pytest mark from fixture to test

### DIFF
--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -282,7 +282,6 @@ def test_reapply_with_ip_setting_table_and_metric_defaults(dummy0_up):
     assert_routes(desired_state[Route.KEY][Route.CONFIG], cur_state)
 
 
-@pytest.mark.tier1
 @pytest.fixture
 def vlan_with_empty_connection_iface_name(eth1_up):
     exec_cmd(
@@ -296,6 +295,7 @@ def vlan_with_empty_connection_iface_name(eth1_up):
     exec_cmd("nmcli c delete eth1.100".split(), check=True)
 
 
+@pytest.mark.tier1
 def test_add_route_to_vlan_with_empty_connection_iface_name(
     vlan_with_empty_connection_iface_name,
 ):


### PR DESCRIPTION
Applying a mark to a fixture function deprecated, in a newer pytest it raises an error (e.g pytest-9.0.1) blocking test execution.

Move the mark from the fixture to the test function using the fixture.

On RHEL-10.2, the default pytest version is 9.0.1 in which it raises an error:
```
# pytest -vvv nm/route_test.py
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.12.11, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
RPMs: NetworkManager-1.55.90-1.el10 NetworkManager-libreswan-1.2.27-4.el10
OS: Red Hat Enterprise Linux 10.2 Beta (Coughlan)
nmstate: nmstate-2.2.56-1.el10

rootdir: /root/nmstate
configfile: pyproject.toml
plugins: timeout-2.4.0
collected 0 items / 1 error

================================================================================= ERRORS =================================================================================
__________________________________________________________ ERROR collecting tests/integration/nm/route_test.py ___________________________________________________________
nm/route_test.py:285: in <module>
    @pytest.mark.tier1
     ^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.12/site-packages/_pytest/mark/structures.py:401: in __call__
    store_mark(unwrapped_func, self.mark, stacklevel=3)
/usr/local/lib/python3.12/site-packages/_pytest/mark/structures.py:466: in store_mark
    warnings.warn(MARKED_FIXTURE, stacklevel=stacklevel)
E   pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
E   See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
======================================================================== short test summary info =========================================================================
ERROR nm/route_test.py - pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================================ 1 error in 0.24s ===========================================================================
```