### PR TITLE
DEMO: ip: Allow ignoring IP address with other protocol

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,3 +34,7 @@ tokio = { version = "1.30", features = ["rt", "net", "time"] }
 platforms = ["*-unknown-linux-gnu"]
 tier = "2"
 all-features = true
+
+# BUG: Remove this before merge
+[patch.crates-io]
+nispor = { git = "https://github.com/nispor/nispor.git" }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -240,6 +240,10 @@ impl InterfaceIpv4 {
                     a.valid_life_time = None;
                     a.preferred_life_time = None;
                 });
+                // Ignore other protocol address
+                addrs.retain(|addr| {
+                    !matches!(addr.protocol, Some(AddressProtocol::Other(_)))
+                });
             }
         }
     }
@@ -279,6 +283,7 @@ impl InterfaceIpv4 {
     // * Remove auto IP address.
     // * Set DHCP options to None if DHCP is false
     // * Remove mptcp_flags is they are for query only
+    // * Remove address holding protocol: `AddressProtocol::Other(d)`
     pub(crate) fn sanitize(
         &mut self,
         is_desired: bool,
@@ -386,6 +391,21 @@ impl InterfaceIpv4 {
             self.dhcp_custom_hostname = None;
         }
         if let Some(addrs) = self.addresses.as_mut() {
+            addrs.retain(|addr| {
+                if let Some(AddressProtocol::Other(d)) = addr.protocol {
+                    if is_desired {
+                        log::warn!(
+                            "Ignoring IPv4 address {}/{} with protocol: \
+                             0x{d:x}",
+                            &addr.ip,
+                            addr.prefix_length
+                        );
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
             for addr in addrs.iter_mut() {
                 addr.mptcp_flags = None;
             }
@@ -660,6 +680,18 @@ impl InterfaceIpv6 {
                             );
                         }
                         false
+                    } else if let Some(AddressProtocol::Other(d)) =
+                        addr.protocol
+                    {
+                        if is_desired {
+                            log::warn!(
+                                "Ignoring IPv6 address {}/{} with protocol: \
+                                 0x{d:x}",
+                                &addr.ip,
+                                addr.prefix_length
+                            );
+                        }
+                        false
                     } else {
                         true
                     }
@@ -906,6 +938,18 @@ pub struct InterfaceIpAddr {
         alias = "preferred-lft"
     )]
     pub preferred_life_time: Option<String>,
+    /// IP address protocol.
+    /// This property is query only, nmstate will not set protocol for desired
+    /// IP address yet.
+    /// Nmstate will not preserve IP address holding
+    /// `AddressProtocol::Other(d)` from current state during apply action
+    /// because they are considered to be managed by external tools.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_enum_string_or_integer"
+    )]
+    pub protocol: Option<AddressProtocol>,
 }
 
 impl Default for InterfaceIpAddr {
@@ -916,6 +960,7 @@ impl Default for InterfaceIpAddr {
             mptcp_flags: None,
             valid_life_time: None,
             preferred_life_time: None,
+            protocol: None,
         }
     }
 }
@@ -986,6 +1031,7 @@ impl std::convert::TryFrom<&str> for InterfaceIpAddr {
             mptcp_flags: None,
             valid_life_time: None,
             preferred_life_time: None,
+            protocol: None,
         })
     }
 }
