### PR TITLE
Bump minimum supported Rust version to 1.88 and Rust edition 2024

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -20,14 +20,14 @@ jobs:
     - name: Install Rust i686 target
       run: rustup target add i686-unknown-linux-gnu
 
-    - name: Install Rust 1.82
-      run: rustup install 1.82 && rustup install 1.82 --target i686-unknown-linux-gnu
+    - name: Install Rust 1.88
+      run: rustup install 1.88 && rustup install 1.88 --target i686-unknown-linux-gnu
 
     - name: Build test
-      run: cd rust && cargo +1.82 build --ignore-rust-version
+      run: cd rust && cargo +1.88 build --ignore-rust-version
 
     - name: Build test (i686)
-      run: cd rust/src/lib && cargo +1.82 build --ignore-rust-version --target i686-unknown-linux-gnu
+      run: cd rust/src/lib && cargo +1.88 build --ignore-rust-version --target i686-unknown-linux-gnu
 
     - name: Unit tests
-      run: cd rust && cargo +1.82 test --ignore-rust-version
+      run: cd rust && cargo +1.88 test --ignore-rust-version

--- a/rust/.rustfmt.toml
+++ b/rust/.rustfmt.toml
@@ -2,4 +2,6 @@ max_width = 80
 wrap_comments = true
 reorder_imports = true
 format_strings = true
-edition = "2021"
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+edition = "2024"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,8 @@ members = [
 ]
 
 [workspace.package]
-rust-version = "1.82"
+rust-version = "1.88"
+edition = "2024"
 
 [workspace.dependencies]
 log = "0.4.17"

--- a/rust/src/cli/Cargo.toml
+++ b/rust/src/cli/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://nmstate.io"
 repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming"]
-edition = "2021"
+edition.workspace = true
 rust-version.workspace = true
 
 [[bin]]

--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
-use std::io::{stdin, stdout, Read, Write};
-use std::process::{Command, Stdio};
-use std::str::FromStr;
+use std::{
+    fs::File,
+    io::{Read, Write, stdin, stdout},
+    process::{Command, Stdio},
+    str::FromStr,
+};
 
 use nmstate::NetworkState;
 

--- a/rust/src/cli/autoconf.rs
+++ b/rust/src/cli/autoconf.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use nmstate::{
     BaseInterface, BondConfig, BondInterface, BondMode, BondPortConfig,

--- a/rust/src/cli/ncl.rs
+++ b/rust/src/cli/ncl.rs
@@ -27,12 +27,13 @@ mod validate;
 
 use env_logger::Builder;
 use log::LevelFilter;
+#[cfg(feature = "query_apply")]
+use validate::validate;
 
 #[cfg(feature = "query_apply")]
 use crate::apply::{
     apply_from_files, apply_from_stdin, commit, rollback, state_edit,
 };
-
 #[cfg(feature = "query_apply")]
 use crate::autoconf::autoconf;
 #[cfg(feature = "gen_conf")]
@@ -48,8 +49,6 @@ use crate::result::print_result_and_exit;
 use crate::service::ncl_service;
 #[cfg(feature = "query_apply")]
 use crate::statistic::statistic;
-#[cfg(feature = "query_apply")]
-use validate::validate;
 
 pub(crate) const DEFAULT_SERVICE_FOLDER: &str = "/etc/nmstate";
 pub(crate) const CONFIG_FOLDER_KEY: &str = "CONFIG_FOLDER";

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -18,9 +18,11 @@
 //!
 //! [`.link`]: https://www.freedesktop.org/software/systemd/man/systemd.link.html
 //! [`ifname=`]: https://www.man7.org/linux/man-pages/man7/dracut.cmdline.7.html
-use std::collections::HashMap;
-use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 use nmstate::{Interface, InterfaceType, NetworkState};
 
@@ -142,13 +144,11 @@ fn run_persist_immediately(
         }
         let iface_name = iface.name();
         let karg = format_ifname_karg(iface_name, &mac);
-        let driver = iface.base_iface().driver.as_deref().and_then(|d| {
-            if d.is_empty() {
-                None
-            } else {
-                Some(d)
-            }
-        });
+        let driver = iface
+            .base_iface()
+            .driver
+            .as_deref()
+            .and_then(|d| if d.is_empty() { None } else { Some(d) });
         log::info!(
             "Will persist the interface {iface_name} driver {} with MAC {mac}",
             driver.unwrap_or("unknown")
@@ -170,16 +170,16 @@ fn run_persist_immediately(
     }
 
     if !dry_run {
-        if let Some(parent) = stamp_path.parent() {
-            if !parent.exists() {
-                std::fs::create_dir(parent)?;
-            }
+        if let Some(parent) = stamp_path.parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir(parent)?;
         }
         std::fs::write(stamp_path, b"")?;
-        if !kargs.is_empty() {
-            if let Some(path) = kargsfile {
-                std::fs::write(path, kargs.join(" "))?;
-            }
+        if !kargs.is_empty()
+            && let Some(path) = kargsfile
+        {
+            std::fs::write(path, kargs.join(" "))?;
         }
     }
 
@@ -323,10 +323,10 @@ pub(crate) fn clean_up(
     }
     if !dry_run {
         std::fs::remove_file(stamp_path)?;
-        if !kargs.is_empty() {
-            if let Some(path) = kargsfile {
-                std::fs::write(path, kargs.join(" "))?;
-            }
+        if !kargs.is_empty()
+            && let Some(path) = kargsfile
+        {
+            std::fs::write(path, kargs.join(" "))?;
         }
     }
     Ok("".to_string())

--- a/rust/src/cli/policy.rs
+++ b/rust/src/cli/policy.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::{
+    collections::HashMap,
+    io::{Read, Write},
+};
 
 use nmstate::{NetworkPolicy, NetworkState};
 use serde::{Deserialize, Serialize};

--- a/rust/src/cli/query.rs
+++ b/rust/src/cli/query.rs
@@ -77,10 +77,10 @@ pub(crate) fn sort_netstate(
                     }
                 }
                 for (k, v) in iface.iter() {
-                    if let Value::String(ref name) = k {
-                        if IFACE_TOP_PRIORTIES.contains(&name.as_str()) {
-                            continue;
-                        }
+                    if let Value::String(name) = &k
+                        && IFACE_TOP_PRIORTIES.contains(&name.as_str())
+                    {
+                        continue;
                     }
                     new_iface.insert(k.clone(), v.clone());
                 }
@@ -152,13 +152,13 @@ fn filter_net_state_with_iface(
 
     if let Some(config_rules) = net_state.rules.config.as_ref() {
         for rule in config_rules {
-            if let Some(table_id) = rule.table_id {
-                if route_table_ids.contains(&table_id) {
-                    if let Some(rules) = ret.rules.config.as_mut() {
-                        rules.push(rule.clone());
-                    } else {
-                        ret.rules.config = Some(vec![rule.clone()]);
-                    }
+            if let Some(table_id) = rule.table_id
+                && route_table_ids.contains(&table_id)
+            {
+                if let Some(rules) = ret.rules.config.as_mut() {
+                    rules.push(rule.clone());
+                } else {
+                    ret.rules.config = Some(vec![rule.clone()]);
                 }
             }
         }

--- a/rust/src/cli/service.rs
+++ b/rust/src/cli/service.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-use std::ffi::OsStr;
-use std::fs;
-use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    ffi::OsStr,
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 use serde::Deserialize;
 

--- a/rust/src/cli/validate.rs
+++ b/rust/src/cli/validate.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::CliError,
-    state::{state_or_policy_from_file, NetworkStateOrPolicy},
+    state::{NetworkStateOrPolicy, state_or_policy_from_file},
 };
 
 pub(crate) fn validate(matches: &clap::ArgMatches) -> Result<String, CliError> {

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -4,7 +4,7 @@ description = "Nmstate C binding"
 version = "2.2.58"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
-edition = "2021"
+edition.workspace = true
 rust-version.workspace = true
 build = "build.rs"
 

--- a/rust/src/clib/apply.rs
+++ b/rust/src/clib/apply.rs
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::CString;
-use std::time::SystemTime;
+use std::{ffi::CString, time::SystemTime};
 
 use libc::{c_char, c_int};
 
 use crate::{
-    init_logger,
+    NMSTATE_FAIL, NMSTATE_PASS, init_logger,
     query::{
         NMSTATE_FLAG_KERNEL_ONLY, NMSTATE_FLAG_MEMORY_ONLY,
         NMSTATE_FLAG_NO_COMMIT, NMSTATE_FLAG_NO_VERIFY,
     },
     state::c_str_to_net_state,
-    NMSTATE_FAIL, NMSTATE_PASS,
 };
 
 const NMSTATE_FLAG_OVERRIDE_IFACE: u32 = 1 << 9;
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_net_state_apply(
     flags: u32,
     state: *const c_char,

--- a/rust/src/clib/checkpoint.rs
+++ b/rust/src/clib/checkpoint.rs
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::{CStr, CString};
-use std::time::SystemTime;
+use std::{
+    ffi::{CStr, CString},
+    time::SystemTime,
+};
 
 use libc::{c_char, c_int};
 
-use crate::{init_logger, NMSTATE_FAIL, NMSTATE_PASS};
+use crate::{NMSTATE_FAIL, NMSTATE_PASS, init_logger};
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_checkpoint_commit(
     checkpoint: *const c_char,
     log: *mut *mut c_char,
@@ -80,7 +82,7 @@ pub extern "C" fn nmstate_checkpoint_commit(
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_checkpoint_rollback(
     checkpoint: *const c_char,
     log: *mut *mut c_char,

--- a/rust/src/clib/format.rs
+++ b/rust/src/clib/format.rs
@@ -5,12 +5,12 @@ use std::ffi::CString;
 use libc::{c_char, c_int};
 
 use crate::{
-    state::{c_str_to_net_state, is_state_in_json},
     NMSTATE_FAIL, NMSTATE_PASS,
+    state::{c_str_to_net_state, is_state_in_json},
 };
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_net_state_format(
     state: *const c_char,
     formated_state: *mut *mut c_char,

--- a/rust/src/clib/gen_conf.rs
+++ b/rust/src/clib/gen_conf.rs
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::CString;
-use std::time::SystemTime;
+use std::{ffi::CString, time::SystemTime};
 
 use libc::{c_char, c_int};
 
 use crate::{
-    init_logger,
+    NMSTATE_FAIL, NMSTATE_PASS, init_logger,
     state::{c_str_to_net_state, is_state_in_json},
-    NMSTATE_FAIL, NMSTATE_PASS,
 };
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_generate_configurations(
     state: *const c_char,
     configs: *mut *mut c_char,

--- a/rust/src/clib/gen_diff.rs
+++ b/rust/src/clib/gen_diff.rs
@@ -5,12 +5,12 @@ use std::ffi::CString;
 use libc::{c_char, c_int};
 
 use crate::{
-    state::{c_str_to_net_state, is_state_in_json},
     NMSTATE_FAIL, NMSTATE_PASS,
+    state::{c_str_to_net_state, is_state_in_json},
 };
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_generate_differences(
     new_state: *const c_char,
     old_state: *const c_char,

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -24,8 +24,6 @@ use libc::{c_char, c_int};
 use nmstate::NmstateError;
 use once_cell::sync::OnceCell;
 
-use crate::logger::MemoryLogger;
-
 #[cfg(feature = "query_apply")]
 pub use crate::apply::nmstate_net_state_apply;
 #[cfg(feature = "query_apply")]
@@ -34,6 +32,7 @@ pub use crate::checkpoint::{
 };
 #[cfg(feature = "gen_conf")]
 pub use crate::gen_conf::nmstate_generate_configurations;
+use crate::logger::MemoryLogger;
 #[cfg(feature = "query_apply")]
 pub use crate::policy::nmstate_net_state_from_policy;
 #[cfg(feature = "query_apply")]
@@ -49,7 +48,7 @@ pub use crate::format::nmstate_net_state_format;
 static INSTANCE: OnceCell<MemoryLogger> = OnceCell::new();
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_cstring_free(cstring: *mut c_char) {
     unsafe {
         if !cstring.is_null() {

--- a/rust/src/clib/logger.rs
+++ b/rust/src/clib/logger.rs
@@ -3,11 +3,13 @@
 // This is based on the work of https://github.com/gahag/memory_logger
 // which is MIT licensed.
 
-use std::sync::{
-    atomic::{AtomicU16, Ordering},
-    Mutex,
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicU16, Ordering},
+    },
+    time::SystemTime,
 };
-use std::time::SystemTime;
 
 use serde::ser::{Serialize, SerializeMap, Serializer};
 

--- a/rust/src/clib/policy.rs
+++ b/rust/src/clib/policy.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::{CStr, CString};
-use std::time::SystemTime;
+use std::{
+    ffi::{CStr, CString},
+    time::SystemTime,
+};
 
 use libc::{c_char, c_int};
 use nmstate::{NetworkPolicy, NetworkState};
 
-use crate::{init_logger, NMSTATE_FAIL, NMSTATE_PASS};
+use crate::{NMSTATE_FAIL, NMSTATE_PASS, init_logger};
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_net_state_from_policy(
     policy: *const c_char,
     current_state: *const c_char,

--- a/rust/src/clib/query.rs
+++ b/rust/src/clib/query.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::CString;
-use std::time::SystemTime;
+use std::{ffi::CString, time::SystemTime};
 
 use libc::{c_char, c_int};
 
-use crate::{init_logger, NMSTATE_FAIL, NMSTATE_PASS};
+use crate::{NMSTATE_FAIL, NMSTATE_PASS, init_logger};
 
 pub(crate) const NMSTATE_FLAG_KERNEL_ONLY: u32 = 1 << 1;
 pub(crate) const NMSTATE_FLAG_NO_VERIFY: u32 = 1 << 2;
@@ -17,7 +16,7 @@ pub(crate) const NMSTATE_FLAG_RUNNING_CONFIG_ONLY: u32 = 1 << 7;
 pub(crate) const NMSTATE_FLAG_YAML_OUTPUT: u32 = 1 << 8;
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_net_state_retrieve(
     flags: u32,
     state: *mut *mut c_char,

--- a/rust/src/clib/validate.rs
+++ b/rust/src/clib/validate.rs
@@ -5,12 +5,12 @@ use std::ffi::{CStr, CString};
 use libc::{c_char, c_int};
 
 use crate::{
-    policy::c_str_to_net_policy, state::c_str_to_net_state, NMSTATE_FAIL,
-    NMSTATE_PASS,
+    NMSTATE_FAIL, NMSTATE_PASS, policy::c_str_to_net_policy,
+    state::c_str_to_net_state,
 };
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn nmstate_validate(
     state_or_policy: *const c_char,
     cur_state: *const c_char,

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/nmstate/nmstate"
 keywords = ["network", "linux"]
 categories = ["network-programming", "os::linux-apis"]
 rust-version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
-use serde::{de, de::IntoDeserializer, de::Visitor, Deserialize, Deserializer};
+use serde::{
+    Deserialize, Deserializer, de,
+    de::{IntoDeserializer, Visitor},
+};
 
 pub(crate) fn u8_or_string<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where

--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
+use std::{
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ip::is_ipv6_addr, ErrorKind, MergedInterface, MergedNetworkState,
-    NmstateError,
+    ErrorKind, MergedInterface, MergedNetworkState, NmstateError,
+    ip::is_ipv6_addr,
 };
 
 const SUPPORTED_DNS_OPTS_NO_VALUE: [&str; 15] = [

--- a/rust/src/lib/gen_conf.rs
+++ b/rust/src/lib/gen_conf.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    nm::nm_gen_conf, Interface, MergedNetworkState, NetworkState,
-    NetworkStateMode, NmstateError,
+    Interface, MergedNetworkState, NetworkState, NetworkStateMode,
+    NmstateError, nm::nm_gen_conf,
 };
 
 impl NetworkState {

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -10,9 +10,8 @@ use crate::{
     LinuxBridgeInterface, LoopbackInterface, MacSecInterface, MacVlanInterface,
     MacVtapInterface, NmstateError, OvsBridgeInterface, OvsInterface,
     VlanInterface, VrfInterface, VxlanInterface, XfrmInterface,
+    state::merge_json_value,
 };
-
-use crate::state::merge_json_value;
 
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
@@ -118,7 +117,7 @@ impl std::fmt::Display for InterfaceType {
                 InterfaceType::Ipsec => "ipsec",
                 InterfaceType::Xfrm => "xfrm",
                 InterfaceType::IpVlan => "ipvlan",
-                InterfaceType::Other(ref s) => s,
+                InterfaceType::Other(s) => s,
             }
         )
     }
@@ -891,14 +890,13 @@ impl MergedInterface {
                 {
                     br_iface.special_merge(des_br_iface, cur_br_iface);
                 }
-            } else if let Interface::OvsBridge(br_iface) = &mut self.merged {
-                if let (
+            } else if let Interface::OvsBridge(br_iface) = &mut self.merged
+                && let (
                     Interface::OvsBridge(des_br_iface),
                     Interface::OvsBridge(cur_br_iface),
                 ) = (desired, current)
-                {
-                    br_iface.special_merge(des_br_iface, cur_br_iface);
-                }
+            {
+                br_iface.special_merge(des_br_iface, cur_br_iface);
             }
         }
     }
@@ -1013,13 +1011,13 @@ impl MergedInterface {
     // Store `Interface` with name and type into `for_apply`.
     // Do nothing if specified interface is already desired.
     pub(crate) fn mark_as_changed(&mut self) {
-        if self.desired.is_none() {
-            if let Some(cur_iface) = self.current.as_ref() {
-                let iface = cur_iface.clone_name_type_only();
-                self.for_apply = Some(iface);
-                self.preserve_current_controller_info();
-                self.preserve_current_identifer_info();
-            }
+        if self.desired.is_none()
+            && let Some(cur_iface) = self.current.as_ref()
+        {
+            let iface = cur_iface.clone_name_type_only();
+            self.for_apply = Some(iface);
+            self.preserve_current_controller_info();
+            self.preserve_current_identifer_info();
         }
     }
 
@@ -1037,24 +1035,23 @@ impl MergedInterface {
         ctrl_type: Option<InterfaceType>,
         ctrl_state: InterfaceState,
     ) -> Result<(), NmstateError> {
-        if self.merged.need_controller() && ctrl_name.is_empty() {
-            if let Some(org_ctrl) = self
+        if self.merged.need_controller()
+            && ctrl_name.is_empty()
+            && let Some(org_ctrl) = self
                 .current
                 .as_ref()
                 .and_then(|c| c.base_iface().controller.as_ref())
-            {
-                if Some(true) == self.for_apply.as_ref().map(|i| i.is_up()) {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Interface {} cannot live without controller, but \
-                             it is detached from original controller \
-                             {org_ctrl}, cannot apply desired `state:up`",
-                            self.merged.name()
-                        ),
-                    ));
-                }
-            }
+            && Some(true) == self.for_apply.as_ref().map(|i| i.is_up())
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Interface {} cannot live without controller, but it is \
+                     detached from original controller {org_ctrl}, cannot \
+                     apply desired `state:up`",
+                    self.merged.name()
+                ),
+            ));
         }
 
         if !self.is_changed() {
@@ -1118,23 +1115,19 @@ impl MergedInterface {
     }
 
     fn preserve_current_controller_info(&mut self) {
-        if let Some(apply_iface) = self.for_apply.as_mut() {
-            if apply_iface.base_iface().controller.is_none() {
-                if let Some(cur_iface) = self.current.as_ref() {
-                    if cur_iface.base_iface().controller.as_ref().is_some() {
-                        apply_iface
-                            .base_iface_mut()
-                            .controller
-                            .clone_from(&cur_iface.base_iface().controller);
-                        apply_iface
-                            .base_iface_mut()
-                            .controller_type
-                            .clone_from(
-                                &cur_iface.base_iface().controller_type,
-                            );
-                    }
-                }
-            }
+        if let Some(apply_iface) = self.for_apply.as_mut()
+            && apply_iface.base_iface().controller.is_none()
+            && let Some(cur_iface) = self.current.as_ref()
+            && cur_iface.base_iface().controller.as_ref().is_some()
+        {
+            apply_iface
+                .base_iface_mut()
+                .controller
+                .clone_from(&cur_iface.base_iface().controller);
+            apply_iface
+                .base_iface_mut()
+                .controller_type
+                .clone_from(&cur_iface.base_iface().controller_type);
         }
     }
 }

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -156,19 +156,17 @@ impl BaseInterface {
     //  * `copy_mac_from` is skip_serializing
     //  * `permanent_mac_address` is skip_serializing
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if let Some(ipv4) = self.ipv4.as_mut() {
-            if let (Some(d), Some(c)) =
+        if let Some(ipv4) = self.ipv4.as_mut()
+            && let (Some(d), Some(c)) =
                 (desired.ipv4.as_ref(), current.ipv4.as_ref())
-            {
-                ipv4.special_merge(d, c);
-            }
+        {
+            ipv4.special_merge(d, c);
         }
-        if let Some(ipv6) = self.ipv6.as_mut() {
-            if let (Some(d), Some(c)) =
+        if let Some(ipv6) = self.ipv6.as_mut()
+            && let (Some(d), Some(c)) =
                 (desired.ipv6.as_ref(), current.ipv6.as_ref())
-            {
-                ipv6.special_merge(d, c);
-            }
+        {
+            ipv6.special_merge(d, c);
         }
         if self.permanent_mac_address.is_none() {
             self.permanent_mac_address
@@ -250,20 +248,18 @@ impl BaseInterface {
         }
         if let Some(ipv6_conf) = self.ipv6.as_mut() {
             ipv6_conf.sanitize(is_desired)?;
-            if ipv6_conf.enabled {
-                if let Some(mtu) = self.mtu {
-                    if mtu < MINIMUM_IPV6_MTU {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "MTU should be >= {MINIMUM_IPV6_MTU} when \
-                                 IPv6 is enabled on interface {}, but got \
-                                 mtu: {mtu}",
-                                self.name.as_str()
-                            ),
-                        ));
-                    }
-                }
+            if ipv6_conf.enabled
+                && let Some(mtu) = self.mtu
+                && mtu < MINIMUM_IPV6_MTU
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "MTU should be >= {MINIMUM_IPV6_MTU} when IPv6 is \
+                         enabled on interface {}, but got mtu: {mtu}",
+                        self.name.as_str()
+                    ),
+                ));
             }
         }
         if let Some(lldp_conf) = self.lldp.as_mut() {
@@ -326,65 +322,63 @@ impl MergedInterface {
         if let (Some(desired), Some(current)) = (
             self.desired.as_ref().map(|i| i.base_iface()),
             self.current.as_ref().map(|i| i.base_iface()),
-        ) {
-            if let (Some(desire_mtu), Some(min_mtu), Some(max_mtu)) =
-                (desired.mtu, current.min_mtu, current.max_mtu)
-            {
-                if desire_mtu > max_mtu {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Desired MTU {} for interface {} is bigger than \
-                             maximum allowed MTU {}",
-                            desire_mtu, desired.name, max_mtu
-                        ),
-                    ));
-                } else if desire_mtu < min_mtu {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Desired MTU {} for interface {} is smaller than \
-                             minimum allowed MTU {}",
-                            desire_mtu, desired.name, min_mtu
-                        ),
-                    ));
-                }
+        ) && let (Some(desire_mtu), Some(min_mtu), Some(max_mtu)) =
+            (desired.mtu, current.min_mtu, current.max_mtu)
+        {
+            if desire_mtu > max_mtu {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired MTU {} for interface {} is bigger than \
+                         maximum allowed MTU {}",
+                        desire_mtu, desired.name, max_mtu
+                    ),
+                ));
+            } else if desire_mtu < min_mtu {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired MTU {} for interface {} is smaller than \
+                         minimum allowed MTU {}",
+                        desire_mtu, desired.name, min_mtu
+                    ),
+                ));
             }
         }
         Ok(())
     }
 
     fn validate_can_have_ip(&mut self) -> Result<(), NmstateError> {
-        if self.is_desired() && self.merged.is_up() {
-            if let Some(apply_iface) = self.for_apply.as_ref() {
-                let base_iface = apply_iface.base_iface();
-                if !base_iface.can_have_ip()
-                    && (base_iface.ipv4.as_ref().map(|ipv4| ipv4.enabled)
-                        == Some(true)
-                        || base_iface.ipv6.as_ref().map(|ipv6| ipv6.enabled)
-                            == Some(true))
+        if self.is_desired()
+            && self.merged.is_up()
+            && let Some(apply_iface) = self.for_apply.as_ref()
+        {
+            let base_iface = apply_iface.base_iface();
+            if !base_iface.can_have_ip()
+                && (base_iface.ipv4.as_ref().map(|ipv4| ipv4.enabled)
+                    == Some(true)
+                    || base_iface.ipv6.as_ref().map(|ipv6| ipv6.enabled)
+                        == Some(true))
+            {
+                if let Some(ctrl) = apply_iface.base_iface().controller.as_ref()
                 {
-                    if let Some(ctrl) =
-                        apply_iface.base_iface().controller.as_ref()
-                    {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Interface {} cannot have IP enabled as it is \
-                                 attached to controller {ctrl} where IP is \
-                                 not allowed on its port",
-                                base_iface.name.as_str()
-                            ),
-                        ));
-                    } else {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Interface {} cannot have IP enabled",
-                                base_iface.name.as_str()
-                            ),
-                        ));
-                    }
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {} cannot have IP enabled as it is \
+                             attached to controller {ctrl} where IP is not \
+                             allowed on its port",
+                            base_iface.name.as_str()
+                        ),
+                    ));
+                } else {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {} cannot have IP enabled",
+                            base_iface.name.as_str()
+                        ),
+                    ));
                 }
             }
         }
@@ -394,63 +388,62 @@ impl MergedInterface {
     /// Copy MAC address when identifier is [InterfaceIdentifier::MacAddress]
     /// Copy PCI address when identifier is [InterfaceIdentifier::PciAddress]
     pub(crate) fn preserve_current_identifer_info(&mut self) {
-        if self.for_apply.as_ref().map(|i| i.is_up()) == Some(true) {
-            if let (Some(apply_iface), Some(cur_iface)) =
+        if self.for_apply.as_ref().map(|i| i.is_up()) == Some(true)
+            && let (Some(apply_iface), Some(cur_iface)) =
                 (self.for_apply.as_mut(), self.current.as_ref())
-            {
-                match cur_iface.base_iface().identifier {
-                    Some(InterfaceIdentifier::MacAddress) => {
-                        if apply_iface.base_iface().identifier.is_none() {
+        {
+            match cur_iface.base_iface().identifier {
+                Some(InterfaceIdentifier::MacAddress) => {
+                    if apply_iface.base_iface().identifier.is_none() {
+                        apply_iface
+                            .base_iface_mut()
+                            .identifier
+                            .clone_from(&cur_iface.base_iface().identifier);
+                        if apply_iface.base_iface().mac_address.is_none() {
                             apply_iface
                                 .base_iface_mut()
-                                .identifier
-                                .clone_from(&cur_iface.base_iface().identifier);
-                            if apply_iface.base_iface().mac_address.is_none() {
-                                apply_iface
-                                    .base_iface_mut()
-                                    .mac_address
-                                    .clone_from(
-                                        &cur_iface.base_iface().mac_address,
-                                    );
-                            }
-                            if apply_iface.base_iface().profile_name.is_none() {
-                                apply_iface
-                                    .base_iface_mut()
-                                    .profile_name
-                                    .clone_from(
-                                        &cur_iface.base_iface().profile_name,
-                                    );
-                            }
+                                .mac_address
+                                .clone_from(
+                                    &cur_iface.base_iface().mac_address,
+                                );
                         }
-                    }
-                    Some(InterfaceIdentifier::PciAddress) => {
-                        if apply_iface.base_iface().identifier.is_none() {
+                        if apply_iface.base_iface().profile_name.is_none() {
                             apply_iface
                                 .base_iface_mut()
-                                .identifier
-                                .clone_from(&cur_iface.base_iface().identifier);
-                            if apply_iface.base_iface().pci_address.is_none() {
-                                apply_iface
-                                    .base_iface_mut()
-                                    .pci_address
-                                    .clone_from(
-                                        &cur_iface.base_iface().pci_address,
-                                    );
-                            }
-                            if apply_iface.base_iface().profile_name.is_none() {
-                                apply_iface
-                                    .base_iface_mut()
-                                    .profile_name
-                                    .clone_from(
-                                        &cur_iface.base_iface().profile_name,
-                                    );
-                            }
+                                .profile_name
+                                .clone_from(
+                                    &cur_iface.base_iface().profile_name,
+                                );
                         }
                     }
-                    // Do not use _ match here, we want developer to be
-                    // notified by compiler when new identifier been added.
-                    Some(InterfaceIdentifier::Name) | None => (),
                 }
+                Some(InterfaceIdentifier::PciAddress) => {
+                    if apply_iface.base_iface().identifier.is_none() {
+                        apply_iface
+                            .base_iface_mut()
+                            .identifier
+                            .clone_from(&cur_iface.base_iface().identifier);
+                        if apply_iface.base_iface().pci_address.is_none() {
+                            apply_iface
+                                .base_iface_mut()
+                                .pci_address
+                                .clone_from(
+                                    &cur_iface.base_iface().pci_address,
+                                );
+                        }
+                        if apply_iface.base_iface().profile_name.is_none() {
+                            apply_iface
+                                .base_iface_mut()
+                                .profile_name
+                                .clone_from(
+                                    &cur_iface.base_iface().profile_name,
+                                );
+                        }
+                    }
+                }
+                // Do not use _ match here, we want developer to be
+                // notified by compiler when new identifier been added.
+                Some(InterfaceIdentifier::Name) | None => (),
             }
         }
     }

--- a/rust/src/lib/ifaces/bond.rs
+++ b/rust/src/lib/ifaces/bond.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::net::Ipv6Addr;
+use std::{
+    collections::{HashMap, HashSet},
+    net::Ipv6Addr,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -78,30 +79,28 @@ impl Default for BondInterface {
 impl BondInterface {
     // * Do not merge bond options from current when bond mode is changing
     pub(crate) fn special_merge(&mut self, desired: &Self, current: &Self) {
-        if let Some(bond_conf) = self.bond.as_mut() {
-            if let (Some(des_bond_conf), Some(cur_bond_conf)) =
+        if let Some(bond_conf) = self.bond.as_mut()
+            && let (Some(des_bond_conf), Some(cur_bond_conf)) =
                 (desired.bond.as_ref(), current.bond.as_ref())
-            {
-                if des_bond_conf.mode != cur_bond_conf.mode {
-                    bond_conf.options.clone_from(&des_bond_conf.options);
-                }
-            }
+            && des_bond_conf.mode != cur_bond_conf.mode
+        {
+            bond_conf.options.clone_from(&des_bond_conf.options);
         }
     }
 
     fn drop_empty_arp_ip_target(&mut self) {
-        if let Some(ref mut bond_conf) = self.bond {
-            if let Some(ref mut bond_opts) = &mut bond_conf.options {
-                if let Some(ref mut arp_ip_target) = bond_opts.arp_ip_target {
-                    if arp_ip_target.is_empty() {
-                        bond_opts.arp_ip_target = None;
-                    }
-                }
-                if let Some(ref mut v) = bond_opts.ns_ip6_target {
-                    if v.is_empty() {
-                        bond_opts.ns_ip6_target = None;
-                    }
-                }
+        if let Some(bond_conf) = self.bond.as_mut()
+            && let Some(bond_opts) = bond_conf.options.as_mut()
+        {
+            if let Some(arp_ip_target) = bond_opts.arp_ip_target.as_ref()
+                && arp_ip_target.is_empty()
+            {
+                bond_opts.arp_ip_target = None;
+            }
+            if let Some(v) = bond_opts.ns_ip6_target.as_mut()
+                && v.is_empty()
+            {
+                bond_opts.ns_ip6_target = None;
             }
         }
     }
@@ -285,48 +284,47 @@ impl BondInterface {
     fn validate_conflict_in_port_and_port_configs(
         &self,
     ) -> Result<(), NmstateError> {
-        if let Some(bond_conf) = self.bond.as_ref() {
-            if let (Some(ports), Some(ports_config)) =
+        if let Some(bond_conf) = self.bond.as_ref()
+            && let (Some(ports), Some(ports_config)) =
                 (&bond_conf.port, &bond_conf.ports_config)
-            {
-                let ports: HashSet<&str> =
-                    ports.iter().map(String::as_str).collect();
-                let port_confs: HashSet<&str> =
-                    ports_config.iter().map(|p| p.name.as_str()).collect();
+        {
+            let ports: HashSet<&str> =
+                ports.iter().map(String::as_str).collect();
+            let port_confs: HashSet<&str> =
+                ports_config.iter().map(|p| p.name.as_str()).collect();
 
-                if ports != port_confs {
-                    let missing_in_config: Vec<&str> =
-                        ports.difference(&port_confs).copied().collect();
-                    let missing_in_ports: Vec<&str> =
-                        port_confs.difference(&ports).copied().collect();
+            if ports != port_confs {
+                let missing_in_config: Vec<&str> =
+                    ports.difference(&port_confs).copied().collect();
+                let missing_in_ports: Vec<&str> =
+                    port_confs.difference(&ports).copied().collect();
 
-                    let mut error_msg_detail = String::new();
+                let mut error_msg_detail = String::new();
 
-                    if !missing_in_config.is_empty() {
-                        error_msg_detail.push_str(&format!(
-                            "Ports in `port` but not in `ports_config`: {}. ",
-                            missing_in_config.join(", ")
-                        ));
-                    }
-                    if !missing_in_ports.is_empty() {
-                        error_msg_detail.push_str(&format!(
-                            "Ports in `ports_config` but not in `port`: {}. ",
-                            missing_in_ports.join(", ")
-                        ));
-                    }
-
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "The port names specified in `port` conflict with \
-                             the port names specified in `ports-config` for \
-                             bond interface: {}. {}",
-                            &self.base.name, error_msg_detail
-                        ),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
+                if !missing_in_config.is_empty() {
+                    error_msg_detail.push_str(&format!(
+                        "Ports in `port` but not in `ports_config`: {}. ",
+                        missing_in_config.join(", ")
+                    ));
                 }
+                if !missing_in_ports.is_empty() {
+                    error_msg_detail.push_str(&format!(
+                        "Ports in `ports_config` but not in `port`: {}. ",
+                        missing_in_ports.join(", ")
+                    ));
+                }
+
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "The port names specified in `port` conflict with the \
+                         port names specified in `ports-config` for bond \
+                         interface: {}. {}",
+                        &self.base.name, error_msg_detail
+                    ),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
         }
 
@@ -430,10 +428,10 @@ impl BondInterface {
         }
 
         for (port_name, port_conf) in des_ports_index.iter() {
-            if let Some(cur_port_conf) = cur_ports_index.get(port_name) {
-                if port_conf.is_changed(cur_port_conf) {
-                    ret.push(port_name);
-                }
+            if let Some(cur_port_conf) = cur_ports_index.get(port_name)
+                && port_conf.is_changed(cur_port_conf)
+            {
+                ret.push(port_name);
             }
         }
         ret
@@ -1248,17 +1246,17 @@ impl BondOptions {
     }
 
     fn validate_ad_actor_system_mac_address(&self) -> Result<(), NmstateError> {
-        if let Some(ad_actor_system) = &self.ad_actor_system {
-            if ad_actor_system.to_uppercase().starts_with("01:00:5E") {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "The ad_actor_system bond option cannot be an IANA \
-                     multicast address(prefix with 01:00:5E)"
-                        .to_string(),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        if let Some(ad_actor_system) = &self.ad_actor_system
+            && ad_actor_system.to_uppercase().starts_with("01:00:5E")
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "The ad_actor_system bond option cannot be an IANA multicast \
+                 address(prefix with 01:00:5E)"
+                    .to_string(),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }
@@ -1266,16 +1264,16 @@ impl BondOptions {
     fn validate_miimon_and_arp_interval(&self) -> Result<(), NmstateError> {
         if let (Some(miimon), Some(arp_interval)) =
             (self.miimon, self.arp_interval)
+            && miimon > 0
+            && arp_interval > 0
         {
-            if miimon > 0 && arp_interval > 0 {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "Bond miimon and arp interval are not compatible options."
-                        .to_string(),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Bond miimon and arp interval are not compatible options."
+                    .to_string(),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }
@@ -1355,25 +1353,25 @@ impl BondOptions {
                     ));
                 }
             } else {
-                if let Some(arp_ip_target) = self.arp_ip_target.as_ref() {
-                    if !arp_ip_target.is_empty() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "The `arp_ip_target` option is only valid when \
-                             'arp_interval' is enabled(>0)."
-                                .to_string(),
-                        ));
-                    }
+                if let Some(arp_ip_target) = self.arp_ip_target.as_ref()
+                    && !arp_ip_target.is_empty()
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "The `arp_ip_target` option is only valid when \
+                         'arp_interval' is enabled(>0)."
+                            .to_string(),
+                    ));
                 }
-                if let Some(ns_ip6_target) = self.ns_ip6_target.as_ref() {
-                    if !ns_ip6_target.is_empty() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "The `ns_ip6_target` option is only valid when \
-                             'arp_interval' is enabled(>0)."
-                                .to_string(),
-                        ));
-                    }
+                if let Some(ns_ip6_target) = self.ns_ip6_target.as_ref()
+                    && !ns_ip6_target.is_empty()
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "The `ns_ip6_target` option is only valid when \
+                         'arp_interval' is enabled(>0)."
+                            .to_string(),
+                    ));
                 }
             }
         }
@@ -1400,25 +1398,24 @@ impl MergedInterface {
                 bond_opts.validate_ad_actor_system_mac_address()?;
                 bond_opts.validate_miimon_and_arp_interval()?;
 
-                if let Interface::Bond(merged_iface) = &self.merged {
-                    if let Some(mode) =
+                if let Interface::Bond(merged_iface) = &self.merged
+                    && let Some(mode) =
                         merged_iface.bond.as_ref().and_then(|b| b.mode)
-                    {
-                        let cur_bond_opts =
-                            if let Some(Interface::Bond(cur_iface)) =
-                                self.current.as_ref()
-                            {
-                                cur_iface
-                                    .bond
-                                    .as_ref()
-                                    .and_then(|b| b.options.as_ref())
-                            } else {
-                                None
-                            };
-                        bond_opts.validate_balance_slb(cur_bond_opts, mode)?;
-                        bond_opts.validate_lacp_opts(mode)?;
-                        bond_opts.validate_arp_interval(cur_bond_opts, mode)?;
-                    }
+                {
+                    let cur_bond_opts =
+                        if let Some(Interface::Bond(cur_iface)) =
+                            self.current.as_ref()
+                        {
+                            cur_iface
+                                .bond
+                                .as_ref()
+                                .and_then(|b| b.options.as_ref())
+                        } else {
+                            None
+                        };
+                    bond_opts.validate_balance_slb(cur_bond_opts, mode)?;
+                    bond_opts.validate_lacp_opts(mode)?;
+                    bond_opts.validate_arp_interval(cur_bond_opts, mode)?;
                 }
             }
         }

--- a/rust/src/lib/ifaces/bridge_vlan.rs
+++ b/rust/src/lib/ifaces/bridge_vlan.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use serde::{
-    ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer, Serialize, Serializer, ser::SerializeTuple,
 };
 
 use crate::{ErrorKind, NmstateError};
@@ -127,17 +126,16 @@ impl BridgePortVlanConfig {
                 ));
             }
 
-            if self.mode == Some(BridgePortVlanMode::Access) {
-                if let Some(tags) = self.trunk_tags.as_ref() {
-                    if !tags.is_empty() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "Bridge VLAN filtering access mode cannot have \
-                             trunk-tags defined"
-                                .to_string(),
-                        ));
-                    }
-                }
+            if self.mode == Some(BridgePortVlanMode::Access)
+                && let Some(tags) = self.trunk_tags.as_ref()
+                && !tags.is_empty()
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "Bridge VLAN filtering access mode cannot have trunk-tags \
+                     defined"
+                        .to_string(),
+                ));
             }
 
             if self.mode == Some(BridgePortVlanMode::Trunk)

--- a/rust/src/lib/ifaces/ethernet.rs
+++ b/rust/src/lib/ifaces/ethernet.rs
@@ -176,12 +176,11 @@ impl MergedInterfaces {
         for iface in self.iter().filter(|i| {
             i.merged.iface_type() == InterfaceType::Ethernet && i.merged.is_up()
         }) {
-            if let Interface::Ethernet(eth_iface) = &iface.merged {
-                if let Some(v) =
+            if let Interface::Ethernet(eth_iface) = &iface.merged
+                && let Some(v) =
                     eth_iface.veth.as_ref().map(|v| v.peer.as_str())
-                {
-                    veth_peers.push(v);
-                }
+            {
+                veth_peers.push(v);
             }
         }
         for iface in self.iter().filter(|i| {
@@ -190,22 +189,21 @@ impl MergedInterfaces {
                 && i.current.is_none()
                 && i.merged.is_up()
         }) {
-            if let Some(Interface::Ethernet(eth_iface)) = &iface.desired {
-                if eth_iface.veth.is_none()
+            if let Some(Interface::Ethernet(eth_iface)) = &iface.desired
+                && eth_iface.veth.is_none()
                     && self.mode != NetworkStateMode::GenerateConfig
                     && !veth_peers.contains(&eth_iface.base.name.as_str())
                     // The `resolve_sriov_reference()` will raise error if
                     // SRIOV VF not found, so we skip check on them here.
                     && !eth_iface.base.name.starts_with("sriov:")
-                {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Ethernet interface {} does not exists",
-                            eth_iface.base.name.as_str()
-                        ),
-                    ));
-                }
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Ethernet interface {} does not exists",
+                        eth_iface.base.name.as_str()
+                    ),
+                ));
             }
         }
 
