### PR TITLE
kernel-mode: Add checkpoint rollback support using gen_revert

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
 nispor = "2.0.0"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
-nix = { version = "0.30", default-features = false, features = ["feature", "hostname"] }
+nix = { version = "0.30", default-features = false, features = ["feature", "hostname", "process", "signal"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }
 zvariant = {version = "5.1.0", default-features = false}
 libc = "0.2.74"

--- a/rust/src/lib/Cargo.toml
+++ b/rust/src/lib/Cargo.toml
@@ -27,7 +27,7 @@ workspace = true
 
 [dependencies.uuid]
 workspace = true
-features = ["v5"]
+features = ["v4", "v5"]
 
 [dependencies.log]
 workspace = true
@@ -47,6 +47,10 @@ workspace = true
 workspace = true
 optional = true
 
+[dependencies.libc]
+workspace = true
+optional = true
+
 [dependencies.tokio]
 workspace = true
 optional = true
@@ -56,6 +60,6 @@ serde_yaml = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf", "gen_revert"]
-query_apply = ["dep:nispor", "dep:nix", "dep:zbus", "dep:tokio"]
+query_apply = ["dep:nispor", "dep:nix", "dep:libc", "dep:zbus", "dep:tokio"]
 gen_conf = []
 gen_revert = []

--- a/rust/src/lib/kernel_checkpoint/mod.rs
+++ b/rust/src/lib/kernel_checkpoint/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod storage;
+mod timeout;
+
+pub(crate) use storage::{
+    is_kernel_checkpoint, kernel_checkpoint_create, kernel_checkpoint_destroy,
+    kernel_checkpoint_get,
+};
+pub(crate) use timeout::spawn_timeout_watchdog;

--- a/rust/src/lib/kernel_checkpoint/storage.rs
+++ b/rust/src/lib/kernel_checkpoint/storage.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::{ErrorKind, NetworkState, NmstateError};
+
+use super::timeout::cancel_timeout_watchdog;
+
+const KERNEL_CHECKPOINT_PREFIX: &str = "kernel:";
+const DEFAULT_CHECKPOINT_DIR: &str = "/run/nmstate/checkpoints";
+const CHECKPOINT_DIR_ENV: &str = "NMSTATE_CHECKPOINT_DIR";
+
+fn get_checkpoint_dir() -> PathBuf {
+    PathBuf::from(
+        std::env::var(CHECKPOINT_DIR_ENV)
+            .unwrap_or_else(|_| DEFAULT_CHECKPOINT_DIR.to_string()),
+    )
+}
+
+/// Get the file path for a checkpoint ID.
+pub(crate) fn get_checkpoint_path(checkpoint_id: &str) -> PathBuf {
+    let filename = checkpoint_id
+        .strip_prefix(KERNEL_CHECKPOINT_PREFIX)
+        .unwrap_or(checkpoint_id);
+    get_checkpoint_dir().join(format!("{}.yaml", filename))
+}
+
+fn ensure_checkpoint_dir() -> Result<(), NmstateError> {
+    let dir = get_checkpoint_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir).map_err(|e| {
+            NmstateError::new(
+                ErrorKind::Bug,
+                format!(
+                    "Failed to create checkpoint directory {}: {}",
+                    dir.display(),
+                    e
+                ),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Create a kernel checkpoint storing the revert state to a file.
+/// Returns the checkpoint ID with "kernel:" prefix.
+pub(crate) fn kernel_checkpoint_create(
+    revert_state: NetworkState,
+) -> Result<String, NmstateError> {
+    ensure_checkpoint_dir()?;
+
+    let uuid = uuid::Uuid::new_v4();
+    let id = format!("{}{}", KERNEL_CHECKPOINT_PREFIX, uuid);
+    let path = get_checkpoint_path(&id);
+
+    let yaml = serde_yaml::to_string(&revert_state).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!("Failed to serialize checkpoint state: {}", e),
+        )
+    })?;
+
+    let mut file = fs::File::create(&path).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to create checkpoint file {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+
+    file.write_all(yaml.as_bytes()).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to write checkpoint file {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+
+    log::debug!("Saved kernel checkpoint to {}", path.display());
+    Ok(id)
+}
+
+/// Get the revert state for a kernel checkpoint from file.
+/// The checkpoint ID can be with or without the "kernel:" prefix.
+pub(crate) fn kernel_checkpoint_get(
+    checkpoint_id: &str,
+) -> Result<Option<NetworkState>, NmstateError> {
+    let id = if checkpoint_id.starts_with(KERNEL_CHECKPOINT_PREFIX) {
+        checkpoint_id.to_string()
+    } else {
+        format!("{}{}", KERNEL_CHECKPOINT_PREFIX, checkpoint_id)
+    };
+
+    let path = get_checkpoint_path(&id);
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to read checkpoint file {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+
+    let state: NetworkState =
+        serde_yaml::from_str(&content).map_err(|e| {
+            NmstateError::new(
+                ErrorKind::Bug,
+                format!(
+                    "Failed to deserialize checkpoint file {}: {}",
+                    path.display(),
+                    e
+                ),
+            )
+        })?;
+
+    log::debug!("Loaded kernel checkpoint from {}", path.display());
+    Ok(Some(state))
+}
+
+/// Destroy (commit) a kernel checkpoint, removing the file
+/// and cancelling any timeout watchdog.
+/// The checkpoint ID can be with or without the "kernel:" prefix.
+pub(crate) fn kernel_checkpoint_destroy(checkpoint_id: &str) {
+    let id = if checkpoint_id.starts_with(KERNEL_CHECKPOINT_PREFIX) {
+        checkpoint_id.to_string()
+    } else {
+        format!("{}{}", KERNEL_CHECKPOINT_PREFIX, checkpoint_id)
+    };
+
+    let path = get_checkpoint_path(&id);
+
+    // Cancel timeout watchdog before removing checkpoint file
+    cancel_timeout_watchdog(&path);
+
+    if path.exists() {
+        if let Err(e) = fs::remove_file(&path) {
+            log::warn!(
+                "Failed to remove checkpoint file {}: {}",
+                path.display(),
+                e
+            );
+        } else {
+            log::debug!("Removed kernel checkpoint file {}", path.display());
+        }
+    }
+}
+
+/// Check if a checkpoint ID is a kernel checkpoint.
+pub(crate) fn is_kernel_checkpoint(checkpoint_id: &str) -> bool {
+    checkpoint_id.starts_with(KERNEL_CHECKPOINT_PREFIX)
+}

--- a/rust/src/lib/kernel_checkpoint/timeout.rs
+++ b/rust/src/lib/kernel_checkpoint/timeout.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::{ForkResult, Pid, fork, setsid};
+
+use crate::{ErrorKind, NmstateError};
+
+const PID_FILE_EXTENSION: &str = "pid";
+
+fn get_pid_file_path(checkpoint_path: &PathBuf) -> PathBuf {
+    checkpoint_path.with_extension(PID_FILE_EXTENSION)
+}
+
+/// Spawn a detached watchdog process that will rollback the checkpoint
+/// after the specified timeout (in seconds).
+///
+/// The watchdog:
+/// 1. Forks and detaches from the parent process (setsid)
+/// 2. Sleeps for `timeout_secs` (sync, no tokio)
+/// 3. If checkpoint file still exists, exec's `nmstatectl rollback`
+///    as a fresh process (avoids tokio-after-fork issues)
+/// 4. Cleans up and exits
+///
+/// The watchdog PID is stored alongside the checkpoint file for
+/// cancellation on commit.
+pub(crate) fn spawn_timeout_watchdog(
+    checkpoint_id: &str,
+    checkpoint_path: &PathBuf,
+    timeout_secs: u32,
+) -> Result<(), NmstateError> {
+    let checkpoint_id_owned = checkpoint_id.to_string();
+    let checkpoint_path_owned = checkpoint_path.clone();
+
+    // Resolve current executable path before fork
+    let exe_path = std::env::current_exe().map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!("Failed to resolve current executable: {}", e),
+        )
+    })?;
+
+    // SAFETY: fork() is safe here because the child only performs
+    // async-signal-safe operations (sleep, file checks) and then
+    // exec's a fresh process for the actual rollback work.
+    match unsafe { fork() } {
+        Ok(ForkResult::Parent { child }) => {
+            // Store child PID for later cancellation
+            let pid_path = get_pid_file_path(&checkpoint_path_owned);
+            if let Err(e) = write_pid_file(&pid_path, child) {
+                log::warn!(
+                    "Failed to write watchdog PID file {}: {}",
+                    pid_path.display(),
+                    e
+                );
+            }
+            log::info!(
+                "Spawned timeout watchdog (PID {}) for checkpoint {}, \
+                 rollback in {}s",
+                child,
+                checkpoint_id,
+                timeout_secs
+            );
+            Ok(())
+        }
+        Ok(ForkResult::Child) => {
+            // Detach from parent session
+            let _ = setsid();
+
+            // Redirect stdio to /dev/null
+            close_stdio();
+
+            // Run the watchdog: sleep then exec rollback
+            run_watchdog(
+                &checkpoint_id_owned,
+                &checkpoint_path_owned,
+                &exe_path,
+                timeout_secs,
+            );
+
+            std::process::exit(0);
+        }
+        Err(e) => {
+            log::warn!(
+                "Failed to fork timeout watchdog for checkpoint {}: {}",
+                checkpoint_id,
+                e
+            );
+            Err(NmstateError::new(
+                ErrorKind::Bug,
+                format!("Failed to fork timeout watchdog: {}", e),
+            ))
+        }
+    }
+}
+
+/// Cancel a running timeout watchdog by killing the process and
+/// removing the PID file.
+pub(crate) fn cancel_timeout_watchdog(checkpoint_path: &PathBuf) {
+    let pid_path = get_pid_file_path(checkpoint_path);
+
+    if let Some(pid) = read_pid_file(&pid_path) {
+        match kill(pid, Signal::SIGTERM) {
+            Ok(()) => {
+                log::info!("Cancelled timeout watchdog (PID {})", pid);
+            }
+            Err(nix::errno::Errno::ESRCH) => {
+                // Process already gone, that's fine
+                log::debug!("Timeout watchdog (PID {}) already exited", pid);
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to kill timeout watchdog (PID {}): {}",
+                    pid,
+                    e
+                );
+            }
+        }
+    }
+
+    // Clean up PID file
+    if pid_path.exists() {
+        if let Err(e) = fs::remove_file(&pid_path) {
+            log::warn!(
+                "Failed to remove PID file {}: {}",
+                pid_path.display(),
+                e
+            );
+        }
+    }
+}
+
+/// Watchdog logic: sleep, then exec nmstatectl rollback.
+/// Only uses sync operations - no tokio after fork.
+fn run_watchdog(
+    checkpoint_id: &str,
+    checkpoint_path: &PathBuf,
+    exe_path: &PathBuf,
+    timeout_secs: u32,
+) {
+    // Sleep for the timeout duration (sync, no tokio)
+    std::thread::sleep(Duration::from_secs(timeout_secs as u64));
+
+    // Check if checkpoint file still exists (commit removes it)
+    if !checkpoint_path.exists() {
+        // Checkpoint was committed, nothing to do
+        return;
+    }
+
+    // Exec nmstatectl rollback as a fresh process.
+    // This avoids tokio-after-fork corruption by starting a clean
+    // process with its own runtime.
+    let result = Command::new(exe_path)
+        .arg("rollback")
+        .arg(checkpoint_id)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match result {
+        Ok(status) => {
+            if !status.success() {
+                watchdog_log(
+                    checkpoint_path,
+                    &format!(
+                        "nmstatectl rollback exited with status: {}",
+                        status
+                    ),
+                );
+            }
+        }
+        Err(e) => {
+            watchdog_log(
+                checkpoint_path,
+                &format!("Failed to exec nmstatectl rollback: {}", e),
+            );
+        }
+    }
+
+    // Clean up PID file
+    let pid_path = get_pid_file_path(checkpoint_path);
+    let _ = fs::remove_file(&pid_path);
+}
+
+fn watchdog_log(checkpoint_path: &PathBuf, msg: &str) {
+    let log_path = checkpoint_path.with_extension("log");
+    if let Ok(mut f) =
+        fs::OpenOptions::new().create(true).append(true).open(&log_path)
+    {
+        let _ = writeln!(f, "{}", msg);
+    }
+}
+
+fn write_pid_file(path: &PathBuf, pid: Pid) -> Result<(), NmstateError> {
+    let mut file = fs::File::create(path).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to create PID file {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+    file.write_all(pid.to_string().as_bytes()).map_err(|e| {
+        NmstateError::new(
+            ErrorKind::Bug,
+            format!(
+                "Failed to write PID file {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+fn read_pid_file(path: &PathBuf) -> Option<Pid> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .map(Pid::from_raw)
+}
+
+fn close_stdio() {
+    if let Ok(devnull) = fs::File::open("/dev/null") {
+        use std::os::unix::io::AsRawFd;
+        let devnull_fd = devnull.as_raw_fd();
+        unsafe {
+            libc::dup2(devnull_fd, libc::STDIN_FILENO);
+            libc::dup2(devnull_fd, libc::STDOUT_FILENO);
+            libc::dup2(devnull_fd, libc::STDERR_FILENO);
+        }
+    }
+}

--- a/rust/src/lib/lib.rs
+++ b/rust/src/lib/lib.rs
@@ -90,6 +90,8 @@ mod error;
 #[cfg(feature = "gen_conf")]
 mod gen_conf;
 mod hostname;
+#[cfg(feature = "query_apply")]
+mod kernel_checkpoint;
 mod ieee8021x;
 mod iface;
 mod ifaces;

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -5,6 +5,11 @@ use std::future::Future;
 use crate::{
     ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
     NetworkStateMode, NmstateError,
+    kernel_checkpoint::{
+        is_kernel_checkpoint, kernel_checkpoint_create,
+        kernel_checkpoint_destroy, kernel_checkpoint_get,
+        spawn_timeout_watchdog,
+    },
     nispor::{
         apply_ifaces_alt_names, nispor_apply, nispor_retrieve,
         persist_alt_name_config, set_running_hostname,
@@ -33,7 +38,7 @@ const MAX_SUPPORTED_INTERFACES: usize = 1000;
 
 impl NetworkState {
     /// Rollback a checkpoint.
-    /// Not available for `kernel only` mode.
+    /// Supports both NetworkManager and kernel checkpoints.
     /// Only available for feature `query_apply`.
     pub fn checkpoint_rollback(checkpoint: &str) -> Result<(), NmstateError> {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -50,16 +55,45 @@ impl NetworkState {
     }
 
     /// Rollback a checkpoint.
-    /// Not available for `kernel only` mode.
+    /// Supports both NetworkManager and kernel checkpoints.
     /// Only available for feature `query_apply`.
     pub async fn checkpoint_rollback_async(
         checkpoint: &str,
     ) -> Result<(), NmstateError> {
-        nm_checkpoint_rollback(checkpoint).await
+        if is_kernel_checkpoint(checkpoint) {
+            // Handle kernel checkpoint rollback
+            match kernel_checkpoint_get(checkpoint)? {
+                Some(revert_state) => {
+                    log::info!("Rolling back kernel checkpoint {}", checkpoint);
+
+                    let mut cur_net_state = NetworkState::new();
+                    cur_net_state.set_kernel_only(true);
+                    cur_net_state.retrieve_async().await?;
+
+                    let merged_revert = MergedNetworkState::new(
+                        revert_state,
+                        cur_net_state,
+                        NetworkStateMode::Apply,
+                        false,
+                    )?;
+
+                    nispor_apply(&merged_revert).await?;
+                    kernel_checkpoint_destroy(checkpoint);
+                    log::info!("Rolled back kernel checkpoint {}", checkpoint);
+                    Ok(())
+                }
+                None => Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!("Kernel checkpoint {} not found", checkpoint),
+                )),
+            }
+        } else {
+            nm_checkpoint_rollback(checkpoint).await
+        }
     }
 
     /// Commit a checkpoint.
-    /// Not available for `kernel only` mode.
+    /// Supports both NetworkManager and kernel checkpoints.
     /// Only available for feature `query_apply`.
     pub fn checkpoint_commit(checkpoint: &str) -> Result<(), NmstateError> {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -76,12 +110,19 @@ impl NetworkState {
     }
 
     /// Commit a checkpoint.
-    /// Not available for `kernel only` mode.
+    /// Supports both NetworkManager and kernel checkpoints.
     /// Only available for feature `query_apply`.
     pub async fn checkpoint_commit_async(
         checkpoint: &str,
     ) -> Result<(), NmstateError> {
-        nm_checkpoint_destroy(checkpoint).await
+        if is_kernel_checkpoint(checkpoint) {
+            // Handle kernel checkpoint commit
+            kernel_checkpoint_destroy(checkpoint);
+            log::info!("Committed kernel checkpoint {}", checkpoint);
+            Ok(())
+        } else {
+            nm_checkpoint_destroy(checkpoint).await
+        }
     }
 
     /// Retrieve the `NetworkState`.
@@ -192,7 +233,6 @@ impl NetworkState {
         if !self.kernel_only {
             self.apply_with_nm_backend().await
         } else {
-            // TODO: Need checkpoint for kernel only mode
             self.apply_without_nm_backend().await
         }
     }
@@ -376,6 +416,11 @@ impl NetworkState {
         cur_net_state.set_include_secrets(true);
         cur_net_state.retrieve_async().await?;
 
+        // Generate revert state BEFORE applying for rollback capability
+        let revert_state = self.generate_revert(&cur_net_state)?;
+        let checkpoint_id = kernel_checkpoint_create(revert_state)?;
+        log::info!("Created kernel checkpoint {}", &checkpoint_id);
+
         let merged_state = MergedNetworkState::new(
             self.clone(),
             cur_net_state.clone(),
@@ -383,12 +428,69 @@ impl NetworkState {
             self.memory_only,
         )?;
 
-        nispor_apply(&merged_state).await?;
+        // Apply with rollback on failure
+        match self
+            .apply_kernel_with_checkpoint(&merged_state, &cur_net_state)
+            .await
+        {
+            Ok(()) => {
+                if !self.no_commit {
+                    kernel_checkpoint_destroy(&checkpoint_id);
+                    log::info!("Committed kernel checkpoint {}", &checkpoint_id);
+                } else {
+                    let timeout = self.timeout.unwrap_or(DEFAULT_ROLLBACK_TIMEOUT);
+                    let checkpoint_path =
+                        crate::kernel_checkpoint::storage::get_checkpoint_path(
+                            &checkpoint_id,
+                        );
+                    if let Err(e) = spawn_timeout_watchdog(
+                        &checkpoint_id,
+                        &checkpoint_path,
+                        timeout,
+                    ) {
+                        log::warn!(
+                            "Failed to spawn timeout watchdog: {}, \
+                             checkpoint {} will not auto-rollback",
+                            e,
+                            &checkpoint_id
+                        );
+                    }
+                    log::info!(
+                        "Kernel checkpoint {} awaiting commit, \
+                         auto-rollback in {}s",
+                        &checkpoint_id,
+                        timeout
+                    );
+                    // Print checkpoint ID so user can commit/rollback later
+                    println!("{}", checkpoint_id);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                log::error!("Apply failed, rolling back: {}", e);
+                if let Err(rollback_err) =
+                    self.rollback_kernel_checkpoint(&checkpoint_id).await
+                {
+                    log::error!("Rollback also failed: {}", rollback_err);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    async fn apply_kernel_with_checkpoint(
+        &self,
+        merged_state: &MergedNetworkState,
+        cur_net_state: &NetworkState,
+    ) -> Result<(), NmstateError> {
+        nispor_apply(merged_state).await?;
+
         if let Some(running_hostname) =
             self.hostname.as_ref().and_then(|c| c.running.as_ref())
         {
             set_running_hostname(running_hostname)?;
         }
+
         if !self.no_verify {
             with_retry(
                 VERIFY_RETRY_INTERVAL_MILLISECONDS,
@@ -402,6 +504,43 @@ impl NetworkState {
             .await
         } else {
             Ok(())
+        }
+    }
+
+    async fn rollback_kernel_checkpoint(
+        &self,
+        checkpoint_id: &str,
+    ) -> Result<(), NmstateError> {
+        match kernel_checkpoint_get(checkpoint_id)? {
+            Some(revert_state) => {
+                log::info!(
+                    "Rolling back to kernel checkpoint {}",
+                    checkpoint_id
+                );
+
+                let mut cur_net_state = NetworkState::new();
+                cur_net_state.set_kernel_only(true);
+                cur_net_state.retrieve_async().await?;
+
+                let merged_revert = MergedNetworkState::new(
+                    revert_state,
+                    cur_net_state,
+                    NetworkStateMode::Apply,
+                    self.memory_only,
+                )?;
+
+                nispor_apply(&merged_revert).await?;
+                kernel_checkpoint_destroy(checkpoint_id);
+                log::info!("Rolled back kernel checkpoint {}", checkpoint_id);
+                Ok(())
+            }
+            None => {
+                log::warn!(
+                    "Kernel checkpoint {} not found, skipping rollback",
+                    checkpoint_id
+                );
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
Use gen_revert to capture the revert state before applying changes in kernel mode, enabling checkpoint/commit/rollback workflow similar to NetworkManager mode.

- Checkpoint files stored at /run/nmstate/checkpoints/ (configurable via NMSTATE_CHECKPOINT_DIR env var)
- Automatic rollback on apply/verification failure
- Timeout-based auto-rollback via forked watchdog process
- Manual commit/rollback via `nmstatectl commit/rollback kernel:<id>`
- Watchdog uses fork+exec to avoid tokio-after-fork issues