### PR TITLE
nm: Reset `auto-route-metric` when convert to static IP

### DIFF
--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -54,7 +54,11 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
             } else {
                 None
             },
-            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
+            auto_route_metric: if dhcp == Some(true) {
+                nm_ip_setting.route_metric.map(|i| i as u32)
+            } else {
+                None
+            },
             dhcp_send_hostname: if enabled && dhcp == Some(true) {
                 Some(dhcp_send_hostname)
             } else {
@@ -123,7 +127,11 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
                     None
                 }
             },
-            auto_route_metric: nm_ip_setting.route_metric.map(|i| i as u32),
+            auto_route_metric: if autoconf == Some(true) {
+                nm_ip_setting.route_metric.map(|i| i as u32)
+            } else {
+                None
+            },
             dhcp_send_hostname: if enabled && dhcp == Some(true) {
                 Some(nm_ip_setting.dhcp_send_hostname.unwrap_or(true))
             } else {

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -15,6 +15,7 @@ use crate::{
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
 const ADDR_GEN_MODE_STABLE_PRIVACY: i32 = 1;
+const DEFAULT_ROUTE_METRIC: i64 = -1;
 
 fn gen_nm_ipv4_setting(
     iface_ip: Option<&InterfaceIpv4>,
@@ -106,6 +107,8 @@ fn gen_nm_ipv4_setting(
                 }
             }
         }
+    } else {
+        nm_setting.route_metric = None;
     }
     if iface_ip.enabled {
         if let Some(routes) = routes {
@@ -232,6 +235,7 @@ fn gen_nm_ipv6_setting(
         }
     } else {
         nm_setting.token = None;
+        nm_setting.route_metric = None;
     }
     if iface_ip.enabled {
         if let Some(routes) = routes {


### PR DESCRIPTION
The `ipv4.auto-route-metric` and `ipv6.auto-route-metric` should be reset to default value in NM connection when interface switched from auto to static.

TODO:
 * Add integration test