@@ -221,14 +219,11 @@ impl MergedInterfaces {
                 Some(Interface::Ethernet(des_eth_iface)),
                 Some(Interface::Ethernet(cur_eth_iface)),
             ) = (iface.desired.as_ref(), iface.current.as_ref())
-            {
-                if let (Some(veth_conf), Some(cur_veth_conf)) =
+                && let (Some(veth_conf), Some(cur_veth_conf)) =
                     (des_eth_iface.veth.as_ref(), cur_eth_iface.veth.as_ref())
-                {
-                    if veth_conf.peer != cur_veth_conf.peer {
-                        pending_deletions.push(cur_veth_conf.peer.to_string());
-                    }
-                }
+                && veth_conf.peer != cur_veth_conf.peer
+            {
+                pending_deletions.push(cur_veth_conf.peer.to_string());
             }
         }
 
@@ -240,10 +235,9 @@ impl MergedInterfaces {
         }) {
             if let Some(Interface::Ethernet(cur_eth_iface)) =
                 iface.current.as_ref()
+                && let Some(veth_conf) = cur_eth_iface.veth.as_ref()
             {
-                if let Some(veth_conf) = cur_eth_iface.veth.as_ref() {
-                    pending_deletions.push(veth_conf.peer.to_string());
-                }
+                pending_deletions.push(veth_conf.peer.to_string());
             }
         }
 
@@ -286,48 +280,45 @@ impl Interfaces {
                 Interface::Ethernet(des_iface),
                 Some(Interface::Ethernet(cur_iface)),
             ) = (iface, current.get_iface(iface.name(), InterfaceType::Veth))
-            {
-                if let (Some(des_peer), cur_peer) = (
+                && let (Some(des_peer), cur_peer) = (
                     des_iface.veth.as_ref().map(|v| v.peer.as_str()),
                     cur_iface.veth.as_ref().map(|v| v.peer.as_str()),
-                ) {
-                    let cur_peer = if let Some(c) = cur_peer {
-                        c
-                    } else {
-                        // The veth peer is in another namespace.
-                        let e = NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Veth interface {} is currently holding peer \
-                                 assigned to other namespace Please remove \
-                                 this veth pair before changing veth peer to \
-                                 {des_peer}",
-                                iface.name(),
-                            ),
-                        );
-                        log::error!("{e}");
-                        return Err(e);
-                    };
+                )
+            {
+                let cur_peer = if let Some(c) = cur_peer {
+                    c
+                } else {
+                    // The veth peer is in another namespace.
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Veth interface {} is currently holding peer \
+                             assigned to other namespace Please remove this \
+                             veth pair before changing veth peer to {des_peer}",
+                            iface.name(),
+                        ),
+                    );
+                    log::error!("{e}");
+                    return Err(e);
+                };
 
-                    if des_peer != cur_peer
-                        && ignored_veth_ifaces.contains(&&cur_peer.to_string())
-                    {
-                        let e = NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Veth interface {} is currently holding peer \
-                                 {} which is marked as ignored. Hence not \
-                                 allowing changing its peer to {}. Please \
-                                 remove this veth pair before changing veth \
-                                 peer",
-                                iface.name(),
-                                cur_peer,
-                                des_peer
-                            ),
-                        );
-                        log::error!("{e}");
-                        return Err(e);
-                    }
+                if des_peer != cur_peer
+                    && ignored_veth_ifaces.contains(&&cur_peer.to_string())
+                {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Veth interface {} is currently holding peer {} \
+                             which is marked as ignored. Hence not allowing \
+                             changing its peer to {}. Please remove this veth \
+                             pair before changing veth peer",
+                            iface.name(),
+                            cur_peer,
+                            des_peer
+                        ),
+                    );
+                    log::error!("{e}");
+                    return Err(e);
                 }
             }
         }
@@ -343,17 +334,17 @@ impl Interfaces {
                 && i.iface_type() == InterfaceType::Veth
                 && !current.kernel_ifaces.contains_key(i.name())
         }) {
-            if let Interface::Ethernet(eth_iface) = iface {
-                if eth_iface.veth.is_none() {
-                    return Err(NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Veth interface {} does not exist, peer name is \
-                             required for creating it",
-                            iface.name()
-                        ),
-                    ));
-                }
+            if let Interface::Ethernet(eth_iface) = iface
+                && eth_iface.veth.is_none()
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Veth interface {} does not exist, peer name is \
+                         required for creating it",
+                        iface.name()
+                    ),
+                ));
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::hash_map::Iter;
-use std::collections::{BTreeMap, HashMap};
-use std::marker::PhantomData;
+use std::{
+    collections::{BTreeMap, HashMap, hash_map::Iter},
+    marker::PhantomData,
+};
 
 use serde::{
-    de, de::MapAccess, de::Visitor, Deserialize, Deserializer, Serialize,
-    Serializer,
+    Deserialize, Deserializer, Serialize, Serializer, de,
+    de::{MapAccess, Visitor},
 };
 
 use crate::MergedInterface;
@@ -533,13 +534,13 @@ pub struct EthtoolFecConfig {
 
 impl EthtoolFecConfig {
     pub(crate) fn sanitize(&mut self, is_desired: bool) {
-        if is_desired && self.auto == Some(true) {
-            if let Some(mode) = self.mode.take() {
-                log::info!(
-                    "Ignoring ethtool fec mode setting {mode} because auto \
-                     enabled"
-                );
-            }
+        if is_desired
+            && self.auto == Some(true)
+            && let Some(mode) = self.mode.take()
+        {
+            log::info!(
+                "Ignoring ethtool fec mode setting {mode} because auto enabled"
+            );
         }
     }
 }

--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -66,16 +66,15 @@ impl HsrInterface {
         &mut self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if is_desired {
-            if let Some(conf) = &mut self.hsr {
-                if let Some(address) = &mut conf.supervision_address {
-                    address.as_mut().make_ascii_uppercase();
-                    log::warn!(
-                        "The supervision-address is read-only, ignoring it on \
-                         desired state."
-                    );
-                }
-            }
+        if is_desired
+            && let Some(conf) = &mut self.hsr
+            && let Some(address) = &mut conf.supervision_address
+        {
+            address.as_mut().make_ascii_uppercase();
+            log::warn!(
+                "The supervision-address is read-only, ignoring it on desired \
+                 state."
+            );
         }
         Ok(())
     }
@@ -234,20 +233,19 @@ impl MergedInterfaces {
 impl MergedInterface {
     /// Explicitly disable IP on HSR ports
     pub(crate) fn post_inter_ifaces_process_hsr(&mut self) {
-        if let Some(apply_iface) = self.for_apply.as_mut() {
-            if apply_iface.is_up()
-                && apply_iface.base_iface().controller_type.as_ref()
-                    == Some(&InterfaceType::Hsr)
-            {
-                apply_iface.base_iface_mut().ipv4 = Some(InterfaceIpv4 {
-                    enabled: false,
-                    ..Default::default()
-                });
-                apply_iface.base_iface_mut().ipv6 = Some(InterfaceIpv6 {
-                    enabled: false,
-                    ..Default::default()
-                });
-            }
+        if let Some(apply_iface) = self.for_apply.as_mut()
+            && apply_iface.is_up()
+            && apply_iface.base_iface().controller_type.as_ref()
+                == Some(&InterfaceType::Hsr)
+        {
+            apply_iface.base_iface_mut().ipv4 = Some(InterfaceIpv4 {
+                enabled: false,
+                ..Default::default()
+            });
+            apply_iface.base_iface_mut().ipv6 = Some(InterfaceIpv6 {
+                enabled: false,
+                ..Default::default()
+            });
         }
     }
 }

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::{
-    ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq,
 };
 
 use crate::{
@@ -162,10 +162,10 @@ impl Interfaces {
             .chain(self.user_ifaces.values_mut())
         {
             iface.base_iface_mut().hide_secrets();
-            if let Interface::MacSec(macsec_iface) = iface {
-                if let Some(macsec_conf) = macsec_iface.macsec.as_mut() {
-                    macsec_conf.hide_secrets();
-                }
+            if let Interface::MacSec(macsec_iface) = iface
+                && let Some(macsec_conf) = macsec_iface.macsec.as_mut()
+            {
+                macsec_conf.hide_secrets();
             }
             if let Interface::Ipsec(ipsec_iface) = iface {
                 ipsec_iface.hide_secrets();
@@ -256,20 +256,17 @@ impl Interfaces {
                     iface.remove_port(ignore_port);
                 }
             }
-            if iface.iface_type() == InterfaceType::Veth {
-                if let Interface::Ethernet(eth_iface) = iface {
-                    if let Some(veth_conf) = eth_iface.veth.as_ref() {
-                        if kernel_iface_names.contains(veth_conf.peer.as_str())
-                        {
-                            log::info!(
-                                "Veth interface {} is holding ignored peer {}",
-                                eth_iface.base.name,
-                                veth_conf.peer.as_str()
-                            );
-                            eth_iface.veth = None;
-                        }
-                    }
-                }
+            if iface.iface_type() == InterfaceType::Veth
+                && let Interface::Ethernet(eth_iface) = iface
+                && let Some(veth_conf) = eth_iface.veth.as_ref()
+                && kernel_iface_names.contains(veth_conf.peer.as_str())
+            {
+                log::info!(
+                    "Veth interface {} is holding ignored peer {}",
+                    eth_iface.base.name,
+                    veth_conf.peer.as_str()
+                );
+                eth_iface.veth = None;
             }
         }
     }
@@ -565,37 +562,35 @@ impl Interfaces {
         }) {
             if let Some(profile_name) =
                 cur_iface.base_iface().profile_name.as_ref()
+                && let Some(des_iface) = self.kernel_ifaces.get(profile_name)
             {
-                if let Some(des_iface) = self.kernel_ifaces.get(profile_name) {
-                    let mut new_iface =
-                        if des_iface.iface_type() == InterfaceType::Unknown {
-                            let mut new_iface_value =
-                                serde_json::to_value(des_iface)?;
-                            if let Some(obj) = new_iface_value.as_object_mut() {
-                                obj.insert(
-                                    "type".to_string(),
-                                    serde_json::Value::String(
-                                        cur_iface.iface_type().to_string(),
-                                    ),
-                                );
-                            }
-                            Interface::deserialize(new_iface_value)?
-                        } else {
-                            des_iface.clone()
-                        };
+                let mut new_iface = if des_iface.iface_type()
+                    == InterfaceType::Unknown
+                {
+                    let mut new_iface_value = serde_json::to_value(des_iface)?;
+                    if let Some(obj) = new_iface_value.as_object_mut() {
+                        obj.insert(
+                            "type".to_string(),
+                            serde_json::Value::String(
+                                cur_iface.iface_type().to_string(),
+                            ),
+                        );
+                    }
+                    Interface::deserialize(new_iface_value)?
+                } else {
+                    des_iface.clone()
+                };
 
-                    new_iface.base_iface_mut().identifier =
-                        Some(InterfaceIdentifier::MacAddress);
-                    new_iface
-                        .base_iface_mut()
-                        .mac_address
-                        .clone_from(&cur_iface.base_iface().mac_address);
-                    new_iface.base_iface_mut().name =
-                        cur_iface.name().to_string();
-                    new_iface.base_iface_mut().profile_name =
-                        Some(profile_name.to_string());
-                    changed_ifaces.push(new_iface);
-                }
+                new_iface.base_iface_mut().identifier =
+                    Some(InterfaceIdentifier::MacAddress);
+                new_iface
+                    .base_iface_mut()
+                    .mac_address
+                    .clone_from(&cur_iface.base_iface().mac_address);
+                new_iface.base_iface_mut().name = cur_iface.name().to_string();
+                new_iface.base_iface_mut().profile_name =
+                    Some(profile_name.to_string());
+                changed_ifaces.push(new_iface);
             }
         }
         for changed_iface in changed_ifaces {
@@ -1047,25 +1042,25 @@ impl MergedInterfaces {
             i.merged.is_up()
                 && i.merged.iface_type() != InterfaceType::OvsInterface
         }) {
-            if let Some(parent) = iface.merged.parent() {
-                if gone_ifaces.contains(&parent.to_string()) {
-                    if iface.is_desired() && iface.merged.is_up() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Interface {} cannot be in up state as its \
-                                 parent {parent} has been marked as absent",
-                                iface.merged.name(),
-                            ),
-                        ));
-                    }
-                    log::info!(
-                        "Marking interface {} as absent as its parent {} is so",
-                        iface.merged.name(),
-                        parent
-                    );
-                    iface.mark_as_absent();
+            if let Some(parent) = iface.merged.parent()
+                && gone_ifaces.contains(&parent.to_string())
+            {
+                if iface.is_desired() && iface.merged.is_up() {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {} cannot be in up state as its parent \
+                             {parent} has been marked as absent",
+                            iface.merged.name(),
+                        ),
+                    ));
                 }
+                log::info!(
+                    "Marking interface {} as absent as its parent {} is so",
+                    iface.merged.name(),
+                    parent
+                );
+                iface.mark_as_absent();
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -71,19 +71,17 @@ impl MergedInterfaces {
                         .desired
                         .as_ref()
                         .and_then(|desire| desire.ports())
+                        && !ports.contains(&merged_iface.merged.name())
                     {
-                        if !ports.contains(&merged_iface.merged.name()) {
-                            return Err(NmstateError::new(
-                                ErrorKind::InvalidArgument,
-                                format!(
-                                    "Interface {} has controller {} but not \
-                                     listed in port list of controller \
-                                     interface",
-                                    merged_iface.merged.name(),
-                                    des_ctrl_name,
-                                ),
-                            ));
-                        }
+                        return Err(NmstateError::new(
+                            ErrorKind::InvalidArgument,
+                            format!(
+                                "Interface {} has controller {} but not \
+                                 listed in port list of controller interface",
+                                merged_iface.merged.name(),
+                                des_ctrl_name,
+                            ),
+                        ));
                     }
                 } else {
                     return Err(NmstateError::new(
@@ -126,31 +124,31 @@ impl MergedInterfaces {
             } else {
                 continue;
             };
-            if let Some(ctrl_name) = port_to_ctrl.get(iface.merged.name()) {
-                if des_ctrl_name != ctrl_name {
-                    if des_ctrl_name.is_empty() {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Interface {} desired to detach controller \
-                                 via controller property set to '', but still \
-                                 been listed as port of controller {} ",
-                                iface.merged.name(),
-                                ctrl_name
-                            ),
-                        ));
-                    } else {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Interface {} has controller property set to \
-                                 {}, but been listed as port of controller {} ",
-                                iface.merged.name(),
-                                des_ctrl_name,
-                                ctrl_name
-                            ),
-                        ));
-                    }
+            if let Some(ctrl_name) = port_to_ctrl.get(iface.merged.name())
+                && des_ctrl_name != ctrl_name
+            {
+                if des_ctrl_name.is_empty() {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {} desired to detach controller via \
+                             controller property set to '', but still been \
+                             listed as port of controller {} ",
+                            iface.merged.name(),
+                            ctrl_name
+                        ),
+                    ));
+                } else {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {} has controller property set to {}, \
+                             but been listed as port of controller {} ",
+                            iface.merged.name(),
+                            des_ctrl_name,
+                            ctrl_name
+                        ),
+                    ));
                 }
             }
         }
@@ -520,13 +518,12 @@ impl MergedInterfaces {
                         .kernel_ifaces
                         .get(parent)
                         .and_then(|i| i.for_apply.as_ref())
+                        && parent_iface.base_iface().is_up_priority_valid()
                     {
-                        if parent_iface.base_iface().is_up_priority_valid() {
-                            pending_changes.insert(
-                                iface_name.to_string(),
-                                parent_iface.base_iface().up_priority + 1,
-                            );
-                        }
+                        pending_changes.insert(
+                            iface_name.to_string(),
+                            parent_iface.base_iface().up_priority + 1,
+                        );
                     }
                 }
             }
