### PR TITLE
alt-name: Remove alt-names when interface marked as absent

### DIFF
--- a/rust/src/lib/nispor/alt_name.rs
+++ b/rust/src/lib/nispor/alt_name.rs
@@ -19,12 +19,21 @@ fn gen_nispor_iface_conf_for_alt_name(
     base_iface: &BaseInterface,
     cur_iface: Option<&BaseInterface>,
 ) -> Result<Option<nispor::IfaceConf>, NmstateError> {
-    if let Some(alt_names) = base_iface.alt_names.as_ref() {
+    let des_alt_names = if base_iface.state == InterfaceState::Absent {
+        // For absent interfaces, remove current alt-names
+        cur_iface.as_ref().and_then(|i| i.alt_names.as_ref())
+    } else {
+        base_iface.alt_names.as_ref()
+    };
+
+    if let Some(des_alt_names) = des_alt_names {
         let mut np_iface = nispor::IfaceConf::default();
 
         np_iface.state = match base_iface.state {
             InterfaceState::Up => nispor::IfaceState::Up,
             InterfaceState::Down => nispor::IfaceState::Down,
+            // Other function will delete this interface, for purging
+            InterfaceState::Absent => nispor::IfaceState::Down,
             _ => return Ok(None),
         };
 
@@ -37,15 +46,17 @@ fn gen_nispor_iface_conf_for_alt_name(
             .map(|entry| entry.name.as_str())
             .collect();
         let mut np_alt_names = Vec::new();
-        for alt_name in alt_names {
+        for des_alt_name in des_alt_names {
+            let des_alt_name_is_absent = des_alt_name.is_absent()
+                || base_iface.state == InterfaceState::Absent;
             match (
-                alt_name.is_absent(),
-                cur_alt_names.contains(&alt_name.name.as_str()),
+                des_alt_name_is_absent,
+                cur_alt_names.contains(&des_alt_name.name.as_str()),
             ) {
                 (true, true) | (false, false) => {
                     np_alt_names.push(nispor::AltNameConf::new(
-                        alt_name.name.to_string(),
-                        alt_name.is_absent(),
+                        des_alt_name.name.to_string(),
+                        des_alt_name_is_absent,
                     ));
                 }
                 (false, true) | (true, false) => {

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -9,6 +9,7 @@ import libnmstate
 from libnmstate.error import NmstateValueError
 from libnmstate.schema import Bond
 from libnmstate.schema import Interface
+from libnmstate.schema import InterfaceAltName
 from libnmstate.schema import LinuxBridge
 from libnmstate.schema import OVSBridge
 from libnmstate.schema import Route
@@ -283,3 +284,43 @@ class TestAltNames:
 
         cur_state = libnmstate.show()
         assert_routes(expected_routes, cur_state)
+
+    # https://issues.redhat.com/browse/RHEL-126481
+    @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        "desired_state_yaml",
+        [
+            """---
+            interfaces:
+            - name: eth1
+              type: ethernet
+              state: absent
+            """,
+            """---
+            interfaces:
+            - name: eth1
+              type: ethernet
+              state: absent
+              alt-names:
+              - name: port1
+              - name: reallyreallylonglonglonginterfacenmae
+            """,
+        ],
+        ids=["without_alt_names", "with_alt_names"],
+    )
+    def test_del_alt_name_of_absent_iface(
+        self, eth1_with_alt_names, desired_state_yaml
+    ):
+        desired_state = load_yaml(desired_state_yaml)
+        libnmstate.apply(desired_state)
+
+        iface_state = show_only(("eth1",))[Interface.KEY][0]
+        assert not iface_state.get(InterfaceAltName.KEY)
+
+        # make sure systemd link file is also deleted
+        retry_till_true_or_timeout(
+            RETRY_TIMEOUT,
+            udev_trigger_check_alt_names,
+            "eth1",
+            [],
+        )


### PR DESCRIPTION
Previously, when desired state has interface marked as absent by still
contains alt-names section in this absent interface, nmstate still try
to set these alt-names even that interface is about to be removed.

Fixed by remove all altnames if interface is marked as absent.

Integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-126481