### PR TITLE
Support referring interface name using its alternative name

### DIFF
--- a/rust/src/lib/ifaces/alt_name.rs
+++ b/rust/src/lib/ifaces/alt_name.rs
@@ -4,7 +4,10 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{BaseInterface, ErrorKind, MergedInterfaces, NmstateError};
+use crate::{
+    BaseInterface, ErrorKind, InterfaceIdentifier, Interfaces,
+    MergedInterfaces, NmstateError,
+};
 
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize,
@@ -128,6 +131,86 @@ impl MergedInterfaces {
                         );
                     }
                 }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Interfaces {
+    pub(crate) fn resolve_alt_name_reference_in_desired(
+        &mut self,
+        current: &Self,
+    ) -> Result<(), NmstateError> {
+        let mut alt_name_to_kernel_name: HashMap<&str, &str> = HashMap::new();
+        // Pending changes: HashMap<alt_name, resolved_kernel_name>
+        let mut pending_changes: HashMap<String, String> = HashMap::new();
+
+        for cur_iface in current.kernel_ifaces.values() {
+            if let Some(alt_names) = cur_iface.base_iface().alt_names.as_ref() {
+                for alt_name in alt_names {
+                    alt_name_to_kernel_name
+                        .insert(alt_name.name.as_str(), cur_iface.name());
+                }
+            }
+        }
+
+        for des_iface in self.kernel_ifaces.values() {
+            // Skip on desire interface which is not `identifier: Some(name)` or
+            // `identifier: None`
+            if !matches!(
+                des_iface.base_iface().identifier.as_ref(),
+                None | Some(InterfaceIdentifier::Name)
+            ) {
+                continue;
+            }
+            if !current.kernel_ifaces.contains_key(des_iface.name())
+                && let Some(kernel_name) =
+                    alt_name_to_kernel_name.get(des_iface.name())
+            {
+                // It is OK to have both alt-name and kernel interface marked
+                // as absent
+                if let Some(exist_kernel_iface) =
+                    self.kernel_ifaces.get(*kernel_name)
+                    && !(exist_kernel_iface.is_absent()
+                        && des_iface.is_absent())
+                {
+                    return Err(NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Interface {}/({}) is alt-name of kernel \
+                             interface {kernel_name}, but desired state also \
+                             contains a conflicting configuration for kernel \
+                             interface {kernel_name}, please merge them",
+                            des_iface.name(),
+                            des_iface.iface_type(),
+                        ),
+                    ));
+                }
+                pending_changes.insert(
+                    des_iface.name().to_string(),
+                    kernel_name.to_string(),
+                );
+            }
+        }
+
+        for (alt_name, kernel_name) in pending_changes.drain() {
+            if let Some(mut des_iface) = self.kernel_ifaces.remove(&alt_name) {
+                // Move interface name to profile name if profile name not
+                // defined in desire or current state.
+                if des_iface.is_up()
+                    && des_iface.base_iface().profile_name.is_none()
+                    && current
+                        .kernel_ifaces
+                        .get(&kernel_name)
+                        .and_then(|i| i.base_iface().profile_name.as_ref())
+                        .is_none()
+                {
+                    des_iface.base_iface_mut().profile_name =
+                        Some(des_iface.base_iface().name.to_string());
+                }
+                des_iface.base_iface_mut().name = kernel_name;
+                self.push(des_iface);
             }
         }
         Ok(())

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -786,6 +786,7 @@ impl MergedInterfaces {
             desired.resolve_pci_identifier(&current)?;
             desired.resolve_unknown_ifaces(&current)?;
             desired.resolve_mac_identifier_in_desired(&current)?;
+            desired.resolve_alt_name_reference_in_desired(&current)?;
         }
 
         desired.auto_managed_controller_ports(&current);

--- a/rust/src/lib/unit_tests/alt_name.rs
+++ b/rust/src/lib/unit_tests/alt_name.rs
@@ -136,3 +136,287 @@ fn test_alt_name_overbook() {
         assert!(e.msg().contains("overbook"));
     }
 }