@@ -586,10 +583,10 @@ impl MergedInterfaces {
             if let Some(ports) = iface.ports() {
                 let ports = HashSet::from_iter(ports.iter().cloned());
                 if !ib_iface_names.is_disjoint(&ports) {
-                    if let Interface::Bond(iface) = iface {
-                        if iface.mode() == Some(BondMode::ActiveBackup) {
-                            continue;
-                        }
+                    if let Interface::Bond(iface) = iface
+                        && iface.mode() == Some(BondMode::ActiveBackup)
+                    {
+                        continue;
                     }
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,

--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -52,31 +52,30 @@ impl IpsecInterface {
     }
 
     pub(crate) fn hide_secrets(&mut self) {
-        if let Some(c) = self.libreswan.as_mut() {
-            if c.psk.is_some() {
-                c.psk = Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
-            }
+        if let Some(c) = self.libreswan.as_mut()
+            && c.psk.is_some()
+        {
+            c.psk = Some(NetworkState::PASSWORD_HID_BY_NMSTATE.to_string());
         }
     }
 
     // * IPv4 `dhcp: false` with empty static address list should be considered
     //   as IPv4 disabled.
     pub(crate) fn sanitize(&mut self, is_desired: bool) {
-        if let Some(ipv4_conf) = self.base.ipv4.as_mut() {
-            if ipv4_conf.dhcp == Some(false)
-                && ipv4_conf.enabled
-                && ipv4_conf.enabled_defined
-            {
-                if is_desired {
-                    log::info!(
-                        "Treating IPv4 `dhcp: false` for IPSec interface {} \
-                         as IPv4 disabled",
-                        self.base.name.as_str()
-                    );
-                }
-                ipv4_conf.enabled = false;
-                ipv4_conf.dhcp = None;
+        if let Some(ipv4_conf) = self.base.ipv4.as_mut()
+            && ipv4_conf.dhcp == Some(false)
+            && ipv4_conf.enabled
+            && ipv4_conf.enabled_defined
+        {
+            if is_desired {
+                log::info!(
+                    "Treating IPv4 `dhcp: false` for IPSec interface {} as \
+                     IPv4 disabled",
+                    self.base.name.as_str()
+                );
             }
+            ipv4_conf.enabled = false;
+            ipv4_conf.dhcp = None;
         }
     }
 }

--- a/rust/src/lib/ifaces/ipvlan.rs
+++ b/rust/src/lib/ifaces/ipvlan.rs
@@ -47,19 +47,19 @@ impl IpVlanInterface {
         &self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if is_desired {
-            if let Some(conf) = &self.ipvlan {
-                if conf.private == Some(true) && conf.vepa == Some(true) {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        "Both private and VEPA flags cannot be enabled at the \
-                         same time"
-                            .to_string(),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
-            }
+        if is_desired
+            && let Some(conf) = &self.ipvlan
+            && conf.private == Some(true)
+            && conf.vepa == Some(true)
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Both private and VEPA flags cannot be enabled at the same \
+                 time"
+                    .to_string(),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{collections::HashMap, marker::PhantomData, str::FromStr};
 
-use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de, de::Visitor};
 
 use crate::{
     BaseInterface, BridgePortVlanConfig, ErrorKind, InterfaceType,
@@ -106,10 +104,9 @@ impl LinuxBridgeInterface {
     ) -> Result<(), NmstateError> {
         if let Some(opts) =
             self.bridge.as_ref().and_then(|b| b.options.as_ref())
+            && is_desired
         {
-            if is_desired {
-                opts.validate_vlan_default_pvid(self)?;
-            }
+            opts.validate_vlan_default_pvid(self)?;
         }
 
         if let Some(opts) =
@@ -181,19 +178,19 @@ impl LinuxBridgeInterface {
     }
 
     fn sort_ports(&mut self) {
-        if let Some(ref mut br_conf) = self.bridge {
-            if let Some(ref mut port_confs) = &mut br_conf.port {
-                port_confs.sort_unstable_by_key(|p| p.name.clone())
-            }
+        if let Some(br_conf) = self.bridge.as_mut()
+            && let Some(port_confs) = br_conf.port.as_mut()
+        {
+            port_confs.sort_unstable_by_key(|p| p.name.clone())
         }
     }
 
     fn remove_runtime_only_timers(&mut self) {
-        if let Some(ref mut br_conf) = self.bridge {
-            if let Some(ref mut opts) = &mut br_conf.options {
-                opts.gc_timer = None;
-                opts.hello_timer = None;
-            }
+        if let Some(br_conf) = self.bridge.as_mut()
+            && let Some(opts) = br_conf.options.as_mut()
+        {
+            opts.gc_timer = None;
+            opts.hello_timer = None;
         }
     }
 
@@ -269,10 +266,10 @@ impl LinuxBridgeInterface {
         }
 
         for (port_name, port_conf) in des_ports_index.iter() {
-            if let Some(cur_port_conf) = cur_ports_index.get(port_name) {
-                if port_conf.is_changed(cur_port_conf) {
-                    ret.push(port_name);
-                }
+            if let Some(cur_port_conf) = cur_ports_index.get(port_name)
+                && port_conf.is_changed(cur_port_conf)
+            {
+                ret.push(port_name);
             }
         }
         ret
@@ -334,10 +331,10 @@ impl LinuxBridgeInterface {
                 new_ports.push(new_port);
             }
         }
-        if !new_ports.is_empty() {
-            if let Some(br_conf) = self.bridge.as_mut() {
-                br_conf.port = Some(new_ports);
-            }
+        if !new_ports.is_empty()
+            && let Some(br_conf) = self.bridge.as_mut()
+        {
+            br_conf.port = Some(new_ports);
         }
     }
 }
@@ -582,17 +579,18 @@ impl LinuxBridgeOptions {
         &self,
         linux_bridge: &LinuxBridgeInterface,
     ) -> Result<(), NmstateError> {
-        if let Some(pvid) = self.vlan_default_pvid {
-            if pvid != 1 && !linux_bridge.vlan_filtering_is_enabled() {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Linux bridge {} has vlan-default-pvid different than \
-                         1 but VLAN filtering is not enabled.",
-                        linux_bridge.base.name.as_str()
-                    ),
-                ));
-            }
+        if let Some(pvid) = self.vlan_default_pvid
+            && pvid != 1
+            && !linux_bridge.vlan_filtering_is_enabled()
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Linux bridge {} has vlan-default-pvid different than 1 \
+                     but VLAN filtering is not enabled.",
+                    linux_bridge.base.name.as_str()
+                ),
+            ));
         }
 
         Ok(())
@@ -649,57 +647,54 @@ impl LinuxBridgeStpOptions {
     }
 
     pub(crate) fn sanitize(&self) -> Result<(), NmstateError> {
-        if let Some(hello_time) = self.hello_time {
-            if !(Self::HELLO_TIME_MIN..=Self::HELLO_TIME_MAX)
+        if let Some(hello_time) = self.hello_time
+            && !(Self::HELLO_TIME_MIN..=Self::HELLO_TIME_MAX)
                 .contains(&hello_time)
-            {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Desired STP hello time {} is not in the range of \
-                         [{},{}]",
-                        hello_time,
-                        Self::HELLO_TIME_MIN,
-                        Self::HELLO_TIME_MAX
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Desired STP hello time {} is not in the range of [{},{}]",
+                    hello_time,
+                    Self::HELLO_TIME_MIN,
+                    Self::HELLO_TIME_MAX
+                ),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
 
-        if let Some(max_age) = self.max_age {
-            if !(Self::MAX_AGE_MIN..=Self::MAX_AGE_MAX).contains(&max_age) {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Desired STP max age {} is not in the range of [{},{}]",
-                        max_age,
-                        Self::MAX_AGE_MIN,
-                        Self::MAX_AGE_MAX
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        if let Some(max_age) = self.max_age
+            && !(Self::MAX_AGE_MIN..=Self::MAX_AGE_MAX).contains(&max_age)
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Desired STP max age {} is not in the range of [{},{}]",
+                    max_age,
+                    Self::MAX_AGE_MIN,
+                    Self::MAX_AGE_MAX
+                ),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
-        if let Some(forward_delay) = self.forward_delay {
-            if !(Self::FORWARD_DELAY_MIN..=Self::FORWARD_DELAY_MAX)
+        if let Some(forward_delay) = self.forward_delay
+            && !(Self::FORWARD_DELAY_MIN..=Self::FORWARD_DELAY_MAX)
                 .contains(&forward_delay)
-            {
-                let e = NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Desired STP forward delay {} is not in the range of \
-                         [{},{}]",
-                        forward_delay,
-                        Self::FORWARD_DELAY_MIN,
-                        Self::FORWARD_DELAY_MAX
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Desired STP forward delay {} is not in the range of \
+                     [{},{}]",
+                    forward_delay,
+                    Self::FORWARD_DELAY_MIN,
+                    Self::FORWARD_DELAY_MAX
+                ),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/mac_vlan.rs
+++ b/rust/src/lib/ifaces/mac_vlan.rs
@@ -48,21 +48,19 @@ impl MacVlanInterface {
         &self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if is_desired {
-            if let Some(conf) = &self.mac_vlan {
-                if conf.accept_all_mac == Some(false)
-                    && conf.mode != MacVlanMode::Passthru
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        "Disable accept-all-mac-addresses(promiscuous) is \
-                         only allowed on passthru mode"
-                            .to_string(),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
-            }
+        if is_desired
+            && let Some(conf) = &self.mac_vlan
+            && conf.accept_all_mac == Some(false)
+            && conf.mode != MacVlanMode::Passthru
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Disable accept-all-mac-addresses(promiscuous) is only \
+                 allowed on passthru mode"
+                    .to_string(),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/mac_vtap.rs
+++ b/rust/src/lib/ifaces/mac_vtap.rs
@@ -48,21 +48,19 @@ impl MacVtapInterface {
         &self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if is_desired {
-            if let Some(conf) = &self.mac_vtap {
-                if conf.accept_all_mac == Some(false)
-                    && conf.mode != MacVtapMode::Passthru
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        "Disable accept-all-mac-addresses(promiscuous) is \
-                         only allowed on passthru mode"
-                            .to_string(),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
-            }
+        if is_desired
+            && let Some(conf) = &self.mac_vtap
+            && conf.accept_all_mac == Some(false)
+            && conf.mode != MacVtapMode::Passthru
+        {
+            let e = NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Disable accept-all-mac-addresses(promiscuous) is only \
+                 allowed on passthru mode"
+                    .to_string(),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/macsec.rs
+++ b/rust/src/lib/ifaces/macsec.rs
@@ -55,44 +55,39 @@ impl MacSecInterface {
         &self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if is_desired {
-            if let Some(conf) = &self.macsec {
-                if conf.mka_cak.is_none() ^ conf.mka_ckn.is_none() {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        "The mka_cak and mka_cnk must be all missing or \
-                         present."
-                            .to_string(),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
-                if let Some(mka_cak) = &conf.mka_cak {
-                    if mka_cak.len() != 32 {
-                        let e = NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "The mka_cak must be a string of 32 characters"
-                                .to_string(),
-                        );
-                        log::error!("{e}");
-                        return Err(e);
-                    }
-                }
-                if let Some(mka_ckn) = &conf.mka_ckn {
-                    if mka_ckn.len() > 64
-                        || mka_ckn.len() < 2
-                        || mka_ckn.len() % 2 == 1
-                    {
-                        let e = NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "The mka_ckn must be a string of even size \
-                             between 2 and 64 characters"
-                                .to_string(),
-                        );
-                        log::error!("{e}");
-                        return Err(e);
-                    }
-                }
+        if is_desired && let Some(conf) = &self.macsec {
+            if conf.mka_cak.is_none() ^ conf.mka_ckn.is_none() {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "The mka_cak and mka_cnk must be all missing or present."
+                        .to_string(),
+                );
+                log::error!("{e}");
+                return Err(e);
+            }
+            if let Some(mka_cak) = &conf.mka_cak
+                && mka_cak.len() != 32
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "The mka_cak must be a string of 32 characters".to_string(),
+                );
+                log::error!("{e}");
+                return Err(e);
+            }
+            if let Some(mka_ckn) = &conf.mka_ckn
+                && (mka_ckn.len() > 64
+                    || mka_ckn.len() < 2
+                    || mka_ckn.len() % 2 == 1)
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "The mka_ckn must be a string of even size between 2 and \
+                     64 characters"
+                        .to_string(),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -26,9 +26,6 @@ mod ovs;
 mod sriov;
 mod vlan;
 
-pub use self::alt_name::{AltNameEntry, AltNameState};
-pub(crate) use self::inter_ifaces::MergedInterfaces;
-pub use self::xfrm::XfrmInterface;
 pub use base::*;
 pub use bond::{
     BondAdSelect, BondAllPortsActive, BondArpAllTargets, BondArpValidate,
@@ -77,3 +74,9 @@ pub use vlan::{
 };
 pub use vrf::{VrfConfig, VrfInterface};
 pub use vxlan::{VxlanConfig, VxlanInterface};
+
+pub(crate) use self::inter_ifaces::MergedInterfaces;
+pub use self::{
+    alt_name::{AltNameEntry, AltNameState},
+    xfrm::XfrmInterface,
+};

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::{
     BaseInterface, BridgePortVlanConfig, ErrorKind, Interface, InterfaceState,
@@ -63,20 +63,20 @@ impl Default for OvsBridgeInterface {
 impl OvsBridgeInterface {
     // Return None when desire state does not mention ports
     pub(crate) fn ports(&self) -> Option<Vec<&str>> {
-        if let Some(br_conf) = &self.bridge {
-            if let Some(port_confs) = &br_conf.ports {
-                let mut port_names = Vec::new();
-                for port_conf in port_confs {
-                    if let Some(bond_conf) = &port_conf.bond {
-                        for port_name in bond_conf.ports() {
-                            port_names.push(port_name);
-                        }
-                    } else {
-                        port_names.push(port_conf.name.as_str());
+        if let Some(br_conf) = &self.bridge
+            && let Some(port_confs) = &br_conf.ports
+        {
+            let mut port_names = Vec::new();
+            for port_conf in port_confs {
+                if let Some(bond_conf) = &port_conf.bond {
+                    for port_name in bond_conf.ports() {
+                        port_names.push(port_name);
                     }
+                } else {
+                    port_names.push(port_conf.name.as_str());
                 }
-                return Some(port_names);
             }
+            return Some(port_names);
         }
         None
     }
@@ -87,24 +87,24 @@ impl OvsBridgeInterface {
 
     pub(crate) fn port_confs(&self) -> Vec<&OvsBridgePortConfig> {
         let mut ret: Vec<&OvsBridgePortConfig> = Vec::new();
-        if let Some(br_conf) = &self.bridge {
-            if let Some(port_confs) = &br_conf.ports {
-                for port_conf in port_confs {
-                    ret.push(port_conf)
-                }
+        if let Some(br_conf) = &self.bridge
+            && let Some(port_confs) = &br_conf.ports
+        {
+            for port_conf in port_confs {
+                ret.push(port_conf)
             }
         }
         ret
     }
 
     pub(crate) fn sort_ports(&mut self) {
-        if let Some(ref mut br_conf) = self.bridge {
-            if let Some(ref mut port_confs) = &mut br_conf.ports {
-                port_confs.sort_unstable_by_key(|p| p.name.clone());
-                for port_conf in port_confs {
-                    if let Some(ref mut bond_conf) = port_conf.bond {
-                        bond_conf.sort_ports();
-                    }
+        if let Some(br_conf) = self.bridge.as_mut()
+            && let Some(port_confs) = br_conf.ports.as_mut()
+        {
+            port_confs.sort_unstable_by_key(|p| p.name.clone());
+            for port_conf in port_confs {
+                if let Some(bond_conf) = port_conf.bond.as_mut() {
+                    bond_conf.sort_ports();
                 }
             }
         }
@@ -115,26 +115,27 @@ impl OvsBridgeInterface {
         &mut self,
         is_desired: bool,
     ) -> Result<(), NmstateError> {
-        if let Some(mtu) = self.base.mtu.as_ref() {
-            if is_desired {
-                log::warn!(
-                    "OVS Bridge {} could not hold 'mtu:{mtu}' configuration \
-                     as it only exists in OVS database, ignoring",
-                    self.base.name.as_str()
-                );
-            }
+        if let Some(mtu) = self.base.mtu.as_ref()
+            && is_desired
+        {
+            log::warn!(
+                "OVS Bridge {} could not hold 'mtu:{mtu}' configuration as it \
+                 only exists in OVS database, ignoring",
+                self.base.name.as_str()
+            );
         }
-        if let Some(mac) = self.base.mac_address.as_ref() {
-            if !mac.is_empty() && is_desired {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "OVS Bridge {} can not hold MAC address, please set \
-                         MAC address on OVS internal interface instead",
-                        self.base.name.as_str()
-                    ),
-                ));
-            }
+        if let Some(mac) = self.base.mac_address.as_ref()
+            && !mac.is_empty()
+            && is_desired
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "OVS Bridge {} can not hold MAC address, please set MAC \
+                     address on OVS internal interface instead",
+                    self.base.name.as_str()
+                ),
+            ));
         }
         self.base.mtu = None;
         self.base.ipv4 = None;
@@ -205,20 +206,18 @@ impl OvsBridgeInterface {
                         .unwrap_or_default()
                 })
             })
-        {
-            if let Some(bond_port_confs) = self
+            && let Some(bond_port_confs) = self
                 .bridge
                 .as_mut()
                 .and_then(|br_conf| br_conf.ports.as_mut())
                 .and_then(|ports| ports.get_mut(index))
                 .and_then(|port_conf| port_conf.bond.as_mut())
                 .and_then(|bond_conf| bond_conf.ports.as_mut())
-            {
-                for bond_port_conf in bond_port_confs {
-                    if bond_port_conf.name == origin_name {
-                        bond_port_conf.name = new_name;
-                        break;
-                    }
+        {
+            for bond_port_conf in bond_port_confs {
+                if bond_port_conf.name == origin_name {
+                    bond_port_conf.name = new_name;
+                    break;
                 }
             }
         }
@@ -246,10 +245,10 @@ impl OvsBridgeInterface {
                 new_ports.push(new_port);
             }
         }
-        if !new_ports.is_empty() {
-            if let Some(br_conf) = self.bridge.as_mut() {
-                br_conf.ports = Some(new_ports);
-            }
+        if !new_ports.is_empty()
+            && let Some(br_conf) = self.bridge.as_mut()
+        {
+            br_conf.ports = Some(new_ports);
         }
     }
 }
@@ -563,7 +562,7 @@ impl OvsBridgeBondConfig {
     }
 
     pub(crate) fn sort_ports(&mut self) {
-        if let Some(ref mut bond_ports) = self.ports {
+        if let Some(bond_ports) = self.ports.as_mut() {
             bond_ports.sort_unstable_by_key(|p| p.name.clone())
         }
     }
@@ -768,10 +767,10 @@ impl MergedInterface {
                     })
                 }
 
-                if let Some(br_conf) = verify_iface.bridge.as_mut() {
-                    if br_conf.ports.is_some() {
-                        br_conf.ports = Some(port_confs);
-                    }
+                if let Some(br_conf) = verify_iface.bridge.as_mut()
+                    && br_conf.ports.is_some()
+                {
+                    br_conf.ports = Some(port_confs);
                 }
             }
         }

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -87,19 +87,18 @@ impl SrIovConfig {
                     address.make_ascii_uppercase()
                 }
 
-                if let Some(VlanProtocol::Ieee8021Ad) = vf.vlan_proto {
-                    if vf.vlan_id.unwrap_or_default() == 0
-                        && vf.qos.unwrap_or_default() == 0
-                    {
-                        let e = NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            "VLAN protocol 802.1ad is not allowed when both \
-                             VLAN ID and VLAN QoS are zero or unset"
-                                .to_string(),
-                        );
-                        log::error!("VF ID {}: {}", vf.id, e);
-                        return Err(e);
-                    }
+                if let Some(VlanProtocol::Ieee8021Ad) = vf.vlan_proto
+                    && vf.vlan_id.unwrap_or_default() == 0
+                    && vf.qos.unwrap_or_default() == 0
+                {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        "VLAN protocol 802.1ad is not allowed when both VLAN \
+                         ID and VLAN QoS are zero or unset"
+                            .to_string(),
+                    );
+                    log::error!("VF ID {}: {}", vf.id, e);
+                    return Err(e);
                 }
             }
             vfs.sort_unstable_by(|a, b| a.id.cmp(&b.id));
@@ -374,20 +373,18 @@ fn get_sriov_vf_iface_name(
 ) -> Option<String> {
     if let Some(Interface::Ethernet(pf_iface)) =
         current.get_iface(pf_name, InterfaceType::Ethernet)
-    {
-        if let Some(vfs) = pf_iface
+        && let Some(vfs) = pf_iface
             .ethernet
             .as_ref()
             .and_then(|e| e.sr_iov.as_ref())
             .and_then(|s| s.vfs.as_ref())
-        {
-            for vf in vfs {
-                if vf.id == vf_id {
-                    if !vf.iface_name.is_empty() {
-                        return Some(vf.iface_name.clone());
-                    }
-                    break;
+    {
+        for vf in vfs {
+            if vf.id == vf_id {
+                if !vf.iface_name.is_empty() {
+                    return Some(vf.iface_name.clone());
                 }
+                break;
             }
         }
     }

--- a/rust/src/lib/ifaces/vlan.rs
+++ b/rust/src/lib/ifaces/vlan.rs
@@ -212,17 +212,15 @@ impl MergedInterface {
                     .as_ref()
                     .and_then(|v| v.reorder_headers.as_ref())
                     != Some(&false)
+                    && let Some(vlan_conf) = apply_iface.vlan.as_mut()
+                    && vlan_conf.reorder_headers.is_none()
                 {
-                    if let Some(vlan_conf) = apply_iface.vlan.as_mut() {
-                        if vlan_conf.reorder_headers.is_none() {
-                            vlan_conf.reorder_headers = Some(true);
-                        }
-                    }
-                }
-            } else if let Some(vlan_conf) = apply_iface.vlan.as_mut() {
-                if vlan_conf.reorder_headers.is_none() {
                     vlan_conf.reorder_headers = Some(true);
                 }
+            } else if let Some(vlan_conf) = apply_iface.vlan.as_mut()
+                && vlan_conf.reorder_headers.is_none()
+            {
+                vlan_conf.reorder_headers = Some(true);
             }
         }
 
@@ -232,21 +230,21 @@ impl MergedInterface {
             Some(Interface::Vlan(cur_iface)),
         ) = (&mut self.for_apply, &mut self.for_verify, &self.current)
         {
-            if let Some(apply_vlan) = &mut apply_iface.vlan {
-                if apply_vlan.base_iface.is_none() {
-                    apply_vlan.base_iface = cur_iface
-                        .vlan
-                        .as_ref()
-                        .and_then(|vlan| vlan.base_iface.clone());
-                }
+            if let Some(apply_vlan) = &mut apply_iface.vlan
+                && apply_vlan.base_iface.is_none()
+            {
+                apply_vlan.base_iface = cur_iface
+                    .vlan
+                    .as_ref()
+                    .and_then(|vlan| vlan.base_iface.clone());
             }
-            if let Some(verify_vlan) = &mut verify_iface.vlan {
-                if verify_vlan.base_iface.is_none() {
-                    verify_vlan.base_iface = cur_iface
-                        .vlan
-                        .as_ref()
-                        .and_then(|vlan| vlan.base_iface.clone());
-                }
+            if let Some(verify_vlan) = &mut verify_iface.vlan
+                && verify_vlan.base_iface.is_none()
+            {
+                verify_vlan.base_iface = cur_iface
+                    .vlan
+                    .as_ref()
+                    .and_then(|vlan| vlan.base_iface.clone());
             }
         }
     }

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -72,14 +71,12 @@ impl VrfInterface {
     ) -> Result<(), NmstateError> {
         // Ignoring the changes of MAC address of VRF as it is a layer 3
         // interface.
-        if is_desired {
-            if let Some(mac) = self.base.mac_address.as_ref() {
-                log::warn!(
-                    "Ignoring MAC address {mac} of VRF interface {} as it is \
-                     a layer 3(IP) interface",
-                    self.base.name.as_str()
-                );
-            }
+        if is_desired && let Some(mac) = self.base.mac_address.as_ref() {
+            log::warn!(
+                "Ignoring MAC address {mac} of VRF interface {} as it is a \
+                 layer 3(IP) interface",
+                self.base.name.as_str()
+            );
         }
         self.base.mac_address = None;
         if self.base.accept_all_mac_addresses == Some(false) {
@@ -266,18 +263,18 @@ impl Routes {
                         format!("VRF defined in Route '{rt}' does not exist"),
                     ));
                 };
-                if let Some(des_table_id) = rt.table_id {
-                    if des_table_id != table_id {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Route '{rt}' has both table id and VRF name \
-                                 defined, but desired table ID is {} while \
-                                 table ID for VRF {} is {}",
-                                des_table_id, vrf_name, table_id
-                            ),
-                        ));
-                    }
+                if let Some(des_table_id) = rt.table_id
+                    && des_table_id != table_id
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Route '{rt}' has both table id and VRF name \
+                             defined, but desired table ID is {} while table \
+                             ID for VRF {} is {}",
+                            des_table_id, vrf_name, table_id
+                        ),
+                    ));
                 }
                 rt.table_id = Some(table_id);
             }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-use std::fmt::Write;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
+use std::{
+    collections::HashSet,
+    fmt::Write,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -291,25 +293,27 @@ impl InterfaceIpv4 {
             if self.auto_gateway.is_none() {
                 self.auto_gateway = Some(true);
             }
-            if let Some(addrs) = self.addresses.as_ref() {
-                if is_desired {
-                    for addr in addrs {
-                        log::info!(
-                            "Static addresses {addr} defined when dynamic IP \
-                             is enabled"
-                        );
-                    }
+            if let Some(addrs) = self.addresses.as_ref()
+                && is_desired
+            {
+                for addr in addrs {
+                    log::info!(
+                        "Static addresses {addr} defined when dynamic IP is \
+                         enabled"
+                    );
                 }
             }
         }
 
-        if let Some(forwarding) = self.forwarding {
-            if !self.enabled && forwarding && is_desired {
-                log::warn!(
-                    "Ignoring `forwarding: {forwarding}` as IPv4 is disabled",
-                );
-                self.forwarding = None;
-            }
+        if let Some(forwarding) = self.forwarding
+            && !self.enabled
+            && forwarding
+            && is_desired
+        {
+            log::warn!(
+                "Ignoring `forwarding: {forwarding}` as IPv4 is disabled",
+            );
+            self.forwarding = None;
         }
 
         if let Some(addrs) = self.addresses.as_mut() {
@@ -369,18 +373,15 @@ impl InterfaceIpv4 {
             self.dhcp_custom_hostname = None;
         }
         if self.dhcp_send_hostname == Some(false) {
-            if is_desired {
-                if let Some(custom_hostname) =
+            if is_desired
+                && let Some(custom_hostname) =
                     self.dhcp_custom_hostname.as_deref()
-                {
-                    if !custom_hostname.is_empty() {
-                        log::warn!(
-                            "Ignoring `dhcp-custom-hostname: \
-                             {custom_hostname}` as `dhcp-send-hostname` is \
-                             disabled"
-                        );
-                    }
-                }
+                && !custom_hostname.is_empty()
+            {
+                log::warn!(
+                    "Ignoring `dhcp-custom-hostname: {custom_hostname}` as \
+                     `dhcp-send-hostname` is disabled"
+                );
             }
             self.dhcp_custom_hostname = None;
         }
@@ -635,14 +636,14 @@ impl InterfaceIpv6 {
             if self.auto_gateway.is_none() {
                 self.auto_gateway = Some(true);
             }
-            if let Some(addrs) = self.addresses.as_ref() {
-                if is_desired {
-                    for addr in addrs {
-                        log::info!(
-                            "Static addresses {addr} defined when dynamic IP \
-                             is enabled"
-                        );
-                    }
+            if let Some(addrs) = self.addresses.as_ref()
+                && is_desired
+            {
+                for addr in addrs {
+                    log::info!(
+                        "Static addresses {addr} defined when dynamic IP is \
+                         enabled"
+                    );
                 }
             }
         }
@@ -705,18 +706,15 @@ impl InterfaceIpv6 {
             sanitize_ipv6_token_to_string(token)?;
         }
         if self.dhcp_send_hostname == Some(false) {
-            if is_desired {
-                if let Some(custom_hostname) =
+            if is_desired
+                && let Some(custom_hostname) =
                     self.dhcp_custom_hostname.as_deref()
-                {
-                    if !custom_hostname.is_empty() {
-                        log::warn!(
-                            "Ignoring `dhcp-custom-hostname: \
-                             {custom_hostname}` as `dhcp-send-hostname` is \
-                             disabled"
-                        );
-                    }
-                }
+                && !custom_hostname.is_empty()
+            {
+                log::warn!(
+                    "Ignoring `dhcp-custom-hostname: {custom_hostname}` as \
+                     `dhcp-send-hostname` is disabled"
+                );
             }
             self.dhcp_custom_hostname = None;
         }
@@ -971,11 +969,7 @@ impl std::convert::TryFrom<&str> for InterfaceIpAddr {
         })?;
 
         let prefix_length = if addr[1].is_empty() {
-            if ip.is_ipv6() {
-                128
-            } else {
-                32
-            }
+            if ip.is_ipv6() { 128 } else { 32 }
         } else {
             addr[1].parse::<u8>().map_err(|parse_error| {
                 let e = NmstateError::new(
@@ -1254,11 +1248,7 @@ pub(crate) fn sanitize_ip_network(
 }
 
 fn is_none_or_empty_mptcp_flags(v: &Option<Vec<MptcpAddressFlag>>) -> bool {
-    if let Some(v) = v {
-        v.is_empty()
-    } else {
-        true
-    }
+    if let Some(v) = v { v.is_empty() } else { true }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -122,74 +122,75 @@ mod unit_tests;
 #[cfg(feature = "query_apply")]
 mod validate;
 
-pub use crate::dispatch::DispatchConfig;
-pub(crate) use crate::dns::MergedDnsState;
-pub use crate::dns::{DnsClientState, DnsState};
-pub use crate::error::{ErrorKind, NmstateError};
-pub use crate::hostname::HostNameState;
-pub(crate) use crate::hostname::MergedHostNameState;
-pub use crate::ieee8021x::Ieee8021XConfig;
-pub(crate) use crate::iface::MergedInterface;
-pub use crate::iface::{
-    Interface, InterfaceIdentifier, InterfaceState, InterfaceType,
-    UnknownInterface,
-};
-pub(crate) use crate::ifaces::MergedInterfaces;
-pub use crate::ifaces::{
-    AltNameEntry, AltNameState, BaseInterface, BondAdSelect,
-    BondAllPortsActive, BondArpAllTargets, BondArpValidate, BondConfig,
-    BondFailOverMac, BondInterface, BondLacpRate, BondMode, BondOptions,
-    BondPortConfig, BondPrimaryReselect, BondXmitHashPolicy,
-    BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
-    BridgePortVlanRange, DummyInterface, EthernetConfig, EthernetDuplex,
-    EthernetInterface, EthtoolCoalesceConfig, EthtoolConfig,
-    EthtoolFeatureConfig, EthtoolFecConfig, EthtoolFecMode, EthtoolPauseConfig,
-    EthtoolRingConfig, HsrConfig, HsrInterface, HsrProtocol, InfiniBandConfig,
-    InfiniBandInterface, InfiniBandMode, Interfaces, IpVlanConfig,
-    IpVlanInterface, IpVlanMode, IpsecInterface, LibreswanAddressFamily,
-    LibreswanConfig, LibreswanConnectionType, LinuxBridgeConfig,
-    LinuxBridgeInterface, LinuxBridgeMulticastRouterType, LinuxBridgeOptions,
-    LinuxBridgePortConfig, LinuxBridgeStpOptions, LoopbackInterface,
-    MacSecConfig, MacSecInterface, MacSecOffload, MacSecValidate,
-    MacVlanConfig, MacVlanInterface, MacVlanMode, MacVtapConfig,
-    MacVtapInterface, MacVtapMode, OvsBridgeBondConfig, OvsBridgeBondMode,
-    OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
-    OvsBridgeOptions, OvsBridgePortConfig, OvsBridgeStpOptions, OvsDpdkConfig,
-    OvsInterface, OvsPatchConfig, SrIovConfig, SrIovVfConfig, VethConfig,
-    VlanConfig, VlanInterface, VlanProtocol, VlanQosMapping,
-    VlanRegistrationProtocol, VrfConfig, VrfInterface, VxlanConfig,
-    VxlanInterface, XfrmInterface,
-};
-pub use crate::ip::{
-    AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr, InterfaceIpv4,
-    InterfaceIpv6, Ipv6AddrGenMode, WaitIp,
-};
-pub use crate::lldp::{
-    LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
-    LldpMacPhy, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs, LldpNeighborTlv,
-    LldpPortId, LldpPortIdType, LldpPpvids, LldpSystemCapabilities,
-    LldpSystemCapability, LldpSystemDescription, LldpSystemName, LldpVlan,
-    LldpVlans,
-};
-pub use crate::mptcp::{MptcpAddressFlag, MptcpConfig};
-pub use crate::net_state::NetworkState;
-pub(crate) use crate::net_state::{MergedNetworkState, NetworkStateMode};
-pub(crate) use crate::ovn::MergedOvnConfiguration;
-pub use crate::ovn::{
-    OvnBridgeMapping, OvnBridgeMappingState, OvnConfiguration,
-};
-pub(crate) use crate::ovs::MergedOvsDbGlobalConfig;
-pub use crate::ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig};
-pub use crate::pci_address::PciAddress;
 #[cfg(feature = "query_apply")]
 pub use crate::policy::{
     NetworkCaptureRules, NetworkPolicy, NetworkStateTemplate,
 };
-pub(crate) use crate::route::MergedRoutes;
-pub use crate::route::{RouteEntry, RouteState, RouteType, Routes};
-pub(crate) use crate::route_rule::MergedRouteRules;
-pub use crate::route_rule::{
-    RouteRuleAction, RouteRuleEntry, RouteRuleState, RouteRules,
-};
 #[cfg(feature = "query_apply")]
 pub use crate::statistic::{NmstateFeature, NmstateStatistic};
+pub use crate::{
+    dispatch::DispatchConfig,
+    dns::{DnsClientState, DnsState},
+    error::{ErrorKind, NmstateError},
+    hostname::HostNameState,
+    ieee8021x::Ieee8021XConfig,
+    iface::{
+        Interface, InterfaceIdentifier, InterfaceState, InterfaceType,
+        UnknownInterface,
+    },
+    ifaces::{
+        AltNameEntry, AltNameState, BaseInterface, BondAdSelect,
+        BondAllPortsActive, BondArpAllTargets, BondArpValidate, BondConfig,
+        BondFailOverMac, BondInterface, BondLacpRate, BondMode, BondOptions,
+        BondPortConfig, BondPrimaryReselect, BondXmitHashPolicy,
+        BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
+        BridgePortVlanRange, DummyInterface, EthernetConfig, EthernetDuplex,
+        EthernetInterface, EthtoolCoalesceConfig, EthtoolConfig,
+        EthtoolFeatureConfig, EthtoolFecConfig, EthtoolFecMode,
+        EthtoolPauseConfig, EthtoolRingConfig, HsrConfig, HsrInterface,
+        HsrProtocol, InfiniBandConfig, InfiniBandInterface, InfiniBandMode,
+        Interfaces, IpVlanConfig, IpVlanInterface, IpVlanMode, IpsecInterface,
+        LibreswanAddressFamily, LibreswanConfig, LibreswanConnectionType,
+        LinuxBridgeConfig, LinuxBridgeInterface,
+        LinuxBridgeMulticastRouterType, LinuxBridgeOptions,
+        LinuxBridgePortConfig, LinuxBridgeStpOptions, LoopbackInterface,
+        MacSecConfig, MacSecInterface, MacSecOffload, MacSecValidate,
+        MacVlanConfig, MacVlanInterface, MacVlanMode, MacVtapConfig,
+        MacVtapInterface, MacVtapMode, OvsBridgeBondConfig, OvsBridgeBondMode,
+        OvsBridgeBondPortConfig, OvsBridgeConfig, OvsBridgeInterface,
+        OvsBridgeOptions, OvsBridgePortConfig, OvsBridgeStpOptions,
+        OvsDpdkConfig, OvsInterface, OvsPatchConfig, SrIovConfig,
+        SrIovVfConfig, VethConfig, VlanConfig, VlanInterface, VlanProtocol,
+        VlanQosMapping, VlanRegistrationProtocol, VrfConfig, VrfInterface,
+        VxlanConfig, VxlanInterface, XfrmInterface,
+    },
+    ip::{
+        AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr,
+        InterfaceIpv4, InterfaceIpv6, Ipv6AddrGenMode, WaitIp,
+    },
+    lldp::{
+        LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,
+        LldpMacPhy, LldpMaxFrameSize, LldpMgmtAddr, LldpMgmtAddrs,
+        LldpNeighborTlv, LldpPortId, LldpPortIdType, LldpPpvids,
+        LldpSystemCapabilities, LldpSystemCapability, LldpSystemDescription,
+        LldpSystemName, LldpVlan, LldpVlans,
+    },
+    mptcp::{MptcpAddressFlag, MptcpConfig},
+    net_state::NetworkState,
+    ovn::{OvnBridgeMapping, OvnBridgeMappingState, OvnConfiguration},
+    ovs::{OvsDbGlobalConfig, OvsDbIfaceConfig},
+    pci_address::PciAddress,
+    route::{RouteEntry, RouteState, RouteType, Routes},
+    route_rule::{RouteRuleAction, RouteRuleEntry, RouteRuleState, RouteRules},
+};
+pub(crate) use crate::{
+    dns::MergedDnsState,
+    hostname::MergedHostNameState,
+    iface::MergedInterface,
+    ifaces::MergedInterfaces,
+    net_state::{MergedNetworkState, NetworkStateMode},
+    ovn::MergedOvnConfiguration,
+    ovs::MergedOvsDbGlobalConfig,
+    route::MergedRoutes,
+    route_rule::MergedRouteRules,
+};

--- a/rust/src/lib/lldp.rs
+++ b/rust/src/lib/lldp.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{de::IgnoredAny, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de::IgnoredAny};
 
 const LLDP_SYS_CAP_OTHER: u16 = 1;
 const LLDP_SYS_CAP_REPEATER: u16 = 2;

--- a/rust/src/lib/mptcp.rs
+++ b/rust/src/lib/mptcp.rs
@@ -59,18 +59,16 @@ impl MergedInterface {
         if let Some(iface) = self.for_apply.as_ref().map(|i| i.base_iface()) {
             if let Some(iface_flags) =
                 iface.mptcp.as_ref().and_then(|m| m.address_flags.as_ref())
+                && iface_flags.contains(&MptcpAddressFlag::Signal)
+                && iface_flags.contains(&MptcpAddressFlag::Fullmesh)
             {
-                if iface_flags.contains(&MptcpAddressFlag::Signal)
-                    && iface_flags.contains(&MptcpAddressFlag::Fullmesh)
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        "MPTCP flags mustn't have both signal and fullmesh"
-                            .to_string(),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "MPTCP flags mustn't have both signal and fullmesh"
+                        .to_string(),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
             validate_iface_mptcp_and_addr_mptcp_flags(iface);
         }

--- a/rust/src/lib/nispor/alt_name.rs
+++ b/rust/src/lib/nispor/alt_name.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-use std::fmt::Write;
+use std::{collections::HashSet, fmt::Write};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -293,10 +292,10 @@ async fn save_systemd_network_link_file(
             };
             // Include driver in match rule in case we have two NIC holding the
             // same MAC. (e.g. M$ Azure - Microsoft Azure Network Adapter)
-            if let Some(cur_base_iface) = cur_base_iface.as_ref() {
-                if let Some(driver) = cur_base_iface.driver.as_ref() {
-                    write!(match_rules, "\nDriver={driver}").ok();
-                }
+            if let Some(cur_base_iface) = cur_base_iface.as_ref()
+                && let Some(driver) = cur_base_iface.driver.as_ref()
+            {
+                write!(match_rules, "\nDriver={driver}").ok();
             }
             match_rules
         }

--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    ErrorKind, Interface, InterfaceType, MergedInterface, MergedInterfaces,
+    MergedNetworkState, NmstateError,
     nispor::{
         apply_ifaces_alt_names,
         dns::apply_dns_conf_to_etc,
@@ -10,8 +12,6 @@ use crate::{
         veth::{nms_veth_conf_to_np, process_new_veth_peer},
         vlan::nms_vlan_conf_to_np,
     },
-    ErrorKind, Interface, InterfaceType, MergedInterface, MergedInterfaces,
-    MergedNetworkState, NmstateError,
 };
 
 pub(crate) async fn nispor_apply(
@@ -114,10 +114,10 @@ fn nmstate_iface_to_np(
 
     let mut np_iface_type = nmstate_iface_type_to_np(&nms_iface.iface_type());
 
-    if let Interface::Ethernet(iface) = nms_iface {
-        if iface.veth.is_some() {
-            np_iface_type = nispor::IfaceType::Veth;
-        }
+    if let Interface::Ethernet(iface) = nms_iface
+        && iface.veth.is_some()
+    {
+        np_iface_type = nispor::IfaceType::Veth;
     }
 
     np_iface.name = nms_iface.name().to_string();
@@ -165,15 +165,14 @@ async fn delete_ifaces(
             continue;
         }
 
-        if let Some(Interface::Ethernet(eth_iface)) = &iface.current {
-            if let Some(peer_name) = eth_iface
+        if let Some(Interface::Ethernet(eth_iface)) = &iface.current
+            && let Some(peer_name) = eth_iface
                 .veth
                 .as_ref()
                 .map(|veth_conf| veth_conf.peer.as_str())
-            {
-                deleted_veths.push(eth_iface.base.name.as_str());
-                deleted_veths.push(peer_name);
-            }
+        {
+            deleted_veths.push(eth_iface.base.name.as_str());
+            deleted_veths.push(peer_name);
         }
 
         if iface.for_apply.as_ref().is_some() {

--- a/rust/src/lib/nispor/base_iface.rs
+++ b/rust/src/lib/nispor/base_iface.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nispor::ethtool::np_ethtool_to_nmstate,
-    nispor::ip::{np_ipv4_to_nmstate, np_ipv6_to_nmstate},
-    nispor::mptcp::get_iface_mptcp_conf,
     AltNameEntry, BaseInterface, InterfaceState, InterfaceType, PciAddress,
+    nispor::{
+        ethtool::np_ethtool_to_nmstate,
+        ip::{np_ipv4_to_nmstate, np_ipv6_to_nmstate},
+        mptcp::get_iface_mptcp_conf,
+    },
 };
 
 fn np_iface_type_to_nmstate(
@@ -76,11 +78,7 @@ pub(crate) fn np_iface_to_base_iface(
         },
         min_mtu: if !running_config_only {
             if let Some(mtu) = np_iface.min_mtu {
-                if mtu >= 0 {
-                    Some(mtu as u64)
-                } else {
-                    None
-                }
+                if mtu >= 0 { Some(mtu as u64) } else { None }
             } else {
                 None
             }
@@ -89,11 +87,7 @@ pub(crate) fn np_iface_to_base_iface(
         },
         max_mtu: if !running_config_only {
             if let Some(mtu) = np_iface.max_mtu {
-                if mtu >= 0 {
-                    Some(mtu as u64)
-                } else {
-                    None
-                }
+                if mtu >= 0 { Some(mtu as u64) } else { None }
             } else {
                 None
             }
@@ -164,9 +158,5 @@ fn get_alt_names(np_iface: &nispor::Iface) -> Option<Vec<AltNameEntry>> {
         })
         .collect();
 
-    if ret.is_empty() {
-        None
-    } else {
-        Some(ret)
-    }
+    if ret.is_empty() { None } else { Some(ret) }
 }

--- a/rust/src/lib/nispor/bond.rs
+++ b/rust/src/lib/nispor/bond.rs
@@ -79,7 +79,7 @@ pub(crate) fn append_bond_port_config(
 
 fn np_bond_options_to_nmstate(np_iface: &nispor::Iface) -> BondOptions {
     let mut options = BondOptions::default();
-    if let Some(ref np_bond) = &np_iface.bond {
+    if let Some(np_bond) = &np_iface.bond {
         options.ad_actor_sys_prio = np_bond.ad_actor_sys_prio;
         options.ad_actor_system.clone_from(&np_bond.ad_actor_system);
         options.ad_select = np_bond.ad_select.as_ref().and_then(|r| match r {

--- a/rust/src/lib/nispor/dns.rs
+++ b/rust/src/lib/nispor/dns.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Write as _FmtWrite;
-use std::io::{Read, Write};
-use std::os::unix::fs::OpenOptionsExt;
+use std::{
+    fmt::Write as _FmtWrite,
+    io::{Read, Write},
+    os::unix::fs::OpenOptionsExt,
+};
 
 use crate::{
     DnsClientState, DnsState, ErrorKind, MergedDnsState, NmstateError,
@@ -23,12 +25,9 @@ pub(crate) fn get_dns() -> Option<DnsState> {
             for line in content.split('\n') {
                 if let Some(srv) =
                     line.strip_prefix("nameserver ").map(|s| s.trim())
+                    && !srv.is_empty()
                 {
-                    if !srv.is_empty() {
-                        conf.server
-                            .get_or_insert(Vec::new())
-                            .push(srv.to_string());
-                    }
+                    conf.server.get_or_insert(Vec::new()).push(srv.to_string());
                 }
                 if let Some(opts) =
                     line.strip_prefix("options ").map(|s| s.trim())

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{fs, path};
+
 use crate::{
     BaseInterface, EthernetConfig, EthernetDuplex, EthernetInterface,
     SrIovConfig, SrIovVfConfig, VlanProtocol,
 };
-use std::{fs, path};
 
 pub(crate) fn np_ethernet_to_nmstate(
     np_iface: &nispor::Iface,
@@ -44,21 +45,21 @@ fn gen_eth_conf(np_iface: &nispor::Iface) -> EthernetConfig {
             }
         }
     }
-    if let Some(ethtool_info) = &np_iface.ethtool {
-        if let Some(link_mode_info) = &ethtool_info.link_mode {
-            if link_mode_info.speed > 0 {
-                eth_conf.speed = Some(link_mode_info.speed);
+    if let Some(ethtool_info) = &np_iface.ethtool
+        && let Some(link_mode_info) = &ethtool_info.link_mode
+    {
+        if link_mode_info.speed > 0 {
+            eth_conf.speed = Some(link_mode_info.speed);
+        }
+        eth_conf.auto_neg = Some(link_mode_info.auto_negotiate);
+        match link_mode_info.duplex {
+            nispor::EthtoolLinkModeDuplex::Full => {
+                eth_conf.duplex = Some(EthernetDuplex::Full);
             }
-            eth_conf.auto_neg = Some(link_mode_info.auto_negotiate);
-            match link_mode_info.duplex {
-                nispor::EthtoolLinkModeDuplex::Full => {
-                    eth_conf.duplex = Some(EthernetDuplex::Full);
-                }
-                nispor::EthtoolLinkModeDuplex::Half => {
-                    eth_conf.duplex = Some(EthernetDuplex::Half);
-                }
-                _ => (),
+            nispor::EthtoolLinkModeDuplex::Half => {
+                eth_conf.duplex = Some(EthernetDuplex::Half);
             }
+            _ => (),
         }
     }
 

--- a/rust/src/lib/nispor/ethtool.rs
+++ b/rust/src/lib/nispor/ethtool.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
-use std::sync::OnceLock;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::OnceLock,
+};
 
 use crate::{
     EthtoolCoalesceConfig, EthtoolConfig, EthtoolFecConfig, EthtoolFecMode,

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -3,8 +3,8 @@
 use std::str::FromStr;
 
 use crate::{
-    nispor::mptcp::get_mptcp_flags, InterfaceIpAddr, InterfaceIpv4,
-    InterfaceIpv6, MergedInterface,
+    InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, MergedInterface,
+    nispor::mptcp::get_mptcp_flags,
 };
 
 pub(crate) fn np_ipv4_to_nmstate(
@@ -156,30 +156,28 @@ pub(crate) fn nmstate_ipv4_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
 
     // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
-        if let (Some(nms_cur_ipv4), Some(nms_des_ipv4)) = (
+    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
+        && let (Some(nms_cur_ipv4), Some(nms_des_ipv4)) = (
             &nms_cur_iface.base_iface().ipv4,
             &nms_merged_iface.merged.base_iface().ipv4,
-        ) {
-            let des_ips: Vec<_> = nms_des_ipv4
-                .addresses
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .collect();
+        )
+    {
+        let des_ips: Vec<_> = nms_des_ipv4
+            .addresses
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .collect();
 
-            for nms_addr in
-                nms_cur_ipv4.addresses.as_deref().unwrap_or_default()
-            {
-                if !des_ips.contains(&nms_addr) {
-                    np_ip_conf.addresses.push({
-                        let mut ip_conf = nispor::IpAddrConf::default();
-                        ip_conf.address = nms_addr.ip.to_string();
-                        ip_conf.prefix_len = nms_addr.prefix_length;
-                        ip_conf.remove = true;
-                        ip_conf
-                    });
-                }
+        for nms_addr in nms_cur_ipv4.addresses.as_deref().unwrap_or_default() {
+            if !des_ips.contains(&nms_addr) {
+                np_ip_conf.addresses.push({
+                    let mut ip_conf = nispor::IpAddrConf::default();
+                    ip_conf.address = nms_addr.ip.to_string();
+                    ip_conf.prefix_len = nms_addr.prefix_length;
+                    ip_conf.remove = true;
+                    ip_conf
+                });
             }
         }
     }
@@ -204,30 +202,28 @@ pub(crate) fn nmstate_ipv6_to_np(
     let mut np_ip_conf = nispor::IpConf::default();
 
     // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref() {
-        if let (Some(nms_cur_ipv6), Some(nms_des_ipv6)) = (
+    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
+        && let (Some(nms_cur_ipv6), Some(nms_des_ipv6)) = (
             &nms_cur_iface.base_iface().ipv6,
             &nms_merged_iface.merged.base_iface().ipv6,
-        ) {
-            let des_ips: Vec<_> = nms_des_ipv6
-                .addresses
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .collect();
+        )
+    {
+        let des_ips: Vec<_> = nms_des_ipv6
+            .addresses
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .collect();
 
-            for nms_addr in
-                nms_cur_ipv6.addresses.as_deref().unwrap_or_default()
-            {
-                if !des_ips.contains(&nms_addr) {
-                    np_ip_conf.addresses.push({
-                        let mut ip_conf = nispor::IpAddrConf::default();
-                        ip_conf.address = nms_addr.ip.to_string();
-                        ip_conf.prefix_len = nms_addr.prefix_length;
-                        ip_conf.remove = true;
-                        ip_conf
-                    });
-                }
+        for nms_addr in nms_cur_ipv6.addresses.as_deref().unwrap_or_default() {
+            if !des_ips.contains(&nms_addr) {
+                np_ip_conf.addresses.push({
+                    let mut ip_conf = nispor::IpAddrConf::default();
+                    ip_conf.address = nms_addr.ip.to_string();
+                    ip_conf.prefix_len = nms_addr.prefix_length;
+                    ip_conf.remove = true;
+                    ip_conf
+                });
             }
         }
     }

--- a/rust/src/lib/nispor/linux_bridge.rs
+++ b/rust/src/lib/nispor/linux_bridge.rs
@@ -3,10 +3,10 @@
 use log::warn;
 
 use crate::{
-    nispor::linux_bridge_port_vlan::parse_port_vlan_conf, BaseInterface,
-    ErrorKind, LinuxBridgeConfig, LinuxBridgeInterface,
+    BaseInterface, ErrorKind, LinuxBridgeConfig, LinuxBridgeInterface,
     LinuxBridgeMulticastRouterType, LinuxBridgeOptions, LinuxBridgePortConfig,
     LinuxBridgeStpOptions, NmstateError, VlanProtocol,
+    nispor::linux_bridge_port_vlan::parse_port_vlan_conf,
 };
 
 pub(crate) fn np_bridge_to_nmstate(
@@ -77,7 +77,7 @@ fn np_bridge_options_to_nmstate(
     np_iface: &nispor::Iface,
 ) -> Result<LinuxBridgeOptions, NmstateError> {
     let mut options = LinuxBridgeOptions::default();
-    if let Some(ref np_bridge) = &np_iface.bridge {
+    if let Some(np_bridge) = &np_iface.bridge {
         options.stp = Some(get_stp_options(np_bridge)?);
         options.gc_timer = np_bridge.gc_timer;
         options.group_addr = np_bridge

--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -26,9 +26,10 @@ mod vlan;
 mod vrf;
 mod vxlan;
 
-pub(crate) use self::alt_name::{
-    apply_ifaces_alt_names, persist_alt_name_config,
-};
 pub(crate) use apply::nispor_apply;
 pub(crate) use hostname::set_running_hostname;
 pub(crate) use show::nispor_retrieve;
+
+pub(crate) use self::alt_name::{
+    apply_ifaces_alt_names, persist_alt_name_config,
+};

--- a/rust/src/lib/nispor/mptcp.rs
+++ b/rust/src/lib/nispor/mptcp.rs
@@ -3,8 +3,8 @@
 use std::net::Ipv6Addr;
 
 use crate::{
-    ip::is_ipv6_unicast_link_local, BaseInterface, ErrorKind, MptcpAddressFlag,
-    MptcpConfig, NmstateError,
+    BaseInterface, ErrorKind, MptcpAddressFlag, MptcpConfig, NmstateError,
+    ip::is_ipv6_unicast_link_local,
 };
 
 pub(crate) fn get_mptcp_flags(
@@ -14,15 +14,15 @@ pub(crate) fn get_mptcp_flags(
     let mut flags = Vec::new();
     if let Some(mptcp_addrs) = np_iface.mptcp.as_ref() {
         for mptcp_addr in mptcp_addrs {
-            if mptcp_addr.address.to_string().as_str() == ip_addr {
-                if let Some(np_flags) = mptcp_addr.flags.as_ref() {
-                    for np_flag in np_flags {
-                        match MptcpAddressFlag::try_from(*np_flag) {
-                            Ok(f) => flags.push(f),
-                            Err(e) => {
-                                log::warn!("{e}");
-                                continue;
-                            }
+            if mptcp_addr.address.to_string().as_str() == ip_addr
+                && let Some(np_flags) = mptcp_addr.flags.as_ref()
+            {
+                for np_flag in np_flags {
+                    match MptcpAddressFlag::try_from(*np_flag) {
+                        Ok(f) => flags.push(f),
+                        Err(e) => {
+                            log::warn!("{e}");
+                            continue;
                         }
                     }
                 }
@@ -41,13 +41,12 @@ pub(crate) fn get_iface_mptcp_conf(
     if let Some(addrs) = iface.ipv4.as_ref().and_then(|i| i.addresses.as_ref())
     {
         for addr in addrs {
-            if let std::net::IpAddr::V4(ip_addr) = &addr.ip {
-                if ip_addr.is_loopback()
+            if let std::net::IpAddr::V4(ip_addr) = &addr.ip
+                && (ip_addr.is_loopback()
                     || ip_addr.is_link_local()
-                    || ip_addr.is_multicast()
-                {
-                    continue;
-                }
+                    || ip_addr.is_multicast())
+            {
+                continue;
             }
             has_mptcp_valid_ip_addr = true;
             if let Some(mptcp_flags) = addr.mptcp_flags.as_ref() {

--- a/rust/src/lib/nispor/route_rule.rs
+++ b/rust/src/lib/nispor/route_rule.rs
@@ -57,10 +57,10 @@ pub(crate) fn get_route_rules(
             }
         }
         // Filter out the routes with protocols that we do not support
-        if let Some(rule_protocol) = np_rule.protocol.as_ref() {
-            if !protocols.contains(rule_protocol) {
-                continue;
-            }
+        if let Some(rule_protocol) = np_rule.protocol.as_ref()
+            && !protocols.contains(rule_protocol)
+        {
+            continue;
         }
         rule.iif.clone_from(&np_rule.iif);
         rule.ip_to.clone_from(&np_rule.dst);

--- a/rust/src/lib/nispor/show.rs
+++ b/rust/src/lib/nispor/show.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 
 use crate::{
+    DummyInterface, Interface, InterfaceType, Interfaces, LoopbackInterface,
+    NetworkState, NmstateError, OvsInterface, UnknownInterface, XfrmInterface,
     nispor::{
         base_iface::np_iface_to_base_iface,
         bond::{append_bond_port_config, np_bond_to_nmstate},
@@ -23,8 +25,6 @@ use crate::{
         vrf::np_vrf_to_nmstate,
         vxlan::np_vxlan_to_nmstate,
     },
-    DummyInterface, Interface, InterfaceType, Interfaces, LoopbackInterface,
-    NetworkState, NmstateError, OvsInterface, UnknownInterface, XfrmInterface,
 };
 
 // Only report DNS config when `kernel_only: true`
@@ -184,11 +184,10 @@ fn set_controller_type(ifaces: &mut Interfaces) {
         }
     }
     for iface in ifaces.kernel_ifaces.values_mut() {
-        if let Some(ctrl) = iface.base_iface().controller.as_ref() {
-            if let Some(ctrl_type) = ctrl_to_type.get(ctrl) {
-                iface.base_iface_mut().controller_type =
-                    Some(ctrl_type.clone());
-            }
+        if let Some(ctrl) = iface.base_iface().controller.as_ref()
+            && let Some(ctrl_type) = ctrl_to_type.get(ctrl)
+        {
+            iface.base_iface_mut().controller_type = Some(ctrl_type.clone());
         }
     }
 }

--- a/rust/src/lib/nispor/veth.rs
+++ b/rust/src/lib/nispor/veth.rs
@@ -43,27 +43,24 @@ pub(crate) fn process_new_veth_peer(
     merged_iface: &MergedInterface,
     merged_ifaces: &MergedInterfaces,
 ) -> Option<nispor::IfaceConf> {
-    if merged_iface.current.is_none() && merged_iface.merged.is_up() {
-        if let Some(Interface::Ethernet(apply_iface)) =
+    if merged_iface.current.is_none()
+        && merged_iface.merged.is_up()
+        && let Some(Interface::Ethernet(apply_iface)) =
             merged_iface.for_apply.as_ref()
+        && let Some(peer) = apply_iface.veth.as_ref().map(|v| v.peer.as_str())
+    {
+        // Mark new veth peer as up if not mentioned in desired state.
+        if merged_ifaces
+            .kernel_ifaces
+            .get(peer)
+            .map(|i| i.for_apply.is_some())
+            != Some(true)
         {
-            if let Some(peer) =
-                apply_iface.veth.as_ref().map(|v| v.peer.as_str())
-            {
-                // Mark new veth peer as up if not mentioned in desired state.
-                if merged_ifaces
-                    .kernel_ifaces
-                    .get(peer)
-                    .map(|i| i.for_apply.is_some())
-                    != Some(true)
-                {
-                    let mut np_iface = nispor::IfaceConf::default();
-                    np_iface.name = peer.to_string();
-                    np_iface.iface_type = Some(nispor::IfaceType::Veth);
-                    np_iface.state = nispor::IfaceState::Up;
-                    return Some(np_iface);
-                }
-            }
+            let mut np_iface = nispor::IfaceConf::default();
+            np_iface.name = peer.to_string();
+            np_iface.iface_type = Some(nispor::IfaceType::Veth);
+            np_iface.state = nispor::IfaceState::Up;
+            return Some(np_iface);
         }
     }
     None

--- a/rust/src/lib/nm/checkpoint.rs
+++ b/rust/src/lib/nm/checkpoint.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmApi;
 use log::warn;
 
-use crate::{nm::error::nm_error_to_nmstate, NmstateError};
+use crate::{
+    NmstateError,
+    nm::{error::nm_error_to_nmstate, nm_dbus::NmApi},
+};
 
 // Wait maximum 60 seconds for rollback
 pub(crate) const CHECKPOINT_ROLLBACK_TIMEOUT: u32 = 60;

--- a/rust/src/lib/nm/conn_matcher.rs
+++ b/rust/src/lib/nm/conn_matcher.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::rc::Rc;
-use std::str::FromStr;
+use std::{collections::HashMap, rc::Rc, str::FromStr};
 
 use super::nm_dbus::{NmActiveConnection, NmConnection, NmIfaceType};
 use crate::{
@@ -178,22 +176,20 @@ impl NmConnectionMatcher {
                 .and_then(|m| m.path.as_deref())
                 .and_then(|s| s.first()),
             nm_conn.iface_type(),
-        ) {
-            if let Some(pci) = nm_pci_addr
-                .strip_prefix("pci-")
-                .and_then(|s| PciAddress::from_str(s).ok())
-            {
-                if nm_iface_type == &NmIfaceType::Veth {
-                    self.saved_by_pci
-                        .entry((pci, NmIfaceType::Ethernet))
-                        .or_default()
-                        .push(nm_conn.clone())
-                }
+        ) && let Some(pci) = nm_pci_addr
+            .strip_prefix("pci-")
+            .and_then(|s| PciAddress::from_str(s).ok())
+        {
+            if nm_iface_type == &NmIfaceType::Veth {
                 self.saved_by_pci
-                    .entry((pci, *nm_iface_type))
+                    .entry((pci, NmIfaceType::Ethernet))
                     .or_default()
                     .push(nm_conn.clone())
             }
+            self.saved_by_pci
+                .entry((pci, *nm_iface_type))
+                .or_default()
+                .push(nm_conn.clone())
         }
     }
 
@@ -237,10 +233,10 @@ impl NmConnectionMatcher {
             .get(&(name.to_string(), *nm_iface_type))?;
 
         for nm_conn in nm_conns {
-            if let Some(uuid) = nm_conn.uuid() {
-                if self.acs_by_uuid.contains_key(uuid) {
-                    return Some(Rc::as_ref(nm_conn));
-                }
+            if let Some(uuid) = nm_conn.uuid()
+                && self.acs_by_uuid.contains_key(uuid)
+            {
+                return Some(Rc::as_ref(nm_conn));
             }
         }
 
@@ -353,23 +349,22 @@ impl NmConnectionMatcher {
         match base_iface.identifier {
             None | Some(InterfaceIdentifier::Name) => (),
             Some(InterfaceIdentifier::MacAddress) => {
-                if let Some(mac) = base_iface.mac_address.as_deref() {
-                    if let Some(nm_conns) = self.saved_by_mac.get(&(
+                if let Some(mac) = base_iface.mac_address.as_deref()
+                    && let Some(nm_conns) = self.saved_by_mac.get(&(
                         mac.to_uppercase(),
                         NmIfaceType::from(&base_iface.iface_type),
-                    )) {
-                        ret.extend(nm_conns.iter().map(Rc::as_ref));
-                    }
+                    ))
+                {
+                    ret.extend(nm_conns.iter().map(Rc::as_ref));
                 }
             }
             Some(InterfaceIdentifier::PciAddress) => {
-                if let Some(pci) = base_iface.pci_address {
-                    if let Some(nm_conns) = self
+                if let Some(pci) = base_iface.pci_address
+                    && let Some(nm_conns) = self
                         .saved_by_pci
                         .get(&(pci, NmIfaceType::from(&base_iface.iface_type)))
-                    {
-                        ret.extend(nm_conns.iter().map(Rc::as_ref));
-                    }
+                {
+                    ret.extend(nm_conns.iter().map(Rc::as_ref));
                 }
             }
         }
@@ -456,10 +451,10 @@ fn get_nm_connection_iface_name(
     nm_conn: &NmConnection,
     merged_ifaces: &MergedInterfaces,
 ) -> Option<String> {
-    if let Some(iface_name) = nm_conn.iface_name() {
-        if !iface_name.is_empty() {
-            return Some(iface_name.to_string());
-        }
+    if let Some(iface_name) = nm_conn.iface_name()
+        && !iface_name.is_empty()
+    {
+        return Some(iface_name.to_string());
     }
 
     if let (Some(vlan_parent), Some(vlan_id)) = (
@@ -477,33 +472,29 @@ fn get_nm_connection_iface_name(
     if nm_conn.iface_type().map(|nm_iface_type| {
         NM_IFACE_TYPES_USE_PARENT_MAC.contains(nm_iface_type)
     }) == Some(false)
-    {
-        if let Some(mac) = nm_conn
+        && let Some(mac) = nm_conn
             .wired
             .as_ref()
             .and_then(|s| s.mac_address.as_deref())
-        {
-            if let Some(name) = merged_ifaces
-                .kernel_ifaces
-                .values()
-                .filter_map(|i| i.current.as_ref())
-                .find_map(|iface| {
-                    let base_iface = iface.base_iface();
-                    if base_iface.mac_address.as_deref() == Some(mac)
-                        && (base_iface.iface_type == iface_type
-                            || ([InterfaceType::Veth, InterfaceType::Ethernet]
-                                .contains(&base_iface.iface_type)
-                                && iface_type == InterfaceType::Ethernet))
-                    {
-                        Some(base_iface.name.to_string())
-                    } else {
-                        None
-                    }
-                })
-            {
-                return Some(name);
-            }
-        }
+        && let Some(name) = merged_ifaces
+            .kernel_ifaces
+            .values()
+            .filter_map(|i| i.current.as_ref())
+            .find_map(|iface| {
+                let base_iface = iface.base_iface();
+                if base_iface.mac_address.as_deref() == Some(mac)
+                    && (base_iface.iface_type == iface_type
+                        || ([InterfaceType::Veth, InterfaceType::Ethernet]
+                            .contains(&base_iface.iface_type)
+                            && iface_type == InterfaceType::Ethernet))
+                {
+                    Some(base_iface.name.to_string())
+                } else {
+                    None
+                }
+            })
+    {
+        return Some(name);
     }
     if nm_conn.vpn.is_some() {
         return nm_conn.id().map(|i| i.to_string());

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
+    NmConnectionMatcher,
     device::create_index_for_nm_devs,
     nm_dbus::{NmConnection, NmDevice, NmIfaceType},
     settings::{fix_ip_dhcp_timeout, iface_to_nm_connections},
-    NmConnectionMatcher,
 };
-
 use crate::{
     InterfaceType, MergedInterface, MergedInterfaces, MergedNetworkState,
     NmstateError,
@@ -124,10 +123,11 @@ pub(crate) fn prepare_nm_conns(
                     nm_devs_to_deactivate.push(nm_dev.clone());
                 }
             }
-            if iface.is_down() && gen_conf_mode {
-                if let Some(nm_conn_set) = nm_conn.connection.as_mut() {
-                    nm_conn_set.autoconnect = Some(false);
-                }
+            if iface.is_down()
+                && gen_conf_mode
+                && let Some(nm_conn_set) = nm_conn.connection.as_mut()
+            {
+                nm_conn_set.autoconnect = Some(false);
             }
             nm_conns_to_update.push(nm_conn);
         }
@@ -153,68 +153,59 @@ fn can_skip_activation(
     // if the controller is desired to be down or absent, activating the
     // connection on the port will risk making the controller activate again,
     // therefore skip the activation on the port
-    if let Some(desired_iface) = merged_iface.for_apply.as_ref() {
-        if let (Some(ctrl_iface), Some(ctrl_type)) = (
+    if let Some(desired_iface) = merged_iface.for_apply.as_ref()
+        && let (Some(ctrl_iface), Some(ctrl_type)) = (
             desired_iface.base_iface().controller.as_deref(),
             desired_iface.base_iface().controller_type.as_ref(),
-        ) {
-            if let Some(merged_ctrl_iface) =
-                merged_ifaces.get_iface(ctrl_iface, ctrl_type.clone())
-            {
-                if merged_ctrl_iface.for_apply.is_some()
-                    && (merged_ctrl_iface.merged.is_absent()
-                        || merged_ctrl_iface.merged.is_down())
-                {
-                    log::info!(
-                        "Skipping activation of {} as its controller {} \
-                         desire to be down or absent",
-                        merged_iface.merged.name(),
-                        ctrl_iface
-                    );
-                    return true;
-                }
-            }
-        }
+        )
+        && let Some(merged_ctrl_iface) =
+            merged_ifaces.get_iface(ctrl_iface, ctrl_type.clone())
+        && merged_ctrl_iface.for_apply.is_some()
+        && (merged_ctrl_iface.merged.is_absent()
+            || merged_ctrl_iface.merged.is_down())
+    {
+        log::info!(
+            "Skipping activation of {} as its controller {} desire to be down \
+             or absent",
+            merged_iface.merged.name(),
+            ctrl_iface
+        );
+        return true;
     }
     // Reapply of connection never reactivate its subordinates, hence we do not
     // skip activation when modifying the connection.
-    if let Some(uuid) = nm_conn.uuid() {
-        if conn_matcher.is_activated(uuid) {
-            return false;
-        }
+    if let Some(uuid) = nm_conn.uuid()
+        && conn_matcher.is_activated(uuid)
+    {
+        return false;
     }
 
     if merged_iface.current.is_none()
         && merged_iface.for_apply.is_some()
         && merged_iface.merged.is_up()
+        && let Some(desired_iface) = merged_iface.for_apply.as_ref()
     {
-        if let Some(desired_iface) = merged_iface.for_apply.as_ref() {
-            if let (Some(ctrl_iface), Some(ctrl_type)) = (
-                desired_iface.base_iface().controller.as_deref(),
-                desired_iface.base_iface().controller_type.as_ref(),
-            ) {
-                if let Some(merged_ctrl_iface) =
-                    merged_ifaces.get_iface(ctrl_iface, ctrl_type.clone())
-                {
-                    if merged_ctrl_iface.current.is_none()
-                        && merged_ctrl_iface.for_apply.is_some()
-                        && merged_ctrl_iface.merged.is_up()
-                    {
-                        log::info!(
-                            "Skipping activation of {} as its controller {} \
-                             will automatically activate it",
-                            merged_iface.merged.name(),
-                            ctrl_iface
-                        );
-                        return true;
-                    }
-                }
-            }
+        if let (Some(ctrl_iface), Some(ctrl_type)) = (
+            desired_iface.base_iface().controller.as_deref(),
+            desired_iface.base_iface().controller_type.as_ref(),
+        ) && let Some(merged_ctrl_iface) =
+            merged_ifaces.get_iface(ctrl_iface, ctrl_type.clone())
+            && merged_ctrl_iface.current.is_none()
+            && merged_ctrl_iface.for_apply.is_some()
+            && merged_ctrl_iface.merged.is_up()
+        {
+            log::info!(
+                "Skipping activation of {} as its controller {} will \
+                 automatically activate it",
+                merged_iface.merged.name(),
+                ctrl_iface
+            );
+            return true;
+        }
 
-            // new OVS port on new OVS bridge can skip activation
-            if nm_conn.iface_type() == Some(&NmIfaceType::OvsPort) {
-                return true;
-            }
+        // new OVS port on new OVS bridge can skip activation
+        if nm_conn.iface_type() == Some(&NmIfaceType::OvsPort) {
+            return true;
         }
     }
     false

--- a/rust/src/lib/nm/device.rs
+++ b/rust/src/lib/nm/device.rs
@@ -2,8 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::NmDevice;
-use crate::InterfaceType;
+use crate::{InterfaceType, nm::nm_dbus::NmDevice};
 
 pub(crate) fn create_index_for_nm_devs(
     nm_devs: &[NmDevice],

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{dns::parse_dns_ipv6_link_local_srv, ip::is_ipv6_addr};
+use super::nm_dbus::{
+    NmActiveConnection, NmDevice, NmDeviceState, NmIfaceType,
+};
 use crate::{
     DnsClientState, ErrorKind, Interface, InterfaceType, MergedInterface,
     MergedInterfaces, MergedNetworkState, NmstateError,
-};
-
-use super::nm_dbus::{
-    NmActiveConnection, NmDevice, NmDeviceState, NmIfaceType,
+    dns::parse_dns_ipv6_link_local_srv, ip::is_ipv6_addr,
 };
 
 const DEFAULT_DNS_PRIORITY: i32 = 40;
@@ -130,10 +129,11 @@ fn find_dns_iface(
     // Try using current DNS interface if in desired list
     if !desired_only {
         for iface_name in cur_dns_ifaces {
-            if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
-                if iface.is_changed() && iface.is_iface_valid_for_dns(is_ipv6) {
-                    return Some(iface_name.to_string());
-                }
+            if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name)
+                && iface.is_changed()
+                && iface.is_iface_valid_for_dns(is_ipv6)
+            {
+                return Some(iface_name.to_string());
             }
         }
     }
@@ -210,13 +210,12 @@ fn find_dns_iface(
 
     // Try again among undesired current interface
     for iface_name in cur_iface_names {
-        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
-            if iface.is_iface_valid_for_dns(is_ipv6)
-                && (!is_external_managed(iface_name, nm_acs))
-                && (!is_unmanaged(iface_name, nm_devs))
-            {
-                return Some(iface_name.to_string());
-            }
+        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name)
+            && iface.is_iface_valid_for_dns(is_ipv6)
+            && (!is_external_managed(iface_name, nm_acs))
+            && (!is_unmanaged(iface_name, nm_devs))
+        {
+            return Some(iface_name.to_string());
         }
     }
 
@@ -260,30 +259,31 @@ pub(crate) fn purge_dns_config(
                         iface.merged.base_iface().state;
                 }
             }
-            if let Some(apply_iface) = iface.for_apply.as_mut() {
-                if apply_iface.base_iface().can_have_ip() {
-                    if is_ipv6 {
-                        if apply_iface.base_iface().ipv6.is_none() {
-                            apply_iface.base_iface_mut().ipv6.clone_from(
-                                &iface.merged.base_iface_mut().ipv6,
-                            );
-                        }
-                    } else if apply_iface.base_iface().ipv4.is_none() {
+            if let Some(apply_iface) = iface.for_apply.as_mut()
+                && apply_iface.base_iface().can_have_ip()
+            {
+                if is_ipv6 {
+                    if apply_iface.base_iface().ipv6.is_none() {
                         apply_iface
                             .base_iface_mut()
-                            .ipv4
-                            .clone_from(&iface.merged.base_iface_mut().ipv4);
+                            .ipv6
+                            .clone_from(&iface.merged.base_iface_mut().ipv6);
                     }
-
-                    set_iface_dns_conf(
-                        is_ipv6,
-                        apply_iface,
-                        Vec::new(),
-                        Vec::new(),
-                        Vec::new(),
-                        None,
-                    )?;
+                } else if apply_iface.base_iface().ipv4.is_none() {
+                    apply_iface
+                        .base_iface_mut()
+                        .ipv4
+                        .clone_from(&iface.merged.base_iface_mut().ipv4);
                 }
+
+                set_iface_dns_conf(
+                    is_ipv6,
+                    apply_iface,
+                    Vec::new(),
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                )?;
             }
         }
     }
@@ -466,27 +466,21 @@ pub(crate) fn get_cur_dns_ifaces(
             continue;
         };
 
-        if let Some(ipv4) = &cur_iface.base_iface().ipv4 {
-            if ipv4.enabled {
-                if let Some(dns_conf) = &ipv4.dns {
-                    if !dns_conf.is_null()
-                        && !v4_ifaces.contains(&cur_iface.name().to_string())
-                    {
-                        v4_ifaces.push(cur_iface.name().to_string())
-                    }
-                }
-            }
+        if let Some(ipv4) = &cur_iface.base_iface().ipv4
+            && ipv4.enabled
+            && let Some(dns_conf) = &ipv4.dns
+            && !dns_conf.is_null()
+            && !v4_ifaces.contains(&cur_iface.name().to_string())
+        {
+            v4_ifaces.push(cur_iface.name().to_string())
         }
-        if let Some(ipv6) = &cur_iface.base_iface().ipv6 {
-            if ipv6.enabled {
-                if let Some(dns_conf) = &ipv6.dns {
-                    if !dns_conf.is_null()
-                        && !v6_ifaces.contains(&cur_iface.name().to_string())
-                    {
-                        v6_ifaces.push(cur_iface.name().to_string())
-                    }
-                }
-            }
+        if let Some(ipv6) = &cur_iface.base_iface().ipv6
+            && ipv6.enabled
+            && let Some(dns_conf) = &ipv6.dns
+            && !dns_conf.is_null()
+            && !v6_ifaces.contains(&cur_iface.name().to_string())
+        {
+            v6_ifaces.push(cur_iface.name().to_string())
         }
     }
     (v4_ifaces, v6_ifaces)
@@ -587,40 +581,36 @@ pub(crate) fn store_dns_search_or_option_to_iface(
     for iface_name in cur_v6_ifaces {
         if let Some(iface) =
             merged_state.interfaces.kernel_ifaces.get_mut(&iface_name)
+            && iface.is_iface_valid_for_dns(true)
+            && let Some(apply_iface) = iface.for_apply.as_mut()
         {
-            if iface.is_iface_valid_for_dns(true) {
-                if let Some(apply_iface) = iface.for_apply.as_mut() {
-                    set_iface_dns_conf(
-                        true,
-                        apply_iface,
-                        Vec::new(),
-                        merged_state.dns.searches.clone(),
-                        merged_state.dns.options.clone(),
-                        Some(DEFAULT_DNS_PRIORITY),
-                    )?;
-                    return Ok(());
-                }
-            }
+            set_iface_dns_conf(
+                true,
+                apply_iface,
+                Vec::new(),
+                merged_state.dns.searches.clone(),
+                merged_state.dns.options.clone(),
+                Some(DEFAULT_DNS_PRIORITY),
+            )?;
+            return Ok(());
         }
     }
 
     for iface_name in cur_v4_ifaces {
         if let Some(iface) =
             merged_state.interfaces.kernel_ifaces.get_mut(&iface_name)
+            && iface.is_iface_valid_for_dns(false)
+            && let Some(apply_iface) = iface.for_apply.as_mut()
         {
-            if iface.is_iface_valid_for_dns(false) {
-                if let Some(apply_iface) = iface.for_apply.as_mut() {
-                    set_iface_dns_conf(
-                        false,
-                        apply_iface,
-                        Vec::new(),
-                        merged_state.dns.searches.clone(),
-                        merged_state.dns.options.clone(),
-                        Some(DEFAULT_DNS_PRIORITY),
-                    )?;
-                    return Ok(());
-                }
-            }
+            set_iface_dns_conf(
+                false,
+                apply_iface,
+                Vec::new(),
+                merged_state.dns.searches.clone(),
+                merged_state.dns.options.clone(),
+                Some(DEFAULT_DNS_PRIORITY),
+            )?;
+            return Ok(());
         }
     }
 

--- a/rust/src/lib/nm/error.rs
+++ b/rust/src/lib/nm/error.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::{
-    ErrorKind as NmErrorKind, NmConnectionError, NmError, NmManagerError,
-    NmSettingError,
+use crate::{
+    ErrorKind, NmstateError,
+    nm::nm_dbus::{
+        ErrorKind as NmErrorKind, NmConnectionError, NmError, NmManagerError,
+        NmSettingError,
+    },
 };
-
-use crate::{ErrorKind, NmstateError};
 
 pub(crate) fn nm_error_to_nmstate(nm_error: NmError) -> NmstateError {
     match nm_error.kind {

--- a/rust/src/lib/nm/gen_conf.rs
+++ b/rust/src/lib/nm/gen_conf.rs
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    ErrorKind, InterfaceIdentifier, MergedInterfaces, MergedNetworkState,
-    NmstateError,
-};
-
 use super::{
+    NmConnectionMatcher,
     connection::prepare_nm_conns,
     dns::{store_dns_config_to_iface, store_dns_search_or_option_to_iface},
     route::store_route_config,
     route_rule::store_route_rule_config,
     settings::uuid_from_name_and_type,
-    NmConnectionMatcher,
+};
+use crate::{
+    ErrorKind, InterfaceIdentifier, MergedInterfaces, MergedNetworkState,
+    NmstateError,
 };
 
 pub(crate) fn nm_gen_conf(
@@ -95,21 +94,17 @@ fn use_uuid_for_non_name_ref_parent(merged_ifaces: &mut MergedInterfaces) {
         .values()
         .filter_map(|i| i.for_apply.as_ref())
     {
-        if let Some(parent) = iface.parent() {
-            if let Some(parent_iface) = merged_ifaces.kernel_ifaces.get(parent)
-            {
-                if parent_iface.merged.base_iface().identifier
-                    != Some(InterfaceIdentifier::Name)
-                    && parent_iface.merged.base_iface().identifier.is_some()
-                {
-                    let parent_uuid = uuid_from_name_and_type(
-                        parent_iface.merged.name(),
-                        &parent_iface.merged.iface_type(),
-                    );
-                    pending_changes
-                        .push((iface.name().to_string(), parent_uuid));
-                }
-            }
+        if let Some(parent) = iface.parent()
+            && let Some(parent_iface) = merged_ifaces.kernel_ifaces.get(parent)
+            && parent_iface.merged.base_iface().identifier
+                != Some(InterfaceIdentifier::Name)
+            && parent_iface.merged.base_iface().identifier.is_some()
+        {
+            let parent_uuid = uuid_from_name_and_type(
+                parent_iface.merged.name(),
+                &parent_iface.merged.iface_type(),
+            );
+            pending_changes.push((iface.name().to_string(), parent_uuid));
         }
     }
     for (child_name, parent_uuid) in pending_changes {

--- a/rust/src/lib/nm/mod.rs
+++ b/rust/src/lib/nm/mod.rs
@@ -20,7 +20,6 @@ mod settings;
 #[cfg(feature = "query_apply")]
 mod show;
 
-pub(crate) use self::conn_matcher::NmConnectionMatcher;
 #[cfg(feature = "query_apply")]
 pub(crate) use checkpoint::{
     nm_checkpoint_create, nm_checkpoint_destroy, nm_checkpoint_rollback,
@@ -32,3 +31,5 @@ pub(crate) use gen_conf::nm_gen_conf;
 pub(crate) use query_apply::nm_apply;
 #[cfg(feature = "query_apply")]
 pub(crate) use show::nm_retrieve;
+
+pub(crate) use self::conn_matcher::NmConnectionMatcher;

--- a/rust/src/lib/nm/nm_dbus/active_connection.rs
+++ b/rust/src/lib/nm/nm_dbus/active_connection.rs
@@ -3,10 +3,10 @@
 use super::NmIfaceType;
 #[cfg(feature = "query_apply")]
 use super::{
-    connection::nm_con_get_from_obj_path,
-    dbus::{obj_path_to_string, NM_DBUS_INTERFACE_AC, NM_DBUS_INTERFACE_ROOT},
-    query_apply::device::nm_dev_from_obj_path,
     ErrorKind, NmError,
+    connection::nm_con_get_from_obj_path,
+    dbus::{NM_DBUS_INTERFACE_AC, NM_DBUS_INTERFACE_ROOT, obj_path_to_string},
+    query_apply::device::nm_dev_from_obj_path,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/rust/src/lib/nm/nm_dbus/connection/bond.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/bond.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 use zvariant::Value;
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/bridge.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/bridge.rs
@@ -15,17 +15,16 @@
 // limitations under the License.
 //
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
+    NmError, NmVlanProtocol, ToDbusValue,
+    connection::{DBUS_ASV_SIGNATURE, DbusDictionary},
     convert::{
         mac_str_to_u8_array, own_value_to_bytes_array, u8_array_to_mac_string,
     },
-    NmError, NmVlanProtocol, ToDbusValue,
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]

--- a/rust/src/lib/nm/nm_dbus/connection/conn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/conn.rs
@@ -1,41 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use log::warn;
-
 use serde::{Deserialize, Serialize};
 use zvariant::{Signature, Type};
 
 use super::super::{
-    connection::bond::{NmSettingBond, NmSettingBondPort},
-    connection::bridge::{NmSettingBridge, NmSettingBridgePort},
-    connection::ethtool::NmSettingEthtool,
-    connection::hsr::NmSettingHsr,
-    connection::ieee8021x::NmSetting8021X,
-    connection::iface_match::NmSettingMatch,
-    connection::infiniband::NmSettingInfiniBand,
-    connection::ip::NmSettingIp,
-    connection::ipvlan::NmSettingIpVlan,
-    connection::loopback::NmSettingLoopback,
-    connection::mac_vlan::NmSettingMacVlan,
-    connection::macsec::NmSettingMacSec,
-    connection::ovs::{
-        NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-        NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
-        NmSettingOvsPort,
-    },
-    connection::sriov::NmSettingSriov,
-    connection::user::NmSettingUser,
-    connection::veth::NmSettingVeth,
-    connection::vlan::NmSettingVlan,
-    connection::vpn::NmSettingVpn,
-    connection::vrf::NmSettingVrf,
-    connection::vxlan::NmSettingVxlan,
-    connection::wired::NmSettingWired,
-    convert::ToDbusValue,
     NmError, NmIfaceType,
+    connection::{
+        bond::{NmSettingBond, NmSettingBondPort},
+        bridge::{NmSettingBridge, NmSettingBridgePort},
+        ethtool::NmSettingEthtool,
+        hsr::NmSettingHsr,
+        ieee8021x::NmSetting8021X,
+        iface_match::NmSettingMatch,
+        infiniband::NmSettingInfiniBand,
+        ip::NmSettingIp,
+        ipvlan::NmSettingIpVlan,
+        loopback::NmSettingLoopback,
+        mac_vlan::NmSettingMacVlan,
+        macsec::NmSettingMacSec,
+        ovs::{
+            NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
+            NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+            NmSettingOvsPort,
+        },
+        sriov::NmSettingSriov,
+        user::NmSettingUser,
+        veth::NmSettingVeth,
+        vlan::NmSettingVlan,
+        vpn::NmSettingVpn,
+        vrf::NmSettingVrf,
+        vxlan::NmSettingVxlan,
+        wired::NmSettingWired,
+    },
+    convert::ToDbusValue,
 };
 
 const NM_AUTOCONENCT_PORT_DEFAULT: i32 = -1;
@@ -345,10 +345,10 @@ impl NmConnection {
     }
 
     pub fn uuid(&self) -> Option<&str> {
-        if let Some(nm_conn_set) = &self.connection {
-            if let Some(ref uuid) = nm_conn_set.uuid {
-                return Some(uuid);
-            }
+        if let Some(nm_conn_set) = &self.connection
+            && let Some(ref uuid) = nm_conn_set.uuid
+        {
+            return Some(uuid);
         }
         None
     }
@@ -508,44 +508,38 @@ pub(crate) async fn nm_con_get_from_obj_path(
         .call::<&str, (), NmConnection>("GetSettings", &())
         .await?;
     nm_conn.obj_path = con_obj_path.to_string();
-    if let Some(ieee_8021x_conf) = nm_conn.ieee8021x.as_mut() {
-        if let Ok(nm_secrets) = proxy
+    if let Some(ieee_8021x_conf) = nm_conn.ieee8021x.as_mut()
+        && let Ok(nm_secrets) = proxy
             .call::<&str, &str, NmConnectionDbusOwnedValue>(
                 "GetSecrets",
                 &"802-1x",
             )
             .await
-        {
-            if let Some(nm_secret) = nm_secrets.get("802-1x") {
-                ieee_8021x_conf.fill_secrets(nm_secret);
-            }
-        }
+        && let Some(nm_secret) = nm_secrets.get("802-1x")
+    {
+        ieee_8021x_conf.fill_secrets(nm_secret);
     }
-    if let Some(macsec_conf) = nm_conn.macsec.as_mut() {
-        if let Ok(nm_secrets) = proxy
+    if let Some(macsec_conf) = nm_conn.macsec.as_mut()
+        && let Ok(nm_secrets) = proxy
             .call::<&str, &str, NmConnectionDbusOwnedValue>(
                 "GetSecrets",
                 &"macsec",
             )
             .await
-        {
-            if let Some(nm_secret) = nm_secrets.get("macsec") {
-                macsec_conf.fill_secrets(nm_secret);
-            }
-        }
+        && let Some(nm_secret) = nm_secrets.get("macsec")
+    {
+        macsec_conf.fill_secrets(nm_secret);
     }
-    if let Some(vpn_conf) = nm_conn.vpn.as_mut() {
-        if let Ok(nm_secrets) = proxy
+    if let Some(vpn_conf) = nm_conn.vpn.as_mut()
+        && let Ok(nm_secrets) = proxy
             .call::<&str, &str, NmConnectionDbusOwnedValue>(
                 "GetSecrets",
                 &"vpn",
             )
             .await
-        {
-            if let Some(nm_secret) = nm_secrets.get("vpn") {
-                vpn_conf.fill_secrets(nm_secret);
-            }
-        }
+        && let Some(nm_secret) = nm_secrets.get("vpn")
+    {
+        vpn_conf.fill_secrets(nm_secret);
     }
     if let Ok(flags) = proxy.get_property::<u32>("Flags").await {
         nm_conn.flags = from_u32_to_vec_nm_conn_flags(flags);

--- a/rust/src/lib/nm/nm_dbus/connection/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/dns.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::str::FromStr;
+use std::{
+    convert::TryFrom,
+    net::{Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 
 use super::super::{ErrorKind, NmError};
 

--- a/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ethtool.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::DbusDictionary, ErrorKind, NmError, ToDbusValue,
+    ErrorKind, NmError, ToDbusValue, connection::DbusDictionary,
 };
 
 const VALID_FEATURES: [&str; 58] = [

--- a/rust/src/lib/nm/nm_dbus/connection/hsr.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/hsr.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]
@@ -42,10 +41,10 @@ impl ToDbusValue for NmSettingHsr {
         if let Some(v) = &self.port2 {
             ret.insert("port2", zvariant::Value::new(v.clone()));
         }
-        if let Some(v) = &self.multicast_spec {
-            if *v > 0 {
-                ret.insert("multicast-spec", zvariant::Value::new(*v));
-            }
+        if let Some(v) = &self.multicast_spec
+            && *v > 0
+        {
+            ret.insert("multicast-spec", zvariant::Value::new(*v));
         }
         if let Some(v) = &self.prp {
             ret.insert("prp", zvariant::Value::new(*v));

--- a/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ieee8021x.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::DbusDictionary, ErrorKind, NmError, ToDbusValue,
+    ErrorKind, NmError, ToDbusValue, connection::DbusDictionary,
 };
 
 const GLIB_FILE_PATH_PREFIX: &str = "file://";

--- a/rust/src/lib/nm/nm_dbus/connection/iface_match.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/iface_match.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/infiniband.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/infiniband.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/ip.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ip.rs
@@ -1,26 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use log::warn;
-
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::dns::{
-        nm_ip_dns_options_to_value, nm_ip_dns_search_to_value,
-        nm_ip_dns_to_value, parse_nm_dns, parse_nm_dns_data,
-        parse_nm_dns_options, parse_nm_dns_search,
-    },
-    connection::route::{
-        nm_ip_routes_to_value, parse_nm_ip_route_data, NmIpRoute,
-    },
-    connection::route_rule::{
-        nm_ip_rules_to_value, parse_nm_ip_rule_data, NmIpRouteRule,
-    },
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
     ErrorKind, NmError, ToDbusValue,
+    connection::{
+        DBUS_ASV_SIGNATURE, DbusDictionary,
+        dns::{
+            nm_ip_dns_options_to_value, nm_ip_dns_search_to_value,
+            nm_ip_dns_to_value, parse_nm_dns, parse_nm_dns_data,
+            parse_nm_dns_options, parse_nm_dns_search,
+        },
+        route::{NmIpRoute, nm_ip_routes_to_value, parse_nm_ip_route_data},
+        route_rule::{
+            NmIpRouteRule, nm_ip_rules_to_value, parse_nm_ip_rule_data,
+        },
+    },
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -217,14 +215,14 @@ impl ToDbusValue for NmSettingIp {
         ret.insert("address-data", zvariant::Value::Array(addresss_data));
         ret.insert("route-data", nm_ip_routes_to_value(&self.routes)?);
         ret.insert("routing-rules", nm_ip_rules_to_value(&self.route_rules)?);
-        if let Some(dns_servers) = self.dns.as_ref() {
-            if !dns_servers.is_empty() {
-                // We still use the `dns` instead of `dns-data` as the
-                // `dns-data` is only supported by NM 1.41+ which is not widely
-                // available yet. And we do not know the NM version yet in this
-                // function context.
-                ret.insert("dns", nm_ip_dns_to_value(dns_servers)?);
-            }
+        if let Some(dns_servers) = self.dns.as_ref()
+            && !dns_servers.is_empty()
+        {
+            // We still use the `dns` instead of `dns-data` as the
+            // `dns-data` is only supported by NM 1.41+ which is not widely
+            // available yet. And we do not know the NM version yet in this
+            // function context.
+            ret.insert("dns", nm_ip_dns_to_value(dns_servers)?);
         }
         if let Some(dns_searches) = self.dns_search.as_ref() {
             ret.insert("dns-search", nm_ip_dns_search_to_value(dns_searches)?);

--- a/rust/src/lib/nm/nm_dbus/connection/ipvlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ipvlan.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/loopback.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/loopback.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/mac_vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mac_vlan.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/macsec.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/macsec.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]
@@ -59,10 +58,10 @@ impl ToDbusValue for NmSettingMacSec {
         if let Some(v) = &self.mka_ckn {
             ret.insert("mka-ckn", zvariant::Value::new(v.clone()));
         }
-        if let Some(v) = &self.port {
-            if *v > 0 {
-                ret.insert("port", zvariant::Value::new(*v));
-            }
+        if let Some(v) = &self.port
+            && *v > 0
+        {
+            ret.insert("port", zvariant::Value::new(*v));
         }
         if let Some(v) = &self.validation {
             ret.insert("validation", zvariant::Value::new(*v));

--- a/rust/src/lib/nm/nm_dbus/connection/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/mod.rs
@@ -45,43 +45,42 @@ mod vrf;
 mod vxlan;
 mod wired;
 
-pub use self::bond::{NmSettingBond, NmSettingBondPort};
-pub use self::bridge::{
-    NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange,
-};
-pub use self::conn::{
-    NmConnection, NmConnectionMultiConnect, NmRange, NmSettingConnection,
-    NmSettingsConnectionFlag,
-};
-pub use self::ethtool::NmSettingEthtool;
-pub use self::hsr::NmSettingHsr;
-pub use self::ieee8021x::NmSetting8021X;
-pub use self::iface_match::NmSettingMatch;
-pub use self::iface_type::NmIfaceType;
-pub use self::infiniband::NmSettingInfiniBand;
-pub use self::ip::{NmSettingIp, NmSettingIpMethod};
-pub use self::ipvlan::NmSettingIpVlan;
-pub use self::loopback::NmSettingLoopback;
-pub use self::mac_vlan::NmSettingMacVlan;
-pub use self::macsec::NmSettingMacSec;
-pub use self::ovs::{
-    NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
-    NmSettingOvsPort,
-};
-pub use self::route::NmIpRoute;
-pub use self::route_rule::{NmIpRouteRule, NmIpRouteRuleAction};
-pub use self::sriov::{NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan};
-pub use self::user::NmSettingUser;
-pub use self::veth::NmSettingVeth;
-pub use self::vlan::{NmSettingVlan, NmSettingVlanFlag, NmVlanProtocol};
-pub use self::vpn::NmSettingVpn;
-pub use self::vrf::NmSettingVrf;
-pub use self::vxlan::NmSettingVxlan;
-pub use self::wired::NmSettingWired;
-
+pub(crate) use self::conn::{DBUS_ASV_SIGNATURE, DbusDictionary};
 #[cfg(feature = "query_apply")]
-pub(crate) use self::conn::{nm_con_get_from_obj_path, NmConnectionDbusValue};
-pub(crate) use self::conn::{DbusDictionary, DBUS_ASV_SIGNATURE};
+pub(crate) use self::conn::{NmConnectionDbusValue, nm_con_get_from_obj_path};
 #[cfg(feature = "query_apply")]
 pub(crate) use self::macros::_from_map;
+pub use self::{
+    bond::{NmSettingBond, NmSettingBondPort},
+    bridge::{NmSettingBridge, NmSettingBridgePort, NmSettingBridgeVlanRange},
+    conn::{
+        NmConnection, NmConnectionMultiConnect, NmRange, NmSettingConnection,
+        NmSettingsConnectionFlag,
+    },
+    ethtool::NmSettingEthtool,
+    hsr::NmSettingHsr,
+    ieee8021x::NmSetting8021X,
+    iface_match::NmSettingMatch,
+    iface_type::NmIfaceType,
+    infiniband::NmSettingInfiniBand,
+    ip::{NmSettingIp, NmSettingIpMethod},
+    ipvlan::NmSettingIpVlan,
+    loopback::NmSettingLoopback,
+    mac_vlan::NmSettingMacVlan,
+    macsec::NmSettingMacSec,
+    ovs::{
+        NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
+        NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+        NmSettingOvsPort,
+    },
+    route::NmIpRoute,
+    route_rule::{NmIpRouteRule, NmIpRouteRuleAction},
+    sriov::{NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan},
+    user::NmSettingUser,
+    veth::NmSettingVeth,
+    vlan::{NmSettingVlan, NmSettingVlanFlag, NmVlanProtocol},
+    vpn::NmSettingVpn,
+    vrf::NmSettingVrf,
+    vxlan::NmSettingVxlan,
+    wired::NmSettingWired,
+};

--- a/rust/src/lib/nm/nm_dbus/connection/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/ovs.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
     NmError, NmRange, ToDbusValue,
+    connection::{DBUS_ASV_SIGNATURE, DbusDictionary},
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -5,8 +5,8 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
     NmError,
+    connection::{DBUS_ASV_SIGNATURE, DbusDictionary},
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
@@ -35,10 +35,10 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
     type Error = NmError;
     fn try_from(mut v: DbusDictionary) -> Result<Self, Self::Error> {
         let mut weight = _from_map!(v, "weight", u32::try_from)?;
-        if let Some(weight_num) = weight {
-            if weight_num == 0 {
-                weight = None;
-            }
+        if let Some(weight_num) = weight
+            && weight_num == 0
+        {
+            weight = None;
         }
         Ok(Self {
             dest: _from_map!(v, "dest", String::try_from)?,

--- a/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route_rule.rs
@@ -20,7 +20,7 @@ use std::convert::TryFrom;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
+    connection::{DBUS_ASV_SIGNATURE, DbusDictionary},
     error::NmError,
 };
 

--- a/rust/src/lib/nm/nm_dbus/connection/sriov.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/sriov.rs
@@ -15,14 +15,13 @@
 // limitations under the License.
 //
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::{DbusDictionary, DBUS_ASV_SIGNATURE},
     NmError, NmVlanProtocol, ToDbusValue,
+    connection::{DBUS_ASV_SIGNATURE, DbusDictionary},
 };
 
 pub(crate) const NM_TERNARY_TRUE: i32 = 1;

--- a/rust/src/lib/nm/nm_dbus/connection/user.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/user.rs
@@ -15,12 +15,11 @@
 // limitations under the License.
 //
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/veth.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/veth.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, convert::ToDbusValue, NmError};
+use super::super::{NmError, connection::DbusDictionary, convert::ToDbusValue};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/vlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vlan.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+};
 
 use log::error;
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::DbusDictionary, ErrorKind, NmError, ToDbusValue,
+    ErrorKind, NmError, ToDbusValue, connection::DbusDictionary,
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]

--- a/rust/src/lib/nm/nm_dbus/connection/vpn.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vpn.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/vrf.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vrf.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]

--- a/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/vxlan.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
-use super::super::{connection::DbusDictionary, NmError, ToDbusValue};
+use super::super::{NmError, ToDbusValue, connection::DbusDictionary};
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
 #[serde(try_from = "DbusDictionary")]
@@ -38,10 +37,10 @@ impl TryFrom<DbusDictionary> for NmSettingVxlan {
 impl ToDbusValue for NmSettingVxlan {
     fn to_value(&self) -> Result<HashMap<&str, zvariant::Value<'_>>, NmError> {
         let mut ret = HashMap::new();
-        if let Some(v) = self.parent.as_deref() {
-            if !v.is_empty() {
-                ret.insert("parent", zvariant::Value::new(v));
-            }
+        if let Some(v) = self.parent.as_deref()
+            && !v.is_empty()
+        {
+            ret.insert("parent", zvariant::Value::new(v));
         }
         if let Some(id) = self.id {
             ret.insert("id", zvariant::Value::new(id));

--- a/rust/src/lib/nm/nm_dbus/connection/wired.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/wired.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use serde::{Deserialize, Serialize};
 
 use super::super::{
-    connection::DbusDictionary,
-    convert::mac_str_to_u8_array,
-    convert::{own_value_to_bytes_array, u8_array_to_mac_string},
     NmError, ToDbusValue,
+    connection::DbusDictionary,
+    convert::{
+        mac_str_to_u8_array, own_value_to_bytes_array, u8_array_to_mac_string,
+    },
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]

--- a/rust/src/lib/nm/nm_dbus/convert.rs
+++ b/rust/src/lib/nm/nm_dbus/convert.rs
@@ -14,8 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use log::error;
 

--- a/rust/src/lib/nm/nm_dbus/dbus.rs
+++ b/rust/src/lib/nm/nm_dbus/dbus.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
 use log::debug;
 use zbus::proxy;

--- a/rust/src/lib/nm/nm_dbus/dns.rs
+++ b/rust/src/lib/nm/nm_dbus/dns.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::{collections::HashMap, convert::TryFrom};
 
-use super::{connection::_from_map, NmError};
+use super::{NmError, connection::_from_map};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct NmDnsEntry {

--- a/rust/src/lib/nm/nm_dbus/error.rs
+++ b/rust/src/lib/nm/nm_dbus/error.rs
@@ -264,17 +264,17 @@ impl std::fmt::Display for NmError {
 #[cfg(feature = "query_apply")]
 impl From<zbus::Error> for NmError {
     fn from(e: zbus::Error) -> Self {
-        if let zbus::Error::MethodError(dbus_err_kind, dbus_err_msg, _) = &e {
-            if dbus_err_kind.starts_with(NM_DBUS_ERR_PREFIX) {
-                return parse_nm_dbus_error(
-                    dbus_err_kind.as_str(),
-                    if let Some(dbus_err_msg) = dbus_err_msg.as_ref() {
-                        dbus_err_msg.as_str()
-                    } else {
-                        ""
-                    },
-                );
-            }
+        if let zbus::Error::MethodError(dbus_err_kind, dbus_err_msg, _) = &e
+            && dbus_err_kind.starts_with(NM_DBUS_ERR_PREFIX)
+        {
+            return parse_nm_dbus_error(
+                dbus_err_kind.as_str(),
+                if let Some(dbus_err_msg) = dbus_err_msg.as_ref() {
+                    dbus_err_msg.as_str()
+                } else {
+                    ""
+                },
+            );
         }
 
         log::warn!("Unknown DBUS error {e:?}");

--- a/rust/src/lib/nm/nm_dbus/gen_conf/iface_match.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/iface_match.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::ToDbusValue;
-
 use super::super::{NmError, NmSettingMatch, ToKeyfile};
+use crate::nm::nm_dbus::ToDbusValue;
 
 impl ToKeyfile for NmSettingMatch {}

--- a/rust/src/lib/nm/nm_dbus/gen_conf/keyfile.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/keyfile.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 use log::error;
 

--- a/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::ToDbusValue;
 use std::collections::HashMap;
 
 use super::super::{
@@ -8,6 +7,7 @@ use super::super::{
     NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
     NmSettingOvsPort, ToKeyfile,
 };
+use crate::nm::nm_dbus::ToDbusValue;
 
 impl ToKeyfile for NmSettingOvsBridge {}
 impl ToKeyfile for NmSettingOvsIface {}

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 use super::super::NmIpRoute;
 

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route_rule.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use log::warn;
 use std::collections::HashMap;
+
+use log::warn;
 
 use super::super::NmIpRouteRule;
 

--- a/rust/src/lib/nm/nm_dbus/gen_conf/sriov.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/sriov.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 use super::super::{
     NmError, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,

--- a/rust/src/lib/nm/nm_dbus/lldp.rs
+++ b/rust/src/lib/nm/nm_dbus/lldp.rs
@@ -5,8 +5,8 @@ use std::convert::TryFrom;
 use serde::Deserialize;
 
 use super::{
-    connection::{DbusDictionary, _from_map},
     NmError,
+    connection::{_from_map, DbusDictionary},
 };
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize)]

--- a/rust/src/lib/nm/nm_dbus/mod.rs
+++ b/rust/src/lib/nm/nm_dbus/mod.rs
@@ -19,28 +19,11 @@ mod gen_conf;
 #[cfg(feature = "query_apply")]
 mod query_apply;
 
-pub use self::active_connection::NmActiveConnection;
-pub use self::connection::{
-    NmConnection, NmConnectionMultiConnect, NmIfaceType, NmIpRoute,
-    NmIpRouteRule, NmIpRouteRuleAction, NmRange, NmSetting8021X, NmSettingBond,
-    NmSettingBondPort, NmSettingBridge, NmSettingBridgePort,
-    NmSettingBridgeVlanRange, NmSettingConnection, NmSettingEthtool,
-    NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod, NmSettingIpVlan,
-    NmSettingLoopback, NmSettingMacSec, NmSettingMacVlan, NmSettingMatch,
-    NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
-    NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf, NmSettingSriovVfVlan,
-    NmSettingUser, NmSettingVeth, NmSettingVlan, NmSettingVlanFlag,
-    NmSettingVpn, NmSettingVrf, NmSettingVxlan, NmSettingWired,
-    NmSettingsConnectionFlag, NmVlanProtocol,
-};
-pub use self::device::{NmDevice, NmDeviceState, NmDeviceStateReason};
+pub(crate) use self::convert::ToDbusValue;
 #[cfg(feature = "query_apply")]
 pub use self::dns::{NmDnsEntry, NmGlobalDnsConfig};
-pub use self::error::{
-    ErrorKind, NmConnectionError, NmDeviceError, NmError, NmManagerError,
-    NmSettingError,
-};
+#[cfg(feature = "gen_conf")]
+pub(crate) use self::gen_conf::ToKeyfile;
 #[cfg(feature = "query_apply")]
 pub use self::lldp::{
     NmLldpNeighbor, NmLldpNeighbor8021Ppvid, NmLldpNeighbor8021Vlan,
@@ -49,7 +32,25 @@ pub use self::lldp::{
 };
 #[cfg(feature = "query_apply")]
 pub use self::nm_api::{NmApi, NmVersion, NmVersionInfo};
-
-pub(crate) use self::convert::ToDbusValue;
-#[cfg(feature = "gen_conf")]
-pub(crate) use self::gen_conf::ToKeyfile;
+pub use self::{
+    active_connection::NmActiveConnection,
+    connection::{
+        NmConnection, NmConnectionMultiConnect, NmIfaceType, NmIpRoute,
+        NmIpRouteRule, NmIpRouteRuleAction, NmRange, NmSetting8021X,
+        NmSettingBond, NmSettingBondPort, NmSettingBridge, NmSettingBridgePort,
+        NmSettingBridgeVlanRange, NmSettingConnection, NmSettingEthtool,
+        NmSettingInfiniBand, NmSettingIp, NmSettingIpMethod, NmSettingIpVlan,
+        NmSettingLoopback, NmSettingMacSec, NmSettingMacVlan, NmSettingMatch,
+        NmSettingOvsBridge, NmSettingOvsDpdk, NmSettingOvsExtIds,
+        NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+        NmSettingOvsPort, NmSettingSriov, NmSettingSriovVf,
+        NmSettingSriovVfVlan, NmSettingUser, NmSettingVeth, NmSettingVlan,
+        NmSettingVlanFlag, NmSettingVpn, NmSettingVrf, NmSettingVxlan,
+        NmSettingWired, NmSettingsConnectionFlag, NmVlanProtocol,
+    },
+    device::{NmDevice, NmDeviceState, NmDeviceStateReason},
+    error::{
+        ErrorKind, NmConnectionError, NmDeviceError, NmError, NmManagerError,
+        NmSettingError,
+    },
+};

--- a/rust/src/lib/nm/nm_dbus/nm_api.rs
+++ b/rust/src/lib/nm/nm_dbus/nm_api.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
-use std::str::FromStr;
-use std::time::{Duration, Instant};
+use std::{
+    convert::TryFrom,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use log::debug;
 
 use super::{
+    NmIfaceType,
     active_connection::{
-        get_nm_ac_by_obj_path, nm_ac_obj_path_uuid_get, NmActiveConnection,
+        NmActiveConnection, get_nm_ac_by_obj_path, nm_ac_obj_path_uuid_get,
     },
-    connection::{nm_con_get_from_obj_path, NmConnection},
+    connection::{NmConnection, nm_con_get_from_obj_path},
     dbus::NmDbus,
     device::{NmDevice, NmDeviceState, NmDeviceStateReason},
     dns::{NmDnsEntry, NmGlobalDnsConfig},
@@ -19,7 +22,6 @@ use super::{
     query_apply::device::{
         nm_dev_delete, nm_dev_disconnect, nm_dev_from_obj_path, nm_dev_get_llpd,
     },
-    NmIfaceType,
 };
 
 pub struct NmApi<'a> {
@@ -148,10 +150,10 @@ impl NmApi<'_> {
     ) -> Result<(), NmError> {
         debug!("connection_deactivate: {uuid}");
         self.extend_timeout_if_required().await?;
-        if let Ok(nm_ac) = get_nm_ac_obj_path_by_uuid(&self.dbus, uuid).await {
-            if !nm_ac.is_empty() {
-                self.dbus.connection_deactivate(&nm_ac).await?;
-            }
+        if let Ok(nm_ac) = get_nm_ac_obj_path_by_uuid(&self.dbus, uuid).await
+            && !nm_ac.is_empty()
+        {
+            self.dbus.connection_deactivate(&nm_ac).await?;
         }
         Ok(())
     }
@@ -198,17 +200,16 @@ impl NmApi<'_> {
                         .as_ref()
                         .map(|c| c.iface_name.is_none())
                         .unwrap_or_default()
-                    {
-                        if let (Ok(nm_dev), Some(nm_set)) = (
+                        && let (Ok(nm_dev), Some(nm_set)) = (
                             nm_dev_from_obj_path(
                                 &self.dbus.connection,
                                 &nm_dev_obj_path,
                             )
                             .await,
                             nm_conn.connection.as_mut(),
-                        ) {
-                            nm_set.iface_name = Some(nm_dev.name.clone());
-                        }
+                        )
+                    {
+                        nm_set.iface_name = Some(nm_dev.name.clone());
                     }
                     nm_conns.push(nm_conn)
                 }
@@ -402,10 +403,10 @@ impl NmApi<'_> {
             // Due to bug https://bugzilla.redhat.com/2090946
             // NetworkManager daemon cannot remove static hostname, hence we
             // just delete the /etc/hostname file
-            if std::path::Path::new("/etc/hostname").exists() {
-                if let Err(e) = std::fs::remove_file("/etc/hostname") {
-                    log::error!("Failed to remove static /etc/hostname: {e}");
-                }
+            if std::path::Path::new("/etc/hostname").exists()
+                && let Err(e) = std::fs::remove_file("/etc/hostname")
+            {
+                log::error!("Failed to remove static /etc/hostname: {e}");
             }
             Ok(())
         } else {
@@ -521,14 +522,13 @@ impl FromStr for NmVersion {
             .take(3)
             .map(|v| v.parse::<u8>())
             .collect::<Result<Vec<u8>, _>>()
+            && ver.len() == 3
         {
-            if ver.len() == 3 {
-                return Ok(NmVersion {
-                    major: ver[0],
-                    minor: ver[1],
-                    micro: ver[2],
-                });
-            }
+            return Ok(NmVersion {
+                major: ver[0],
+                minor: ver[1],
+                micro: ver[2],
+            });
         }
         Err(NmError::new(
             ErrorKind::InvalidArgument,

--- a/rust/src/lib/nm/nm_dbus/query_apply/device.rs
+++ b/rust/src/lib/nm/nm_dbus/query_apply/device.rs
@@ -3,11 +3,11 @@
 use std::convert::TryFrom;
 
 use super::super::{
+    ErrorKind, NmDevice, NmDeviceState, NmDeviceStateReason, NmError,
+    NmIfaceType,
     connection::DbusDictionary,
     dbus::{NM_DBUS_INTERFACE_DEV, NM_DBUS_INTERFACE_ROOT},
     lldp::NmLldpNeighbor,
-    ErrorKind, NmDevice, NmDeviceState, NmDeviceStateReason, NmError,
-    NmIfaceType,
 };
 
 const NM_DEVICE_TYPE_UNKNOWN: u32 = 0;

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -3,7 +3,8 @@
 use std::collections::HashSet;
 
 use super::super::{
-    connection::{prepare_nm_conns, PreparedNmConnections},
+    NmConnectionMatcher,
+    connection::{PreparedNmConnections, prepare_nm_conns},
     device::create_index_for_nm_devs,
     error::nm_error_to_nmstate,
     nm_dbus::{NmApi, NmConnection, NmIfaceType, NmVersion, NmVersionInfo},
@@ -18,9 +19,7 @@ use super::super::{
     },
     route::store_route_config,
     route_rule::store_route_rule_config,
-    NmConnectionMatcher,
 };
-
 use crate::{
     InterfaceType, MergedInterfaces, MergedNetworkState, NmstateError,
 };
@@ -197,48 +196,46 @@ async fn delete_ifaces(
 
         // Delete all existing connections for this interface
         for nm_conn in nm_conns_to_delete {
-            if let Some(uuid) = nm_conn.uuid() {
-                if !uuids_to_delete.contains(uuid) {
-                    log::info!(
-                        "Deleting NM connection for absent interface {}/{}: {}",
-                        &iface.name(),
-                        &iface.iface_type(),
-                        uuid
-                    );
-                    uuids_to_delete.insert(uuid);
-                }
+            if let Some(uuid) = nm_conn.uuid()
+                && !uuids_to_delete.contains(uuid)
+            {
+                log::info!(
+                    "Deleting NM connection for absent interface {}/{}: {}",
+                    &iface.name(),
+                    &iface.iface_type(),
+                    uuid
+                );
+                uuids_to_delete.insert(uuid);
             }
             // Delete OVS port profile along with OVS system and internal
             // Interface
-            if nm_conn.controller_type() == Some(&NmIfaceType::OvsPort) {
-                if let Some(ctrl) = nm_conn.controller() {
-                    if is_uuid(ctrl) {
-                        if !uuids_to_delete.contains(ctrl) {
+            if nm_conn.controller_type() == Some(&NmIfaceType::OvsPort)
+                && let Some(ctrl) = nm_conn.controller()
+            {
+                if is_uuid(ctrl) {
+                    if !uuids_to_delete.contains(ctrl) {
+                        log::info!(
+                            "Deleting NM OVS port connection {} for absent \
+                             OVS interface {}",
+                            ctrl,
+                            &iface.name(),
+                        );
+                        uuids_to_delete.insert(ctrl);
+                    }
+                } else {
+                    let nm_conns = conn_matcher
+                        .get_saved_by_name_type(ctrl, &NmIfaceType::OvsPort);
+                    for nm_conn in nm_conns {
+                        if let Some(uuid) = nm_conn.uuid()
+                            && !uuids_to_delete.contains(uuid)
+                        {
                             log::info!(
                                 "Deleting NM OVS port connection {} for \
                                  absent OVS interface {}",
-                                ctrl,
+                                uuid,
                                 &iface.name(),
                             );
-                            uuids_to_delete.insert(ctrl);
-                        }
-                    } else {
-                        let nm_conns = conn_matcher.get_saved_by_name_type(
-                            ctrl,
-                            &NmIfaceType::OvsPort,
-                        );
-                        for nm_conn in nm_conns {
-                            if let Some(uuid) = nm_conn.uuid() {
-                                if !uuids_to_delete.contains(uuid) {
-                                    log::info!(
-                                        "Deleting NM OVS port connection {} \
-                                         for absent OVS interface {}",
-                                        uuid,
-                                        &iface.name(),
-                                    );
-                                    uuids_to_delete.insert(uuid);
-                                }
-                            }
+                            uuids_to_delete.insert(uuid);
                         }
                     }
                 }
@@ -277,21 +274,20 @@ async fn delete_remain_virtual_interface_as_desired(
         })
         .map(|i| &i.merged)
     {
-        if iface.is_virtual() {
-            if let Some(nm_dev) =
+        if iface.is_virtual()
+            && let Some(nm_dev) =
                 nm_devs_indexed.get(&(iface.name(), iface.iface_type()))
-            {
-                log::info!(
-                    "Deleting interface {}/{}: {}",
-                    &iface.name(),
-                    &iface.iface_type(),
-                    &nm_dev.obj_path
-                );
-                // There might be an race with on-going profile/connection
-                // deletion, verification will raise error for it later.
-                if let Err(e) = nm_api.device_delete(&nm_dev.obj_path).await {
-                    log::debug!("Failed to delete interface {e:?}");
-                }
+        {
+            log::info!(
+                "Deleting interface {}/{}: {}",
+                &iface.name(),
+                &iface.iface_type(),
+                &nm_dev.obj_path
+            );
+            // There might be an race with on-going profile/connection
+            // deletion, verification will raise error for it later.
+            if let Err(e) = nm_api.device_delete(&nm_dev.obj_path).await {
+                log::debug!("Failed to delete interface {e:?}");
             }
         }
     }
@@ -312,18 +308,17 @@ async fn delete_orphan_ports(
         if nm_conn.iface_type() != Some(&NmIfaceType::OvsPort) {
             continue;
         }
-        if let Some(ctrl_uuid) = nm_conn.controller() {
-            if uuids_deleted.contains(ctrl_uuid) {
-                if let Some(uuid) = nm_conn.uuid() {
-                    log::info!(
-                        "Deleting NM orphan profile {}/{}: {}",
-                        nm_conn.iface_name().unwrap_or(""),
-                        nm_conn.iface_type().cloned().unwrap_or_default(),
-                        uuid
-                    );
-                    uuids_to_delete.push(uuid);
-                }
-            }
+        if let Some(ctrl_uuid) = nm_conn.controller()
+            && uuids_deleted.contains(ctrl_uuid)
+            && let Some(uuid) = nm_conn.uuid()
+        {
+            log::info!(
+                "Deleting NM orphan profile {}/{}: {}",
+                nm_conn.iface_name().unwrap_or(""),
+                nm_conn.iface_type().cloned().unwrap_or_default(),
+                uuid
+            );
+            uuids_to_delete.push(uuid);
         }
     }
     for uuid in &uuids_to_delete {
@@ -371,8 +366,7 @@ fn gen_nm_conn_need_to_deactivate_first(
                 ret.push(nm_conn.clone());
             } else if let Some(nm_applied_conn) =
                 conn_matcher.get_applied_by_uuid(uuid)
-            {
-                if (remove_routes_need_deactivate
+                && ((remove_routes_need_deactivate
                     && is_route_removed(nm_conn, nm_applied_conn))
                     || is_vrf_table_id_changed(nm_conn, nm_applied_conn)
                     || is_vlan_changed(nm_conn, nm_applied_conn)
@@ -388,10 +382,9 @@ fn gen_nm_conn_need_to_deactivate_first(
                         nm_conn,
                         &bond_queue_id_changed_ports,
                     )
-                    || is_ipvlan_changed(nm_conn, nm_applied_conn)
-                {
-                    ret.push((*nm_applied_conn).clone());
-                }
+                    || is_ipvlan_changed(nm_conn, nm_applied_conn))
+            {
+                ret.push((*nm_applied_conn).clone());
             }
         }
     }
@@ -448,16 +441,15 @@ fn is_bridge_port_changed_default_pvid(
     nm_conn: &NmConnection,
     default_pvid_changed_brs: &[&str],
 ) -> bool {
-    if nm_conn.controller_type() == Some(&NmIfaceType::Bridge) {
-        if let Some(ctrl_name) = nm_conn.controller() {
-            if default_pvid_changed_brs.contains(&ctrl_name) {
-                log::info!(
-                    "Reactivating linux bridge port as its controller has \
-                     `vlan-default-pvid` changes"
-                );
-                return true;
-            }
-        }
+    if nm_conn.controller_type() == Some(&NmIfaceType::Bridge)
+        && let Some(ctrl_name) = nm_conn.controller()
+        && default_pvid_changed_brs.contains(&ctrl_name)
+    {
+        log::info!(
+            "Reactivating linux bridge port as its controller has \
+             `vlan-default-pvid` changes"
+        );
+        return true;
     }
     false
 }
@@ -479,16 +471,14 @@ fn is_bond_port_queue_id_changed(
     nm_conn: &NmConnection,
     changed_ports: &[&str],
 ) -> bool {
-    if nm_conn.controller_type() == Some(&NmIfaceType::Bond) {
-        if let Some(iface_name) = nm_conn.iface_name() {
-            if changed_ports.contains(&iface_name) {
-                log::info!(
-                    "Reactivating bond port {iface_name} as its queue ID has \
-                     changed"
-                );
-                return true;
-            }
-        }
+    if nm_conn.controller_type() == Some(&NmIfaceType::Bond)
+        && let Some(iface_name) = nm_conn.iface_name()
+        && changed_ports.contains(&iface_name)
+    {
+        log::info!(
+            "Reactivating bond port {iface_name} as its queue ID has changed"
+        );
+        return true;
     }
     false
 }

--- a/rust/src/lib/nm/query_apply/connection.rs
+++ b/rust/src/lib/nm/query_apply/connection.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::{
+    NmConnectionMatcher,
     error::nm_error_to_nmstate,
     nm_dbus::{
         self, NmActiveConnection, NmApi, NmConnection, NmIfaceType,
         NmSettingsConnectionFlag,
     },
-    NmConnectionMatcher,
 };
 use crate::{ErrorKind, MergedNetworkState, NmstateError};
 
@@ -33,15 +33,15 @@ pub(crate) async fn delete_exist_connections(
                 !nm_conn.flags.contains(&NmSettingsConnectionFlag::Volatile)
             })
         {
-            if let Some(uuid) = saved_nm_conn.uuid() {
-                if !excluded_uuids.contains(&uuid) {
-                    uuids_to_delete.push(uuid);
-                    log::info!(
-                        "Deleting existing duplicate connection {uuid}: {}/{}",
-                        merged_iface.merged.name(),
-                        merged_iface.merged.iface_type(),
-                    );
-                }
+            if let Some(uuid) = saved_nm_conn.uuid()
+                && !excluded_uuids.contains(&uuid)
+            {
+                uuids_to_delete.push(uuid);
+                log::info!(
+                    "Deleting existing duplicate connection {uuid}: {}/{}",
+                    merged_iface.merged.name(),
+                    merged_iface.merged.iface_type(),
+                );
             }
         }
     }
@@ -187,24 +187,20 @@ async fn _activate_nm_connections(
             } else {
                 if let (Some(ctrller), Some(ctrller_type)) =
                     (nm_conn.controller(), nm_conn.controller_type())
+                    && nm_conn.iface_type() != Some(&NmIfaceType::OvsIface)
                 {
-                    if nm_conn.iface_type() != Some(&NmIfaceType::OvsIface) {
-                        // OVS port does not do auto port activation.
-                        if new_controllers.contains(&(ctrller, *ctrller_type))
-                            && ctrller_type != &NmIfaceType::OvsPort
-                        {
-                            log::info!(
-                                "Skip connection activation as its controller \
-                                 already activated its ports: {}: {}/{}",
-                                uuid,
-                                nm_conn.iface_name().unwrap_or(""),
-                                nm_conn
-                                    .iface_type()
-                                    .cloned()
-                                    .unwrap_or_default()
-                            );
-                            continue;
-                        }
+                    // OVS port does not do auto port activation.
+                    if new_controllers.contains(&(ctrller, *ctrller_type))
+                        && ctrller_type != &NmIfaceType::OvsPort
+                    {
+                        log::info!(
+                            "Skip connection activation as its controller \
+                             already activated its ports: {}: {}/{}",
+                            uuid,
+                            nm_conn.iface_name().unwrap_or(""),
+                            nm_conn.iface_type().cloned().unwrap_or_default()
+                        );
+                        continue;
                     }
                 }
                 log::info!(
@@ -242,14 +238,13 @@ pub(crate) async fn deactivate_nm_connections(
                 nm_conn.iface_name().unwrap_or(""),
                 nm_conn.iface_type().cloned().unwrap_or_default()
             );
-            if let Err(e) = nm_api.connection_deactivate(uuid).await {
-                if e.kind
+            if let Err(e) = nm_api.connection_deactivate(uuid).await
+                && e.kind
                     != nm_dbus::ErrorKind::Manager(
                         nm_dbus::NmManagerError::ConnectionNotActive,
                     )
-                {
-                    return Err(nm_error_to_nmstate(e));
-                }
+            {
+                return Err(nm_error_to_nmstate(e));
             }
         }
     }

--- a/rust/src/lib/nm/query_apply/device.rs
+++ b/rust/src/lib/nm/query_apply/device.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    InterfaceType, NmstateError,
     nm::{
         error::nm_error_to_nmstate,
         nm_dbus::{ErrorKind, NmApi, NmDevice, NmDeviceError, NmIfaceType},
     },
-    InterfaceType, NmstateError,
 };
 
 fn nm_iface_type_to_nmstate(nm_iface_type: &NmIfaceType) -> InterfaceType {
@@ -48,10 +48,10 @@ pub(crate) async fn deactivate_nm_devices(
 ) -> Result<(), NmstateError> {
     for nm_dev in nm_devs {
         log::info!("Deactivating device {}", &nm_dev.name);
-        if let Err(e) = nm_api.device_disconnect(&nm_dev.obj_path).await {
-            if e.kind != ErrorKind::Device(NmDeviceError::NotActive) {
-                return Err(nm_error_to_nmstate(e));
-            }
+        if let Err(e) = nm_api.device_disconnect(&nm_dev.obj_path).await
+            && e.kind != ErrorKind::Device(NmDeviceError::NotActive)
+        {
+            return Err(nm_error_to_nmstate(e));
         }
     }
     Ok(())

--- a/rust/src/lib/nm/query_apply/dispatch.rs
+++ b/rust/src/lib/nm/query_apply/dispatch.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::os::unix::fs::OpenOptionsExt;
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    io::{Read, Write},
+    os::unix::fs::OpenOptionsExt,
+};
 
 use crate::{DispatchConfig, ErrorKind, MergedInterfaces, NmstateError};
 
@@ -195,15 +196,13 @@ fn delete_dispatch_script(
     let file_path = gen_file_path(iface_name, nm_action);
     let path = std::path::Path::new(&file_path);
 
-    if path.exists() {
-        if let Err(e) = std::fs::remove_file(path) {
-            return Err(NmstateError::new(
-                ErrorKind::PermissionError,
-                format!(
-                    "Failed to remove dispatch script {file_path}, error: {e}"
-                ),
-            ));
-        }
+    if path.exists()
+        && let Err(e) = std::fs::remove_file(path)
+    {
+        return Err(NmstateError::new(
+            ErrorKind::PermissionError,
+            format!("Failed to remove dispatch script {file_path}, error: {e}"),
+        ));
     }
     Ok(())
 }

--- a/rust/src/lib/nm/query_apply/dns.rs
+++ b/rust/src/lib/nm/query_apply/dns.rs
@@ -14,10 +14,9 @@ use super::super::{
         NmSettingIp,
     },
 };
-
 use crate::{
-    ip::is_ipv6_unicast_link_local, DnsClientState, DnsState, Interfaces,
-    MergedInterfaces, MergedNetworkState, NmstateError,
+    DnsClientState, DnsState, Interfaces, MergedInterfaces, MergedNetworkState,
+    NmstateError, ip::is_ipv6_unicast_link_local,
 };
 
 pub(crate) fn nm_dns_to_nmstate(
@@ -153,15 +152,15 @@ async fn retrieve_configured_dns_info(
     if !use_global_servers {
         let mut nm_ifaces_dns_confs: Vec<&DnsClientState> = Vec::new();
         for iface in ifaces.kernel_ifaces.values() {
-            if let Some(ip_conf) = iface.base_iface().ipv6.as_ref() {
-                if let Some(dns_conf) = ip_conf.dns.as_ref() {
-                    nm_ifaces_dns_confs.push(dns_conf);
-                }
+            if let Some(ip_conf) = iface.base_iface().ipv6.as_ref()
+                && let Some(dns_conf) = ip_conf.dns.as_ref()
+            {
+                nm_ifaces_dns_confs.push(dns_conf);
             }
-            if let Some(ip_conf) = iface.base_iface().ipv4.as_ref() {
-                if let Some(dns_conf) = ip_conf.dns.as_ref() {
-                    nm_ifaces_dns_confs.push(dns_conf);
-                }
+            if let Some(ip_conf) = iface.base_iface().ipv4.as_ref()
+                && let Some(dns_conf) = ip_conf.dns.as_ref()
+            {
+                nm_ifaces_dns_confs.push(dns_conf);
             }
         }
         nm_ifaces_dns_confs
@@ -377,17 +376,19 @@ fn cur_dns_ifaces_still_valid_for_dns(
 ) -> bool {
     let (cur_v4_ifaces, cur_v6_ifaces) = get_cur_dns_ifaces(merged_ifaces);
     for iface_name in &cur_v4_ifaces {
-        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
-            if iface.is_changed() && !iface.is_iface_valid_for_dns(false) {
-                return false;
-            }
+        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name)
+            && iface.is_changed()
+            && !iface.is_iface_valid_for_dns(false)
+        {
+            return false;
         }
     }
     for iface_name in &cur_v6_ifaces {
-        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name) {
-            if iface.is_changed() && !iface.is_iface_valid_for_dns(true) {
-                return false;
-            }
+        if let Some(iface) = merged_ifaces.kernel_ifaces.get(iface_name)
+            && iface.is_changed()
+            && !iface.is_iface_valid_for_dns(true)
+        {
+            return false;
         }
     }
     true

--- a/rust/src/lib/nm/query_apply/ieee8021x.rs
+++ b/rust/src/lib/nm/query_apply/ieee8021x.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmSetting8021X;
-
 use crate::Ieee8021XConfig;
 
 pub(crate) fn nm_802_1x_to_nmstate(

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
-use std::ops::BitXor;
+use std::{collections::HashSet, ops::BitXor};
 
-use super::super::nm_dbus::{
-    NmIpRouteRuleAction, NmSettingIp, NmSettingIpMethod,
+use super::{
+    super::nm_dbus::{NmIpRouteRuleAction, NmSettingIp, NmSettingIpMethod},
+    dns::nm_dns_to_nmstate,
 };
-
-use super::dns::nm_dns_to_nmstate;
-
 use crate::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpv4, InterfaceIpv6,
     Ipv6AddrGenMode, RouteRuleAction, RouteRuleEntry, WaitIp,

--- a/rust/src/lib/nm/query_apply/lldp.rs
+++ b/rust/src/lib/nm/query_apply/lldp.rs
@@ -5,7 +5,6 @@ use std::fmt::Write;
 use super::super::nm_dbus::{
     NmConnection, NmLldpNeighbor, NmLldpNeighbor8021Vlan,
 };
-
 use crate::{
     LldpAddressFamily, LldpChassisId, LldpConfig, LldpMacPhy, LldpMaxFrameSize,
     LldpMgmtAddr, LldpMgmtAddrs, LldpNeighborTlv, LldpPortId, LldpPpvids,
@@ -130,12 +129,12 @@ fn get_port_id(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
 }
 
 fn get_sys_caps(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
-    if let Some(s) = nm_info.system_capabilities {
-        if let Ok(caps) = u16::try_from(s) {
-            return Some(LldpNeighborTlv::SystemCapabilities(
-                LldpSystemCapabilities::from(caps),
-            ));
-        }
+    if let Some(s) = nm_info.system_capabilities
+        && let Ok(caps) = u16::try_from(s)
+    {
+        return Some(LldpNeighborTlv::SystemCapabilities(
+            LldpSystemCapabilities::from(caps),
+        ));
     }
     None
 }
@@ -166,18 +165,19 @@ fn get_vlans(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
 }
 
 fn get_mac_phy_conf(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
-    if let Some(nm_conf) = nm_info.ieee_802_3_mac_phy_conf.as_ref() {
-        if let (Some(a), Some(p), Some(o)) = (
+    if let Some(nm_conf) = nm_info.ieee_802_3_mac_phy_conf.as_ref()
+        && let (Some(a), Some(p), Some(o)) = (
             nm_conf.autoneg,
             nm_conf.pmd_autoneg_cap,
             nm_conf.operational_mau_type,
-        ) {
-            if let (Ok(o), Ok(p)) = (u16::try_from(o), u16::try_from(p)) {
-                return Some(LldpNeighborTlv::Ieee8023MacPhyConf(
-                    LldpMacPhy::new(a > 0, o, p),
-                ));
-            }
-        }
+        )
+        && let (Ok(o), Ok(p)) = (u16::try_from(o), u16::try_from(p))
+    {
+        return Some(LldpNeighborTlv::Ieee8023MacPhyConf(LldpMacPhy::new(
+            a > 0,
+            o,
+            p,
+        )));
     }
     None
 }
@@ -204,38 +204,37 @@ fn get_mgmt_addrs(nm_info: &NmLldpNeighbor) -> Option<LldpNeighborTlv> {
                 nm_mgmt_addr.address.as_ref(),
                 nm_mgmt_addr.interface_number_subtype,
                 nm_mgmt_addr.interface_number,
-            ) {
-                if let Ok(at) = u16::try_from(at) {
-                    let mut mgmt_addr = LldpMgmtAddr::default();
-                    let at = LldpAddressFamily::from(at);
-                    let addr = match at {
-                        LldpAddressFamily::Ipv4 => {
-                            if a.len() != 4 {
-                                continue;
-                            }
-                            std::net::Ipv4Addr::new(a[0], a[1], a[2], a[3])
-                                .to_string()
-                        }
-                        LldpAddressFamily::Ipv6 => {
-                            if a.len() != 16 {
-                                continue;
-                            }
-                            let mut buff = [0u8; 16];
-                            buff.copy_from_slice(&a[..16]);
-                            std::net::Ipv6Addr::from(buff).to_string()
-                        }
-                        LldpAddressFamily::Mac => u8_addr_to_mac_string(a),
-                        _ => {
+            ) && let Ok(at) = u16::try_from(at)
+            {
+                let mut mgmt_addr = LldpMgmtAddr::default();
+                let at = LldpAddressFamily::from(at);
+                let addr = match at {
+                    LldpAddressFamily::Ipv4 => {
+                        if a.len() != 4 {
                             continue;
                         }
-                    };
+                        std::net::Ipv4Addr::new(a[0], a[1], a[2], a[3])
+                            .to_string()
+                    }
+                    LldpAddressFamily::Ipv6 => {
+                        if a.len() != 16 {
+                            continue;
+                        }
+                        let mut buff = [0u8; 16];
+                        buff.copy_from_slice(&a[..16]);
+                        std::net::Ipv6Addr::from(buff).to_string()
+                    }
+                    LldpAddressFamily::Mac => u8_addr_to_mac_string(a),
+                    _ => {
+                        continue;
+                    }
+                };
 
-                    mgmt_addr.address_subtype = at;
-                    mgmt_addr.address = addr;
-                    mgmt_addr.interface_number_subtype = it;
-                    mgmt_addr.interface_number = i;
-                    addrs.push(mgmt_addr);
-                }
+                mgmt_addr.address_subtype = at;
+                mgmt_addr.address = addr;
+                mgmt_addr.interface_number_subtype = it;
+                mgmt_addr.interface_number = i;
+                addrs.push(mgmt_addr);
             }
         }
         return Some(LldpNeighborTlv::ManagementAddresses(LldpMgmtAddrs::new(

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -20,25 +20,28 @@ pub(crate) mod vpn;
 mod vrf;
 mod vxlan;
 
-pub(crate) use self::apply::nm_apply;
-pub(crate) use self::connection::{
-    activate_nm_connections, deactivate_nm_connections,
-    delete_exist_connections, save_nm_connections,
+pub(crate) use self::{
+    apply::nm_apply,
+    connection::{
+        activate_nm_connections, deactivate_nm_connections,
+        delete_exist_connections, save_nm_connections,
+    },
+    device::deactivate_nm_devices,
+    dns::retrieve_dns_state,
+    hsr::is_hsr_changed,
+    ieee8021x::nm_802_1x_to_nmstate,
+    ip::{
+        nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6,
+        query_nmstate_wait_ip,
+    },
+    ipvlan::is_ipvlan_changed,
+    lldp::{get_lldp, is_lldp_enabled},
+    mptcp::is_mptcp_flags_changed,
+    ovs::delete_orphan_ovs_ports,
+    route::is_route_removed,
+    user::get_description,
+    veth::is_veth_peer_changed,
+    vlan::is_vlan_changed,
+    vrf::is_vrf_table_id_changed,
+    vxlan::is_vxlan_changed,
 };
-pub(crate) use self::device::deactivate_nm_devices;
-pub(crate) use self::dns::retrieve_dns_state;
-pub(crate) use self::hsr::is_hsr_changed;
-pub(crate) use self::ieee8021x::nm_802_1x_to_nmstate;
-pub(crate) use self::ip::{
-    nm_ip_setting_to_nmstate4, nm_ip_setting_to_nmstate6, query_nmstate_wait_ip,
-};
-pub(crate) use self::ipvlan::is_ipvlan_changed;
-pub(crate) use self::lldp::{get_lldp, is_lldp_enabled};
-pub(crate) use self::mptcp::is_mptcp_flags_changed;
-pub(crate) use self::ovs::delete_orphan_ovs_ports;
-pub(crate) use self::route::is_route_removed;
-pub(crate) use self::user::get_description;
-pub(crate) use self::veth::is_veth_peer_changed;
-pub(crate) use self::vlan::is_vlan_changed;
-pub(crate) use self::vrf::is_vrf_table_id_changed;
-pub(crate) use self::vxlan::is_vxlan_changed;

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -3,12 +3,13 @@
 use std::collections::HashSet;
 
 use super::{
-    super::nm_dbus::{NmApi, NmConnection, NmIfaceType},
-    super::show::fill_iface_by_nm_conn_data,
-    super::NmConnectionMatcher,
+    super::{
+        NmConnectionMatcher,
+        nm_dbus::{NmApi, NmConnection, NmIfaceType},
+        show::fill_iface_by_nm_conn_data,
+    },
     connection::{delete_connections, is_uuid},
 };
-
 use crate::{
     InterfaceType, MergedInterface, MergedInterfaces, NetworkState,
     NmstateError,

--- a/rust/src/lib/nm/query_apply/user.rs
+++ b/rust/src/lib/nm/query_apply/user.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::NmConnection;
-
-use super::super::settings::NMSTATE_DESCRIPTION;
+use super::super::{nm_dbus::NmConnection, settings::NMSTATE_DESCRIPTION};
 
 pub(crate) fn get_description(nm_conn: &NmConnection) -> Option<String> {
     Some(

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -2,16 +2,15 @@
 
 use std::str::FromStr;
 
+use super::super::{
+    NmConnectionMatcher,
+    nm_dbus::{NmActiveConnection, NmIfaceType, NmSettingVpn},
+    show::fill_iface_by_nm_conn_data,
+};
 use crate::{
     Interface, InterfaceState, InterfaceType, IpsecInterface,
     LibreswanAddressFamily, LibreswanConfig, LibreswanConnectionType,
     NmstateError,
-};
-
-use super::super::{
-    nm_dbus::{NmActiveConnection, NmIfaceType, NmSettingVpn},
-    show::fill_iface_by_nm_conn_data,
-    NmConnectionMatcher,
 };
 
 pub(crate) fn get_supported_vpn_ifaces(
@@ -34,37 +33,31 @@ pub(crate) fn get_supported_vpn_ifaces(
         } else {
             continue;
         };
-        if let Some(nm_set_vpn) = nm_conn.vpn.as_ref() {
-            if nm_set_vpn.service_type.as_deref()
+        if let Some(nm_set_vpn) = nm_conn.vpn.as_ref()
+            && nm_set_vpn.service_type.as_deref()
                 == Some(NmSettingVpn::SERVICE_TYPE_LIBRESWAN)
-            {
-                let name = match nm_conn.id() {
-                    Some(n) => n.to_string(),
-                    None => continue,
+        {
+            let name = match nm_conn.id() {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // taking profile name as interface name of VPN.
+            let mut iface = IpsecInterface::new();
+            iface.base.iface_type = InterfaceType::Ipsec;
+            // We are solely depend on NetworkManager reporting IPSec
+            // connection status, hence use NmActiveConnection.state
+            // for interface.state
+            iface.base.state =
+                if nm_ac.state == NmActiveConnection::STATE_ACTIVATED {
+                    InterfaceState::Up
+                } else {
+                    InterfaceState::Down
                 };
-                // taking profile name as interface name of VPN.
-                let mut iface = IpsecInterface::new();
-                iface.base.iface_type = InterfaceType::Ipsec;
-                // We are solely depend on NetworkManager reporting IPSec
-                // connection status, hence use NmActiveConnection.state
-                // for interface.state
-                iface.base.state =
-                    if nm_ac.state == NmActiveConnection::STATE_ACTIVATED {
-                        InterfaceState::Up
-                    } else {
-                        InterfaceState::Down
-                    };
-                iface.base.name = name;
-                iface.libreswan = Some(get_libreswan_conf(nm_set_vpn));
-                let mut iface = Interface::Ipsec(Box::new(iface));
-                fill_iface_by_nm_conn_data(
-                    &mut iface,
-                    None,
-                    Some(nm_conn),
-                    None,
-                );
-                ret.push(iface);
-            }
+            iface.base.name = name;
+            iface.libreswan = Some(get_libreswan_conf(nm_set_vpn));
+            let mut iface = Interface::Ipsec(Box::new(iface));
+            fill_iface_by_nm_conn_data(&mut iface, None, Some(nm_conn), None);
+            ret.push(iface);
         }
     }
     Ok(ret)

--- a/rust/src/lib/nm/settings/bond.rs
+++ b/rust/src/lib/nm/settings/bond.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::net::Ipv6Addr;
+use std::{collections::HashMap, net::Ipv6Addr};
 
-use crate::nm::nm_dbus::{NmConnection, NmSettingBond};
-
-use crate::{BondConfig, BondInterface, BondOptions};
+use crate::{
+    BondConfig, BondInterface, BondOptions,
+    nm::nm_dbus::{NmConnection, NmSettingBond},
+};
 
 const DEFAULT_ARP_MISSED_MAX: u8 = 2;
 
@@ -224,15 +224,15 @@ fn apply_bond_options(
             if v { "1".to_string() } else { "0".to_string() },
         );
     }
-    if let Some(v) = bond_opts.ns_ip6_target.as_ref() {
-        if !v.is_empty() {
-            let ip6_targets: Vec<String> =
-                v.iter().map(Ipv6Addr::to_string).collect();
-            nm_bond_set.options.insert(
-                "ns_ip6_target".to_string(),
-                ip6_targets.join(",").to_string(),
-            );
-        }
+    if let Some(v) = bond_opts.ns_ip6_target.as_ref()
+        && !v.is_empty()
+    {
+        let ip6_targets: Vec<String> =
+            v.iter().map(Ipv6Addr::to_string).collect();
+        nm_bond_set.options.insert(
+            "ns_ip6_target".to_string(),
+            ip6_targets.join(",").to_string(),
+        );
     }
 
     // Remove all empty string option
@@ -265,10 +265,10 @@ pub(crate) fn gen_nm_bond_port_setting(
 
     // NetworkManager 1.42.8- does not support priority, hence we do not touch
     // it unless non-default defined or pre-exist.
-    if let Some(v) = bond_port_conf.priority {
-        if nm_set.priority.is_some() || v != 0 {
-            nm_set.priority = Some(v);
-        }
+    if let Some(v) = bond_port_conf.priority
+        && (nm_set.priority.is_some() || v != 0)
+    {
+        nm_set.priority = Some(v);
     }
 
     if let Some(v) = bond_port_conf.queue_id {

--- a/rust/src/lib/nm/settings/bridge.rs
+++ b/rust/src/lib/nm/settings/bridge.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::{
-    NmConnection, NmSettingBridge, NmSettingBridgeVlanRange, NmVlanProtocol,
-};
-
 use crate::{
     BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode, Interface,
     LinuxBridgeInterface, LinuxBridgeOptions, LinuxBridgeStpOptions,
     MergedInterface, VlanProtocol,
+    nm::nm_dbus::{
+        NmConnection, NmSettingBridge, NmSettingBridgeVlanRange, NmVlanProtocol,
+    },
 };
 
 pub(crate) fn gen_nm_br_setting(

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::nm_dbus::{
-    NmConnection, NmIfaceType, NmSettingConnection, NmSettingMacVlan,
-    NmSettingVeth, NmSettingVrf, NmSettingVxlan, NmSettingsConnectionFlag,
-};
 use super::{
-    super::NmConnectionMatcher,
+    super::{
+        NmConnectionMatcher,
+        nm_dbus::{
+            NmConnection, NmIfaceType, NmSettingConnection, NmSettingMacVlan,
+            NmSettingVeth, NmSettingVrf, NmSettingVxlan,
+            NmSettingsConnectionFlag,
+        },
+    },
     bond::{gen_nm_bond_port_setting, gen_nm_bond_setting},
     bridge::{gen_nm_br_port_setting, gen_nm_br_setting},
     ethtool::gen_ethtool_setting,
@@ -30,7 +33,6 @@ use super::{
     vpn::gen_nm_ipsec_vpn_setting,
     wired::gen_nm_wired_setting,
 };
-
 use crate::{
     Interface, InterfaceIdentifier, InterfaceType, MergedInterface,
     MergedNetworkState, NmstateError, OvsBridgePortConfig,
@@ -79,15 +81,15 @@ pub(crate) fn iface_to_nm_connections(
             }
         } else if !iface.is_userspace() {
             // User want to convert unmanaged interface to managed
-            if let Some(cur_iface) = merged_iface.current.as_ref() {
-                if cur_iface.is_ignore() {
-                    return persisten_iface_cur_conf(
-                        cur_iface,
-                        merged_state,
-                        conn_matcher,
-                        gen_conf_mode,
-                    );
-                }
+            if let Some(cur_iface) = merged_iface.current.as_ref()
+                && cur_iface.is_ignore()
+            {
+                return persisten_iface_cur_conf(
+                    cur_iface,
+                    merged_state,
+                    conn_matcher,
+                    gen_conf_mode,
+                );
             }
         }
     }
@@ -251,63 +253,62 @@ pub(crate) fn iface_to_nm_connections(
     if let (Some(ctrl), Some(ctrl_type)) = (
         iface.base_iface().controller.as_ref(),
         iface.base_iface().controller_type.as_ref(),
-    ) {
-        if let Some(ctrl_iface) =
-            merged_state.interfaces.get_iface(ctrl, ctrl_type.clone())
-        {
-            match &ctrl_iface.merged {
-                Interface::Bond(bond_iface) => {
-                    gen_nm_bond_port_setting(bond_iface, &mut nm_conn);
-                }
-                Interface::LinuxBridge(br_iface) => {
-                    gen_nm_br_port_setting(br_iface, &mut nm_conn);
-                }
-                Interface::OvsBridge(ovs_br_iface) => {
-                    fix_ovs_iface_controller_setting(
-                        iface,
-                        &mut nm_conn,
-                        &merged_state.interfaces,
-                    );
-                    let ovs_port_name =
-                        match get_ovs_port_name(ovs_br_iface, iface.name()) {
-                            Some(name) => name,
-                            None => {
-                                // We are attaching iface to OVS bridge using
-                                // `controller` property
-                                iface.name().to_string()
-                            }
-                        };
-                    // When user attaching change controller property
-                    // on OVS system or internal interface, we should
-                    // modify it OVS port also.
-                    if !ctrl_iface.is_changed()
-                        && merged_iface
-                            .for_apply
+    ) && let Some(ctrl_iface) =
+        merged_state.interfaces.get_iface(ctrl, ctrl_type.clone())
+    {
+        match &ctrl_iface.merged {
+            Interface::Bond(bond_iface) => {
+                gen_nm_bond_port_setting(bond_iface, &mut nm_conn);
+            }
+            Interface::LinuxBridge(br_iface) => {
+                gen_nm_br_port_setting(br_iface, &mut nm_conn);
+            }
+            Interface::OvsBridge(ovs_br_iface) => {
+                fix_ovs_iface_controller_setting(
+                    iface,
+                    &mut nm_conn,
+                    &merged_state.interfaces,
+                );
+                let ovs_port_name =
+                    match get_ovs_port_name(ovs_br_iface, iface.name()) {
+                        Some(name) => name,
+                        None => {
+                            // We are attaching iface to OVS bridge using
+                            // `controller` property
+                            iface.name().to_string()
+                        }
+                    };
+                // When user attaching change controller property
+                // on OVS system or internal interface, we should
+                // modify it OVS port also.
+                if !ctrl_iface.is_changed()
+                    && merged_iface
+                        .for_apply
+                        .as_ref()
+                        .and_then(|i| i.base_iface().controller.as_ref())
+                        != merged_iface
+                            .current
                             .as_ref()
                             .and_then(|i| i.base_iface().controller.as_ref())
-                            != merged_iface.current.as_ref().and_then(|i| {
-                                i.base_iface().controller.as_ref()
-                            })
-                    {
-                        let exist_nm_ovs_port_conn = conn_matcher
-                            .get_prefered_saved_by_name_type(
-                                &ovs_port_name,
-                                &NmIfaceType::OvsPort,
-                            );
+                {
+                    let exist_nm_ovs_port_conn = conn_matcher
+                        .get_prefered_saved_by_name_type(
+                            &ovs_port_name,
+                            &NmIfaceType::OvsPort,
+                        );
 
-                        ret.push(create_ovs_port_nm_conn(
-                            ctrl,
-                            &OvsBridgePortConfig {
-                                name: ovs_port_name,
-                                ..Default::default()
-                            },
-                            exist_nm_ovs_port_conn,
-                            stable_uuid,
-                        )?);
-                    }
+                    ret.push(create_ovs_port_nm_conn(
+                        ctrl,
+                        &OvsBridgePortConfig {
+                            name: ovs_port_name,
+                            ..Default::default()
+                        },
+                        exist_nm_ovs_port_conn,
+                        stable_uuid,
+                    )?);
                 }
-                _ => (),
             }
+            _ => (),
         }
     }
 
@@ -365,10 +366,10 @@ pub(crate) fn gen_nm_conn_setting(
         });
         new_nm_conn_set.iface_type =
             Some(NmIfaceType::from(&iface.iface_type()));
-        if let Interface::Ethernet(eth_iface) = iface {
-            if eth_iface.veth.is_some() {
-                new_nm_conn_set.iface_type = Some(NmIfaceType::Veth);
-            }
+        if let Interface::Ethernet(eth_iface) = iface
+            && eth_iface.veth.is_some()
+        {
+            new_nm_conn_set.iface_type = Some(NmIfaceType::Veth);
         }
         new_nm_conn_set
     };

--- a/rust/src/lib/nm/settings/dns.rs
+++ b/rust/src/lib/nm/settings/dns.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmSettingIp;
-
 use crate::DnsClientState;
 
 pub(crate) fn apply_nm_dns_setting(

--- a/rust/src/lib/nm/settings/ethtool.rs
+++ b/rust/src/lib/nm/settings/ethtool.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::{NmConnection, NmSettingEthtool};
 use crate::{
     ErrorKind, EthtoolCoalesceConfig, EthtoolFeatureConfig, EthtoolFecConfig,
     EthtoolFecMode, EthtoolPauseConfig, EthtoolRingConfig, Interface,
     NmstateError,
+    nm::nm_dbus::{NmConnection, NmSettingEthtool},
 };
 
 const KERNEL_ETHTOOL_FEATURE_2_NM: [(&str, &str); 10] = [

--- a/rust/src/lib/nm/settings/hsr.rs
+++ b/rust/src/lib/nm/settings/hsr.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmConnection;
-
-use crate::{HsrInterface, HsrProtocol};
+use crate::{HsrInterface, HsrProtocol, nm::nm_dbus::NmConnection};
 
 pub(crate) fn gen_nm_hsr_setting(
     iface: &HsrInterface,

--- a/rust/src/lib/nm/settings/ieee8021x.rs
+++ b/rust/src/lib/nm/settings/ieee8021x.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::{NmConnection, NmSetting8021X};
-
 use crate::{Interface, NetworkState};
 
 pub(crate) fn gen_nm_802_1x_setting(

--- a/rust/src/lib/nm/settings/infiniband.rs
+++ b/rust/src/lib/nm/settings/infiniband.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmConnection;
-
-use crate::InfiniBandInterface;
+use crate::{InfiniBandInterface, nm::nm_dbus::NmConnection};
 
 pub(crate) fn gen_nm_ib_setting(
     iface: &InfiniBandInterface,
@@ -11,13 +9,10 @@ pub(crate) fn gen_nm_ib_setting(
     let mut nm_ib_set =
         nm_conn.infiniband.as_ref().cloned().unwrap_or_default();
     if let Some(ib_conf) = iface.ib.as_ref() {
-        nm_ib_set.parent = ib_conf.base_iface.as_ref().and_then(|p| {
-            if p.is_empty() {
-                None
-            } else {
-                Some(p.clone())
-            }
-        });
+        nm_ib_set.parent = ib_conf
+            .base_iface
+            .as_ref()
+            .and_then(|p| if p.is_empty() { None } else { Some(p.clone()) });
         nm_ib_set.pkey = ib_conf.pkey.and_then(|p| {
             if p == u16::MAX {
                 None

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -6,11 +6,11 @@ use super::{
     dns::apply_nm_dns_setting, route::gen_nm_ip_routes,
     route_rule::gen_nm_ip_rules,
 };
-use crate::nm::nm_dbus::{NmConnection, NmSettingIp, NmSettingIpMethod};
 use crate::{
     BaseInterface, Dhcpv4ClientId, Dhcpv6Duid, ErrorKind, Interface,
     InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, InterfaceType,
     Ipv6AddrGenMode, NmstateError, RouteEntry, WaitIp,
+    nm::nm_dbus::{NmConnection, NmSettingIp, NmSettingIpMethod},
 };
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
@@ -164,7 +164,7 @@ fn gen_nm_ipv6_setting(
                 return Err(NmstateError::new(
                     ErrorKind::NotImplementedError,
                     "Autoconf without DHCP is not supported yet".to_string(),
-                ))
+                ));
             }
             (false, false) => {
                 let ipv6_routes =

--- a/rust/src/lib/nm/settings/ipvlan.rs
+++ b/rust/src/lib/nm/settings/ipvlan.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmConnection;
-
-use crate::{IpVlanInterface, IpVlanMode};
+use crate::{IpVlanInterface, IpVlanMode, nm::nm_dbus::NmConnection};
 
 pub(crate) fn gen_nm_ipvlan_setting(
     iface: &IpVlanInterface,

--- a/rust/src/lib/nm/settings/loopback.rs
+++ b/rust/src/lib/nm/settings/loopback.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmConnection;
-
-use crate::LoopbackInterface;
+use crate::{LoopbackInterface, nm::nm_dbus::NmConnection};
 
 pub(crate) fn gen_nm_loopback_setting(
     iface: &LoopbackInterface,

--- a/rust/src/lib/nm/settings/mac_vlan.rs
+++ b/rust/src/lib/nm/settings/mac_vlan.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmSettingMacVlan;
-
-use crate::{MacVlanConfig, MacVtapConfig};
+use crate::{MacVlanConfig, MacVtapConfig, nm::nm_dbus::NmSettingMacVlan};
 
 impl From<&MacVlanConfig> for NmSettingMacVlan {
     fn from(config: &MacVlanConfig) -> Self {

--- a/rust/src/lib/nm/settings/macsec.rs
+++ b/rust/src/lib/nm/settings/macsec.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::{NmConnection, NmSettingMacSec};
-
-use crate::{MacSecInterface, MacSecOffload};
+use crate::{
+    MacSecInterface, MacSecOffload,
+    nm::nm_dbus::{NmConnection, NmSettingMacSec},
+};
 
 pub(crate) fn gen_nm_macsec_setting(
     iface: &MacSecInterface,

--- a/rust/src/lib/nm/settings/mod.rs
+++ b/rust/src/lib/nm/settings/mod.rs
@@ -27,13 +27,12 @@ mod vrf;
 mod vxlan;
 mod wired;
 
-pub(crate) use self::connection::iface_to_nm_connections;
-pub(crate) use self::ip::fix_ip_dhcp_timeout;
-
-#[cfg(feature = "gen_conf")]
-pub(crate) use self::connection::uuid_from_name_and_type;
-
 #[cfg(feature = "query_apply")]
 pub(crate) use self::bond::get_bond_balance_slb;
+#[cfg(feature = "gen_conf")]
+pub(crate) use self::connection::uuid_from_name_and_type;
 #[cfg(feature = "query_apply")]
 pub(crate) use self::user::NMSTATE_DESCRIPTION;
+pub(crate) use self::{
+    connection::iface_to_nm_connections, ip::fix_ip_dhcp_timeout,
+};

--- a/rust/src/lib/nm/settings/mptcp.rs
+++ b/rust/src/lib/nm/settings/mptcp.rs
@@ -3,7 +3,6 @@
 use std::io::Read;
 
 use super::super::nm_dbus::NmSettingConnection;
-
 use crate::{ErrorKind, MptcpAddressFlag, MptcpConfig, NmstateError};
 
 const NM_MPTCP_FLAG_ALSO_WITHOUT_DEFAULT_ROUTE: u32 = 0x08;

--- a/rust/src/lib/nm/settings/ovs.rs
+++ b/rust/src/lib/nm/settings/ovs.rs
@@ -2,12 +2,14 @@
 
 use std::collections::HashMap;
 
-use super::super::nm_dbus::{
-    NmConnection, NmIfaceType, NmRange, NmSettingOvsDpdk, NmSettingOvsExtIds,
-    NmSettingOvsIface, NmSettingOvsOtherConfig, NmSettingOvsPatch,
+use super::super::{
+    nm_dbus::{
+        NmConnection, NmIfaceType, NmRange, NmSettingOvsDpdk,
+        NmSettingOvsExtIds, NmSettingOvsIface, NmSettingOvsOtherConfig,
+        NmSettingOvsPatch,
+    },
+    settings::connection::gen_nm_conn_setting,
 };
-use super::super::settings::connection::gen_nm_conn_setting;
-
 use crate::{
     BaseInterface, BridgePortTrunkTag, Interface, InterfaceType,
     MergedInterfaces, NmstateError, OvsBridgeBondMode, OvsBridgeInterface,
@@ -120,21 +122,21 @@ pub(crate) fn gen_nm_ovs_br_setting(
     let mut nm_ovs_br_set =
         nm_conn.ovs_bridge.as_ref().cloned().unwrap_or_default();
 
-    if let Some(br_conf) = &ovs_br_iface.bridge {
-        if let Some(br_opts) = &br_conf.options {
-            nm_ovs_br_set.stp = br_opts.stp.as_ref().and_then(|s| s.enabled);
-            nm_ovs_br_set.rstp = br_opts.rstp;
-            nm_ovs_br_set.mcast_snooping_enable = br_opts.mcast_snooping_enable;
-            if let Some(fail_mode) = &br_opts.fail_mode {
-                if !fail_mode.is_empty() {
-                    nm_ovs_br_set.fail_mode = Some(fail_mode.to_string());
-                }
-            }
-            if let Some(dp_type) = &br_opts.datapath {
-                if !dp_type.is_empty() {
-                    nm_ovs_br_set.datapath_type = Some(dp_type.to_string());
-                }
-            }
+    if let Some(br_conf) = &ovs_br_iface.bridge
+        && let Some(br_opts) = &br_conf.options
+    {
+        nm_ovs_br_set.stp = br_opts.stp.as_ref().and_then(|s| s.enabled);
+        nm_ovs_br_set.rstp = br_opts.rstp;
+        nm_ovs_br_set.mcast_snooping_enable = br_opts.mcast_snooping_enable;
+        if let Some(fail_mode) = &br_opts.fail_mode
+            && !fail_mode.is_empty()
+        {
+            nm_ovs_br_set.fail_mode = Some(fail_mode.to_string());
+        }
+        if let Some(dp_type) = &br_opts.datapath
+            && !dp_type.is_empty()
+        {
+            nm_ovs_br_set.datapath_type = Some(dp_type.to_string());
         }
     }
     nm_conn.ovs_bridge = Some(nm_ovs_br_set);
@@ -156,20 +158,20 @@ pub(crate) fn gen_nm_ovs_iface_setting(
         nm_ovs_patch.peer = Some(peer.to_string());
         nm_conn.ovs_patch = Some(nm_ovs_patch);
         nm_conn.ovs_iface = Some(nm_ovs_iface_set);
-    } else if let Some(dpdk_iface) = iface.dpdk.as_ref() {
-        if !dpdk_iface.devargs.is_empty() {
-            let mut nm_ovs_iface_set =
-                nm_conn.ovs_iface.as_ref().cloned().unwrap_or_default();
-            nm_ovs_iface_set.iface_type = Some("dpdk".to_string());
-            let mut nm_ovs_dpdk = NmSettingOvsDpdk::default();
-            nm_ovs_dpdk.devargs = Some(dpdk_iface.devargs.to_string());
-            nm_ovs_dpdk.n_rxq = dpdk_iface.rx_queue;
-            nm_ovs_dpdk.n_rxq_desc = dpdk_iface.n_rxq_desc;
-            nm_ovs_dpdk.n_txq_desc = dpdk_iface.n_txq_desc;
-            nm_ovs_dpdk.lsc_interrupt = dpdk_iface.lsc_interrupt;
-            nm_conn.ovs_dpdk = Some(nm_ovs_dpdk);
-            nm_conn.ovs_iface = Some(nm_ovs_iface_set);
-        }
+    } else if let Some(dpdk_iface) = iface.dpdk.as_ref()
+        && !dpdk_iface.devargs.is_empty()
+    {
+        let mut nm_ovs_iface_set =
+            nm_conn.ovs_iface.as_ref().cloned().unwrap_or_default();
+        nm_ovs_iface_set.iface_type = Some("dpdk".to_string());
+        let mut nm_ovs_dpdk = NmSettingOvsDpdk::default();
+        nm_ovs_dpdk.devargs = Some(dpdk_iface.devargs.to_string());
+        nm_ovs_dpdk.n_rxq = dpdk_iface.rx_queue;
+        nm_ovs_dpdk.n_rxq_desc = dpdk_iface.n_rxq_desc;
+        nm_ovs_dpdk.n_txq_desc = dpdk_iface.n_txq_desc;
+        nm_ovs_dpdk.lsc_interrupt = dpdk_iface.lsc_interrupt;
+        nm_conn.ovs_dpdk = Some(nm_ovs_dpdk);
+        nm_conn.ovs_iface = Some(nm_ovs_iface_set);
     }
     if nm_conn.ovs_iface.is_none() {
         let mut nm_set = NmSettingOvsIface::default();

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmIpRoute;
-
 use crate::{
-    ip::is_ipv6_addr, InterfaceIpAddr, NmstateError, RouteEntry, RouteType,
+    InterfaceIpAddr, NmstateError, RouteEntry, RouteType, ip::is_ipv6_addr,
 };
 
 const IPV4_EMPTY_NEXT_HOP: &str = "0.0.0.0";

--- a/rust/src/lib/nm/settings/route_rule.rs
+++ b/rust/src/lib/nm/settings/route_rule.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmIpRouteRule;
-
 use crate::{
-    ip::is_ipv6_addr, ip::AddressFamily, ErrorKind, InterfaceIpAddr,
-    NmstateError, RouteRuleEntry,
+    ErrorKind, InterfaceIpAddr, NmstateError, RouteRuleEntry,
+    ip::{AddressFamily, is_ipv6_addr},
 };
 
 const AF_INET6: i32 = 10;
@@ -18,10 +17,10 @@ pub(crate) fn gen_nm_ip_rules<'a>(
     for rule in rules {
         let mut nm_rule = NmIpRouteRule::default();
         nm_rule.family = Some(if is_ipv6 { AF_INET6 } else { AF_INET });
-        if let Some(family) = rule.family {
-            if is_ipv6 != matches!(family, AddressFamily::IPv6) {
-                continue;
-            }
+        if let Some(family) = rule.family
+            && is_ipv6 != matches!(family, AddressFamily::IPv6)
+        {
+            continue;
         }
         if let Some(addr) = rule.ip_from.as_deref() {
             match (is_ipv6, is_ipv6_addr(addr)) {

--- a/rust/src/lib/nm/settings/sriov.rs
+++ b/rust/src/lib/nm/settings/sriov.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::{
-    NmConnection, NmSettingSriovVf, NmSettingSriovVfVlan,
+use crate::{
+    EthernetInterface, SrIovVfConfig,
+    nm::nm_dbus::{NmConnection, NmSettingSriovVf, NmSettingSriovVfVlan},
 };
-use crate::{EthernetInterface, SrIovVfConfig};
 
 pub(crate) fn gen_nm_sriov_setting(
     iface: &EthernetInterface,

--- a/rust/src/lib/nm/settings/user.rs
+++ b/rust/src/lib/nm/settings/user.rs
@@ -2,9 +2,10 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::{NmConnection, NmSettingUser};
-
-use crate::Interface;
+use crate::{
+    Interface,
+    nm::nm_dbus::{NmConnection, NmSettingUser},
+};
 
 pub(crate) const NMSTATE_DESCRIPTION: &str = "nmstate.interface.description";
 

--- a/rust/src/lib/nm/settings/veth.rs
+++ b/rust/src/lib/nm/settings/veth.rs
@@ -2,8 +2,8 @@
 
 use super::{
     super::{
-        nm_dbus::{NmConnection, NmIfaceType, NmSettingVeth},
         NmConnectionMatcher,
+        nm_dbus::{NmConnection, NmIfaceType, NmSettingVeth},
     },
     connection::gen_nm_conn_setting,
     ip::gen_nm_ip_setting,

--- a/rust/src/lib/nm/settings/vlan.rs
+++ b/rust/src/lib/nm/settings/vlan.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::{NmConnection, NmSettingVlanFlag};
-
 use crate::{VlanInterface, VlanProtocol, VlanRegistrationProtocol};
 
 const NM_802_1_AD: &str = "802.1ad";

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -2,8 +2,10 @@
 
 use std::collections::HashMap;
 
-use crate::nm::nm_dbus::{NmConnection, NmSettingVpn};
-use crate::{IpsecInterface, NetworkState};
+use crate::{
+    IpsecInterface, NetworkState,
+    nm::nm_dbus::{NmConnection, NmSettingVpn},
+};
 
 pub(crate) fn gen_nm_ipsec_vpn_setting(
     iface: &IpsecInterface,

--- a/rust/src/lib/nm/settings/vrf.rs
+++ b/rust/src/lib/nm/settings/vrf.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmSettingVrf;
-
 use crate::VrfConfig;
 
 impl From<&VrfConfig> for NmSettingVrf {

--- a/rust/src/lib/nm/settings/vxlan.rs
+++ b/rust/src/lib/nm/settings/vxlan.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::nm_dbus::NmSettingVxlan;
-
 use crate::VxlanConfig;
 
 impl From<&VxlanConfig> for NmSettingVxlan {

--- a/rust/src/lib/nm/settings/wired.rs
+++ b/rust/src/lib/nm/settings/wired.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::NmConnection;
-
-use crate::{Interface, InterfaceIdentifier};
+use crate::{Interface, InterfaceIdentifier, nm::nm_dbus::NmConnection};
 
 pub(crate) fn gen_nm_wired_setting(
     iface: &Interface,
@@ -27,27 +25,27 @@ pub(crate) fn gen_nm_wired_setting(
         flag_need_wired = true;
     }
 
-    if let Interface::Ethernet(eth_iface) = iface {
-        if let Some(eth_conf) = eth_iface.ethernet.as_ref() {
-            match eth_conf.auto_neg {
-                Some(true) => {
-                    flag_need_wired = true;
-                    nm_wired_set.auto_negotiate = Some(true);
-                    nm_wired_set.speed = None;
-                    nm_wired_set.duplex = None;
-                }
-                Some(false) => {
-                    flag_need_wired = true;
-                    nm_wired_set.auto_negotiate = Some(false);
-                    if let Some(v) = eth_conf.speed {
-                        nm_wired_set.speed = Some(v);
-                    }
-                    if let Some(v) = eth_conf.duplex {
-                        nm_wired_set.duplex = Some(format!("{v}"));
-                    }
-                }
-                None => (),
+    if let Interface::Ethernet(eth_iface) = iface
+        && let Some(eth_conf) = eth_iface.ethernet.as_ref()
+    {
+        match eth_conf.auto_neg {
+            Some(true) => {
+                flag_need_wired = true;
+                nm_wired_set.auto_negotiate = Some(true);
+                nm_wired_set.speed = None;
+                nm_wired_set.duplex = None;
             }
+            Some(false) => {
+                flag_need_wired = true;
+                nm_wired_set.auto_negotiate = Some(false);
+                if let Some(v) = eth_conf.speed {
+                    nm_wired_set.speed = Some(v);
+                }
+                if let Some(v) = eth_conf.duplex {
+                    nm_wired_set.duplex = Some(format!("{v}"));
+                }
+            }
+            None => (),
         }
     }
 

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::nm::nm_dbus::{
-    NmActiveConnection, NmApi, NmConnection, NmDevice, NmDeviceState,
-    NmIfaceType, NmLldpNeighbor,
-};
-
 use super::{
+    NmConnectionMatcher,
     error::nm_error_to_nmstate,
     query_apply::{
         device::nm_dev_iface_type_to_nmstate, dispatch::get_dispatches,
@@ -15,7 +11,6 @@ use super::{
         retrieve_dns_state, vpn::get_supported_vpn_ifaces,
     },
     settings::get_bond_balance_slb,
-    NmConnectionMatcher,
 };
 use crate::{
     BaseInterface, BondConfig, BondInterface, BondOptions, DummyInterface,
@@ -25,6 +20,10 @@ use crate::{
     MacVlanInterface, MacVtapInterface, MergedNetworkState, NetworkState,
     NetworkStateMode, NmstateError, OvsBridgeInterface, OvsInterface,
     PciAddress, UnknownInterface, VlanInterface, VrfInterface, VxlanInterface,
+    nm::nm_dbus::{
+        NmActiveConnection, NmApi, NmConnection, NmDevice, NmDeviceState,
+        NmIfaceType, NmLldpNeighbor,
+    },
 };
 
 /// The `current_state` is NetworkState retrieved by nispor, and will be used
@@ -106,16 +105,16 @@ pub(crate) async fn nm_retrieve(
 
         let nm_ac = conn_matcher.get_nm_ac(iface.base_iface());
 
-        if let Some(state_flag) = nm_ac.map(|nm_ac| nm_ac.state_flags) {
-            if (state_flag & NmActiveConnection::STATE_FLAG_EXTERNAL) > 0 {
-                log::debug!(
-                    "Found external managed interface {}/{}",
-                    iface.name(),
-                    iface.iface_type()
-                );
-                net_state.append_interface_data(iface);
-                continue;
-            }
+        if let Some(state_flag) = nm_ac.map(|nm_ac| nm_ac.state_flags)
+            && (state_flag & NmActiveConnection::STATE_FLAG_EXTERNAL) > 0
+        {
+            log::debug!(
+                "Found external managed interface {}/{}",
+                iface.name(),
+                iface.iface_type()
+            );
+            net_state.append_interface_data(iface);
+            continue;
         }
 
         let nm_saved_conn = conn_matcher.get_prefered_saved(iface.base_iface());
@@ -241,20 +240,19 @@ pub(crate) fn fill_iface_by_nm_conn_data(
             ..Default::default()
         };
         bond_iface.bond = Some(bond_config);
-    } else if let Interface::MacSec(mac_sec_iface) = iface {
-        if let Some(macsec_set) =
+    } else if let Interface::MacSec(mac_sec_iface) = iface
+        && let Some(macsec_set) =
             nm_applied_conn.and_then(|n| n.macsec.as_ref())
+    {
+        let mut macsec_config = MacSecConfig::new();
+        macsec_config.mka_ckn.clone_from(&macsec_set.mka_ckn);
+        // The `mka_cak` is stored in saved NmConnection only
+        if let Some(saved_conn) = nm_saved_conn.as_ref()
+            && let Some(macsec_saved_set) = saved_conn.macsec.as_ref()
         {
-            let mut macsec_config = MacSecConfig::new();
-            macsec_config.mka_ckn.clone_from(&macsec_set.mka_ckn);
-            // The `mka_cak` is stored in saved NmConnection only
-            if let Some(saved_conn) = nm_saved_conn.as_ref() {
-                if let Some(macsec_saved_set) = saved_conn.macsec.as_ref() {
-                    macsec_config.mka_cak.clone_from(&macsec_saved_set.mka_cak);
-                }
-            }
-            mac_sec_iface.macsec = Some(macsec_config);
+            macsec_config.mka_cak.clone_from(&macsec_saved_set.mka_cak);
         }
+        mac_sec_iface.macsec = Some(macsec_config);
     }
 }
 
@@ -415,13 +413,12 @@ fn fill_identifier(base_iface: &mut BaseInterface, nm_conn: &NmConnection) {
     base_iface.mac_address = None;
     base_iface.pci_address = None;
 
-    if let Some(nm_set) = nm_conn.wired.as_ref() {
-        if let Some(mac) = nm_set.mac_address.as_deref() {
-            if !mac.is_empty() {
-                base_iface.identifier = Some(InterfaceIdentifier::MacAddress);
-                base_iface.mac_address = Some(mac.to_string());
-            }
-        }
+    if let Some(nm_set) = nm_conn.wired.as_ref()
+        && let Some(mac) = nm_set.mac_address.as_deref()
+        && !mac.is_empty()
+    {
+        base_iface.identifier = Some(InterfaceIdentifier::MacAddress);
+        base_iface.mac_address = Some(mac.to_string());
     }
 
     if let Some(pci_addr_str) = nm_conn
@@ -430,11 +427,10 @@ fn fill_identifier(base_iface: &mut BaseInterface, nm_conn: &NmConnection) {
         .and_then(|s| s.path.as_ref())
         .and_then(|p| p.first())
         .and_then(|p| p.strip_prefix("pci-"))
+        && let Ok(pci_addr) = PciAddress::try_from(pci_addr_str)
     {
-        if let Ok(pci_addr) = PciAddress::try_from(pci_addr_str) {
-            base_iface.identifier = Some(InterfaceIdentifier::PciAddress);
-            base_iface.pci_address = Some(pci_addr);
-        }
+        base_iface.identifier = Some(InterfaceIdentifier::PciAddress);
+        base_iface.pci_address = Some(pci_addr);
     }
 }
 
@@ -446,12 +442,11 @@ fn get_connection_name(
     nm_conn: &NmConnection,
     saved_nm_conn: Option<&NmConnection>,
 ) -> Option<String> {
-    if let Some(saved_nm_conn) = saved_nm_conn.as_ref() {
-        if saved_nm_conn.uuid() == nm_conn.uuid() {
-            if let Some(nm_set) = saved_nm_conn.connection.as_ref() {
-                return nm_set.id.clone();
-            }
-        }
+    if let Some(saved_nm_conn) = saved_nm_conn.as_ref()
+        && saved_nm_conn.uuid() == nm_conn.uuid()
+        && let Some(nm_set) = saved_nm_conn.connection.as_ref()
+    {
+        return nm_set.id.clone();
     }
     if let Some(nm_set) = nm_conn.connection.as_ref() {
         return nm_set.id.clone();

--- a/rust/src/lib/ovn.rs
+++ b/rust/src/lib/ovn.rs
@@ -197,17 +197,17 @@ impl MergedOvnConfiguration {
         let mut desired_ovn_maps: BTreeMap<&str, &str> = BTreeMap::new();
 
         for cur_map in current.bridge_mappings.as_ref().unwrap_or(&empty_vec) {
-            if let Some(cur_br) = cur_map.bridge.as_deref() {
-                if !deleted_localnets.contains(&cur_map.localnet.as_str()) {
-                    desired_ovn_maps.insert(cur_map.localnet.as_str(), cur_br);
-                }
+            if let Some(cur_br) = cur_map.bridge.as_deref()
+                && !deleted_localnets.contains(&cur_map.localnet.as_str())
+            {
+                desired_ovn_maps.insert(cur_map.localnet.as_str(), cur_br);
             }
         }
         for des_map in desired.bridge_mappings.as_ref().unwrap_or(&empty_vec) {
-            if let Some(des_br) = des_map.bridge.as_deref() {
-                if !des_map.is_absent() {
-                    desired_ovn_maps.insert(des_map.localnet.as_str(), des_br);
-                }
+            if let Some(des_br) = des_map.bridge.as_deref()
+                && !des_map.is_absent()
+            {
+                desired_ovn_maps.insert(des_map.localnet.as_str(), des_br);
             }
         }
 

--- a/rust/src/lib/ovs.rs
+++ b/rust/src/lib/ovs.rs
@@ -192,10 +192,10 @@ impl MergedOvsDbGlobalConfig {
         mut desired: Option<OvsDbGlobalConfig>,
         current: OvsDbGlobalConfig,
     ) -> Result<Self, NmstateError> {
-        if let Some(desired) = desired.as_mut() {
-            if !desired.is_purge() {
-                desired.sanitize()?;
-            }
+        if let Some(desired) = desired.as_mut()
+            && !desired.is_purge()
+        {
+            desired.sanitize()?;
         }
         Ok(Self { desired, current })
     }

--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use serde_json::Value;
 
 use super::{
-    json_rpc::OvsDbJsonRpc, OvsDbMethodEcho, OvsDbMethodTransact,
-    OvsDbOperation, OvsDbSelect,
+    OvsDbMethodEcho, OvsDbMethodTransact, OvsDbOperation, OvsDbSelect,
+    json_rpc::OvsDbJsonRpc,
 };
 use crate::{ErrorKind, NmstateError};
 
@@ -201,35 +201,35 @@ impl TryFrom<&Value> for OvsDbEntry {
         );
         let v = v.clone();
         let mut ret = OvsDbEntry::default();
-        if let Value::Object(mut v) = v {
-            if let Some(Value::String(n)) = v.remove("name") {
-                ret.name = n;
-                if let Some(Value::Array(uuid)) = v.remove("_uuid") {
-                    if let Some(Value::String(uuid)) = uuid.get(1) {
-                        ret.uuid = uuid.to_string();
-                    }
-                }
-                if let Some(Value::String(iface_type)) = v.remove("type") {
-                    ret.iface_type = iface_type;
-                }
-                if let Some(Value::Array(ids)) = v.remove("external_ids") {
-                    ret.external_ids = parse_str_map(&ids);
-                }
-                if let Some(Value::Array(cfgs)) = v.remove("other_config") {
-                    ret.other_config = parse_str_map(&cfgs);
-                }
-                if let Some(Value::Array(ports)) = v.remove("ports") {
-                    ret.ports = parse_uuid_array(&ports);
-                }
-                if let Some(Value::Array(ports)) = v.remove("interfaces") {
-                    ret.ports = parse_uuid_array(&ports);
-                }
-                for (key, value) in v.iter() {
-                    ret.options.insert(key.to_string(), value.clone());
-                }
-
-                return Ok(ret);
+        if let Value::Object(mut v) = v
+            && let Some(Value::String(n)) = v.remove("name")
+        {
+            ret.name = n;
+            if let Some(Value::Array(uuid)) = v.remove("_uuid")
+                && let Some(Value::String(uuid)) = uuid.get(1)
+            {
+                ret.uuid = uuid.to_string();
             }
+            if let Some(Value::String(iface_type)) = v.remove("type") {
+                ret.iface_type = iface_type;
+            }
+            if let Some(Value::Array(ids)) = v.remove("external_ids") {
+                ret.external_ids = parse_str_map(&ids);
+            }
+            if let Some(Value::Array(cfgs)) = v.remove("other_config") {
+                ret.other_config = parse_str_map(&cfgs);
+            }
+            if let Some(Value::Array(ports)) = v.remove("ports") {
+                ret.ports = parse_uuid_array(&ports);
+            }
+            if let Some(Value::Array(ports)) = v.remove("interfaces") {
+                ret.ports = parse_uuid_array(&ports);
+            }
+            for (key, value) in v.iter() {
+                ret.options.insert(key.to_string(), value.clone());
+            }
+
+            return Ok(ret);
         }
         log::error!("{e}");
         Err(e)
@@ -243,17 +243,16 @@ pub(crate) fn parse_str_map(v: &[Value]) -> HashMap<String, String> {
             "map" => {
                 if let Some(ids) = v.get(1).and_then(|i| i.as_array()) {
                     for kv in ids {
-                        if let Some(kv) = kv.as_array() {
-                            if let (
+                        if let Some(kv) = kv.as_array()
+                            && let (
                                 Some(Value::String(k)),
                                 Some(Value::String(v)),
                             ) = (kv.first(), kv.get(1))
-                            {
-                                if k == NM_RESERVED_EXTERNAL_ID {
-                                    continue;
-                                }
-                                ret.insert(k.to_string(), v.to_string());
+                        {
+                            if k == NM_RESERVED_EXTERNAL_ID {
+                                continue;
                             }
+                            ret.insert(k.to_string(), v.to_string());
                         }
                     }
                 }
@@ -273,17 +272,16 @@ pub(crate) fn parse_uuid_array(v: &[Value]) -> Vec<String> {
             "set" => {
                 if let Some(vs) = v.get(1).and_then(|i| i.as_array()) {
                     for v in vs {
-                        if let Some(kv) = v.as_array() {
-                            if let (
+                        if let Some(kv) = v.as_array()
+                            && let (
                                 Some(Value::String(k)),
                                 Some(Value::String(v)),
                             ) = (kv.first(), kv.get(1))
-                            {
-                                if k != "uuid" {
-                                    continue;
-                                }
-                                ret.push(v.to_string());
+                        {
+                            if k != "uuid" {
+                                continue;
                             }
+                            ret.push(v.to_string());
                         }
                     }
                 }

--- a/rust/src/lib/ovsdb/global_conf.rs
+++ b/rust/src/lib/ovsdb/global_conf.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use serde_json::{Map, Value};
 
 use super::{
-    db::parse_str_map, OvsDbConnection, OvsDbMethodTransact, OvsDbMutate,
-    OvsDbMutation, OvsDbOperation, OvsDbSelect, OvsDbUpdate, OVS_DB_NAME,
+    OVS_DB_NAME, OvsDbConnection, OvsDbMethodTransact, OvsDbMutate,
+    OvsDbMutation, OvsDbOperation, OvsDbSelect, OvsDbUpdate, db::parse_str_map,
 };
 use crate::{ErrorKind, MergedNetworkState, NmstateError, OvsDbGlobalConfig};
 

--- a/rust/src/lib/ovsdb/json_rpc.rs
+++ b/rust/src/lib/ovsdb/json_rpc.rs
@@ -107,7 +107,7 @@ impl OvsDbJsonRpc {
                         format!(
                             "Failed to read data from OVSDB connection: {e}"
                         ),
-                    ))
+                    ));
                 }
             };
             log::debug!(

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -7,13 +7,16 @@ mod method;
 mod operation;
 mod show;
 
-pub(crate) use self::db::{
-    OvsDbCondition, OvsDbConnection, DEFAULT_OVS_DB_SOCKET_PATH, OVS_DB_NAME,
+pub(crate) use show::{ovsdb_is_running, ovsdb_retrieve};
+
+pub(crate) use self::{
+    db::{
+        DEFAULT_OVS_DB_SOCKET_PATH, OVS_DB_NAME, OvsDbCondition,
+        OvsDbConnection,
+    },
+    global_conf::ovsdb_apply_global_conf,
+    method::{OvsDbMethodEcho, OvsDbMethodTransact},
+    operation::{
+        OvsDbMutate, OvsDbMutation, OvsDbOperation, OvsDbSelect, OvsDbUpdate,
+    },
 };
-pub(crate) use self::global_conf::ovsdb_apply_global_conf;
-pub(crate) use self::method::{OvsDbMethodEcho, OvsDbMethodTransact};
-pub(crate) use self::operation::{
-    OvsDbMutate, OvsDbMutation, OvsDbOperation, OvsDbSelect, OvsDbUpdate,
-};
-pub(crate) use show::ovsdb_is_running;
-pub(crate) use show::ovsdb_retrieve;

--- a/rust/src/lib/ovsdb/show.rs
+++ b/rust/src/lib/ovsdb/show.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use super::db::{OvsDbConnection, OvsDbEntry, parse_str_map};
 use crate::{
     BridgePortTrunkTag, BridgePortVlanConfig, BridgePortVlanMode,
     BridgePortVlanRange, Interface, InterfaceType, Interfaces, NetworkState,
@@ -13,8 +14,6 @@ use crate::{
     OvsDbIfaceConfig, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
     UnknownInterface,
 };
-
-use super::db::{parse_str_map, OvsDbConnection, OvsDbEntry};
 
 pub(crate) async fn ovsdb_is_running() -> bool {
     if let Ok(mut cli) = OvsDbConnection::new().await {
@@ -169,24 +168,22 @@ fn parse_ovs_bond_conf(
         }
     }
 
-    if bond_conf.mode.is_none() {
-        if let Some(Value::String(lacp)) = ovsdb_port.options.get("lacp") {
-            if lacp.as_str() == "active" {
-                bond_conf.mode = Some(OvsBridgeBondMode::Lacp);
-            }
-        }
+    if bond_conf.mode.is_none()
+        && let Some(Value::String(lacp)) = ovsdb_port.options.get("lacp")
+        && lacp.as_str() == "active"
+    {
+        bond_conf.mode = Some(OvsBridgeBondMode::Lacp);
     }
 
-    if let Some(Value::Number(v)) = ovsdb_port.options.get("bond_updelay") {
-        if let Some(v) = v.as_u64() {
-            bond_conf.bond_updelay = if v == 0 { None } else { Some(v as u32) };
-        }
+    if let Some(Value::Number(v)) = ovsdb_port.options.get("bond_updelay")
+        && let Some(v) = v.as_u64()
+    {
+        bond_conf.bond_updelay = if v == 0 { None } else { Some(v as u32) };
     }
-    if let Some(Value::Number(v)) = ovsdb_port.options.get("bond_downdelay") {
-        if let Some(v) = v.as_u64() {
-            bond_conf.bond_downdelay =
-                if v == 0 { None } else { Some(v as u32) };
-        }
+    if let Some(Value::Number(v)) = ovsdb_port.options.get("bond_downdelay")
+        && let Some(v) = v.as_u64()
+    {
+        bond_conf.bond_downdelay = if v == 0 { None } else { Some(v as u32) };
     }
     let external_ids = HashMap::from_iter(
         ovsdb_port
@@ -246,11 +243,9 @@ fn parse_ovs_vlan_conf(
                 }
             } else if let Some(Value::Number(trunk_tag)) =
                 ovsdb_port.options.get("trunks")
+                && let Some(tag) = trunk_tag.as_u64()
             {
-                if let Some(tag) = trunk_tag.as_u64() {
-                    ret.trunk_tags =
-                        Some(vec![BridgePortTrunkTag::Id(tag as u16)]);
-                }
+                ret.trunk_tags = Some(vec![BridgePortTrunkTag::Id(tag as u16)]);
             }
         }
         Some(ret)
@@ -321,20 +316,20 @@ fn parse_ovs_iface_dpdk_conf(
                 devargs: devargs.to_string(),
                 ..Default::default()
             };
-            if let Some(n_rxq) = options.get("n_rxq") {
-                if let Ok(i) = n_rxq.parse::<u32>() {
-                    conf.rx_queue = Some(i)
-                }
+            if let Some(n_rxq) = options.get("n_rxq")
+                && let Ok(i) = n_rxq.parse::<u32>()
+            {
+                conf.rx_queue = Some(i)
             }
-            if let Some(n_rxq_desc) = options.get("n_rxq_desc") {
-                if let Ok(i) = n_rxq_desc.parse::<u32>() {
-                    conf.n_rxq_desc = Some(i)
-                }
+            if let Some(n_rxq_desc) = options.get("n_rxq_desc")
+                && let Ok(i) = n_rxq_desc.parse::<u32>()
+            {
+                conf.n_rxq_desc = Some(i)
             }
-            if let Some(n_txq_desc) = options.get("n_txq_desc") {
-                if let Ok(i) = n_txq_desc.parse::<u32>() {
-                    conf.n_txq_desc = Some(i)
-                }
+            if let Some(n_txq_desc) = options.get("n_txq_desc")
+                && let Ok(i) = n_txq_desc.parse::<u32>()
+            {
+                conf.n_txq_desc = Some(i)
             }
             if let Some(lsc_interrupt) = options.get("dpdk-lsc-interrupt") {
                 conf.lsc_interrupt = match lsc_interrupt.as_str() {

--- a/rust/src/lib/pci_address.rs
+++ b/rust/src/lib/pci_address.rs
@@ -9,8 +9,9 @@
 
 use std::str::FromStr;
 
-use crate::{ErrorKind, NmstateError};
 use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, NmstateError};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(into = "String")]

--- a/rust/src/lib/policy/capture.rs
+++ b/rust/src/lib/policy/capture.rs
@@ -3,18 +3,17 @@
 use std::collections::HashMap;
 
 use serde::{
-    ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer, Serialize, Serializer, ser::SerializeMap,
 };
-
-use crate::{ErrorKind, NetworkState, NmstateError};
 
 use super::{
     iface::{get_iface_match, update_ifaces},
     json::{get_value_from_json, value_retain_only, value_to_string},
     route::{get_route_match, update_routes},
     route_rule::{get_route_rule_match, update_route_rules},
-    token::{parse_str_to_capture_tokens, NetworkCaptureToken},
+    token::{NetworkCaptureToken, parse_str_to_capture_tokens},
 };
+use crate::{ErrorKind, NetworkState, NmstateError};
 
 pub(crate) const PROPERTY_SPLITTER: &str = ".";
 const SORT_CAPTURE_MAX_ROUND: usize = 10;
@@ -543,11 +542,11 @@ fn process_tokens_without_pipe(
         ret.action = NetworkCaptureAction::Equal;
         let (key, key_capture) =
             get_condition_key(&tokens[..pos], line, &tokens[pos])?;
-        if ret.key_capture.is_none() {
-            if let Some((cap_name, pos)) = key_capture {
-                ret.key_capture = Some(cap_name);
-                ret.key_capture_pos = pos;
-            }
+        if ret.key_capture.is_none()
+            && let Some((cap_name, pos)) = key_capture
+        {
+            ret.key_capture = Some(cap_name);
+            ret.key_capture_pos = pos;
         }
         ret.key = key;
         let (value, value_capture) =
@@ -572,11 +571,11 @@ fn process_tokens_without_pipe(
         ret.action = NetworkCaptureAction::Replace;
         let (key, key_capture) =
             get_condition_key(&tokens[..pos], line, &tokens[pos])?;
-        if ret.key_capture.is_none() {
-            if let Some((cap_name, pos)) = key_capture {
-                ret.key_capture = Some(cap_name);
-                ret.key_capture_pos = pos;
-            }
+        if ret.key_capture.is_none()
+            && let Some((cap_name, pos)) = key_capture
+        {
+            ret.key_capture = Some(cap_name);
+            ret.key_capture_pos = pos;
         }
         ret.key = key;
         let (value, value_capture) =

--- a/rust/src/lib/policy/iface.rs
+++ b/rust/src/lib/policy/iface.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Interface, Interfaces, NetworkState, NmstateError};
-
 use super::json::{search_item, update_items};
+use crate::{Interface, Interfaces, NetworkState, NmstateError};
 
 pub(crate) fn get_iface_match(
     prop_path: &[String],

--- a/rust/src/lib/policy/json.rs
+++ b/rust/src/lib/policy/json.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ErrorKind, NmstateError};
-
 use super::capture::PROPERTY_SPLITTER;
+use crate::{ErrorKind, NmstateError};
 
 pub(crate) fn get_value_from_json(
     prop_path: &[String],
@@ -324,14 +323,14 @@ pub(crate) fn value_retain_only(
     data: &mut serde_json::Value,
     prop_path: &[String],
 ) {
-    if let Some(data) = data.as_object_mut() {
-        if !prop_path.is_empty() {
-            data.retain(|k, _| k == &prop_path[0]);
-            if prop_path.len() >= 2 {
-                if let Some(leaf) = data.get_mut(&prop_path[0]) {
-                    value_retain_only(leaf, &prop_path[1..]);
-                }
-            }
+    if let Some(data) = data.as_object_mut()
+        && !prop_path.is_empty()
+    {
+        data.retain(|k, _| k == &prop_path[0]);
+        if prop_path.len() >= 2
+            && let Some(leaf) = data.get_mut(&prop_path[0])
+        {
+            value_retain_only(leaf, &prop_path[1..]);
         }
     }
 }

--- a/rust/src/lib/policy/mod.rs
+++ b/rust/src/lib/policy/mod.rs
@@ -9,6 +9,7 @@ mod route_rule;
 mod template;
 pub(crate) mod token;
 
-pub use self::capture::NetworkCaptureRules;
-pub use self::net_policy::NetworkPolicy;
-pub use self::template::NetworkStateTemplate;
+pub use self::{
+    capture::NetworkCaptureRules, net_policy::NetworkPolicy,
+    template::NetworkStateTemplate,
+};

--- a/rust/src/lib/policy/net_policy.rs
+++ b/rust/src/lib/policy/net_policy.rs
@@ -4,9 +4,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{NetworkState, NmstateError};
-
 use super::{NetworkCaptureRules, NetworkStateTemplate};
+use crate::{NetworkState, NmstateError};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/rust/src/lib/policy/route.rs
+++ b/rust/src/lib/policy/route.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{NetworkState, NmstateError, RouteEntry, Routes};
-
 use super::json::{search_item, update_items};
+use crate::{NetworkState, NmstateError, RouteEntry, Routes};
 
 pub(crate) fn get_route_match(
     prop_path: &[String],

--- a/rust/src/lib/policy/route_rule.rs
+++ b/rust/src/lib/policy/route_rule.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{NetworkState, NmstateError, RouteRuleEntry, RouteRules};
-
 use super::json::{search_item, update_items};
+use crate::{NetworkState, NmstateError, RouteRuleEntry, RouteRules};
 
 pub(crate) fn get_route_rule_match(
     prop_path: &[String],

--- a/rust/src/lib/policy/template.rs
+++ b/rust/src/lib/policy/template.rs
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::fmt::Write;
+use std::{collections::HashMap, fmt::Write};
 
 use serde::{Deserialize, Serialize};
-
-use crate::{ErrorKind, NetworkState, NmstateError};
 
 use super::{
     capture::get_value,
     token::{
-        parse_str_to_template_tokens, NetworkCaptureToken, NetworkTemplateToken,
+        NetworkCaptureToken, NetworkTemplateToken, parse_str_to_template_tokens,
     },
 };
+use crate::{ErrorKind, NetworkState, NmstateError};
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[non_exhaustive]

--- a/rust/src/lib/policy/token.rs
+++ b/rust/src/lib/policy/token.rs
@@ -370,36 +370,32 @@ pub(crate) fn parse_str_to_template_tokens(
         .as_slice()
         .iter()
         .find(|c| matches!(c, &NetworkTemplateToken::ReferenceStart(_)))
-    {
-        if !ret
+        && !ret
             .as_slice()
             .iter()
             .any(|c| matches!(c, &NetworkTemplateToken::ReferenceEnd(_)))
-        {
-            return Err(NmstateError::new_policy_error(
-                "No reference end }} found".to_string(),
-                line,
-                token_start.pos(),
-            ));
-        }
+    {
+        return Err(NmstateError::new_policy_error(
+            "No reference end }} found".to_string(),
+            line,
+            token_start.pos(),
+        ));
     }
 
     if let Some(token_end) = ret
         .as_slice()
         .iter()
         .find(|c| matches!(c, &NetworkTemplateToken::ReferenceEnd(_)))
-    {
-        if !ret
+        && !ret
             .as_slice()
             .iter()
             .any(|c| matches!(c, &NetworkTemplateToken::ReferenceStart(_)))
-        {
-            return Err(NmstateError::new_policy_error(
-                "No reference start {{ found".to_string(),
-                line,
-                token_end.pos(),
-            ));
-        }
+    {
+        return Err(NmstateError::new_policy_error(
+            "No reference start {{ found".to_string(),
+            line,
+            token_end.pos(),
+        ));
     }
 
     if let (Some(token_start_pos), Some(token_end_pos)) = (

--- a/rust/src/lib/query_apply/base.rs
+++ b/rust/src/lib/query_apply/base.rs
@@ -125,23 +125,23 @@ impl BaseInterface {
             self.wait_ip = other.wait_ip;
         }
 
-        if other.ipv4.is_some() {
-            if let Some(ref other_ipv4) = other.ipv4 {
-                if let Some(ref mut self_ipv4) = self.ipv4 {
-                    self_ipv4.update(other_ipv4);
-                } else {
-                    self.ipv4.clone_from(&other.ipv4);
-                }
+        if other.ipv4.is_some()
+            && let Some(ref other_ipv4) = other.ipv4
+        {
+            if let Some(ref mut self_ipv4) = self.ipv4 {
+                self_ipv4.update(other_ipv4);
+            } else {
+                self.ipv4.clone_from(&other.ipv4);
             }
         }
 
-        if other.ipv6.is_some() {
-            if let Some(ref other_ipv6) = other.ipv6 {
-                if let Some(ref mut self_ipv6) = self.ipv6 {
-                    self_ipv6.update(other_ipv6);
-                } else {
-                    self.ipv6.clone_from(&other.ipv6);
-                }
+        if other.ipv6.is_some()
+            && let Some(ref other_ipv6) = other.ipv6
+        {
+            if let Some(ref mut self_ipv6) = self.ipv6 {
+                self_ipv6.update(other_ipv6);
+            } else {
+                self.ipv6.clone_from(&other.ipv6);
             }
         }
         if other.mptcp.is_some() {

--- a/rust/src/lib/query_apply/bond.rs
+++ b/rust/src/lib/query_apply/bond.rs
@@ -38,10 +38,10 @@ impl BondOptions {
     // Only allow update `balance_slb` as that is userspace value.
     // Other options should be provided by nispor via kernel netlink.
     pub(crate) fn update(&mut self, other: Option<&Self>) {
-        if let Some(other) = other {
-            if let Some(value) = other.balance_slb {
-                self.balance_slb = Some(value);
-            }
+        if let Some(other) = other
+            && let Some(value) = other.balance_slb
+        {
+            self.balance_slb = Some(value);
         }
     }
 }
@@ -52,39 +52,37 @@ impl MergedInterface {
         let mut des_queue_ids: HashMap<&str, u16> = HashMap::new();
         let mut cur_queue_ids: HashMap<&str, u16> = HashMap::new();
 
-        if let Some(Interface::Bond(des_iface)) = self.desired.as_ref() {
-            if let Some(port_confs) = des_iface
+        if let Some(Interface::Bond(des_iface)) = self.desired.as_ref()
+            && let Some(port_confs) = des_iface
                 .bond
                 .as_ref()
                 .and_then(|b| b.ports_config.as_ref())
+        {
+            for port_conf in port_confs
+                .iter()
+                .filter(|p| p.queue_id.is_some() && p.queue_id != Some(0))
             {
-                for port_conf in port_confs
-                    .iter()
-                    .filter(|p| p.queue_id.is_some() && p.queue_id != Some(0))
-                {
-                    des_queue_ids.insert(
-                        port_conf.name.as_str(),
-                        port_conf.queue_id.unwrap_or_default(),
-                    );
-                }
+                des_queue_ids.insert(
+                    port_conf.name.as_str(),
+                    port_conf.queue_id.unwrap_or_default(),
+                );
             }
         }
 
-        if let Some(Interface::Bond(cur_iface)) = self.current.as_ref() {
-            if let Some(port_confs) = cur_iface
+        if let Some(Interface::Bond(cur_iface)) = self.current.as_ref()
+            && let Some(port_confs) = cur_iface
                 .bond
                 .as_ref()
                 .and_then(|b| b.ports_config.as_ref())
+        {
+            for port_conf in port_confs
+                .iter()
+                .filter(|p| p.queue_id.is_some() && p.queue_id != Some(0))
             {
-                for port_conf in port_confs
-                    .iter()
-                    .filter(|p| p.queue_id.is_some() && p.queue_id != Some(0))
-                {
-                    cur_queue_ids.insert(
-                        port_conf.name.as_str(),
-                        port_conf.queue_id.unwrap_or_default(),
-                    );
-                }
+                cur_queue_ids.insert(
+                    port_conf.name.as_str(),
+                    port_conf.queue_id.unwrap_or_default(),
+                );
             }
         }
 

--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -14,11 +14,11 @@ impl EthernetInterface {
             sriov_conf.sanitize_desired_for_verify();
         }
 
-        if let Some(eth_conf) = self.ethernet.as_mut() {
-            if eth_conf.auto_neg == Some(true) {
-                eth_conf.speed = None;
-                eth_conf.duplex = None;
-            }
+        if let Some(eth_conf) = self.ethernet.as_mut()
+            && eth_conf.auto_neg == Some(true)
+        {
+            eth_conf.speed = None;
+            eth_conf.duplex = None;
         }
     }
 
@@ -51,10 +51,10 @@ impl EthernetInterface {
         &self,
         cur_ifaces: &Interfaces,
     ) -> Result<(), NmstateError> {
-        if let Some(eth_conf) = &self.ethernet {
-            if let Some(sriov_conf) = &eth_conf.sr_iov {
-                sriov_conf.verify_sriov(self.base.name.as_str(), cur_ifaces)?;
-            }
+        if let Some(eth_conf) = &self.ethernet
+            && let Some(sriov_conf) = &eth_conf.sr_iov
+        {
+            sriov_conf.verify_sriov(self.base.name.as_str(), cur_ifaces)?;
         }
         Ok(())
     }
@@ -96,20 +96,19 @@ fn is_sriov_supported(iface_name: &str) -> bool {
 impl Interfaces {
     pub(crate) fn check_sriov_capability(&self) -> Result<(), NmstateError> {
         for iface in self.kernel_ifaces.values() {
-            if let Interface::Ethernet(eth_iface) = iface {
-                if eth_iface.sriov_is_enabled()
-                    && !is_sriov_supported(iface.name())
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::NotSupportedError,
-                        format!(
-                            "SR-IOV is not supported by interface {}",
-                            iface.name()
-                        ),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
+            if let Interface::Ethernet(eth_iface) = iface
+                && eth_iface.sriov_is_enabled()
+                && !is_sriov_supported(iface.name())
+            {
+                let e = NmstateError::new(
+                    ErrorKind::NotSupportedError,
+                    format!(
+                        "SR-IOV is not supported by interface {}",
+                        iface.name()
+                    ),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
         }
         Ok(())
@@ -129,10 +128,9 @@ impl NetworkState {
                 Interface::Ethernet(iface),
                 Some(Interface::Ethernet(cur_iface)),
             ) = (iface, current.interfaces.kernel_ifaces.get(iface.name()))
+                && (iface.sriov_is_enabled() || cur_iface.sriov_is_enabled())
             {
-                if iface.sriov_is_enabled() || cur_iface.sriov_is_enabled() {
-                    return true;
-                }
+                return true;
             }
         }
         false
@@ -168,16 +166,15 @@ impl NetworkState {
         }) {
             if let Some(true) =
                 iface.ethernet.as_ref().map(|e| e.sr_iov.is_some())
+                && let Some(eth_conf) = iface.ethernet.as_ref()
             {
-                if let Some(eth_conf) = iface.ethernet.as_ref() {
-                    pf_ifaces.push(Interface::Ethernet(Box::new(
-                        EthernetInterface {
-                            base: iface.base.clone_name_type_only(),
-                            ethernet: Some(eth_conf.clone()),
-                            ..Default::default()
-                        },
-                    )));
-                }
+                pf_ifaces.push(Interface::Ethernet(Box::new(
+                    EthernetInterface {
+                        base: iface.base.clone_name_type_only(),
+                        ethernet: Some(eth_conf.clone()),
+                        ..Default::default()
+                    },
+                )));
             }
         }
 

--- a/rust/src/lib/query_apply/hostname.rs
+++ b/rust/src/lib/query_apply/hostname.rs
@@ -38,35 +38,35 @@ impl MergedHostNameState {
             ));
         };
 
-        if let Some(running) = desired.running.as_ref() {
-            if Some(running) != current.running.as_ref() {
-                let e = NmstateError::new(
-                    ErrorKind::VerificationError,
-                    format!(
-                        "Verification fail, desire hostname.running: {}, \
-                         current: {:?}",
-                        running,
-                        current.running.as_ref()
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        if let Some(running) = desired.running.as_ref()
+            && Some(running) != current.running.as_ref()
+        {
+            let e = NmstateError::new(
+                ErrorKind::VerificationError,
+                format!(
+                    "Verification fail, desire hostname.running: {}, current: \
+                     {:?}",
+                    running,
+                    current.running.as_ref()
+                ),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
-        if let Some(config) = desired.config.as_ref() {
-            if Some(config) != current.config.as_ref() {
-                let e = NmstateError::new(
-                    ErrorKind::VerificationError,
-                    format!(
-                        "Verification fail, desire hostname.config: {}, \
-                         current: {:?}",
-                        config,
-                        current.config.as_ref()
-                    ),
-                );
-                log::error!("{e}");
-                return Err(e);
-            }
+        if let Some(config) = desired.config.as_ref()
+            && Some(config) != current.config.as_ref()
+        {
+            let e = NmstateError::new(
+                ErrorKind::VerificationError,
+                format!(
+                    "Verification fail, desire hostname.config: {}, current: \
+                     {:?}",
+                    config,
+                    current.config.as_ref()
+                ),
+            );
+            log::error!("{e}");
+            return Err(e);
         }
 
         Ok(())

--- a/rust/src/lib/query_apply/iface.rs
+++ b/rust/src/lib/query_apply/iface.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state::get_json_value_difference, ErrorKind, Interface, InterfaceType,
-    LinuxBridgeInterface, NmstateError,
+    ErrorKind, Interface, InterfaceType, LinuxBridgeInterface, NmstateError,
+    state::get_json_value_difference,
 };
 
 impl Interface {
@@ -49,27 +49,25 @@ impl Interface {
                 serde_json::Value::Number(des),
                 serde_json::Value::Number(cur),
             ) = (desire, current)
-            {
-                if desire.as_u64().unwrap_or(0) as i128
+                && desire.as_u64().unwrap_or(0) as i128
                     - cur.as_u64().unwrap_or(0) as i128
                     == 1
-                    && LinuxBridgeInterface::is_interger_rounded_up(&reference)
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::KernelIntegerRoundedError,
-                        format!(
-                            "Linux kernel configured with 250 HZ will round \
-                             up/down the integer in linux bridge {} option \
-                             '{}' from {:?} to {:?}.",
-                            self.name(),
-                            reference,
-                            des,
-                            cur
-                        ),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
+                && LinuxBridgeInterface::is_interger_rounded_up(&reference)
+            {
+                let e = NmstateError::new(
+                    ErrorKind::KernelIntegerRoundedError,
+                    format!(
+                        "Linux kernel configured with 250 HZ will round \
+                         up/down the integer in linux bridge {} option '{}' \
+                         from {:?} to {:?}.",
+                        self.name(),
+                        reference,
+                        des,
+                        cur
+                    ),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
 
             Err(NmstateError::new(

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state::{gen_diff_json_value, merge_json_value},
     ErrorKind, Interface, InterfaceType, Interfaces, MergedInterfaces,
     NmstateError,
+    state::{gen_diff_json_value, merge_json_value},
 };
 
 impl Interfaces {
@@ -236,10 +236,10 @@ impl MergedInterfaces {
                 // Do not verify physical interface with state:down
                 if iface.is_up() {
                     iface.verify(cur_iface)?;
-                    if let Interface::Ethernet(eth_iface) = iface {
-                        if eth_iface.sriov_is_enabled() {
-                            eth_iface.verify_sriov(&current)?;
-                        }
+                    if let Interface::Ethernet(eth_iface) = iface
+                        && eth_iface.sriov_is_enabled()
+                    {
+                        eth_iface.verify_sriov(&current)?;
                     }
                 }
             } else if iface.is_up() {

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -190,30 +190,26 @@ impl Interface {
         if let (Some(des_ip), Some(cur_ip)) = (
             self.base_iface_mut().ipv4.as_mut(),
             current.base_iface_mut().ipv4.as_mut(),
-        ) {
-            if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
-                (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
-            {
-                if des_ip.allow_extra_address != Some(false) {
-                    cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
-                }
-                // Remove allow_extra_address as current does not have it
-                des_ip.allow_extra_address = None
+        ) && let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
+            (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
+        {
+            if des_ip.allow_extra_address != Some(false) {
+                cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
             }
+            // Remove allow_extra_address as current does not have it
+            des_ip.allow_extra_address = None
         }
         if let (Some(des_ip), Some(cur_ip)) = (
             self.base_iface_mut().ipv6.as_mut(),
             current.base_iface_mut().ipv6.as_mut(),
-        ) {
-            if let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
-                (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
-            {
-                if des_ip.allow_extra_address != Some(false) {
-                    cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
-                }
-                // Remove allow_extra_address as current does not have it
-                des_ip.allow_extra_address = None
+        ) && let (Some(des_ip_addrs), Some(cur_ip_addrs)) =
+            (des_ip.addresses.as_ref(), cur_ip.addresses.as_mut())
+        {
+            if des_ip.allow_extra_address != Some(false) {
+                cur_ip_addrs.retain(|i| des_ip_addrs.contains(i))
             }
+            // Remove allow_extra_address as current does not have it
+            des_ip.allow_extra_address = None
         }
     }
 }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -3,6 +3,8 @@
 use std::future::Future;
 
 use crate::{
+    ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
+    NetworkStateMode, NmstateError,
     nispor::{
         apply_ifaces_alt_names, nispor_apply, nispor_retrieve,
         persist_alt_name_config, set_running_hostname,
@@ -12,11 +14,9 @@ use crate::{
         nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_retrieve,
     },
     ovsdb::{
-        ovsdb_apply_global_conf, ovsdb_is_running, ovsdb_retrieve,
-        DEFAULT_OVS_DB_SOCKET_PATH,
+        DEFAULT_OVS_DB_SOCKET_PATH, ovsdb_apply_global_conf, ovsdb_is_running,
+        ovsdb_retrieve,
     },
-    ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
-    NetworkStateMode, NmstateError,
 };
 
 const DEFAULT_ROLLBACK_TIMEOUT: u32 = 60;

--- a/rust/src/lib/query_apply/ovn.rs
+++ b/rust/src/lib/query_apply/ovn.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state::get_json_value_difference, ErrorKind, MergedOvnConfiguration,
-    NmstateError, OvnConfiguration,
+    ErrorKind, MergedOvnConfiguration, NmstateError, OvnConfiguration,
+    state::get_json_value_difference,
 };
 
 impl MergedOvnConfiguration {

--- a/rust/src/lib/query_apply/ovs.rs
+++ b/rust/src/lib/query_apply/ovs.rs
@@ -3,10 +3,11 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    state::get_json_value_difference, ErrorKind, Interface, InterfaceState,
-    InterfaceType, Interfaces, MergedInterfaces, MergedOvsDbGlobalConfig,
-    NetworkState, NmstateError, OvsBridgeBondConfig, OvsBridgeConfig,
-    OvsBridgeInterface, OvsDbGlobalConfig, OvsDbIfaceConfig, OvsInterface,
+    ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
+    MergedInterfaces, MergedOvsDbGlobalConfig, NetworkState, NmstateError,
+    OvsBridgeBondConfig, OvsBridgeConfig, OvsBridgeInterface,
+    OvsDbGlobalConfig, OvsDbIfaceConfig, OvsInterface,
+    state::get_json_value_difference,
 };
 
 impl MergedOvsDbGlobalConfig {
@@ -186,10 +187,9 @@ impl MergedInterfaces {
                     // Remove allow_extra_patch_ports as current state
                     // does not have it
                     if let Some(Interface::OvsBridge(c)) = i.for_verify.as_mut()
+                        && let Some(c) = c.bridge.as_mut()
                     {
-                        if let Some(c) = c.bridge.as_mut() {
-                            c.allow_extra_patch_ports = None;
-                        }
+                        c.allow_extra_patch_ports = None;
                     }
                     Some(o)
                 } else {

--- a/rust/src/lib/query_apply/route.rs
+++ b/rust/src/lib/query_apply/route.rs
@@ -65,12 +65,11 @@ impl MergedRoutes {
         let mut cur_routes: Vec<RouteEntry> = Vec::new();
         if let Some(cur_rts) = current.config.clone() {
             for mut cur_rt in cur_rts {
-                if let Some(via) = cur_rt.next_hop_iface.as_ref() {
-                    if ignored_ifaces.contains(&via.as_str())
-                        && cur_rt.route_type.is_none()
-                    {
-                        continue;
-                    }
+                if let Some(via) = cur_rt.next_hop_iface.as_ref()
+                    && ignored_ifaces.contains(&via.as_str())
+                    && cur_rt.route_type.is_none()
+                {
+                    continue;
                 }
                 cur_rt.sanitize_current_route_for_verify();
                 cur_routes.push(cur_rt);

--- a/rust/src/lib/query_apply/route_rule.rs
+++ b/rust/src/lib/query_apply/route_rule.rs
@@ -44,10 +44,10 @@ impl MergedRouteRules {
         let mut cur_rules: Vec<&RouteRuleEntry> = Vec::new();
         if let Some(rules) = current.config.as_ref() {
             for cur_rule in rules {
-                if let Some(iif) = cur_rule.iif.as_ref() {
-                    if ignored_ifaces.contains(&iif.as_str()) {
-                        continue;
-                    }
+                if let Some(iif) = cur_rule.iif.as_ref()
+                    && ignored_ifaces.contains(&iif.as_str())
+                {
+                    continue;
                 }
                 cur_rules.push(cur_rule);
             }

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -57,10 +57,10 @@ impl SrIovConfig {
                 }
             };
 
-        if let Some(desired_autoprobe) = self.drivers_autoprobe {
-            if !desired_autoprobe {
-                return Ok(());
-            }
+        if let Some(desired_autoprobe) = self.drivers_autoprobe
+            && !desired_autoprobe
+        {
+            return Ok(());
         }
 
         if let Some(cur_autoprobe) = cur_pf_iface
@@ -68,10 +68,9 @@ impl SrIovConfig {
             .as_ref()
             .and_then(|eth_conf| eth_conf.sr_iov.as_ref())
             .and_then(|sriov_conf| sriov_conf.drivers_autoprobe.as_ref())
+            && !cur_autoprobe
         {
-            if !cur_autoprobe {
-                return Ok(());
-            }
+            return Ok(());
         }
 
         let vfs = if let Some(vfs) = cur_pf_iface

--- a/rust/src/lib/revert/ifaces/ethernet.rs
+++ b/rust/src/lib/revert/ifaces/ethernet.rs
@@ -10,16 +10,16 @@ impl EthernetInterface {
     ) {
         if let (Interface::Ethernet(desired), Interface::Ethernet(current)) =
             (desired, current)
+            && desired.sriov_is_enabled()
+            && !current.sriov_is_enabled()
         {
-            if desired.sriov_is_enabled() && !current.sriov_is_enabled() {
-                self.ethernet
-                    .get_or_insert(EthernetConfig::new())
-                    .sr_iov
-                    .get_or_insert(SrIovConfig {
-                        total_vfs: Some(0),
-                        ..Default::default()
-                    });
-            }
+            self.ethernet
+                .get_or_insert(EthernetConfig::new())
+                .sr_iov
+                .get_or_insert(SrIovConfig {
+                    total_vfs: Some(0),
+                    ..Default::default()
+                });
         }
     }
 }

--- a/rust/src/lib/revert/ifaces/iface.rs
+++ b/rust/src/lib/revert/ifaces/iface.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    revert::state::gen_revert_state, Interface, InterfaceState,
-    MergedInterface, NmstateError,
+    Interface, InterfaceState, MergedInterface, NmstateError,
+    revert::state::gen_revert_state,
 };
 
 impl MergedInterface {

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{hash_map::Entry, HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-use std::net::Ipv4Addr;
-use std::str::FromStr;
+use std::{
+    collections::{HashMap, HashSet, hash_map::Entry},
+    hash::{Hash, Hasher},
+    net::Ipv4Addr,
+    str::FromStr,
+};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ip::{is_ipv6_addr, sanitize_ip_network},
     ErrorKind, InterfaceType, MergedInterfaces, NmstateError,
+    ip::{is_ipv6_addr, sanitize_ip_network},
 };
 
 const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
@@ -509,23 +511,23 @@ impl RouteEntry {
                     ),
                 ));
             }
-            if let Some(dst) = self.destination.as_deref() {
-                if is_ipv6_addr(dst) {
-                    return Err(NmstateError::new(
-                        ErrorKind::NotSupportedError,
-                        "IPv6 ECMP route with weight is not supported yet"
-                            .to_string(),
-                    ));
-                }
-            }
-        }
-        if let Some(cwnd) = self.cwnd {
-            if cwnd == 0 {
+            if let Some(dst) = self.destination.as_deref()
+                && is_ipv6_addr(dst)
+            {
                 return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "The value of 'cwnd' cannot be 0".to_string(),
+                    ErrorKind::NotSupportedError,
+                    "IPv6 ECMP route with weight is not supported yet"
+                        .to_string(),
                 ));
             }
+        }
+        if let Some(cwnd) = self.cwnd
+            && cwnd == 0
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "The value of 'cwnd' cannot be 0".to_string(),
+            ));
         }
         if self.mtu == Some(0) {
             return Err(NmstateError::new(
@@ -871,36 +873,26 @@ impl MergedRoutes {
 // 0.0.0.0/8 and its subnet cannot be used as the route destination network
 // for unicast route
 fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
-    if let Some(dst) = route.destination.as_deref() {
-        if !is_ipv6_addr(dst) {
-            let ip_net: Vec<&str> = dst.split('/').collect();
-            let ip_addr = Ipv4Addr::from_str(ip_net[0])?;
-            if ip_addr.octets()[0] == 0 {
-                if dst.contains('/') {
-                    let prefix = match ip_net[1].parse::<i32>() {
-                        Ok(p) => p,
-                        Err(_) => {
-                            return Err(NmstateError::new(
-                                ErrorKind::InvalidArgument,
-                                format!(
-                                    "The prefix of the route destination \
-                                     network '{dst}' is invalid"
-                                ),
-                            ));
-                        }
-                    };
-                    if prefix >= 8 && route.is_unicast() {
-                        let e = NmstateError::new(
+    if let Some(dst) = route.destination.as_deref()
+        && !is_ipv6_addr(dst)
+    {
+        let ip_net: Vec<&str> = dst.split('/').collect();
+        let ip_addr = Ipv4Addr::from_str(ip_net[0])?;
+        if ip_addr.octets()[0] == 0 {
+            if dst.contains('/') {
+                let prefix = match ip_net[1].parse::<i32>() {
+                    Ok(p) => p,
+                    Err(_) => {
+                        return Err(NmstateError::new(
                             ErrorKind::InvalidArgument,
-                            "0.0.0.0/8 and its subnet cannot be used as the \
-                             route destination for unicast route, please use \
-                             the default gateway 0.0.0.0/0 instead"
-                                .to_string(),
-                        );
-                        log::error!("{e}");
-                        return Err(e);
+                            format!(
+                                "The prefix of the route destination network \
+                                 '{dst}' is invalid"
+                            ),
+                        ));
                     }
-                } else if route.is_unicast() {
+                };
+                if prefix >= 8 && route.is_unicast() {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         "0.0.0.0/8 and its subnet cannot be used as the route \
@@ -911,9 +903,19 @@ fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
                     log::error!("{e}");
                     return Err(e);
                 }
+            } else if route.is_unicast() {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    "0.0.0.0/8 and its subnet cannot be used as the route \
+                     destination for unicast route, please use the default \
+                     gateway 0.0.0.0/0 instead"
+                        .to_string(),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
-            return Ok(());
         }
+        return Ok(());
     }
     Ok(())
 }

--- a/rust/src/lib/route_rule.rs
+++ b/rust/src/lib/route_rule.rs
@@ -5,8 +5,8 @@ use std::hash::{Hash, Hasher};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ip::{is_ipv6_addr, sanitize_ip_network, AddressFamily},
     ErrorKind, InterfaceIpAddr, InterfaceType, NmstateError,
+    ip::{AddressFamily, is_ipv6_addr, sanitize_ip_network},
 };
 
 const ROUTE_RULE_DEFAULT_PRIORIRY: i64 = 30000;
@@ -153,35 +153,33 @@ impl RouteRuleEntry {
             log::error!("{e}");
             return Err(e);
         } else if let Some(family) = self.family {
-            if let Some(ip_from) = self.ip_from.as_ref() {
-                if is_ipv6_addr(ip_from.as_str())
+            if let Some(ip_from) = self.ip_from.as_ref()
+                && is_ipv6_addr(ip_from.as_str())
                     != matches!(family, AddressFamily::IPv6)
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "The ip-from format mismatches with the family \
-                             set '{self}'"
-                        ),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "The ip-from format mismatches with the family set \
+                         '{self}'"
+                    ),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
-            if let Some(ip_to) = self.ip_to.as_ref() {
-                if is_ipv6_addr(ip_to.as_str())
+            if let Some(ip_to) = self.ip_to.as_ref()
+                && is_ipv6_addr(ip_to.as_str())
                     != matches!(family, AddressFamily::IPv6)
-                {
-                    let e = NmstateError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "The ip-to format mismatches with the family set \
-                             {self}"
-                        ),
-                    );
-                    log::error!("{e}");
-                    return Err(e);
-                }
+            {
+                let e = NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "The ip-to format mismatches with the family set \
+                         {self}"
+                    ),
+                );
+                log::error!("{e}");
+                return Err(e);
             }
         }
         Ok(())

--- a/rust/src/lib/statistic/feature/ovs.rs
+++ b/rust/src/lib/statistic/feature/ovs.rs
@@ -36,10 +36,9 @@ impl OvsBridgeInterface {
         let mut ret = Vec::new();
         if let Some(ports) =
             self.bridge.as_ref().and_then(|b| b.ports.as_deref())
+            && ports.iter().any(|p| p.bond.is_some())
         {
-            if ports.iter().any(|p| p.bond.is_some()) {
-                ret.push(NmstateFeature::OvsBond);
-            }
+            ret.push(NmstateFeature::OvsBond);
         }
         ret
     }

--- a/rust/src/lib/statistic/mod.rs
+++ b/rust/src/lib/statistic/mod.rs
@@ -5,5 +5,4 @@ mod inter_ifaces;
 mod ip;
 mod net_state;
 
-pub use self::feature::NmstateFeature;
-pub use self::net_state::NmstateStatistic;
+pub use self::{feature::NmstateFeature, net_state::NmstateStatistic};

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -67,9 +67,11 @@ fn test_linux_bridge_ignore_port() {
     assert_eq!(des_iface.ports(), Some(vec!["eth2"]));
     assert_eq!(cur_iface.ports(), Some(vec!["eth2"]));
 
-    assert!(merged_ifaces
-        .get_iface("eth1", InterfaceType::Ethernet)
-        .is_none());
+    assert!(
+        merged_ifaces
+            .get_iface("eth1", InterfaceType::Ethernet)
+            .is_none()
+    );
 }
 
 #[test]
@@ -669,9 +671,10 @@ fn test_bridge_validate_diff_group_forward_mask_and_group_fwd_mask() {
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
-        assert!(e
-            .msg()
-            .contains("Linux bridge br0 has different group_forward_mask:"));
+        assert!(
+            e.msg()
+                .contains("Linux bridge br0 has different group_forward_mask:")
+        );
     }
 }
 

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    BondMode, ErrorKind, HsrProtocol, Interface, InterfaceState, InterfaceType,
+    Interfaces, MergedInterfaces,
     unit_tests::testlib::{
         get_mac, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
         new_unknown_iface, new_vlan_iface,
     },
-    BondMode, ErrorKind, HsrProtocol, Interface, InterfaceState, InterfaceType,
-    Interfaces, MergedInterfaces,
 };
 
 #[test]
@@ -91,11 +91,13 @@ fn test_vlan_over_ethernet_can_exist_after_ethernet_absent() {
         .as_ref()
         .unwrap();
     assert!(iface.is_absent());
-    assert!(merged_ifaces
-        .get_iface("eth0.10", InterfaceType::Vlan)
-        .unwrap()
-        .for_apply
-        .is_none());
+    assert!(
+        merged_ifaces
+            .get_iface("eth0.10", InterfaceType::Vlan)
+            .unwrap()
+            .for_apply
+            .is_none()
+    );
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
+    MergedInterfaces, OvsBridgeInterface,
     unit_tests::testlib::{
         bond_with_ports, bridge_with_ports, new_br_iface, new_eth_iface,
         new_nested_4_ifaces, new_ovs_br_iface, new_ovs_iface,
     },
-    ErrorKind, Interface, InterfaceState, InterfaceType, Interfaces,
-    MergedInterfaces, OvsBridgeInterface,
 };
 
 #[test]
@@ -871,12 +871,16 @@ fn test_do_not_auto_manage_ports_if_current_has_ignore() {
         .as_ref()
         .unwrap();
 
-    assert!(merged_ifaces
-        .get_iface("eth1", InterfaceType::Ethernet)
-        .is_none());
-    assert!(merged_ifaces
-        .get_iface("eth2", InterfaceType::Ethernet)
-        .is_none());
+    assert!(
+        merged_ifaces
+            .get_iface("eth1", InterfaceType::Ethernet)
+            .is_none()
+    );
+    assert!(
+        merged_ifaces
+            .get_iface("eth2", InterfaceType::Ethernet)
+            .is_none()
+    );
 
     assert_eq!(br_iface.ports(), Some(vec![]));
 }
@@ -987,13 +991,15 @@ fn test_gen_topoligies_bridge_over_vlan() {
 
     assert_eq!(
         top,
-        vec![[
-            "static_ip4,auto_ip6".to_string(),
-            InterfaceType::LinuxBridge.to_string(),
-            InterfaceType::Vlan.to_string(),
-            InterfaceType::Ethernet.to_string()
+        vec![
+            [
+                "static_ip4,auto_ip6".to_string(),
+                InterfaceType::LinuxBridge.to_string(),
+                InterfaceType::Vlan.to_string(),
+                InterfaceType::Ethernet.to_string()
+            ]
+            .join(" -> ")
         ]
-        .join(" -> ")]
     );
 }
 
@@ -1049,12 +1055,14 @@ fn test_gen_topoligies_ovs_bridge() {
 
     assert_eq!(
         top,
-        vec![[
-            "static_ip4,auto_ip6".to_string(),
-            InterfaceType::OvsInterface.to_string(),
-            InterfaceType::OvsBridge.to_string(),
-            InterfaceType::Ethernet.to_string()
+        vec![
+            [
+                "static_ip4,auto_ip6".to_string(),
+                InterfaceType::OvsInterface.to_string(),
+                InterfaceType::OvsBridge.to_string(),
+                InterfaceType::Ethernet.to_string()
+            ]
+            .join(" -> ")
         ]
-        .join(" -> ")]
     );
 }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ip::sanitize_ip_network, unit_tests::testlib::new_eth_iface, BaseInterface,
-    ErrorKind, Interface, InterfaceState, Interfaces, MergedInterfaces,
+    BaseInterface, ErrorKind, Interface, InterfaceState, Interfaces,
+    MergedInterfaces, ip::sanitize_ip_network,
+    unit_tests::testlib::new_eth_iface,
 };
 
 fn gen_test_eth_ifaces() -> Interfaces {

--- a/rust/src/lib/unit_tests/ipsec.rs
+++ b/rust/src/lib/unit_tests/ipsec.rs
@@ -37,9 +37,11 @@ fn test_ipsec_hide_psk() {
     .unwrap();
 
     state.hide_secrets();
-    assert!(!serde_yaml::to_string(&state)
-        .unwrap()
-        .contains("TOP_SECRET"));
+    assert!(
+        !serde_yaml::to_string(&state)
+            .unwrap()
+            .contains("TOP_SECRET")
+    );
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::dns::{reselect_dns_ifaces, store_dns_config_to_iface},
     DnsClientState, ErrorKind, InterfaceType, MergedNetworkState, NetworkState,
+    nm::dns::{reselect_dns_ifaces, store_dns_config_to_iface},
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/nm/route.rs
+++ b/rust/src/lib/unit_tests/nm/route.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::route::store_route_config,
-    unit_tests::testlib::{
-        gen_test_routes_conf, new_eth_iface, new_test_nic_with_static_ip,
-        TEST_IPV4_ADDR1, TEST_IPV4_NET1, TEST_IPV6_ADDR1, TEST_IPV6_NET1,
-        TEST_NIC,
-    },
     InterfaceType, Interfaces, MergedNetworkState, NetworkState, RouteEntry,
     RouteState,
+    nm::route::store_route_config,
+    unit_tests::testlib::{
+        TEST_IPV4_ADDR1, TEST_IPV4_NET1, TEST_IPV6_ADDR1, TEST_IPV6_NET1,
+        TEST_NIC, gen_test_routes_conf, new_eth_iface,
+        new_test_nic_with_static_ip,
+    },
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    nm::route_rule::store_route_rule_config,
-    unit_tests::testlib::{
-        gen_test_routes_conf, gen_test_rules_conf, new_eth_iface,
-        new_test_nic_with_static_ip, TEST_NIC, TEST_RULE_IPV4_FROM,
-        TEST_RULE_IPV4_TO, TEST_RULE_IPV6_FROM, TEST_RULE_IPV6_TO,
-        TEST_RULE_PRIORITY1, TEST_RULE_PRIORITY2, TEST_TABLE_ID1,
-        TEST_TABLE_ID2,
-    },
     Interface, InterfaceType, Interfaces, MergedNetworkState, NetworkState,
     RouteRuleEntry,
+    nm::route_rule::store_route_rule_config,
+    unit_tests::testlib::{
+        TEST_NIC, TEST_RULE_IPV4_FROM, TEST_RULE_IPV4_TO, TEST_RULE_IPV6_FROM,
+        TEST_RULE_IPV6_TO, TEST_RULE_PRIORITY1, TEST_RULE_PRIORITY2,
+        TEST_TABLE_ID1, TEST_TABLE_ID2, gen_test_routes_conf,
+        gen_test_rules_conf, new_eth_iface, new_test_nic_with_static_ip,
+    },
 };
 
 fn get_iface<'a>(

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -3,11 +3,11 @@
 use std::collections::HashMap;
 
 use crate::{
+    NetworkState,
     policy::{
         capture::{NetworkCaptureAction, NetworkCaptureCommand},
         token::NetworkCaptureToken,
     },
-    NetworkState,
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/policy/error.rs
+++ b/rust/src/lib/unit_tests/policy/error.rs
@@ -3,10 +3,10 @@
 use std::collections::HashMap;
 
 use crate::{
+    ErrorKind, NetworkState, NetworkStateTemplate,
     policy::{
         capture::NetworkCaptureCommand, token::parse_str_to_template_tokens,
     },
-    ErrorKind, NetworkState, NetworkStateTemplate,
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/policy/token.rs
+++ b/rust/src/lib/unit_tests/policy/token.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::policy::token::{parse_str_to_capture_tokens, NetworkCaptureToken};
+use crate::policy::token::{NetworkCaptureToken, parse_str_to_capture_tokens};
 
 #[test]
 fn test_policy_token_quoted_string() {

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    query_apply::is_route_delayed_by_nm,
-    unit_tests::testlib::{
-        gen_merged_ifaces_for_route_test, gen_route_entry,
-        gen_test_route_entries, gen_test_routes_conf, TEST_IPV4_ADDR1,
-        TEST_IPV4_NET1, TEST_IPV6_ADDR1, TEST_IPV6_ADDR2, TEST_IPV6_NET1,
-        TEST_IPV6_NET2, TEST_NIC, TEST_ROUTE_METRIC,
-    },
     ErrorKind, InterfaceType, Interfaces, MergedRoutes, RouteEntry, RouteState,
     Routes,
+    query_apply::is_route_delayed_by_nm,
+    unit_tests::testlib::{
+        TEST_IPV4_ADDR1, TEST_IPV4_NET1, TEST_IPV6_ADDR1, TEST_IPV6_ADDR2,
+        TEST_IPV6_NET1, TEST_IPV6_NET2, TEST_NIC, TEST_ROUTE_METRIC,
+        gen_merged_ifaces_for_route_test, gen_route_entry,
+        gen_test_route_entries, gen_test_routes_conf,
+    },
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/route_rule.rs
+++ b/rust/src/lib/unit_tests/route_rule.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    unit_tests::testlib::gen_test_rule_entries, MergedRouteRules,
-    RouteRuleEntry, RouteRules,
+    MergedRouteRules, RouteRuleEntry, RouteRules,
+    unit_tests::testlib::gen_test_rule_entries,
 };
 
 #[test]

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state::get_json_value_difference, unit_tests::testlib::new_eth_iface,
     BridgePortVlanMode, ErrorKind, EthernetConfig, EthernetDuplex, Interface,
     InterfaceType, Interfaces, MergedInterfaces, NetworkState, SrIovConfig,
-    SrIovVfConfig,
+    SrIovVfConfig, state::get_json_value_difference,
+    unit_tests::testlib::new_eth_iface,
 };
 
 #[test]
@@ -14,7 +14,7 @@ fn test_sriov_vf_mac_mix_case() {
 
     let mut cur_ifaces = Interfaces::new();
     let mut cur_iface = new_eth_iface("eth1");
-    if let Interface::Ethernet(ref mut eth_iface) = cur_iface {
+    if let Interface::Ethernet(eth_iface) = &mut cur_iface {
         let mut eth_conf = EthernetConfig::new();
         let mut sriov_conf = SrIovConfig::new();
         let mut vf_conf = SrIovVfConfig::new();
@@ -33,7 +33,7 @@ fn test_sriov_vf_mac_mix_case() {
 
     let mut des_ifaces = Interfaces::new();
     let mut des_iface = new_eth_iface("eth1");
-    if let Interface::Ethernet(ref mut eth_iface) = des_iface {
+    if let Interface::Ethernet(eth_iface) = &mut des_iface {
         let mut eth_conf = EthernetConfig::new();
         let mut sriov_conf = SrIovConfig::new();
         let mut vf_conf = SrIovVfConfig::new();
@@ -539,7 +539,7 @@ fn test_verify_sriov_port_name_ovs_bond() {
 fn test_sriov_vf_auto_fill_vf_conf() {
     let mut cur_ifaces = Interfaces::new();
     let mut cur_iface = new_eth_iface("eth1");
-    if let Interface::Ethernet(ref mut eth_iface) = cur_iface {
+    if let Interface::Ethernet(eth_iface) = &mut cur_iface {
         let mut eth_conf = EthernetConfig::new();
         let mut sriov_conf = SrIovConfig::new();
         let mut vfs = Vec::new();
@@ -565,23 +565,22 @@ fn test_sriov_vf_auto_fill_vf_conf() {
 
     let mut pre_apply_current = cur_ifaces.clone();
     for iface in pre_apply_current.kernel_ifaces.values_mut() {
-        if let Interface::Ethernet(ref mut eth_iface) = iface {
-            if let Some(vfs) = eth_iface
+        if let Interface::Ethernet(eth_iface) = iface
+            && let Some(vfs) = eth_iface
                 .ethernet
                 .as_mut()
                 .and_then(|eth_conf| eth_conf.sr_iov.as_mut())
                 .and_then(|sr_iov_conf| sr_iov_conf.vfs.as_mut())
-            {
-                for vf in vfs {
-                    vf.trust = Some(false);
-                }
+        {
+            for vf in vfs {
+                vf.trust = Some(false);
             }
         }
     }
 
     let mut des_ifaces = Interfaces::new();
     let mut des_iface = new_eth_iface("eth1");
-    if let Interface::Ethernet(ref mut eth_iface) = des_iface {
+    if let Interface::Ethernet(eth_iface) = &mut des_iface {
         let mut eth_conf = EthernetConfig::new();
         let mut sriov_conf = SrIovConfig::new();
         let mut vf_conf = SrIovVfConfig::new();

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -285,8 +285,8 @@ fn new_test_nic2_with_static_ip() -> Interface {
     .unwrap()
 }
 
-pub(crate) fn gen_merged_ifaces_for_route_test(
-) -> (MergedInterfaces, Interfaces) {
+pub(crate) fn gen_merged_ifaces_for_route_test()
+-> (MergedInterfaces, Interfaces) {
     let mut ifaces = Interfaces::new();
     ifaces.push(new_test_nic_with_static_ip());
     ifaces.push(new_test_nic2_with_static_ip());


### PR DESCRIPTION
zbus 5.13.1 has bumped to Rust 1.85 with Rust edition 2024. As one of
our major dependency, we have no choice but bump to 1.85+.

Bumping to 1.88 and migrate to Rust edition 2024 allows use using
[if-while let chain][1] which could greatly decrease our code
indentation level. The Rust 1.88 is the minimum version of this feature
went stable.

[1]: https://doc.rust-lang.org/edition-guide/rust-2024/let-chains.html

Resolves: https://issues.redhat.com/browse/NMT-2166

=============== Reference ==================
Current Rust shipping status of commercial Linux distributions(they are known to be slow on updates) :
 * RHEL 9.8: Rust 1.91
 * RHEL 10.1: Rust 1.88
 * SLES 15 SP7: Rust 1.92
 * SLES 16: Rust 1.88
 * Ubuntu 24.04 LTS: Rust 1.82
 * Ubuntu 26.04 LTS(unreleased): Rust 1.88

Firefox Rust version policy: https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html