### PR TITLE
hsr: Automatically disable IP on hsr port

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -126,8 +126,13 @@ impl std::fmt::Display for InterfaceType {
 
 impl InterfaceType {
     const USERSPACE_IFACE_TYPES: [Self; 2] = [Self::OvsBridge, Self::Ipsec];
-    const CONTROLLER_IFACES_TYPES: [Self; 4] =
-        [Self::Bond, Self::LinuxBridge, Self::OvsBridge, Self::Vrf];
+    const CONTROLLER_IFACES_TYPES: [Self; 5] = [
+        Self::Bond,
+        Self::LinuxBridge,
+        Self::OvsBridge,
+        Self::Vrf,
+        Self::Hsr,
+    ];
 
     // other interfaces are also considered as userspace
     pub(crate) fn is_userspace(&self) -> bool {
@@ -682,6 +687,7 @@ impl Interface {
                 Self::OvsBridge(iface) => iface.ports(),
                 Self::Bond(iface) => iface.ports(),
                 Self::Vrf(iface) => iface.ports(),
+                Self::Hsr(iface) => iface.ports(),
                 _ => None,
             }
         }
@@ -851,6 +857,7 @@ impl MergedInterface {
         self.post_inter_ifaces_process_vrf()?;
         self.post_inter_ifaces_process_bond()?;
         self.post_inter_ifaces_process_vlan();
+        self.post_inter_ifaces_process_hsr();
 
         if let Some(apply_iface) = self.for_apply.as_mut() {
             apply_iface.sanitize(true)?;
@@ -1050,7 +1057,7 @@ impl MergedInterface {
             }
         }
 
-        if !self.is_desired() {
+        if !self.is_changed() {
             self.mark_as_changed();
             if ctrl_state == InterfaceState::Up {
                 self.merged.base_iface_mut().state = InterfaceState::Up;

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -364,14 +364,27 @@ impl MergedInterface {
                         || base_iface.ipv6.as_ref().map(|ipv6| ipv6.enabled)
                             == Some(true))
                 {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Interface {} cannot have IP enabled as it is \
-                             attached to a controller where IP is not allowed",
-                            base_iface.name.as_str()
-                        ),
-                    ));
+                    if let Some(ctrl) =
+                        apply_iface.base_iface().controller.as_ref()
+                    {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Interface {} cannot have IP enabled as it is \
+                                 attached to controller {ctrl} where IP is \
+                                 not allowed on its port",
+                                base_iface.name.as_str()
+                            ),
+                        ));
+                    } else {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Interface {} cannot have IP enabled",
+                                base_iface.name.as_str()
+                            ),
+                        ));
+                    }
                 }
             }
         }