+
+#[test]
+fn test_remove_iface_via_alt_name_ref() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: veryveryveryverylonglonglongname
+            type: ethernet
+            state: absent",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname",
+    )
+    .unwrap();
+
+    let merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let merged_iface =
+        merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    let for_apply = merged_iface.for_apply.as_ref().unwrap();
+    let for_verify = merged_iface.for_verify.as_ref().unwrap();
+    let merged = &merged_iface.merged;
+
+    assert!(for_apply.is_absent());
+    assert!(for_verify.is_absent());
+    assert!(merged.is_absent());
+}
+
+#[test]
+fn test_change_iface_via_alt_name_ref() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: veryveryveryverylonglonglongname
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+            ipv4:
+              enabled: false
+              ",
+    )
+    .unwrap();
+
+    let merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let merged_iface =
+        merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    let for_apply = merged_iface.for_apply.as_ref().unwrap();
+    let for_verify = merged_iface.for_verify.as_ref().unwrap();
+    let merged = &merged_iface.merged;
+
+    assert_eq!(
+        for_apply.base_iface().profile_name.as_deref(),
+        Some("veryveryveryverylonglonglongname")
+    );
+    assert_eq!(
+        for_apply.base_iface().ipv4.as_ref().map(|i| i.enabled),
+        Some(true)
+    );
+    assert_eq!(
+        for_apply.base_iface().ipv4.as_ref().and_then(|i| i.dhcp),
+        Some(true)
+    );
+
+    assert_eq!(
+        for_verify.base_iface().profile_name.as_deref(),
+        Some("veryveryveryverylonglonglongname")
+    );
+    assert_eq!(
+        for_verify.base_iface().ipv4.as_ref().map(|i| i.enabled),
+        Some(true)
+    );
+    assert_eq!(
+        for_verify.base_iface().ipv4.as_ref().and_then(|i| i.dhcp),
+        Some(true)
+    );
+
+    assert_eq!(
+        merged.base_iface().profile_name.as_deref(),
+        Some("veryveryveryverylonglonglongname")
+    );
+
+    assert_eq!(
+        merged.base_iface().ipv4.as_ref().map(|i| i.enabled),
+        Some(true)
+    );
+    assert_eq!(
+        merged.base_iface().ipv4.as_ref().and_then(|i| i.dhcp),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_iface_ref_by_alt_name_but_desired_as_absent() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: absent
+          - name: veryveryveryverylonglonglongname
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+            ipv4:
+              enabled: false",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("eth1"));
+        assert!(e.msg().contains("veryveryveryverylonglonglongname"));
+        assert!(e.msg().contains("conflict"));
+    }
+}
+
+#[test]
+fn test_iface_ref_by_alt_name_but_conflict_desired() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+          - name: veryveryveryverylonglonglongname
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+            ipv4:
+              enabled: false",
+    )
+    .unwrap();
+
+    let result =
+        MergedNetworkState::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("eth1"));
+        assert!(e.msg().contains("veryveryveryverylonglonglongname"));
+        assert!(e.msg().contains("conflict"));
+    }
+}
+
+#[test]
+fn test_iface_ref_by_alt_name_ok_to_conflict_when_both_absent() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: absent
+          - name: veryveryveryverylonglonglongname
+            type: ethernet
+            state: absent",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+            ipv4:
+              enabled: false",
+    )
+    .unwrap();
+    let merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let merged_iface =
+        merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    let for_apply = merged_iface.for_apply.as_ref().unwrap();
+    let for_verify = merged_iface.for_verify.as_ref().unwrap();
+    let merged = &merged_iface.merged;
+
+    assert!(for_apply.is_absent());
+    assert!(for_verify.is_absent());
+    assert!(merged.is_absent());
+}
+
+#[test]
+fn test_do_not_resolve_mac_identifer_iface_to_alt_name() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: port1
+            type: ethernet
+            identifier: mac-address
+            mac-address: 52:54:00:15:17:64
+            state: absent",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            mac-address: 52:54:00:15:17:63
+            alt-names:
+              - name: port1
+              - name: veryveryveryverylonglonglongname
+            ipv4:
+              enabled: false
+          - name: eth2
+            type: ethernet
+            mac-address: 52:54:00:15:17:64
+            ipv4:
+              enabled: false",
+    )
+    .unwrap();
+    let merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let merged_iface =
+        merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    assert!(merged_iface.for_apply.is_none());
+    assert!(merged_iface.for_verify.is_none());
+    assert!(merged_iface.desired.is_none());
+}

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -324,3 +324,113 @@ class TestAltNames:
             "eth1",
             [],
         )
