### PR TITLE
ipv4: Add new parameter prefix-route-metric

### DIFF
--- a/automation/run-lint-tests.sh
+++ b/automation/run-lint-tests.sh
@@ -8,6 +8,8 @@ PROJECT_PATH="$(dirname $EXEC_PATH)"
 
 cd $PROJECT_PATH
 
+black --version
+
 black \
     --check \
     --diff \
@@ -15,10 +17,14 @@ black \
     rust/src/python/libnmstate \
     tests/integration
 
+flake8 --version
+
 flake8 \
     --statistics \
     rust/src/python/setup.py \
     rust/src/python/libnmstate \
     tests/integration
+
+yamllint --version
 
 yamllint examples/

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{
     BaseInterface, DnsClientState, ErrorKind, MergedInterface,
-    MptcpAddressFlag, NmstateError, RouteRuleEntry,
+    MptcpAddressFlag, NmstateError, RouteEntry, RouteRuleEntry,
 };
 
 const AF_INET: u8 = 2;
@@ -83,9 +83,9 @@ struct InterfaceIp {
         skip_serializing_if = "Option::is_none",
         rename = "auto-route-metric",
         default,
-        deserialize_with = "crate::deserializer::option_u32_or_string"
+        deserialize_with = "crate::deserializer::option_i64_or_string"
     )]
-    pub auto_route_metric: Option<u32>,
+    pub auto_route_metric: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "addr-gen-mode")]
     pub addr_gen_mode: Option<Ipv6AddrGenMode>,
     #[serde(
@@ -105,12 +105,15 @@ struct InterfaceIp {
         rename = "dhcp-custom-hostname"
     )]
     pub dhcp_custom_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forwarding: Option<bool>,
     #[serde(
         skip_serializing_if = "Option::is_none",
+        rename = "prefix-route-metric",
         default,
-        deserialize_with = "crate::deserializer::option_bool_or_string"
+        deserialize_with = "crate::deserializer::option_i64_or_string"
     )]
-    pub forwarding: Option<bool>,
+    pub prefix_route_metric: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
@@ -184,7 +187,7 @@ pub struct InterfaceIpv4 {
     /// Metric for routes retrieved from DHCP server.
     /// Only available for DHCPv4 enabled interface.
     /// Deserialize from `auto-route-metric`
-    pub auto_route_metric: Option<u32>,
+    pub auto_route_metric: Option<i64>,
     /// Whether to include hostname in DHCP request.
     /// If the hostname is FQDN, the `Fully Qualified Domain Name (FQDN)`
     /// option(81) defined in RFC 4702 will be used.
@@ -203,6 +206,9 @@ pub struct InterfaceIpv4 {
     pub dhcp_custom_hostname: Option<String>,
     pub(crate) dns: Option<DnsClientState>,
     pub(crate) rules: Option<HashSet<RouteRuleEntry>>,
+    /// Metric for routes of prefixes directly connected to the interface.
+    /// Deserialize from `prefix-route-metric`
+    pub prefix_route_metric: Option<i64>,
 }
 
 impl InterfaceIpv4 {
@@ -276,6 +282,69 @@ impl InterfaceIpv4 {
         self.sanitize(false).ok();
     }
 
+    pub(crate) fn sanitize_auto_metric_and_prefix_metric(
+        &mut self,
+    ) -> Result<(), NmstateError> {
+        if let Some(prefix_metric) = self.prefix_route_metric
+            && prefix_metric != RouteEntry::USE_DEFAULT_METRIC
+            && let Some(auto_metric) = self.auto_route_metric
+            && auto_metric != RouteEntry::USE_DEFAULT_METRIC
+            && prefix_metric != auto_metric
+        {
+            return Err(NmstateError::new(
+                ErrorKind::NotSupportedError,
+                format!(
+                    "Different value of ipv4.auto-route-metric ({}) and \
+                     ipv4.prefix-route-metric ({}) are not supported yet by \
+                     NetworkManager",
+                    auto_metric, prefix_metric,
+                ),
+            ));
+        }
+
+        if let Some(metric) = self.prefix_route_metric
+            && (metric < RouteEntry::USE_DEFAULT_METRIC
+                || metric > u32::MAX as i64)
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Invalid value for ipv4.prefix-route-metric: {metric}, \
+                     should be in range of [{};{}]",
+                    RouteEntry::USE_DEFAULT_METRIC,
+                    u32::MAX,
+                ),
+            ));
+        }
+        if let Some(metric) = self.auto_route_metric
+            && (metric < RouteEntry::USE_DEFAULT_METRIC
+                || metric > u32::MAX as i64)
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Invalid value for ipv4.auto-route-metric: {metric}, \
+                     should be in range of [{};{}]",
+                    RouteEntry::USE_DEFAULT_METRIC,
+                    u32::MAX,
+                ),
+            ));
+        }
+
+        if self.prefix_route_metric == Some(RouteEntry::USE_DEFAULT_METRIC)
+            && self.auto_route_metric.is_some()
+        {
+            self.prefix_route_metric = self.auto_route_metric;
+        }
+        if self.auto_route_metric == Some(RouteEntry::USE_DEFAULT_METRIC)
+            && self.prefix_route_metric.is_some()
+        {
+            self.auto_route_metric = self.prefix_route_metric;
+        }
+
+        Ok(())
+    }
+
     // * Remove link-local address
     // * Set auto_dns, auto_gateway and auto_routes to true if DHCP enabled and
     //   those options is None
