### PR TITLE
ci: increase integration test timeout to 45 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
         run: ./automation/run-lint-tests.sh
 
   integ:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     needs: [rust_lint, py_lint, rpm_build]
     strategy:


### PR DESCRIPTION
Some jobs are now running out of time before they are able to complete all tests:

https://github.com/nmstate/nmstate/actions/runs/21132725440/job/60772534942