### PR TITLE
SRIOV: Raise error if desired VFS count exceeded the max

### DIFF
--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -62,6 +62,14 @@ pub struct SrIovConfig {
     /// The number of VFs enabled on PF.
     /// Deserialize and serialize from/to `total-vfs`.
     pub total_vfs: Option<u32>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_u32_or_string"
+    )]
+    /// Query only property for the maximum number of VFs supported on PF.
+    /// Deserialize and serialize from/to `max-vfs`.
+    pub max_vfs: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// VF specific configurations.
     /// * Setting to `Some(Vec::new())` will revert all VF configurations back
@@ -404,6 +412,28 @@ impl MergedInterface {
             self.for_verify.as_mut(),
             self.current.as_ref(),
         ) {
+            if let Some(max_vfs) = cur_iface
+                .ethernet
+                .as_ref()
+                .and_then(|e| e.sr_iov.as_ref())
+                .and_then(|s| s.max_vfs)
+                && let Some(total_vfs) = apply_iface
+                    .ethernet
+                    .as_ref()
+                    .and_then(|e| e.sr_iov.as_ref())
+                    .and_then(|s| s.total_vfs)
+                && max_vfs < total_vfs
+            {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Desired VFS count {total_vfs} exceeded the maximum \
+                         supported VFS count {max_vfs} for interface {}",
+                        apply_iface.base.name
+                    ),
+                ));
+            }
+
             let cur_conf =
                 cur_iface.ethernet.as_ref().and_then(|e| e.sr_iov.as_ref());
             if let (Some(apply_conf), Some(verify_conf)) = (

--- a/rust/src/lib/nispor/ethernet.rs
+++ b/rust/src/lib/nispor/ethernet.rs
@@ -93,6 +93,7 @@ fn gen_sriov_conf(sriov_info: &nispor::SriovInfo) -> SrIovConfig {
         vfs.push(vf);
     }
     ret.total_vfs = Some(vfs.len() as u32);
+    ret.max_vfs = sriov_info.max_num_vfs;
     ret.vfs = Some(vfs);
     ret
 }

--- a/rust/src/lib/query_apply/sriov.rs
+++ b/rust/src/lib/query_apply/sriov.rs
@@ -10,6 +10,7 @@ use crate::{
 impl SrIovConfig {
     // * Set 'vfs: []' to None which is just reverting all VF config to default.
     // * Set `vf.iface_name` empty string,
+    // * Set `max_vfs` as None because it is query only
     pub(crate) fn sanitize_desired_for_verify(&mut self) {
         if let Some(vfs) = self.vfs.as_mut() {
             for vf in vfs.iter_mut() {
@@ -19,6 +20,7 @@ impl SrIovConfig {
                 self.vfs = None;
             }
         }
+        self.max_vfs = None;
     }
 
     pub(crate) fn update(&mut self, other: Option<&SrIovConfig>) {

--- a/rust/src/lib/unit_tests/sriov.rs
+++ b/rust/src/lib/unit_tests/sriov.rs
@@ -903,3 +903,88 @@ fn test_sriov_not_allow_802_1ad_vlan_protocol_for_vlan_0_and_qos_0() {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);
     }
 }
+
+#[test]
+fn test_desired_sriov_vfs_count_exceeded_max() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 64
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 0
+              max-vfs: 63",
+    )
+    .unwrap();
+
+    let result =
+        MergedInterfaces::new(desired, current, Default::default(), false);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+        assert!(e.msg().contains("maximum"));
+        assert!(e.msg().contains("63"));
+        assert!(e.msg().contains("64"));
+        assert!(e.msg().contains("eth1"));
+    }
+}
+
+#[test]
+fn test_ignore_sriov_max_vfs_when_verify() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 62
+              max-vfs: 64
+        ",
+    )
+    .unwrap();
+
+    let current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 0
+              max-vfs: 63
+        ",
+    )
+    .unwrap();
+
+    let post_apply_current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 62
+              max-vfs: 63",
+    )
+    .unwrap();
+
+    let merged_ifaces =
+        MergedInterfaces::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    merged_ifaces.verify(&post_apply_current).unwrap();
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -301,6 +301,7 @@ class Ethernet:
     class SRIOV:
         DRIVERS_AUTOPROBE = "drivers-autoprobe"
         TOTAL_VFS = "total-vfs"
+        MAX_VFS = "max-vfs"
         VFS_SUBTREE = "vfs"
 
         class VFS:

--- a/tests/integration/sriov_test.py
+++ b/tests/integration/sriov_test.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 import libnmstate
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Bond
 from libnmstate.schema import Ethernet
 from libnmstate.schema import Ethtool
@@ -58,6 +59,11 @@ def find_vf_iface_name(pf_name, vf_id):
     return os.listdir(
         f"/sys/class/net/{pf_name}/device/virtfn{vf_id}/net"
     ).pop()
+
+
+def get_max_vfs_count(pf_name):
+    with open(f"/sys/class/net/{pf_name}/device/sriov_totalvfs", "r") as fd:
+        return int(fd.read())
 
 
 @pytest.fixture
@@ -554,6 +560,45 @@ class TestSrIov:
                     Interface.NAME: pf_name,
                     Ethernet.CONFIG_SUBTREE: {
                         Ethernet.SRIOV_SUBTREE: {Ethernet.SRIOV.TOTAL_VFS: 2},
+                    },
+                }
+            ]
+        }
+        libnmstate.apply(desired_state)
+        vf_ifaces = get_sriov_vf_names(pf_name)
+        assert len(vf_ifaces) == 2
+
+    def test_raise_error_if_exceeded_maximum_supported_vfs_count(self):
+        pf_name = _test_nic_name()
+        max_vfs = get_max_vfs_count(pf_name)
+
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Ethernet.CONFIG_SUBTREE: {
+                        Ethernet.SRIOV_SUBTREE: {
+                            Ethernet.SRIOV.TOTAL_VFS: max_vfs + 1
+                        },
+                    },
+                }
+            ]
+        }
+        with pytest.raises(NmstateValueError):
+            libnmstate.apply(desired_state)
+
+    def test_ignore_query_only_prop_max_vfs(self, disable_sriov):
+        pf_name = _test_nic_name()
+
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: pf_name,
+                    Ethernet.CONFIG_SUBTREE: {
+                        Ethernet.SRIOV_SUBTREE: {
+                            Ethernet.SRIOV.TOTAL_VFS: 2,
+                            Ethernet.SRIOV.MAX_VFS: 0,
+                        },
                     },
                 }
             ]


### PR DESCRIPTION
Introducing `max-vfs` property to sr-iov section, example:

```yml
---
interfaces:
  - name: ens2f0
    type: ethernet
    state: up
    ethernet:
      sr-iov:
        drivers-autoprobe: true
        total-vfs: 0
        max-vfs: 63
```

Nmstate will raise error if desired SRIOV VFS count exceeded the
maximum supported SRIOV count.

Unit test cases included:
 * Ignore desired `max-vfs` when verifying.
 * Raise error if desired `total-vfs` exceeded the maximum.

Integration test case included:
 * Raise error if desired `total-vfs` exceeded the maximum.
 * `max-vfs` in desired state is ignored and apply action pass without
   failure.

Resolves: https://issues.redhat.com/browse/RHEL-109800