### PR TITLE
CI: Change license checker to check python files in all test folders

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -6,9 +6,7 @@ header:
   paths:
     - 'rust/src/python/*'
     - 'rust/src/*'
-    - 'tests/integration/*.py'
-    - 'tests/integration/testlib/*.py'
-    - 'tests/integration/nm/*.py'
+    - 'tests/integration/**/*.py'
 
   paths-ignore:
     - 'target'


### PR DESCRIPTION
Using `tests/integration/**/*.py` to check python script in all folders
of test directory.