### PR TITLE
test: Fix `/var/cache/dnf/metadata_lock.pid`

### DIFF
--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -116,4 +116,5 @@ function create_container {
       echo "Waiting for systemd in container to be ready..."
       sleep 0.1;
   done
+  container_exec "dnf clean all -y"
 }


### PR DESCRIPTION
In container test, we see this problem happening again:

```
[Errno 2] No such file or directory: '/var/cache/dnf/metadata_lock.pid'
```

Adding a `dnf clean all -y` right after `systemctl is-system-running`.