@@ -283,6 +352,7 @@ impl InterfaceIpv4 {
     // * Remove auto IP address.
     // * Set DHCP options to None if DHCP is false
     // * Remove mptcp_flags is they are for query only
+    // * Validate auto metric and prefix metric
     pub(crate) fn sanitize(
         &mut self,
         is_desired: bool,
@@ -359,6 +429,7 @@ impl InterfaceIpv4 {
         if !self.enabled {
             self.dhcp = None;
             self.addresses = None;
+            self.prefix_route_metric = None;
         }
 
         if self.dhcp != Some(true) {
@@ -393,6 +464,9 @@ impl InterfaceIpv4 {
             for addr in addrs.iter_mut() {
                 addr.mptcp_flags = None;
             }
+        }
+        if is_desired && self.enabled {
+            self.sanitize_auto_metric_and_prefix_metric()?;
         }
         Ok(())
     }
@@ -446,6 +520,7 @@ impl From<InterfaceIp> for InterfaceIpv4 {
             dhcp_send_hostname: ip.dhcp_send_hostname,
             dhcp_custom_hostname: ip.dhcp_custom_hostname,
             forwarding: ip.forwarding,
+            prefix_route_metric: ip.prefix_route_metric,
             ..Default::default()
         }
     }
@@ -472,6 +547,7 @@ impl From<InterfaceIpv4> for InterfaceIp {
             dhcp_send_hostname: ip.dhcp_send_hostname,
             dhcp_custom_hostname: ip.dhcp_custom_hostname,
             forwarding: ip.forwarding,
+            prefix_route_metric: ip.prefix_route_metric,
             ..Default::default()
         }
     }
@@ -552,7 +628,7 @@ pub struct InterfaceIpv6 {
     /// Metric for routes retrieved from DHCP server.
     /// Only available for autoconf enabled interface.
     /// Deserialize from `auto-route-metric`.
-    pub auto_route_metric: Option<u32>,
+    pub auto_route_metric: Option<i64>,
     /// IETF draft(expired) Tokenised IPv6 Identifiers. Should be only
     /// containing the tailing 64 bites for IPv6 address.
     pub token: Option<String>,
@@ -684,9 +760,11 @@ impl InterfaceIpv6 {
             self.auto_gateway = None;
             self.auto_routes = None;
             self.auto_table_id = None;
-            self.auto_route_metric = None;
             self.dhcp_send_hostname = None;
             self.dhcp_custom_hostname = None;
+        }
+        if self.autoconf == Some(false) {
+            self.auto_route_metric = None;
         }
         if let Some(addrs) = self.addresses.as_mut() {
             for addr in addrs.iter_mut() {
@@ -794,6 +872,11 @@ impl<'de> Deserialize<'de> for InterfaceIpv6 {
         let v = serde_json::Value::deserialize(deserializer)?;
 
         if let Some(v_map) = v.as_object() {
+            if v_map.contains_key("prefix-route-metric") {
+                return Err(serde::de::Error::custom(
+                    "prefix-route-metric is not allowed for IPv6",
+                ));
+            }
             if v_map.contains_key("dhcp_client_id") {
                 return Err(serde::de::Error::custom(
                     "dhcp-client-id is not allowed for IPv6",

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpv4, InterfaceIpv6,
-    Ipv6AddrGenMode, RouteRuleAction, RouteRuleEntry, WaitIp,
+    Ipv6AddrGenMode, RouteEntry, RouteRuleAction, RouteRuleEntry, WaitIp,
 };
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
@@ -54,7 +54,8 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             } else {
                 None
             },
-            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
+            // -1 is a special value meaning use NetworkManager's default metric
+            auto_route_metric: nm_ip_setting.route_metric.or(Some(-1)),
             dhcp_send_hostname: if enabled && dhcp == Some(true) {
                 Some(dhcp_send_hostname)
             } else {
@@ -72,6 +73,9 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             } else {
                 None
             },
+            prefix_route_metric: nm_ip_setting
+                .route_metric
+                .or(Some(RouteEntry::USE_DEFAULT_METRIC)),
             ..Default::default()
         }
     } else {
@@ -123,7 +127,8 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
                     None
                 }
             },
-            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
+            // -1 is a special value meaning use NetworkManager's default metric
+            auto_route_metric: nm_ip_setting.route_metric.or(Some(-1)),
             dhcp_send_hostname: if enabled && dhcp == Some(true) {
                 Some(nm_ip_setting.dhcp_send_hostname.unwrap_or(true))
             } else {

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -65,9 +65,16 @@ fn gen_nm_ipv4_setting(
     nm_setting.method = Some(method);
     nm_setting.addresses = addresses;
     nm_setting.forwarding = iface_ip.forwarding.map(i32::from);
+
+    if iface_ip.prefix_route_metric.is_some() {
+        nm_setting.route_metric = iface_ip.prefix_route_metric;
+    }
+
     if iface_ip.is_auto() {
         nm_setting.dhcp_timeout = Some(i32::MAX);
-        nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
+        if iface_ip.auto_route_metric.is_some() {
+            nm_setting.route_metric = iface_ip.auto_route_metric;
+        }
         nm_setting.dhcp_client_id = Some(nmstate_dhcp_client_id_to_nm(
             iface_ip
                 .dhcp_client_id
@@ -189,6 +196,7 @@ fn gen_nm_ipv6_setting(
     nm_setting.addresses = addresses;
     nm_setting.addr_gen_mode =
         Some(nmstate_addr_gen_mode_to_nm(iface_ip.addr_gen_mode.as_ref()));
+
     if iface_ip.is_auto() {
         nm_setting.dhcp_timeout = Some(i32::MAX);
         nm_setting.ra_timeout = Some(i32::MAX);
@@ -207,7 +215,9 @@ fn gen_nm_ipv6_setting(
                 nm_setting.token = Some(token.to_string());
             }
         }
-        nm_setting.route_metric = iface_ip.auto_route_metric.map(|i| i.into());
+        if iface_ip.auto_route_metric.is_some() {
+            nm_setting.route_metric = iface_ip.auto_route_metric;
+        }
         apply_dhcp_opts(
             &mut nm_setting,
             iface_ip.auto_dns,

--- a/rust/src/lib/query_apply/ip.rs
+++ b/rust/src/lib/query_apply/ip.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Interface, InterfaceIpv4, InterfaceIpv6};
+use crate::{Interface, InterfaceIpv4, InterfaceIpv6, RouteEntry};
 
 impl InterfaceIpv4 {
     // Sort addresses and dedup
@@ -35,6 +35,14 @@ impl InterfaceIpv4 {
                 addrs.sort_unstable();
                 addrs.dedup();
             }
+        }
+        // We do not verify prefix_route_metric or auto_route_metric if set to
+        // RouteEntry::USE_DEFAULT_METRIC
+        if self.prefix_route_metric == Some(RouteEntry::USE_DEFAULT_METRIC) {
+            self.prefix_route_metric = None;
+        }
+        if self.auto_route_metric == Some(RouteEntry::USE_DEFAULT_METRIC) {
+            self.auto_route_metric = None;
         }
     }
     pub(crate) fn update(&mut self, other: &Self) {
@@ -84,6 +92,9 @@ impl InterfaceIpv4 {
         }
         if other.forwarding.is_some() {
             self.forwarding = other.forwarding;
+        }
+        if other.prefix_route_metric.is_some() {
+            self.prefix_route_metric = other.prefix_route_metric;
         }
     }
 }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BaseInterface, ErrorKind, Interface, InterfaceState, Interfaces,
-    MergedInterfaces, ip::sanitize_ip_network,
+    MergedInterfaces, RouteEntry, ip::sanitize_ip_network,
     unit_tests::testlib::new_eth_iface,
 };
 
@@ -22,7 +22,6 @@ state: up
 ipv4:
   enabled: "true"
   dhcp: "false"
-  forwarding: "true"
   address:
   - ip: "192.168.1.1"
     prefix-length: "24"
@@ -40,7 +39,6 @@ ipv6:
 
     assert!(ipv4_conf.enabled);
     assert_eq!(ipv4_conf.dhcp, Some(false));
-    assert_eq!(ipv4_conf.forwarding, Some(true));
     assert_eq!(
         ipv4_conf.addresses.as_deref().unwrap()[0].ip.to_string(),
         "192.168.1.1"
@@ -630,4 +628,102 @@ ipv6:
     let err_str = err.to_string();
 
     assert!(err_str.starts_with("InvalidArgument:"));
+}
+
+#[test]
+fn test_no_error_on_diff_auto_metric_without_dhcpv4() {
+    let mut iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: false
+          auto-route-metric: 100
+          prefix-route-metric: 101"#,
+    )
+    .unwrap();
+
+    iface.sanitize(true).unwrap();
+}
+
+#[test]
+fn test_no_error_on_diff_auto_metric_if_one_is_default() {
+    for (auto_metric, prefix_metric) in [
+        (RouteEntry::USE_DEFAULT_METRIC, 101),
+        (101, RouteEntry::USE_DEFAULT_METRIC),
+    ] {
+        let mut iface: Interface = serde_yaml::from_str(&format!(
+            r#"---
+            name: eth1
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+              auto-route-metric: {auto_metric}
+              prefix-route-metric: {prefix_metric}"#,
+        ))
+        .unwrap();
+
+        iface.sanitize(true).unwrap();
+
+        let base_iface = iface.base_iface();
+
+        assert_eq!(
+            base_iface.ipv4.as_ref().and_then(|i| i.auto_route_metric),
+            Some(101)
+        );
+        assert_eq!(
+            base_iface.ipv4.as_ref().and_then(|i| i.prefix_route_metric),
+            Some(101)
+        );
+    }
+}
+
+#[test]
+fn test_error_on_diff_auto_metric_with_dhcpv4() {
+    let mut iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: true
+          auto-route-metric: 100
+          prefix-route-metric: 101"#,
+    )
+    .unwrap();
+
+    let error = iface.sanitize(true).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::NotSupportedError);
+    assert!(error.msg().contains("Different"));
+    assert!(error.msg().contains("ipv4.auto-route-metric"));
+    assert!(error.msg().contains("ipv4.prefix-route-metric"));
+}
+
+#[test]
+fn test_error_on_route_metric_out_of_range() {
+    for prop_name in ["auto-route-metric", "prefix-route-metric"] {
+        for invalid_value in [-2i64, u32::MAX as i64 + 1] {
+            let mut iface: Interface = serde_yaml::from_str(&format!(
+                r#"---
+                name: eth1
+                type: ethernet
+                state: up
+                ipv4:
+                  enabled: true
+                  dhcp: true
+                  {prop_name}: {invalid_value}"#
+            ))
+            .unwrap();
+
+            let error = iface.sanitize(true).unwrap_err();
+            assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+            assert!(error.msg().contains("Invalid value"));
+            assert!(error.msg().contains(&format!("ipv4.{prop_name}")));
+        }
+    }
 }

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -173,6 +173,7 @@ class InterfaceIP:
     ALLOW_EXTRA_ADDRESS = "allow-extra-address"
     DHCP_SEND_HOSTNAME = "dhcp-send-hostname"
     DHCP_CUSTOM_HOSTNAME = "dhcp-custom-hostname"
+    PREFIX_ROUTE_METRIC = "prefix-route-metric"
 
 
 class InterfaceIPv4(InterfaceIP):

--- a/rust/src/python/libnmstate/state.py
+++ b/rust/src/python/libnmstate/state.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Mapping
 
-
 PASSWORD_HID_BY_NMSTATE = "<_password_hid_by_nmstate>"
 
 

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -28,7 +28,6 @@ from .testlib.vlan import vlan_interface
 from .testlib.yaml import load_yaml
 from .testlib.route import assert_routes
 
-
 TEST_ALT_NAMES = [
     "port1",
     "reallyreallylonglonglonginterfacenmae",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,6 @@ from .testlib.veth import create_veth_pair
 from .testlib.veth import remove_veth_pair
 from .testlib.ipsec import IpsecTestEnv
 
-
 REPORT_HEADER = """RPMs: {rpms}
 OS: {osname}
 nmstate: {nmstate_version}

--- a/tests/integration/dns_test.py
+++ b/tests/integration/dns_test.py
@@ -23,7 +23,6 @@ from .testlib.servicelib import disable_service
 from .testlib.statelib import show_only
 from .testlib.yaml import load_yaml
 
-
 IPV4_DNS_NAMESERVERS = ["8.8.8.8", "1.1.1.1"]
 EXTRA_IPV4_DNS_NAMESERVER = "9.9.9.9"
 IPV6_DNS_NAMESERVERS = ["2001:4860:4860::8888", "2606:4700:4700::1111"]

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -2330,7 +2330,7 @@ def test_append_static_dns_before_auto_dns(dhcpcli_up_with_dns_cleanup):
 def test_static_ipv6_route_not_covert_auto_ip(dhcpcli_up_with_dynamic_ip):
     iface_state = dhcpcli_up_with_dynamic_ip[Interface.KEY][0]
 
-    (pre_dhcpv4_addrs, pre_dhcpv6_addrs) = get_dhcp_addr(iface_state)
+    pre_dhcpv4_addrs, pre_dhcpv6_addrs = get_dhcp_addr(iface_state)
 
     state_yml = """---
     routes:
@@ -2349,7 +2349,7 @@ def test_static_ipv6_route_not_covert_auto_ip(dhcpcli_up_with_dynamic_ip):
     assert _poll(_has_dhcpv6_addr)
 
     current_state = statelib.show_only((DHCP_CLI_NIC,))
-    (new_dhcpv4_addrs, new_dhcpv6_addrs) = get_dhcp_addr(
+    new_dhcpv4_addrs, new_dhcpv6_addrs = get_dhcp_addr(
         current_state[Interface.KEY][0]
     )
     assert pre_dhcpv4_addrs == new_dhcpv4_addrs

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -2398,3 +2398,23 @@ def test_enable_ipv4_forwarding_on_auto_iface_without_dhcp_srv():
         )
         libnmstate.apply(desired_state)
         assertlib.assert_state_match(desired_state)
+
+
+def test_different_auto_route_metric_and_prefix_route_metric(eth1_up):
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: True,
+                    InterfaceIPv4.PREFIX_ROUTE_METRIC: 901,
+                    InterfaceIPv4.AUTO_ROUTE_METRIC: 902,
+                },
+            }
+        ]
+    }
+    with pytest.raises((libnmstate.error.NmstateNotSupportedError)):
+        libnmstate.apply(desired_state)

--- a/tests/integration/hsr_test.py
+++ b/tests/integration/hsr_test.py
@@ -14,7 +14,6 @@ from .testlib.env import nm_minor_version
 from .testlib.hsrlib import hsr_interface
 from .testlib.ifacelib import get_mac_address
 
-
 ETH1 = "eth1"
 ETH2 = "eth2"
 ETH3 = "eth3"

--- a/tests/integration/infiniband_test.py
+++ b/tests/integration/infiniband_test.py
@@ -22,7 +22,6 @@ from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import linux_bridge
 from .testlib.bridgelib import add_port_to_bridge
 
-
 TEST_BRIDGE0 = "linux-br0"
 TEST_BOND99 = "bond99"
 TEST_PKEY1 = "0x80fe"

--- a/tests/integration/interface_common_test.py
+++ b/tests/integration/interface_common_test.py
@@ -17,7 +17,6 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.genconf import gen_conf_apply
 
-
 DUMMY_INTERFACE = "dummy_test"
 
 

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -17,7 +17,6 @@ from .testlib.ipsec import IpsecTestEnv
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import show_only
 
-
 RETRY_COUNT = 10
 
 IPSEC_CONN_NAME = "ipsec-cli-conn"

--- a/tests/integration/lldp_test.py
+++ b/tests/integration/lldp_test.py
@@ -18,7 +18,6 @@ from .testlib import statelib
 from .testlib.veth import create_veth_pair
 from .testlib.veth import remove_veth_pair
 
-
 LLDPTEST = "lldptest"
 LLDPTEST_PEER = "lldptest.peer"
 

--- a/tests/integration/mac_vlan_test.py
+++ b/tests/integration/mac_vlan_test.py
@@ -11,7 +11,6 @@ from libnmstate.schema import MacVlan
 
 from .testlib import assertlib
 
-
 ETH1 = "eth1"
 MACVLAN0 = "macvlan0"
 

--- a/tests/integration/mac_vtap_test.py
+++ b/tests/integration/mac_vtap_test.py
@@ -11,7 +11,6 @@ from libnmstate.schema import MacVtap
 
 from .testlib import assertlib
 
-
 ETH1 = "eth1"
 MACVLAN0 = "macvtap0"
 

--- a/tests/integration/mptcp_test.py
+++ b/tests/integration/mptcp_test.py
@@ -15,7 +15,6 @@ from libnmstate.schema import Mptcp
 from .testlib import assertlib
 from .testlib import cmdlib
 
-
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV6_ADDRESS1 = "2001:db8:1::1"
 

--- a/tests/integration/nm/bond_test.py
+++ b/tests/integration/nm/bond_test.py
@@ -26,7 +26,6 @@ from ..testlib.nmplugin import nm_service_restart
 from ..testlib.retry import retry_till_true_or_timeout
 from ..testlib.vlan import vlan_interface
 
-
 BOND0 = "bondtest0"
 TEST_VLAN = "bondtest.101"
 TEST_VLAN_ID = 101
@@ -261,7 +260,7 @@ def bond0_with_mac_ref_ports(eth1_up, eth2_up):
 
 
 def test_absent_bond_peserve_bond_port_in_mac_ref(bond0_with_mac_ref_ports):
-    (eth1_mac, eth2_mac) = bond0_with_mac_ref_ports
+    eth1_mac, eth2_mac = bond0_with_mac_ref_ports
     port1_nm_conn_uuid = cmdlib.exec_cmd(
         "nmcli -g connection.uuid c show port1".split(),
         check=True,

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -23,7 +23,6 @@ from ..testlib.ifacelib import get_mac_address
 from ..testlib.route import assert_routes
 from ..testlib.statelib import show_only
 
-
 NM_CONFIG_FOLDER = "/etc/NetworkManager/system-connections"
 MAX_RETRY_COUNT = 20
 

--- a/tests/integration/nm/hsr_test.py
+++ b/tests/integration/nm/hsr_test.py
@@ -7,7 +7,6 @@ import libnmstate
 from ..testlib.yaml import load_yaml
 from ..testlib.cmdlib import exec_cmd
 
-
 HSR_NIC = "hsr0"
 
 

--- a/tests/integration/nm/ieee802_1x_test.py
+++ b/tests/integration/nm/ieee802_1x_test.py
@@ -17,7 +17,6 @@ from ..testlib.veth import create_veth_pair
 from ..testlib.veth import remove_veth_pair
 from ..testlib.statelib import show_only
 
-
 TEST_1X_CLI_NIC = "1x_cli"
 TEST_1X_SRV_NIC = "1x_srv"
 TEST_1X_NET_NAME_SPACE = "test_802_1x"

--- a/tests/integration/nm/ip_test.py
+++ b/tests/integration/nm/ip_test.py
@@ -13,7 +13,6 @@ from ..testlib import cmdlib
 from ..testlib import assertlib
 from ..testlib.statelib import show_only
 
-
 IPV4_ADDRESS1 = "192.0.2.251"
 IPV4_ADDRESS2 = "192.0.2.1"
 IPV4_NET1 = "198.51.100.0/24"

--- a/tests/integration/nm/linux_bridge_test.py
+++ b/tests/integration/nm/linux_bridge_test.py
@@ -24,7 +24,6 @@ from ..testlib.env import nm_minor_version
 from ..testlib.statelib import show_only
 from ..testlib.yaml import load_yaml
 
-
 BRIDGE0 = "brtest0"
 DUMMY0 = "dummy0"
 DUMMY1 = "dummy1"

--- a/tests/integration/nm/veth_test.py
+++ b/tests/integration/nm/veth_test.py
@@ -12,7 +12,6 @@ from libnmstate.schema import Veth
 from ..testlib import cmdlib
 from ..testlib.veth import veth_interface
 
-
 VETH1 = "veth1"
 VETH1PEER = "veth1peer"
 VETH1PEER2 = "veth1ep"

--- a/tests/integration/nmstate_autoconf_test.py
+++ b/tests/integration/nmstate_autoconf_test.py
@@ -18,7 +18,6 @@ from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.veth import veth_interface
 
-
 LLDPTEST1 = "lldptest1"
 LLDPTEST1_PEER = "lldptest1.peer"
 LLDPTEST2 = "lldptest2"

--- a/tests/integration/nmstatectl_edit_test.py
+++ b/tests/integration/nmstatectl_edit_test.py
@@ -5,7 +5,6 @@ import os
 
 from .testlib import cmdlib
 
-
 RC_SUCCESS = 0
 
 

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -26,7 +26,6 @@ from .testlib.examplelib import load_example
 from .testlib.statelib import state_match
 from .testlib.statelib import show_only
 
-
 APPLY_CMD = ["nmstatectl", "apply"]
 SET_CMD = ["nmstatectl", "set"]
 SHOW_CMD = ["nmstatectl", "show"]

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import json
 
 import pytest
 
@@ -2620,3 +2621,115 @@ def test_kernel_mode_fail_on_same_dst_metric_routes(
     desired_state[Route.KEY] = {Route.CONFIG: load_yaml(routes)}
     with pytest.raises(NmstateValueError):
         libnmstate.apply(desired_state, kernel_only=True)
+
+
+@pytest.fixture
+def eth1_up_with_prefix_route_metric(eth1_up):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: true
+            dhcp: false
+            prefix-route-metric: 102
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 24
+        """
+    )
+    libnmstate.apply(desired_state)
+    yield
+
+
+def assert_prefix_routes(expected_routes):
+    cur_routes = json.loads(
+        cmdlib.exec_cmd("ip -j route show scope link dev eth1".split())[1]
+    )
+    assert len(cur_routes) == len(expected_routes)
+    for expected_route in expected_routes:
+        assert any(
+            cur_rt["metric"] == expected_route[Route.METRIC]
+            and cur_rt["dst"] == expected_route[Route.DESTINATION]
+            for cur_rt in cur_routes
+        )
+
+
+def test_prefix_route_metric_on_static_ip(eth1_up_with_prefix_route_metric):
+    expected_routes = load_yaml(
+        """---
+        - destination: 192.0.2.0/24
+          next-hop-interface: eth1
+          metric: 102
+        """
+    )
+    assert_prefix_routes(expected_routes)
+
+
+def preserve_prefix_route_metric_if_not_desired(
+    eth1_up_with_prefix_route_metric,
+):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: true
+            dhcp: false
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 24
+        """
+    )
+    libnmstate.apply(desired_state)
+
+    expected_routes = load_yaml(
+        """---
+        - destination: 192.0.2.0/24
+          next-hop-interface: eth1
+          metric: 102
+        """
+    )
+
+    assert_prefix_routes(expected_routes)
+
+
+@pytest.mark.parametrize(
+    "values",
+    [(Route.USE_DEFAULT_METRIC, 101), (101, Route.USE_DEFAULT_METRIC)],
+    ids=["default-prefix-route", "default-auto-route"],
+)
+def test_not_conflict_on_default_prefix_route_metric(eth1_up, values):
+    prefix_metric = values[0]
+    auto_metric = values[1]
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+        - name: eth1
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: true
+            dhcp: true
+            prefix-route-metric: {prefix_metric}
+            auto-route-metric: {auto_metric}
+            address:
+            - ip: 192.0.2.252
+              prefix-length: 24
+        """
+    )
+    libnmstate.apply(desired_state)
+
+    expected_routes = load_yaml(
+        """---
+        - destination: 192.0.2.0/24
+          next-hop-interface: eth1
+          metric: 101
+        """
+    )
+
+    assert_prefix_routes(expected_routes)

--- a/tests/integration/testlib/examplelib.py
+++ b/tests/integration/testlib/examplelib.py
@@ -7,7 +7,6 @@ import yaml
 
 import libnmstate
 
-
 PATH_MAX = 4096
 
 

--- a/tests/integration/testlib/route.py
+++ b/tests/integration/testlib/route.py
@@ -4,7 +4,6 @@ import copy
 
 from libnmstate.schema import Route
 
-
 KERNEL_DEFAULT_TABLE_ID = 254
 
 

--- a/tests/integration/veth_test.py
+++ b/tests/integration/veth_test.py
@@ -19,7 +19,6 @@ from .testlib import statelib
 from .testlib.apply import apply_with_description
 from .testlib.veth import veth_interface
 
-
 VETH1 = "veth1"
 VETH1PEER = "veth1peer"
 VETH2PEER = "veth2peer"

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -17,7 +17,6 @@ from libnmstate.schema import VRF
 from .testlib import assertlib
 from .testlib.apply import apply_with_description
 
-
 TEST_VRF0 = "test-vrf0"
 TEST_VRF1 = "test-vrf1"
 TEST_VRF_PORT0 = "eth1"


### PR DESCRIPTION
Introducing `ipv4.prefix-route-metric` for setting route metric for
prefix routes. Example YAML for set prefix route (192.0.2.0/24) metric
to 100:

```yml
---
interfaces:
- name: eth1
  state: up
  ipv4:
    enabled: true
    dhcp: false
    prefix-route-metric: 100
    address:
    - ip: 192.0.2.252
      prefix-length: 24
```

Due to limitation of NetworkManager, we do not support
`prefix-route-metric` different from `auto-routes-metric`. An error will
be raise if otherwise.

Valid value range is [RouteEntry::USE_DEFAULT_METRIC, u32::MAX].

NetworkManager does not create IPv6 prefix route, so this property does
not exist in ipv6.

Unit test cases and integration test cases included.

Resolves: https://github.com/nmstate/nmstate/issues/3080
Resolves: https://redhat.atlassian.net/browse/RHEL-147209