--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -3,8 +3,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    BaseInterface, ErrorKind, Interface, InterfaceType, MergedInterfaces,
-    NmstateError,
+    BaseInterface, ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6,
+    InterfaceType, MergedInterface, MergedInterfaces, NmstateError,
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -54,6 +54,12 @@ impl Default for HsrInterface {
 impl HsrInterface {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn ports(&self) -> Option<Vec<&str>> {
+        self.hsr.as_ref().map(|hsr_conf| {
+            vec![hsr_conf.port1.as_str(), hsr_conf.port2.as_str()]
+        })
     }
 
     pub(crate) fn sanitize(
@@ -222,6 +228,27 @@ impl MergedInterfaces {
         }
 
         Ok(())
+    }
+}
+
+impl MergedInterface {
+    /// Explicitly disable IP on HSR ports
+    pub(crate) fn post_inter_ifaces_process_hsr(&mut self) {
+        if let Some(apply_iface) = self.for_apply.as_mut() {
+            if apply_iface.is_up()
+                && apply_iface.base_iface().controller_type.as_ref()
+                    == Some(&InterfaceType::Hsr)
+            {
+                apply_iface.base_iface_mut().ipv4 = Some(InterfaceIpv4 {
+                    enabled: false,
+                    ..Default::default()
+                });
+                apply_iface.base_iface_mut().ipv6 = Some(InterfaceIpv6 {
+                    enabled: false,
+                    ..Default::default()
+                });
+            }
+        }
     }
 }
 

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -397,7 +397,7 @@ pub(crate) fn gen_nm_conn_setting(
         .map(NmIfaceType::from);
     let ctrl_name = iface.base_iface().controller.as_deref();
     if let Some(ctrl_name) = ctrl_name {
-        if ctrl_name.is_empty() {
+        if ctrl_name.is_empty() || nm_ctrl_type == Some(NmIfaceType::Hsr) {
             nm_conn_set.controller = None;
             nm_conn_set.controller_type = None;
         } else if let Some(nm_ctrl_type) = nm_ctrl_type {

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -9,8 +9,8 @@ use super::{
 use crate::nm::nm_dbus::{NmConnection, NmSettingIp, NmSettingIpMethod};
 use crate::{
     BaseInterface, Dhcpv4ClientId, Dhcpv6Duid, ErrorKind, Interface,
-    InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, Ipv6AddrGenMode,
-    NmstateError, RouteEntry, WaitIp,
+    InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, InterfaceType,
+    Ipv6AddrGenMode, NmstateError, RouteEntry, WaitIp,
 };
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
@@ -259,7 +259,10 @@ pub(crate) fn gen_nm_ip_setting(
     nm_conn: &mut NmConnection,
 ) -> Result<(), NmstateError> {
     let base_iface = iface.base_iface();
-    if base_iface.can_have_ip() {
+    // Explicitly disable IP on HSR ports.
+    if base_iface.can_have_ip()
+        || base_iface.controller_type == Some(InterfaceType::Hsr)
+    {
         gen_nm_ipv4_setting(base_iface.ipv4.as_ref(), routes, nm_conn)?;
         gen_nm_ipv6_setting(base_iface.ipv6.as_ref(), routes, nm_conn)?;
         apply_nmstate_wait_ip(base_iface, nm_conn);

--- a/rust/src/lib/unit_tests/hsr.rs
+++ b/rust/src/lib/unit_tests/hsr.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, Interfaces, MergedInterfaces};
+
+#[test]
+fn test_hsr_port_cannot_have_ip_enabled_explicitly() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: hsr0
+          type: hsr
+          state: up
+          hsr:
+            port1: eth1
+            port2: eth2
+            protocol: prp
+            multicast-spec: 40
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: true
+            dhcp: true
+          ipv6:
+            enabled: true
+            dhcp: true
+            autoconf: true",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+        - name: eth2
+          type: ethernet
+        ",
+    )
+    .unwrap();
+
+    let result = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    );
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("hsr0"));
+        assert!(e.msg().contains("eth1"));
+    }
+}
+
+#[test]
+fn test_auto_include_hsr_port_as_changed() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: hsr0
+          type: hsr
+          state: up
+          hsr:
+            port1: eth1
+            port2: eth2
+            protocol: prp
+            multicast-spec: 40",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          ipv4:
+            enabled: true
+            dhcp: true
+          ipv6:
+            enabled: true
+            dhcp: true
+            autoconf: true
+        - name: eth2
+          type: ethernet
+          ipv4:
+            enabled: true
+            dhcp: true
+          ipv6:
+            enabled: true
+            dhcp: true
+            autoconf: true
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let port1 = merged_ifaces.kernel_ifaces["eth1"]
+        .for_apply
+        .as_ref()
+        .unwrap();
+    let port2 = merged_ifaces.kernel_ifaces["eth2"]
+        .for_apply
+        .as_ref()
+        .unwrap();
+
+    assert_eq!(
+        port1.base_iface().ipv4.as_ref().map(|i| i.enabled),
+        Some(false)
+    );
+    assert_eq!(
+        port1.base_iface().ipv6.as_ref().map(|i| i.enabled),
+        Some(false)
+    );
+    assert_eq!(
+        port2.base_iface().ipv4.as_ref().map(|i| i.enabled),
+        Some(false)
+    );
+    assert_eq!(
+        port2.base_iface().ipv6.as_ref().map(|i| i.enabled),
+        Some(false)
+    );
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -19,6 +19,8 @@ mod gen_diff;
 #[cfg(test)]
 mod gen_revert;
 #[cfg(test)]
+mod hsr;
+#[cfg(test)]
 mod identifier;
 #[cfg(test)]
 mod ifaces;

--- a/tests/integration/nm/hsr_test.py
+++ b/tests/integration/nm/hsr_test.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import libnmstate
+
+from ..testlib.yaml import load_yaml
+from ..testlib.cmdlib import exec_cmd
+
+
+HSR_NIC = "hsr0"
+
+
+@pytest.fixture
+def eth1_up_with_auto_ip(eth1_up):
+    state = load_yaml(
+        """---
+    interfaces:
+      - name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: true
+        ipv6:
+          enabled: true
+          dhcp: true
+          autoconf: true"""
+    )
+
+    libnmstate.apply(state)
+    yield
+
+
+@pytest.fixture
+def clean_up():
+    yield
+    state = load_yaml(
+        f"""---
+            interfaces:
+            - name: {HSR_NIC}
+              type: hsr
+              state: absent
+        """
+    )
+    libnmstate.apply(state)
+
+
+def test_auto_disable_ip_of_hsr_ports(eth1_up_with_auto_ip, eth1_up, clean_up):
+    state = load_yaml(
+        """---
+            interfaces:
+              - name: hsr0
+                type: hsr
+                state: up
+                copy-mac-from: eth1
+                hsr:
+                  port1: eth1
+                  port2: eth2
+                  multicast-spec: 40
+                  protocol: prp
+            """
+    )
+    libnmstate.apply(state)
+
+    assert (
+        exec_cmd("nmcli -g ipv4.method c show eth1".split(), check=True)[1]
+        == "disabled\n"
+    )
+    assert (
+        exec_cmd("nmcli -g ipv6.method c show eth1".split(), check=True)[1]
+        == "disabled\n"
+    )
+
+    assert (
+        exec_cmd("nmcli -g ipv4.method c show eth2".split(), check=True)[1]
+        == "disabled\n"
+    )
+    assert (
+        exec_cmd("nmcli -g ipv6.method c show eth2".split(), check=True)[1]
+        == "disabled\n"
+    )


### PR DESCRIPTION
When user not mention HSR port or its IP settings, nmstate should
automatically disable IP on HSR ports.

When usr explicitly desired IP enabled on HSR port, nmstate raise error
because HSR port cannot hold any IP configurations.

Both Unit test case and integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-100774