### PR TITLE
route: add support for lock-mtu option

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -31,6 +31,7 @@ const IPV4_EMPTY_NEXT_HOP_ADDRESS: &str = "0.0.0.0";
 const IPV6_EMPTY_NEXT_HOP_ADDRESS: &str = "::";
 
 // kernel values
+const RTAX_MTU: u32 = 2;
 const RTAX_CWND: u32 = 7;
 
 pub(crate) async fn get_routes(
@@ -185,8 +186,11 @@ fn np_routetype_to_nmstate(
     }
     // according to `man ip-route`, cwnd is useless without the lock flag, so
     // we require both cwnd and its lock flag to consider cwnd as set.
-    let cwnd_lock = np_route.lock.unwrap_or(0) & (1 << RTAX_CWND) != 0;
+    let lock = np_route.lock.unwrap_or(0);
+    let cwnd_lock = lock & (1 << RTAX_CWND) != 0;
     route_entry.cwnd = if cwnd_lock { np_route.cwnd } else { None };
+    let mtu_lock = lock & (1 << RTAX_MTU) != 0;
+    route_entry.lock_mtu = mtu_lock.then_some(true);
 
     route_entry
 }
@@ -249,11 +253,14 @@ fn np_route_to_nmstate(
         .map(|n| n.to_string());
     // according to `man ip-route`, cwnd is useless without the lock flag, so
     // we require both cwnd and its lock flag to consider cwnd as set.
-    let cwnd_lock = np_route.lock.unwrap_or(0) & (1 << RTAX_CWND) != 0;
+    let lock = np_route.lock.unwrap_or(0);
+    let cwnd_lock = lock & (1 << RTAX_CWND) != 0;
     route_entry.cwnd = if cwnd_lock { np_route.cwnd } else { None };
     route_entry.initcwnd = np_route.initcwnd;
     route_entry.initrwnd = np_route.initrwnd;
     route_entry.mtu = np_route.mtu;
+    let mtu_lock = lock & (1 << RTAX_MTU) != 0;
+    route_entry.lock_mtu = mtu_lock.then_some(true);
     route_entry.quickack = np_route.quickack.map(|q| q > 0);
     route_entry.advmss = np_route.advmss;
 

--- a/rust/src/lib/nm/nm_dbus/connection/route.rs
+++ b/rust/src/lib/nm/nm_dbus/connection/route.rs
@@ -26,6 +26,7 @@ pub struct NmIpRoute {
     pub initcwnd: Option<u32>,
     pub initrwnd: Option<u32>,
     pub mtu: Option<u32>,
+    pub lock_mtu: Option<bool>,
     pub quickack: Option<bool>,
     pub advmss: Option<u32>,
     _other: DbusDictionary,
@@ -54,6 +55,7 @@ impl TryFrom<DbusDictionary> for NmIpRoute {
             initcwnd: _from_map!(v, "initcwnd", u32::try_from)?,
             initrwnd: _from_map!(v, "initrwnd", u32::try_from)?,
             mtu: _from_map!(v, "mtu", u32::try_from)?,
+            lock_mtu: _from_map!(v, "lock-mtu", bool::try_from)?,
             quickack: _from_map!(v, "quickack", bool::try_from)?,
             advmss: _from_map!(v, "advmss", u32::try_from)?,
             _other: v,
@@ -142,6 +144,12 @@ impl NmIpRoute {
         if let Some(v) = &self.mtu {
             ret.append(
                 zvariant::Value::new("mtu"),
+                zvariant::Value::new(zvariant::Value::new(v)),
+            )?;
+        }
+        if let Some(v) = &self.lock_mtu {
+            ret.append(
+                zvariant::Value::new("lock-mtu"),
                 zvariant::Value::new(zvariant::Value::new(v)),
             )?;
         }

--- a/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/route.rs
@@ -46,6 +46,9 @@ impl NmIpRoute {
             if let Some(v) = self.mtu.as_ref() {
                 write!(opt_string, ",mtu={v}").ok();
             }
+            if let Some(v) = self.lock_mtu.as_ref() {
+                write!(opt_string, ",lock-mtu={v}").ok();
+            }
             if let Some(v) = self.quickack.as_ref() {
                 write!(opt_string, ",quickack={v}").ok();
             }

--- a/rust/src/lib/nm/settings/route.rs
+++ b/rust/src/lib/nm/settings/route.rs
@@ -64,6 +64,7 @@ pub(crate) fn gen_nm_ip_routes(
         nm_route.initcwnd = route.initcwnd;
         nm_route.initrwnd = route.initrwnd;
         nm_route.mtu = route.mtu;
+        nm_route.lock_mtu = route.lock_mtu;
         nm_route.quickack = route.quickack;
         nm_route.advmss = route.advmss;
         ret.push(nm_route);

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -303,6 +303,13 @@ pub struct RouteEntry {
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
     pub advmss: Option<u32>,
+    /// Lock route MTU, preventing Path MTU Discovery from adjusting it
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
+    pub lock_mtu: Option<bool>,
     /// Store the routes to the route table specified VRF bind to.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vrf_name: Option<String>,
@@ -416,6 +423,9 @@ impl RouteEntry {
         if self.advmss.is_some() && self.advmss != other.advmss {
             return false;
         }
+        if self.lock_mtu.is_some() && self.lock_mtu != other.lock_mtu {
+            return false;
+        }
         if self.vrf_name.is_some() && self.vrf_name != other.vrf_name {
             return false;
         }
@@ -436,6 +446,7 @@ impl RouteEntry {
                     .map(|d| is_ipv6_addr(d.as_str()))
                     .unwrap_or_default(),
                 self.quickack.unwrap_or_default(),
+                self.lock_mtu.unwrap_or_default(),
             ],
             vec![
                 self.next_hop_iface
@@ -629,6 +640,9 @@ impl std::fmt::Display for RouteEntry {
         }
         if let Some(v) = self.advmss {
             props.push(format!("advmss: {v}"));
+        }
+        if let Some(v) = self.lock_mtu {
+            props.push(format!("lock-mtu: {v}"));
         }
         if let Some(v) = self.vrf_name.as_ref() {
             props.push(format!("vrf-name: {v}"));

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -864,3 +864,76 @@ fn test_route_advmss_deserialize_from_string() {
 
     assert_eq!(route.advmss, Some(1500));
 }
+
+#[test]
+fn test_route_lock_mtu_not_equal() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        lock-mtu: true
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        lock-mtu: false
+        "#,
+    )
+    .unwrap();
+
+    assert!(route1 != route2);
+}
+
+#[test]
+fn test_route_lock_mtu_is_match() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        lock-mtu: true
+        "#,
+    )
+    .unwrap();
+
+    let route2: RouteEntry = serde_yaml::from_str(
+        r#"
+        state: absent
+        lock-mtu: true
+        "#,
+    )
+    .unwrap();
+
+    assert!(route2.is_match(&route1));
+}
+
+#[test]
+fn test_route_lock_mtu_display() {
+    let route1: RouteEntry = serde_yaml::from_str(
+        r#"
+        destination: "2001:db8::/64"
+        mtu: 1280
+        lock-mtu: true
+        "#,
+    )
+    .unwrap();
+
+    let route1_str = route1.to_string();
+
+    assert!(route1_str.contains("lock-mtu: true"));
+}
+
+#[test]
+fn test_route_lock_mtu_deserialize_from_string() {
+    let route = serde_yaml::from_str::<RouteEntry>(
+        r#"
+        lock-mtu: "true"
+        "#,
+    )
+    .unwrap();
+
+    assert_eq!(route.lock_mtu, Some(true));
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -56,6 +56,7 @@ class Route:
     MTU = "mtu"
     QUICKACK = "quickack"
     ADVMSS = "advmss"
+    LOCK_MTU = "lock-mtu"
     VRF_NAME = "vrf-name"
 
 

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -480,13 +480,14 @@ def test_gen_conf_route_next_hop_iface_ref_by_mac(eth1_eth2_up_with_no_config):
         assert_routes(expected_routes, cur_state)
 
 
-def test_gen_conf_route_initcwnd_mtu_quickack_advmss():
+def test_gen_conf_route_initcwnd_mtu_quickack_advmss_lock_mtu():
     desired_state = load_yaml(
         """---
         routes:
           config:
               - destination: 203.0.113.0/24
                 mtu: 1550
+                lock-mtu: true
                 advmss: 1200
                 next-hop-address: 192.0.2.252
                 next-hop-interface: eth1
@@ -496,6 +497,7 @@ def test_gen_conf_route_initcwnd_mtu_quickack_advmss():
                 quickack: true
               - destination: 2001:db8:a::/64
                 mtu: 1280
+                lock-mtu: true
                 advmss: 1300
                 next-hop-address: 2001:db8:1::2
                 next-hop-interface: eth1

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2412,6 +2412,34 @@ def test_add_route_with_quickack(eth1_up):
     assert_routes(routes, cur_state)
 
 
+@pytest.mark.tier1
+def test_add_route_with_lock_mtu(eth1_up):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV4_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV4_ADDRESS1,
+            Route.MTU: 1550,
+            Route.LOCK_MTU: True,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_TEST_NET1,
+            Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
+            Route.MTU: 1280,
+            Route.LOCK_MTU: True,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Interface.KEY: [ETH1_INTERFACE_STATE],
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)
+
+
 # https://github.com/nmstate/nmstate/issues/2881
 @pytest.mark.tier1
 def test_add_route_with_advmss(eth1_up):


### PR DESCRIPTION
When lock-mtu is set to true, the route MTU is locked, preventing Path MTU Discovery (PMTUD) from automatically adjusting it.

Example:
```
routes:
  config:
    - destination: 2001:db8:c::/64
      next-hop-interface: eth1
      next-hop-address: 2001:db8:1::2
      mtu: 1280
      lock-mtu: true
```