### PR TITLE
Unify maintainers for nmstate and k-nmstate

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,15 +1,17 @@
 The current Maintainers Group for the nmstate Project consists of:
 
-| Name | Employer |
-| ---- | -------- |
-| [Gris Ge](https://github.com/cathay4t) | Red Hat |
-| [Fernando Fernandez Mancera](https://github.com/ffmancera) | SUSE |
-| [Íñigo Huguet](https://github.com/ihuguet) | Red Hat |
+| Name                                                       | Employer | Focus      |
+|------------------------------------------------------------|----------|------------|
+| [Gris Ge](https://github.com/cathay4t)                     | Red Hat  | Everything |
+| [Fernando Fernandez Mancera](https://github.com/ffmancera) | SUSE     | Kernel     |
+| [Íñigo Huguet](https://github.com/ihuguet)                 | Red Hat  | Everything |
+| [Enrique Llorente Pastora](https://github.com/qinqon)      | Red Hat  | Kubernetes |
+| [Mateusz Kowalski](https://github.com/mkowalski)           | Red Hat  | Kubernetes |
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for general contribution guidelines.
 
 Emeritus Maintainers
 
-| Name |
-| ---- |
+| Name                                    |
+|-----------------------------------------|
 | [Edward Haas](https://github.com/EdDev) |


### PR DESCRIPTION
For admin purposes we are combining maintainers of nmstate and k-nmstate. We are adding a column with focus so that we can "label" people with respect to their area of expertise.