### PR TITLE
vrf: Handle ignore interface when verifying desired state

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -744,6 +744,15 @@ impl Interface {
             br_iface.remove_port(port_name);
         } else if let Interface::Bond(iface) = self {
             iface.remove_port(port_name);
+        } else if let Interface::Vrf(iface) = self {
+            iface.remove_port(port_name);
+        } else {
+            log::error!(
+                "BUG: Interface::remove_port() been invoked against \
+                 unsupported interface type {} for interface {}",
+                self.iface_type(),
+                self.name(),
+            );
         }
     }
 

--- a/rust/src/lib/ifaces/vrf.rs
+++ b/rust/src/lib/ifaces/vrf.rs
@@ -145,6 +145,16 @@ impl VrfInterface {
             *port_name = new_name;
         }
     }
+
+    pub(crate) fn remove_port(&mut self, port_to_remove: &str) {
+        if let Some(ports) = self
+            .vrf
+            .as_mut()
+            .and_then(|vrf_conf| vrf_conf.port.as_mut())
+        {
+            ports.retain(|port_name| port_name != port_to_remove);
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/rust/src/lib/unit_tests/vrf.rs
+++ b/rust/src/lib/unit_tests/vrf.rs
@@ -287,3 +287,147 @@ fn test_route_vrf_name_table_id_conflict() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_vrf_verify_ports_mixed_with_ignore_ifaces() {
+    let pre_apply_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: ignore
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            ports:
+            - eth1
+            - eth2
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            ports:
+            - eth2
+        ",
+    )
+    .unwrap();
+
+    let post_apply_ifaces: Interfaces = pre_apply_ifaces.clone();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    merged_ifaces.verify(&post_apply_ifaces).unwrap();
+}
+
+#[test]
+fn test_vrf_verify_with_all_ignore_ifaces_and_desire_empty() {
+    let pre_apply_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: ignore
+        - name: eth2
+          type: ethernet
+          state: ignore
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            ports:
+            - eth1
+            - eth2
+        ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+            ports: []
+        ",
+    )
+    .unwrap();
+
+    let post_apply_ifaces: Interfaces = pre_apply_ifaces.clone();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    merged_ifaces.verify(&post_apply_ifaces).unwrap();
+}
+
+#[test]
+fn test_vrf_verify_with_all_ignore_ifaces_and_desire_full() {
+    let pre_apply_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+           - name: eth1
+             type: ethernet
+             state: ignore
+           - name: eth2
+             type: ethernet
+             state: ignore
+           - name: vrf0
+             type: vrf
+             state: up
+             vrf:
+               route-table-id: 100
+               ports:
+               - eth1
+               - eth2
+           ",
+    )
+    .unwrap();
+
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+           - name: vrf0
+             type: vrf
+             state: up
+             vrf:
+               route-table-id: 100
+               ports:
+               - eth1
+               - eth2
+           ",
+    )
+    .unwrap();
+
+    let post_apply_ifaces: Interfaces = pre_apply_ifaces.clone();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    merged_ifaces.verify(&post_apply_ifaces).unwrap();
+}

