### PR TITLE
nm hsr: do not deactivate undesired HSR port

### DIFF
--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     BaseInterface, ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6,
-    InterfaceType, MergedInterface, MergedInterfaces, NmstateError,
+    InterfaceState, InterfaceType, MergedInterface, MergedInterfaces,
+    NmstateError,
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -187,7 +188,7 @@ impl MergedInterfaces {
 
         for (hsr_iface, hsr_conf, mac) in
             self.kernel_ifaces.iter().filter_map(|(_, iface)| {
-                if !iface.is_desired() {
+                if !iface.is_desired() || !iface.merged.is_up() {
                     return None;
                 }
 
@@ -238,6 +239,10 @@ impl MergedInterfaces {
         for (ifname, mac) in pending_changes {
             if let Some(iface) = self.kernel_ifaces.get_mut(&ifname) {
                 iface.mark_as_changed();
+                if let Some(for_apply) = iface.for_apply.as_mut() {
+                    for_apply.base_iface_mut().state = InterfaceState::Up;
+                }
+                iface.merged.base_iface_mut().state = InterfaceState::Up;
                 iface.set_copy_from_mac(mac.clone());
             }
         }

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -49,7 +49,9 @@ pub(crate) fn prepare_nm_conns(
     let nm_devs_indexed = create_index_for_nm_devs(nm_devs);
     let mut nm_devs_to_deactivate: Vec<NmDevice> = ifaces
         .iter()
-        .filter(|iface| iface.merged.is_down())
+        .filter(|iface| {
+            iface.for_apply.as_ref().map(|i| i.is_down()) == Some(true)
+        })
         .filter_map(|iface| {
             nm_devs_indexed
                 .get(&(iface.merged.name(), iface.merged.iface_type()))

--- a/tests/integration/nm/hsr_test.py
+++ b/tests/integration/nm/hsr_test.py
@@ -63,6 +63,9 @@ def test_auto_disable_ip_of_hsr_ports(eth1_up_with_auto_ip, eth2_up, clean_up):
     )
     libnmstate.apply(state)
 
+    assert "eth1" in exec_cmd("nmcli c show --active".split(), check=True)[1]
+    assert "eth2" in exec_cmd("nmcli c show --active".split(), check=True)[1]
+
     assert (
         exec_cmd("nmcli -g ipv4.method c show eth1".split(), check=True)[1]
         == "disabled\n"

--- a/tests/integration/nm/hsr_test.py
+++ b/tests/integration/nm/hsr_test.py
@@ -46,7 +46,7 @@ def clean_up():
     libnmstate.apply(state)
 
 
-def test_auto_disable_ip_of_hsr_ports(eth1_up_with_auto_ip, eth1_up, clean_up):
+def test_auto_disable_ip_of_hsr_ports(eth1_up_with_auto_ip, eth2_up, clean_up):
     state = load_yaml(
         """---
             interfaces:


### PR DESCRIPTION
When undesired HSR port interface been marked as changed due to its
controller requested, if this interface's current state is
`state: down`, then nmstate will deactivate this port after activated.

This is caused by `mark_as_changed()` function does not change
`interface.state`, the `merged` Interface is still holding current down
state.

In nm `prepare_nm_conns()` function, any changed interface holding
`state: down` in merged state will be stored into
`nm_devs_to_deactivate` which will be deactivated as final state of
apply action. Hence nmstate deactivate previous down state HSR port even
its controller request its attachment.

This only happen on HSR ports, because:
 1. The `MergedInterfaces.handle_changed_ports()` will invoke
    `apply_ctrller_change()` to properly setup interface state if not
    desired or changed.
 2. The `MergedInterfaces.copy_hsr_mac()` was invoked before
    `MergedInterfaces.handle_changed_ports()` which mark the interface
    as changed but still have merged interface as `state: down`.
 3. The HSR port information is stored in HSR interface itself, so even
    hsr port NM connection deactivated, the verification stage still
    pass because port list matches even NM deactivated the NM
    connection.

To fix the issue:
 1. The `MergedInterfaces.copy_hsr_mac()` should mark HSR port as up to
    make the MAC address change effective.
 2. The NM `prepare_nm_conns()` function should always check `for_apply`
    interface instead of merged in case other function forgot to update
    merged state.

Integration test case updated to reflect the reproducer.