### PR TITLE
Support referring alternative-name as port/parent/next-hop-interface

### DIFF
--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -217,7 +217,7 @@ mod tests {
             .parse()
             .expect("Year should be a valid number");
         assert!(
-            year >= 2020 && year <= 2100,
+            (2020..=2100).contains(&year),
             "Year should be reasonable: {}",
             year
         );
@@ -227,7 +227,7 @@ mod tests {
             .parse()
             .expect("Month should be a valid number");
         assert!(
-            month >= 1 && month <= 12,
+            (1..=12).contains(&month),
             "Month should be between 1 and 12: {}",
             month
         );
@@ -237,7 +237,7 @@ mod tests {
             .parse()
             .expect("Day should be a valid number");
         assert!(
-            day >= 1 && day <= 31,
+            (1..=31).contains(&day),
             "Day should be between 1 and 31: {}",
             day
         );

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -752,6 +752,7 @@ pub(crate) struct MergedInterfaces {
     pub(crate) ignored_ifaces: Vec<(String, InterfaceType)>,
     pub(crate) memory_only: bool,
     pub(crate) mode: NetworkStateMode,
+    pub(crate) iface_name_search: InterfaceNameSearch,
 }
 
 impl MergedInterfaces {
@@ -856,6 +857,8 @@ impl MergedInterfaces {
                 );
             }
         }
+        let iface_name_search =
+            InterfaceNameSearch::new(merged_kernel_ifaces.values());
         let mut ret = Self {
             kernel_ifaces: merged_kernel_ifaces,
             user_ifaces: merged_user_ifaces,
@@ -863,6 +866,7 @@ impl MergedInterfaces {
             ignored_ifaces,
             memory_only,
             mode,
+            iface_name_search,
         };
 
         ret.process()?;
@@ -1070,9 +1074,8 @@ impl MergedInterfaces {
     // Use kernel interface name first, then fallback to profile name
     // Raise error when referring to a profile name has multiple interfaces.
     fn resolve_parent_name_ref(&mut self) -> Result<(), NmstateError> {
-        let iface_name_search = InterfaceNameSearch::new(self);
-
-        for iface in self.iter_mut() {
+        let iface_name_search = &self.iface_name_search;
+        for iface in self.kernel_ifaces.values_mut() {
             let des_iface = if let Some(d) = iface.desired.as_mut() {
                 d
             } else {
@@ -1119,6 +1122,7 @@ impl MergedInterfaces {
                 des_iface.change_parent_name(kernel_name);
                 for_apply.change_parent_name(kernel_name);
                 for_verify.change_parent_name(kernel_name);
+                iface.merged.change_parent_name(kernel_name);
             } else {
                 // This function is not responsible to validate whether
                 // port interface exists or not. For example,
@@ -1193,17 +1197,17 @@ fn get_ignored_ifaces(
 pub(crate) struct InterfaceNameSearch {
     kernel_nics: HashSet<String>,
     profile_2_kernel: HashMap<String, Vec<String>>,
+    alt_name_2_kernel: HashMap<String, String>,
 }
 
 impl InterfaceNameSearch {
-    pub(crate) fn new(merged_ifaces: &MergedInterfaces) -> Self {
+    pub(crate) fn new<'a, T>(merged_ifaces: T) -> Self
+    where
+        T: Iterator<Item = &'a MergedInterface> + Clone,
+    {
         let mut kernel_nics: HashSet<String> = HashSet::new();
 
-        for iface in merged_ifaces
-            .kernel_ifaces
-            .values()
-            .filter(|i| i.merged.is_up())
-        {
+        for iface in merged_ifaces.clone().filter(|i| i.merged.is_up()) {
             if let Some(cur_iface) = iface.current.as_ref() {
                 // Existing kernel interface
                 kernel_nics.insert(cur_iface.name().to_string());
@@ -1218,7 +1222,7 @@ impl InterfaceNameSearch {
         }
 
         let mut profile_2_kernel: HashMap<String, Vec<String>> = HashMap::new();
-        for iface in merged_ifaces.kernel_ifaces.values() {
+        for iface in merged_ifaces.clone() {
             let base_iface = iface.merged.base_iface();
             if let Some(profile_name) = base_iface.profile_name.as_deref() {
                 profile_2_kernel
@@ -1228,20 +1232,37 @@ impl InterfaceNameSearch {
             }
         }
 
+        let mut alt_name_2_kernel: HashMap<String, String> = HashMap::new();
+        for iface in merged_ifaces.clone().filter(|i| i.merged.is_up()) {
+            let base_iface = iface.merged.base_iface();
+            if let Some(alt_names) = base_iface.alt_names.as_deref() {
+                for alt_name in alt_names.iter().filter(|a| !a.is_absent()) {
+                    alt_name_2_kernel.insert(
+                        alt_name.name.to_string(),
+                        base_iface.name.to_string(),
+                    );
+                }
+            }
+        }
+
         Self {
             kernel_nics,
             profile_2_kernel,
+            alt_name_2_kernel,
         }
     }
 
-    /// Search interface kernel name by specified name.
-    /// If any kernel interface name matches with specified, return it
-    /// Vec with that interface name only.
-    /// If no kernel interface name found, search by profile name.
-    /// Because profile name can be duplicate among interfaces,
-    /// return Vec<&str> will contains all matches.
+    /// Search interface kernel name by specified name:
+    ///  * Kernel interface name
+    ///  * Kernel alternative name
+    ///  * Profile name. Because profile name can be duplicate among interfaces,
+    ///    return all matches.
     pub(crate) fn get<'a>(&'a self, name: &str) -> Vec<&'a str> {
-        if let Some(n) = self.kernel_nics.get(name) {
+        if let Some(n) = self
+            .kernel_nics
+            .get(name)
+            .or_else(|| self.alt_name_2_kernel.get(name))
+        {
             vec![n]
         } else if let Some(nics) = self.profile_2_kernel.get(name) {
             nics.as_slice().iter().map(|s| s.as_str()).collect()

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -209,9 +209,9 @@ impl MergedInterfaces {
                     ));
                 } else if let Some(kernel_name) = kernel_names.first() {
                     des_iface
-                        .change_port_name(&port_name, kernel_name.to_string());
+                        .change_port_name(port_name, kernel_name.to_string());
                     for_apply
-                        .change_port_name(&port_name, kernel_name.to_string());
+                        .change_port_name(port_name, kernel_name.to_string());
                     for_verify
                         .change_port_name(&port_name, kernel_name.to_string());
                 } else {

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -7,8 +7,6 @@ use crate::{
     MergedInterface, MergedInterfaces, NmstateError, OvsInterface,
 };
 
-use super::InterfaceNameSearch;
-
 fn is_port_overbook(
     port_to_ctrl: &mut HashMap<String, String>,
     port: &str,
@@ -163,9 +161,13 @@ impl MergedInterfaces {
     // to profile name.
     // Raise error when referring to a profile name has multiple interfaces.
     pub(crate) fn resolve_port_name_ref(&mut self) -> Result<(), NmstateError> {
-        let iface_name_search = InterfaceNameSearch::new(self);
+        let iface_name_search = &self.iface_name_search;
 
-        for iface in self.iter_mut() {
+        for iface in self
+            .kernel_ifaces
+            .values_mut()
+            .chain(self.user_ifaces.values_mut())
+        {
             let des_iface = if let Some(d) = iface.desired.as_mut() {
                 d
             } else {
@@ -189,10 +191,23 @@ impl MergedInterfaces {
             } else {
                 continue;
             };
-            for port_name in ports {
-                let kernel_names = iface_name_search.get(&port_name);
+            let mut resolved_ports: HashSet<&str> = HashSet::new();
+            for port_name in ports.iter() {
+                let kernel_names = iface_name_search.get(port_name);
                 // Prefer kernel name as port name
                 if kernel_names.contains(&port_name.as_str()) {
+                    if !resolved_ports.insert(port_name.as_str()) {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Controller {} ({}) has multiple ports \
+                                 pointing to the same kernel interface \
+                                 {port_name}",
+                                des_iface.name(),
+                                des_iface.iface_type()
+                            ),
+                        ));
+                    }
                     continue;
                 }
                 if kernel_names.len() > 1 {
@@ -208,12 +223,28 @@ impl MergedInterfaces {
                         ),
                     ));
                 } else if let Some(kernel_name) = kernel_names.first() {
+                    if !resolved_ports.insert(kernel_name) {
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Controller {} ({}) has {port_name} pointing \
+                                 to the kernel interface {kernel_name}, but \
+                                 {kernel_name} is already defined in this \
+                                 controller port list",
+                                des_iface.name(),
+                                des_iface.iface_type()
+                            ),
+                        ));
+                    }
                     des_iface
                         .change_port_name(port_name, kernel_name.to_string());
                     for_apply
                         .change_port_name(port_name, kernel_name.to_string());
                     for_verify
-                        .change_port_name(&port_name, kernel_name.to_string());
+                        .change_port_name(port_name, kernel_name.to_string());
+                    iface
+                        .merged
+                        .change_port_name(port_name, kernel_name.to_string());
                 } else {
                     // This function is not responsible to validate whether
                     // port interface exists or not. For example,

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -27,7 +27,7 @@ mod sriov;
 mod vlan;
 
 pub use self::alt_name::{AltNameEntry, AltNameState};
-pub(crate) use self::inter_ifaces::{InterfaceNameSearch, MergedInterfaces};
+pub(crate) use self::inter_ifaces::MergedInterfaces;
 pub use self::xfrm::XfrmInterface;
 pub use base::*;
 pub use bond::{

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -8,7 +8,6 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ifaces::InterfaceNameSearch,
     ip::{is_ipv6_addr, sanitize_ip_network},
     ErrorKind, InterfaceType, MergedInterfaces, NmstateError,
 };
@@ -119,7 +118,7 @@ impl Routes {
         &mut self,
         merged_ifaces: &MergedInterfaces,
     ) -> Result<(), NmstateError> {
-        let iface_name_search = InterfaceNameSearch::new(merged_ifaces);
+        let iface_name_search = &merged_ifaces.iface_name_search;
 
         if let Some(config_routes) = self.config.as_mut() {
             for route in config_routes.iter_mut() {

--- a/rust/src/lib/unit_tests/alt_name.rs
+++ b/rust/src/lib/unit_tests/alt_name.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, MergedNetworkState, NetworkState};
+
+#[test]
+fn test_alt_name_conflict_with_other_port() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: port1
+            type: ethernet
+            identifier: mac-address
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+          - name: bond99
+            type: bond
+            bond:
+              mode: 0
+              ports:
+                - eth1
+                - veryveryveryverylonglonglongname",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("eth1"));
+        assert!(e.msg().contains("bond99"));
+        assert!(e.msg().contains("veryveryveryverylonglonglongname"));
+    }
+}
+
+#[test]
+fn test_two_alt_name_conflict_with_each_other() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: port1
+            type: ethernet
+            identifier: mac-address
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+          - name: bond99
+            type: bond
+            bond:
+              mode: 0
+              ports:
+                - port1
+                - veryveryveryverylonglonglongname",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("eth1"));
+        assert!(e.msg().contains("bond99"));
+        assert!(e.msg().contains("veryveryveryverylonglonglongname"));
+    }
+}
+
+#[test]
+fn test_alt_name_overbook() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: port1
+            type: ethernet
+            identifier: mac-address
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+          - name: bond99
+            type: bond
+            bond:
+              mode: 0
+              ports:
+                - port1
+          - name: bond98
+            type: bond
+            bond:
+              mode: 0
+              ports:
+                - veryveryveryverylonglonglongname",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("eth1"));
+        assert!(e.msg().contains("bond99"));
+        assert!(e.msg().contains("bond98"));
+        assert!(e.msg().contains("overbook"));
+    }
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]
+mod alt_name;
+#[cfg(test)]
 mod base;
 #[cfg(test)]
 mod bond;

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -27,12 +27,12 @@ fn get_iface<'a>(
         .unwrap()
 }
 
-fn get_routing_rules<'a>(iface: &Interface, ipv6: bool) -> Vec<RouteRuleEntry> {
+fn get_routing_rules(iface: &Interface, ipv6: bool) -> Vec<RouteRuleEntry> {
     let rules = match ipv6 {
         false => iface.base_iface().ipv4.as_ref().unwrap().rules.as_ref(),
         true => iface.base_iface().ipv6.as_ref().unwrap().rules.as_ref(),
     };
-    let mut rules: Vec<_> = rules.unwrap().into_iter().cloned().collect();
+    let mut rules: Vec<_> = rules.unwrap().iter().cloned().collect();
     rules.sort();
     rules
 }

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -128,8 +128,7 @@ pub(crate) fn bond_with_ports(name: &str, ports: &[&str]) -> Interface {
 pub(crate) fn get_mac(iface: &Option<Interface>) -> Option<String> {
     iface
         .as_ref()
-        .map(|i| i.base_iface().mac_address.clone())
-        .flatten()
+        .and_then(|i| i.base_iface().mac_address.clone())
 }
 
 pub(crate) const TEST_NIC: &str = "eth1";

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -1,16 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
+
 import pytest
 
 import libnmstate
 
 from libnmstate.error import NmstateValueError
+from libnmstate.schema import Bond
+from libnmstate.schema import Interface
+from libnmstate.schema import LinuxBridge
+from libnmstate.schema import OVSBridge
+from libnmstate.schema import Route
+from libnmstate.schema import VLAN
 
+from .testlib.bondlib import bond_interface
+from .testlib.bridgelib import linux_bridge
 from .testlib.cmdlib import exec_cmd
 from .testlib.env import is_k8s
 from .testlib.iproutelib import get_ip_link_alt_names
+from .testlib.ovslib import Bridge as OVSBridgeEnv
 from .testlib.retry import retry_till_true_or_timeout
+from .testlib.statelib import show_only
+from .testlib.statelib import state_match
+from .testlib.vlan import vlan_interface
 from .testlib.yaml import load_yaml
+from .testlib.route import assert_routes
+
 
 TEST_ALT_NAMES = [
     "port1",
@@ -18,6 +34,10 @@ TEST_ALT_NAMES = [
 ]
 
 RETRY_TIMEOUT = 10
+
+TEST_BOND_NIC = "bond99"
+TEST_BRIDGE_NIC = "br0"
+TEST_VLAN_NIC = "vlan101"
 
 
 @pytest.fixture
@@ -176,3 +196,90 @@ class TestAltNames:
         retry_till_true_or_timeout(
             RETRY_TIMEOUT, udev_trigger_check_alt_names, "eth1", TEST_ALT_NAMES
         )
+
+    # https://issues.redhat.com/browse/RHEL-126508
+    @pytest.mark.tier1
+    def test_ref_alt_name_in_bond(self, eth1_with_alt_names):
+        with bond_interface(TEST_BOND_NIC, [TEST_ALT_NAMES[0]]):
+            iface = show_only((TEST_BOND_NIC,))[Interface.KEY][0]
+            assert iface[Bond.CONFIG_SUBTREE][Bond.PORT] == ["eth1"]
+
+    # https://issues.redhat.com/browse/RHEL-126508
+    @pytest.mark.tier1
+    def test_ref_alt_name_in_linux_bridge(self, eth1_with_alt_names):
+        with linux_bridge(TEST_BRIDGE_NIC, {}, ports=[TEST_ALT_NAMES[0]]):
+            iface = show_only((TEST_BRIDGE_NIC,))[Interface.KEY][0]
+            assert state_match(
+                [{"name": "eth1"}],
+                iface[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE],
+            )
+
+    # https://issues.redhat.com/browse/RHEL-126508
+    @pytest.mark.tier1
+    def test_ref_alt_name_in_ovs_bridge(self, eth1_with_alt_names):
+        ovs_br = OVSBridgeEnv(TEST_BRIDGE_NIC)
+        ovs_br.add_system_port(TEST_ALT_NAMES[0])
+
+        with ovs_br.create():
+            iface = show_only((TEST_BRIDGE_NIC,))[Interface.KEY][0]
+            assert state_match(
+                [{"name": "eth1"}],
+                iface[OVSBridge.CONFIG_SUBTREE][OVSBridge.PORT_SUBTREE],
+            )
+
+    # https://issues.redhat.com/browse/RHEL-126508
+    @pytest.mark.tier1
+    def test_ref_alt_name_in_vlan(self, eth1_with_alt_names):
+        with vlan_interface(TEST_VLAN_NIC, 101, TEST_ALT_NAMES[0]):
+            iface = show_only((TEST_VLAN_NIC,))[Interface.KEY][0]
+            assert iface[VLAN.CONFIG_SUBTREE][VLAN.BASE_IFACE] == "eth1"
+            assert iface[VLAN.CONFIG_SUBTREE][VLAN.ID] == 101
+
+    # https://issues.redhat.com/browse/RHEL-126508
+    @pytest.mark.tier1
+    def test_ref_alt_name_in_route(self, eth1_with_alt_names):
+        desired_state = load_yaml(
+            """---
+            routes:
+              config:
+                - destination: 203.0.113.0/24
+                  next-hop-address: 192.0.2.1
+                  next-hop-interface: reallyreallylonglonglonginterfacenmae
+                  metric: 109
+                - destination: 203.0.113.0/24
+                  next-hop-address: 192.0.2.2
+                  next-hop-interface: port1
+                  metric: 109
+                - destination: 2001:db8:2::/64
+                  next-hop-address: 2001:db8:1::2
+                  next-hop-interface: port1
+                - destination: 2001:db8:2::/64
+                  next-hop-address: 2001:db8:1::3
+                  next-hop-interface: reallyreallylonglonglonginterfacenmae
+            interfaces:
+            - name: eth1
+              type: ethernet
+              state: up
+              ipv4:
+                address:
+                - ip: 192.0.2.251
+                  prefix-length: 24
+                dhcp: false
+                enabled: true
+              ipv6:
+                enabled: true
+                autoconf: false
+                dhcp: false
+                address:
+                  - ip: 2001:db8:1::1
+                    prefix-length: 64
+            """
+        )
+        expected_routes = copy.deepcopy(desired_state[Route.KEY][Route.CONFIG])
+        libnmstate.apply(desired_state)
+
+        for route in expected_routes:
+            route[Route.NEXT_HOP_INTERFACE] = "eth1"
+
+        cur_state = libnmstate.show()
+        assert_routes(expected_routes, cur_state)

--- a/tests/integration/testlib/bridgelib.py
+++ b/tests/integration/testlib/bridgelib.py
@@ -18,6 +18,7 @@ def linux_bridge(
     extra_iface_state=None,
     create=True,
     kernel_mode=False,
+    ports=None,
 ):
     desired_state = {
         Interface.KEY: [
@@ -35,7 +36,12 @@ def linux_bridge(
         desired_iface_state[LinuxBridge.CONFIG_SUBTREE] = bridge_subtree_state
     if extra_iface_state:
         desired_iface_state.update(extra_iface_state)
-
+    if ports:
+        for port in ports:
+            desired_iface_state.setdefault(LinuxBridge.CONFIG_SUBTREE, {})
+            add_port_to_bridge(
+                desired_iface_state[LinuxBridge.CONFIG_SUBTREE], port
+            )
     if create:
         libnmstate.apply(desired_state, kernel_only=kernel_mode)
 


### PR DESCRIPTION
With path, user can refer alternative-name as
port/parent/next-hop-interface.

For example, this YAML is using alternative-name as bond port name:

```yml
---
interfaces:
- name: port1
  type: ethernet
  identifier: mac-address
  mac-address: 52:54:00:15:17:63
  alt-names:
    - name: port1
    - name: veryveryveryverylonglonglongname
- name: bond99
  type: bond
  bond:
    mode: 0
    ports:
      - port1
```

Included these unit test cases for these invalid usages:
* Multiple alt-names pointing to the same kernel interface.
* Alt-names pointing to kernel interface which is already in port list.
* Port overbook among multiple controllers.

Included integration test cases for these use cases:
* Refer alt-name in bond port list.
* Refer alt-name in linux bridge port list.
* Refer alt-name in OVS bridge port list.
* Refer alt-name as VLAN parent.
* Refer alt-name in route next-hop-interface.

Resolves: https://issues.redhat.com/browse/RHEL-126508