### PR TITLE
Add SUSE to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,19 @@
+
+> **Note**
+> Do you want to add yourself to this list? Simply fork the repository and open a PR with the required change.
+> We have a short description of the adopter types at the bottom of this page. Each adopter type is in alphabetical order.
+
+# NMstate Adopters
+
+| Type   | Name          | Since | Website                        | Use-Case                                                                                        |
+|:-------|:--------------|:------|:-------------------------------|:------------------------------------------------------------------------------------------------|
+| Vendor | Red Hat, Inc. | 2022  | [link](https://www.redhat.com) | NMstate is distributed together with RHEL, as the supported way to configure system networking. |
+| Vendor | SUSE          |       | [link](https://www.suse.com)   | NMstate is used to configure NetworkManager on SUSE Linux.                                      |
+
+### Adopter Types
+
+**End-user**: The organization runs NMstate in production in some way.
+
+**Integration**: The organization has a product that integrates with NMstate, but does not contain NMstate.
+
+**Vendor**: The organization packages NMstate in their product and sells it as part of their product.


### PR DESCRIPTION
Based on the publicly available documentation[1] we are adding SUSE Linux as a vendor using nmstate.

[1] https://documentation.suse.com/suse-edge/3.4/html/edge/components-nmc.html