--- a/tests/integration/nm/vrf_test.py
+++ b/tests/integration/nm/vrf_test.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import yaml
+
+import libnmstate
+from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import VRF
+
+from ..testlib.statelib import show_only
+from ..testlib.cmdlib import exec_cmd
+
+
+@pytest.fixture
+def vrf0_with_unmanaged_port_veth1():
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            port: []
+            route-table-id: 100
+        """,
+        Loader=yaml.SafeLoader,
+    )
+
+    libnmstate.apply(desired_state)
+    exec_cmd("ip link add veth1 type veth peer veth1_peer".split(), check=True)
+    exec_cmd("nmcli d set veth1 managed false".split(), check=True)
+    exec_cmd("nmcli d set veth1_peer managed false".split(), check=True)
+    exec_cmd("ip link set veth1 master vrf0".split(), check=True)
+    exec_cmd("ip link set veth1 up".split(), check=True)
+    exec_cmd("ip link set veth1_peer up".split(), check=True)
+    yield
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: vrf0
+          type: vrf
+          state: absent
+          vrf:
+            port: []
+        """,
+        Loader=yaml.SafeLoader,
+    )
+
+    libnmstate.apply(desired_state)
+    exec_cmd("ip link del veth1".split(), check=True)
+
+
+def test_vrf_apply_with_empty_port_list_and_unmanged_port(
+    vrf0_with_unmanaged_port_veth1,
+):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            port: []
+        """,
+        Loader=yaml.SafeLoader,
+    )
+
+    libnmstate.apply(desired_state)
+
+    iface_state = show_only(("vrf0",))[Interface.KEY][0]
+    assert iface_state[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] == ["veth1"]
+    iface_state = show_only(("veth1",))[Interface.KEY][0]
+    assert iface_state[Interface.STATE] == InterfaceState.IGNORE
+
+
+def test_vrf_take_over_unmanaged_port(vrf0_with_unmanaged_port_veth1):
+    desired_state = yaml.load(
+        """---
+        interfaces:
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            port:
+            - veth1
+        - name: veth1
+          type: ethernet
+          state: up
+        """,
+        Loader=yaml.SafeLoader,
+    )
+
+    libnmstate.apply(desired_state)
+
+    iface_state = show_only(("vrf0",))[Interface.KEY][0]
+    assert iface_state[VRF.CONFIG_SUBTREE][VRF.PORT_SUBTREE] == ["veth1"]
+
+    iface_state = show_only(("veth1",))[Interface.KEY][0]
+    assert iface_state[Interface.STATE] == InterfaceState.UP

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -15,7 +15,6 @@ from libnmstate.schema import Route
 from libnmstate.schema import VRF
 
 from .testlib import assertlib
-from .testlib import cmdlib
 from .testlib.apply import apply_with_description
 
 
@@ -125,70 +124,6 @@ def vrf1_with_eth1_and_eth2(eth1_up, eth2_up):
     )
 
     assertlib.assert_absent(TEST_VRF1)
-
-
-@pytest.fixture
-def unmanaged_port_up():
-    cmdlib.exec_cmd(
-        f"ip link add {TEST_VRF_VETH0} type veth peer {TEST_VRF_VETH1}".split()
-    )
-    cmdlib.exec_cmd(f"ip link set {TEST_VRF_VETH0} up".split())
-    cmdlib.exec_cmd(f"ip link set {TEST_VRF_VETH1} up".split())
-    yield TEST_VRF_VETH0
-    cmdlib.exec_cmd(f"ip link del {TEST_VRF_VETH0}".split())
-    apply_with_description(
-        "Delete the vrf interface test-vrf0 and veth device veth0",
-        {
-            Interface.KEY: [
-                {
-                    Interface.NAME: TEST_VRF_VETH0,
-                    Interface.TYPE: InterfaceType.VETH,
-                    Interface.STATE: InterfaceState.ABSENT,
-                },
-                {
-                    Interface.NAME: TEST_VRF0,
-                    Interface.TYPE: InterfaceType.VRF,
-                    Interface.STATE: InterfaceState.ABSENT,
-                },
-            ]
-        },
-    )
-
-
-@pytest.fixture
-def vrf1_with_unmanaged_port(unmanaged_port_up):
-    vrf_iface_info = {
-        Interface.NAME: TEST_VRF1,
-        Interface.TYPE: InterfaceType.VRF,
-        VRF.CONFIG_SUBTREE: {
-            VRF.PORT_SUBTREE: [unmanaged_port_up],
-            VRF.ROUTE_TABLE_ID: TEST_ROUTE_TABLE_ID1,
-        },
-    }
-    veth_iface_info = {
-        Interface.NAME: unmanaged_port_up,
-        Interface.TYPE: InterfaceType.ETHERNET,
-        Interface.STATE: InterfaceState.UP,
-    }
-    apply_with_description(
-        f"Attach ethernet {unmanaged_port_up} to the vrf interface test-vrf1 "
-        "and set vrf route table ID to 101",
-        {Interface.KEY: [vrf_iface_info, veth_iface_info]},
-    )
-    try:
-        yield vrf_iface_info
-    finally:
-        apply_with_description(
-            "Delete the test-vrf1 interface",
-            {
-                Interface.KEY: [
-                    {
-                        Interface.NAME: TEST_VRF1,
-                        Interface.STATE: InterfaceState.ABSENT,
-                    }
-                ]
-            },
-        )
 
 
 @pytest.fixture
@@ -407,9 +342,6 @@ class TestVrf:
             desired_state,
         )
         assertlib.assert_state_match(desired_state)
-
-    def test_takes_over_unmanaged_vrf(self, vrf1_with_unmanaged_port):
-        pass
 
     def test_vrf_ignore_mac_address(self, vrf0_with_port0):
         apply_with_description(


### PR DESCRIPTION
During verification process, when post apply state does not match with
desired state due to VRF port been marked as `state: ignore`.

This is caused by `Interface::remove_port()` silently ignore VRF interface
when been invoked by `Interfaces::remove_unknown_type_port()` during
verification process.

Besides adding `VrfInterface::remove_port()`, added error log to
`Interface::remove_port()` when got unexpected interface type instead of
silently ignore.

Both unit test case and integration test case are included.

Resolves: https://issues.redhat.com/browse/RHEL-1417