+
+    # https://issues.redhat.com/browse/RHEL-126510
+    @pytest.mark.tier1
+    def test_ref_alt_name_as_interface_name(self, eth1_with_alt_names):
+        desired_state = load_yaml(
+            """---
+                interfaces:
+                - name: reallyreallylonglonglonginterfacenmae
+                  type: ethernet
+                  state: up
+                  mtu: 1280
+                """
+        )
+        libnmstate.apply(desired_state)
+
+        iface_state = show_only(("eth1",))[Interface.KEY][0]
+        assert iface_state[Interface.MTU] == 1280
+
+    # https://issues.redhat.com/browse/RHEL-126510
+    @pytest.mark.tier1
+    def test_remove_interface_ref_by_alt_name(self, eth1_with_alt_names):
+        desired_state = load_yaml(
+            """---
+                interfaces:
+                - name: reallyreallylonglonglonginterfacenmae
+                  type: ethernet
+                  state: absent
+                """
+        )
+        libnmstate.apply(desired_state)
+
+        # Since we mark eth1 as absent, it should not hold any alt-names
+        iface_state = show_only(("eth1",))[Interface.KEY][0]
+        assert not iface_state.get(InterfaceAltName.KEY)
+
+        # make sure systemd link file is also deleted
+        retry_till_true_or_timeout(
+            RETRY_TIMEOUT,
+            udev_trigger_check_alt_names,
+            "eth1",
+            [],
+        )
+
+    @pytest.mark.parametrize(
+        "desired_state_yaml",
+        [
+            """---
+            interfaces:
+            - name: reallyreallylonglonglonginterfacenmae
+              type: ethernet
+              state: absent
+            - name: eth1
+              type: ethernet
+              state: up
+            """,
+            """---
+            interfaces:
+            - name: reallyreallylonglonglonginterfacenmae
+              type: ethernet
+              state: up
+            - name: eth1
+              type: ethernet
+              state: absent
+            """,
+            """---
+            interfaces:
+            - name: reallyreallylonglonglonginterfacenmae
+              type: ethernet
+              state: up
+            - name: eth1
+              type: ethernet
+              state: up
+            """,
+        ],
+        ids=["absent_up", "up_absent", "up_up"],
+    )
+    def test_ref_alt_name_conflict_in_desire(
+        self, eth1_with_alt_names, desired_state_yaml
+    ):
+        desired_state = load_yaml(desired_state_yaml)
+        with pytest.raises(NmstateValueError):
+            libnmstate.apply(desired_state)
+
+    def test_both_alt_name_iface_and_kernel_iface_mark_as_absent(
+        self, eth1_with_alt_names
+    ):
+        desired_state = load_yaml(
+            """---
+            interfaces:
+            - name: reallyreallylonglonglonginterfacenmae
+              type: ethernet
+              state: absent
+            - name: eth1
+              type: ethernet
+              state: absent
+            """
+        )
+        libnmstate.apply(desired_state)
+
+        # Since we mark eth1 as absent, it should not hold any alt-names
+        iface_state = show_only(("eth1",))[Interface.KEY][0]
+        assert not iface_state.get(InterfaceAltName.KEY)
+
+        # make sure systemd link file is also deleted
+        retry_till_true_or_timeout(
+            RETRY_TIMEOUT,
+            udev_trigger_check_alt_names,
+            "eth1",
+            [],
+        )


### PR DESCRIPTION
Example YAML:

```yml
---
interfaces:
  - name: veryveryveryverylonglonglongname
    type: ethernet
    ipv4:
      address:
      - ip: 192.0.2.251
        prefix-length: 24
      dhcp: false
      enabled: true
    ipv6:
      enabled: false
```

Will raise error if you have conflict interfaces settings like one
interface refer to kernel name, another interface refer to alt-name.
But it is OK to both interface marked as absent.

We will not resolve the `interface.name` property to alt-name when the
`interface.identifier` is defined and not `InterfaceIdentifier::Name`.

Unit test cases and integration test cases included.

Resolves: https://issues.redhat.com/browse/RHEL-126510