@@ -1410,5 +1456,138 @@ fn apply_ip_prefix_len(ip: IpAddr, prefix_length: usize) -> IpAddr {
             u32::from(i) & (u32::MAX << (IPV4_ADDR_LEN - prefix_length)),
         )
         .into(),
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize,
+)]
+#[serde(into = "String")]
+#[non_exhaustive]
+pub enum AddressProtocol {
+    Loopback,
+    RouterAnnouncement,
+    LinkLocal,
+    Other(u8),
+}
+
+impl From<AddressProtocol> for String {
+    fn from(v: AddressProtocol) -> Self {
+        v.to_string()
+    }
+}
+
+// Using iproute string here
+impl std::fmt::Display for AddressProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Loopback => write!(f, "lo"),
+            Self::RouterAnnouncement => write!(f, "ra"),
+            Self::LinkLocal => write!(f, "kernel_ll"),
+            Self::Other(d) => write!(f, "0x{d:x}"),
+        }
+    }
+}
+
+impl std::convert::TryFrom<&str> for AddressProtocol {
+    type Error = NmstateError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Ok(match value {
+            "lo" => Self::Loopback,
+            "ra" => Self::RouterAnnouncement,
+            "kernel_ll" => Self::LinkLocal,
+            v => {
+                if let Some(s) = v.strip_prefix("0x") {
+                    u8::from_str_radix(s, 16)
+                        .map_err(|_| {
+                            NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Invalid address protocol '{v}', should \
+                                     lo, ra, kernel_ll or integer from 1 to \
+                                     255"
+                                ),
+                            )
+                        })?
+                        .into()
+                } else {
+                    v.parse::<u8>()
+                        .map_err(|_| {
+                            NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Invalid address protocol '{v}', should \
+                                     lo, ra, kernel_ll or integer from 1 to \
+                                     255"
+                                ),
+                            )
+                        })?
+                        .into()
+                }
+            }
+        })
+    }
+}
+
+impl From<nispor::AddressProtocol> for AddressProtocol {
+    fn from(d: nispor::AddressProtocol) -> Self {
+        match d {
+            nispor::AddressProtocol::Loopback => Self::Loopback,
+            nispor::AddressProtocol::RouterAnnouncement => {
+                Self::RouterAnnouncement
+            }
+            nispor::AddressProtocol::LinkLocal => Self::LinkLocal,
+            _ => Self::Other(u8::from(d)),
+        }
+    }
+}
+
+impl From<AddressProtocol> for nispor::AddressProtocol {
+    fn from(v: AddressProtocol) -> Self {
+        match v {
+            AddressProtocol::Loopback => Self::Loopback,
+            AddressProtocol::RouterAnnouncement => Self::RouterAnnouncement,
+            AddressProtocol::LinkLocal => Self::LinkLocal,
+            AddressProtocol::Other(d) => Self::Other(d),
+        }
+    }
+}
+
+const IFAPROT_KERNEL_LO: u8 = 1;
+const IFAPROT_KERNEL_RA: u8 = 2;
+const IFAPROT_KERNEL_LL: u8 = 3;
+
+impl From<u8> for AddressProtocol {
+    fn from(d: u8) -> Self {
+        match d {
+            IFAPROT_KERNEL_LO => Self::Loopback,
+            IFAPROT_KERNEL_RA => Self::RouterAnnouncement,
+            IFAPROT_KERNEL_LL => Self::LinkLocal,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AddressProtocol {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let err_msg = "Invalid address protocol 'd', should be lo, ra, \
+                       kernel_ll or integer from 1 to 255";
+        let v = serde_json::Value::deserialize(deserializer)?;
+        if let Some(v) = v.as_str() {
+            Self::try_from(v)
+                .map_err(|e| serde::de::Error::custom(e.to_string()))
+        } else if let Some(d) = v.as_u64() {
+            if d > u8::MAX as u64 {
+                Err(serde::de::Error::custom(err_msg))
+            } else {
+                Ok(Self::from(d as u8))
+            }
+        } else {
+            Err(serde::de::Error::custom(err_msg))
+        }
     }
 }

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -165,8 +165,8 @@ pub use crate::{
         VxlanConfig, VxlanInterface, XfrmInterface,
     },
     ip::{
-        AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpAddr,
-        InterfaceIpv4, InterfaceIpv6, Ipv6AddrGenMode, WaitIp,
+        AddressFamily, AddressProtocol, Dhcpv4ClientId, Dhcpv6Duid,
+        InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, Ipv6AddrGenMode, WaitIp,
     },
     lldp::{
         LldpAddressFamily, LldpChassisId, LldpChassisIdType, LldpConfig,

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -3,8 +3,8 @@
 use std::str::FromStr;
 
 use crate::{
-    InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, MergedInterface,
-    nispor::mptcp::get_mptcp_flags,
+    AddressProtocol, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
+    MergedInterface, nispor::mptcp::get_mptcp_flags,
 };
 
 pub(crate) fn np_ipv4_to_nmstate(
@@ -53,6 +53,7 @@ pub(crate) fn np_ipv4_to_nmstate(
                     } else {
                         None
                     },
+                    protocol: np_addr.protocol.map(AddressProtocol::from),
                     ..Default::default()
                 }),
                 Err(e) => {
@@ -127,6 +128,7 @@ pub(crate) fn np_ipv6_to_nmstate(
                     } else {
                         None
                     },
+                    protocol: np_addr.protocol.map(AddressProtocol::from),
                     ..Default::default()
                 }),
                 Err(e) => {

--- a/rust/src/lib/nm/route.rs
+++ b/rust/src/lib/nm/route.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{MergedNetworkState, NmstateError};
+use crate::{AddressProtocol, MergedNetworkState, NmstateError};
 
 pub(crate) fn store_route_config(
     merged_state: &mut MergedNetworkState,
@@ -26,12 +26,40 @@ pub(crate) fn store_route_config(
                             .base_iface_mut()
                             .ipv4
                             .clone_from(&iface.merged.base_iface_mut().ipv4);
+                        if let Some(addrs) = apply_iface
+                            .base_iface_mut()
+                            .ipv4
+                            .as_mut()
+                            .and_then(|i| i.addresses.as_mut())
+                        {
+                            // Ignore other protocol address
+                            addrs.retain(|addr| {
+                                !matches!(
+                                    addr.protocol,
+                                    Some(AddressProtocol::Other(_))
+                                )
+                            });
+                        }
                     }
                     if apply_iface.base_iface_mut().ipv6.is_none() {
                         apply_iface
                             .base_iface_mut()
                             .ipv6
                             .clone_from(&iface.merged.base_iface_mut().ipv6);
+                        if let Some(addrs) = apply_iface
+                            .base_iface_mut()
+                            .ipv6
+                            .as_mut()
+                            .and_then(|i| i.addresses.as_mut())
+                        {
+                            // Ignore other protocol address
+                            addrs.retain(|addr| {
+                                !matches!(
+                                    addr.protocol,
+                                    Some(AddressProtocol::Other(_))
+                                )
+                            });
+                        }
                     }
                     apply_iface.base_iface_mut().routes = Some(rts.clone());
                 }

--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -34,8 +34,8 @@ use super::{
     wired::gen_nm_wired_setting,
 };
 use crate::{
-    Interface, InterfaceIdentifier, InterfaceType, MergedInterface,
-    MergedNetworkState, NmstateError, OvsBridgePortConfig,
+    AddressProtocol, Interface, InterfaceIdentifier, InterfaceType,
+    MergedInterface, MergedNetworkState, NmstateError, OvsBridgePortConfig,
 };
 
 pub(crate) fn iface_to_nm_connections(
@@ -467,9 +467,31 @@ fn preserve_current_ip(iface: &mut Interface, cur_iface: Option<&Interface>) {
     if iface.base_iface().ipv4.is_none() {
         iface.base_iface_mut().ipv4 =
             cur_iface.as_ref().and_then(|i| i.base_iface().ipv4.clone());
+        // Ignore other protocol address
+        if let Some(addrs) = iface
+            .base_iface_mut()
+            .ipv4
+            .as_mut()
+            .and_then(|ip| ip.addresses.as_mut())
+        {
+            addrs.retain(|addr| {
+                !matches!(addr.protocol, Some(AddressProtocol::Other(_)))
+            })
+        }
     }
     if iface.base_iface().ipv6.is_none() {
         iface.base_iface_mut().ipv6 =
             cur_iface.as_ref().and_then(|i| i.base_iface().ipv6.clone());
+        // Ignore other protocol address
+        if let Some(addrs) = iface
+            .base_iface_mut()
+            .ipv6
+            .as_mut()
+            .and_then(|ip| ip.addresses.as_mut())
+        {
+            addrs.retain(|addr| {
+                !matches!(addr.protocol, Some(AddressProtocol::Other(_)))
+            })
+        }
     }
 }

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -34,6 +34,9 @@ impl InterfaceIpv4 {
             } else {
                 addrs.sort_unstable();
                 addrs.dedup();
+                for addr in addrs {
+                    addr.protocol = None;
+                }
             }
         }
     }
@@ -125,6 +128,9 @@ impl InterfaceIpv6 {
         if let Some(addrs) = self.addresses.as_mut() {
             addrs.sort_unstable();
             addrs.dedup();
+            for addr in addrs {
+                addr.protocol = None;
+            }
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -170,6 +170,7 @@ class InterfaceIP:
     ALLOW_EXTRA_ADDRESS = "allow-extra-address"
     DHCP_SEND_HOSTNAME = "dhcp-send-hostname"
     DHCP_CUSTOM_HOSTNAME = "dhcp-custom-hostname"
+    PROTOCOL = "protocol"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -22,10 +22,12 @@ from libnmstate.error import NmstateVerificationError
 
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV4_ADDRESS2 = "192.0.2.252"
+IPV4_ADDRESS3 = "192.0.2.253"
 IPV4_TEST_NET1 = "203.0.113.0/24"
 IPV4_GATEWAY1 = "192.0.2.1"
 IPV6_ADDRESS1 = "2001:db8:1::1"
 IPV6_ADDRESS2 = "2001:db8:1::2"
+IPV6_ADDRESS3 = "2001:db8:1::3"
 IPV6_TEST_NET1 = "2001:db8:e::/64"
 IPV6_GATEWAY1 = "2001:db8:1::f"
 TEST_GATEAY4 = "192.0.2.1"
@@ -488,3 +490,164 @@ def test_apply_absent_routes_to_ignored_iface(
             and route[Route.DESTINATION] == IPV6_TEST_NET1
             for route in routes
         )
+
+
+@pytest.fixture
+def external_managed_dummy1_with_static_ip_and_other_protocol_addr():
+    with nm_unmanaged_dummy(DUMMY1):
+        exec_cmd(
+            f"ip addr add {IPV4_ADDRESS1} dev {DUMMY1}".split(),
+            check=True,
+        )
+        exec_cmd(
+            f"ip addr add {IPV4_ADDRESS3} proto 84 dev {DUMMY1}".split(),
+            check=True,
+        )
+        exec_cmd(
+            f"ip addr add {IPV6_ADDRESS1} dev {DUMMY1}".split(),
+            check=True,
+        )
+        exec_cmd(
+            f"ip addr add {IPV6_ADDRESS3} proto 84 dev {DUMMY1}".split(),
+            check=True,
+        )
+        exec_cmd(f"nmcli d set {DUMMY1} managed true".split(), check=True)
+        yield
+
+
+# TODO: Add OCP jira issue and mark as tier1
+def test_modify_route_of_ext_iface_should_ignore_other_protocol_addr(
+    external_managed_dummy1_with_static_ip_and_other_protocol_addr,
+):
+    desired_routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: DUMMY1,
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+    ]
+    libnmstate.apply({Route.KEY: {Route.CONFIG: desired_routes}})
+
+    cur_state = libnmstate.show()
+    assert_routes(desired_routes, cur_state)
+
+    # The NM saved config should not contains IPV4_ADDRESS3 and IPV6_ADDRESS3
+
+    assert (
+        IPV4_ADDRESS1
+        in exec_cmd(
+            f"nmcli -f ipv4.addresses c show {DUMMY1}".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV4_ADDRESS3
+        not in exec_cmd(
+            f"nmcli -f ipv4.addresses c show {DUMMY1}".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV6_ADDRESS1
+        in exec_cmd(
+            f"nmcli -f ipv6.addresses c show {DUMMY1}".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV6_ADDRESS3
+        not in exec_cmd(
+            f"nmcli -f ipv6.addresses c show {DUMMY1}".split(), check=True
+        )[1]
+    )
+
+
+@pytest.fixture
+def eth1_with_static_ip_and_other_protocol_addr(eth1_up):
+    libnmstate.apply(
+        yaml.load(
+            f"""---
+            interfaces:
+            - name: eth1
+              state: up
+              ipv4:
+                address:
+                - ip: {IPV4_ADDRESS1}
+                  prefix-length: 24
+                dhcp: false
+                enabled: true
+              ipv6:
+                address:
+                  - ip: {IPV6_ADDRESS1}
+                    prefix-length: 64
+                autoconf: false
+                dhcp: false
+                enabled: true
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+    exec_cmd(
+        f"ip addr add {IPV4_ADDRESS3} proto 84 dev eth1".split(),
+        check=True,
+    )
+    exec_cmd(
+        f"ip addr add {IPV6_ADDRESS3} proto 84 dev eth1".split(),
+        check=True,
+    )
+    yield
+
+
+# TODO: Add OCP jira issue and mark as tier1
+def test_modify_route_of_iface_should_ignore_other_protocol_addr(
+    eth1_with_static_ip_and_other_protocol_addr,
+):
+    desired_routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.TABLE_ID: 254,
+        },
+    ]
+    libnmstate.apply({Route.KEY: {Route.CONFIG: desired_routes}})
+
+    cur_state = libnmstate.show()
+    assert_routes(desired_routes, cur_state)
+
+    # The NM saved config should not contains IPV4_ADDRESS3 and IPV6_ADDRESS3
+
+    assert (
+        IPV4_ADDRESS1
+        in exec_cmd(
+            f"nmcli -f ipv4.addresses c show eth1".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV4_ADDRESS3
+        not in exec_cmd(
+            f"nmcli -f ipv4.addresses c show eth1".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV6_ADDRESS1
+        in exec_cmd(
+            f"nmcli -f ipv6.addresses c show eth1".split(), check=True
+        )[1]
+    )
+    assert (
+        IPV6_ADDRESS3
+        not in exec_cmd(
+            f"nmcli -f ipv6.addresses c show eth1".split(), check=True
+        )[1]
+    )

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1299,3 +1299,45 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
         kernel_only=True,
     )
     assertlib.assert_state_match(new_desired_state, kernel_only=True)
+
+
+def test_ignore_ip_addr_with_other_protocol(eth1_up):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.2.250
+              prefix-length: 24
+              protocol: 0x84
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+              - ip: 2001:db8:1::1
+                prefix-length: 64
+              - ip: 2001:db8:1::2
+                prefix-length: 64
+                protocol: 0x84
+        """
+    )
+    libnmstate.apply(desired_state)
+
+    cur_state = statelib.show_only(("eth1",))[Interface.KEY][0]
+
+    assert all(
+        addr.get(InterfaceIPv4.ADDRESS) != "192.0.2.250"
+        for addr in cur_state[Interface.IPV4][InterfaceIPv4.ADDRESS]
+    )
+    assert all(
+        addr.get(InterfaceIPv6.ADDRESS) != "2001:db8:1::2"
+        for addr in cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]
+    )


### PR DESCRIPTION
This patch introduce query only property for IP address protocol:

```yml
interfaces:
- name: eth1
  type: ethernet
  state: up
  ipv4:
    enabled: true
    address:
    - ip: 192.0.2.29
      prefix-length: 32
      protocol: '0xfa'
  ipv6:
    enabled: true
    address:
    - ip: 2001:db8::ffff
      prefix-length: 128
      protocol: '0xfa'
```

The IP address protocol could be used to identify whether specified IP
address is managed by Non-NM/nmstate tools.
For example, ovn-kubernetes uses 84 protocol for IP address managed by
OVN tool, that IP address is dynamically assigned by OVN which should
not be persistent into NM configuration.

When desired state is modifying routes, nmstate will automatically
preserve current IP address to make sure the IP stack is preserved.
We should ignore ip address with other(not 1,2,3 which is assigned by
kernel) protocol when preserving.

Integration test case included:
 1. Ignore IP address with other protocol in desire state.
 2. When modifying routes on external managed interface, other protocol
    IP address should not be persistent into config.
 3. When modifying routes on managed routes holding other protocol,
    other protocol IP address should not be persistent into config.