### PR TITLE
ifaces: Fix error when referring existing controller

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces_controller.rs
+++ b/rust/src/lib/ifaces/inter_ifaces_controller.rs
@@ -430,62 +430,68 @@ impl MergedInterfaces {
         // Use the push order to allow user providing help on dependency order
 
         for (iface_name, iface_type) in &self.insert_order {
-            let iface = match self.get_iface(iface_name, iface_type.clone()) {
-                Some(i) => {
-                    if let Some(i) = i.for_apply.as_ref() {
-                        i
-                    } else {
-                        continue;
-                    }
-                }
-                None => continue,
+            let Some(iface) = self
+                .get_iface(iface_name, iface_type.clone())
+                .and_then(|i| i.for_apply.as_ref())
+            else {
+                continue;
             };
-            if !iface.is_up() {
+            if !iface.is_up() || iface.base_iface().is_up_priority_valid() {
                 continue;
             }
 
-            if iface.base_iface().is_up_priority_valid() {
+            let Some(ctrl_name) = iface.base_iface().controller.as_ref() else {
+                continue;
+            };
+
+            if ctrl_name.is_empty() {
                 continue;
             }
-
-            if let Some(ref ctrl_name) = iface.base_iface().controller {
-                if ctrl_name.is_empty() {
-                    continue;
-                }
-                let ctrl_iface = self
-                    .get_iface(
-                        ctrl_name,
-                        iface
-                            .base_iface()
-                            .controller_type
-                            .clone()
-                            .unwrap_or_default(),
-                    )
-                    .and_then(|i| i.for_apply.as_ref());
-                if let Some(ctrl_iface) = ctrl_iface {
-                    if let Some(ctrl_pri) = pending_changes.remove(ctrl_name) {
-                        pending_changes.insert(ctrl_name.to_string(), ctrl_pri);
-                        pending_changes
-                            .insert(iface_name.to_string(), ctrl_pri + 1);
-                    } else if ctrl_iface.base_iface().is_up_priority_valid() {
-                        pending_changes.insert(
-                            iface_name.to_string(),
-                            ctrl_iface.base_iface().up_priority + 1,
-                        );
-                    } else {
-                        // Its controller does not have valid up priority yet.
-                        log::debug!(
-                            "Controller {ctrl_name} of {iface_name} is has no \
-                             up priority"
-                        );
-                        ret = false;
-                    }
+            let Some(ctrl_iface) = self.get_iface(
+                ctrl_name,
+                iface
+                    .base_iface()
+                    .controller_type
+                    .clone()
+                    .unwrap_or_default(),
+            ) else {
+                log::error!(
+                    "BUG: validate_controller_not_in_port_list() should \
+                     already validate the existence of controller interface, \
+                     should never hit this: {self:?}"
+                );
+                continue;
+            };
+            if let Some(ctrl_iface) = ctrl_iface.for_apply.as_ref() {
+                if let Some(ctrl_pri) = pending_changes.remove(ctrl_name) {
+                    pending_changes.insert(ctrl_name.to_string(), ctrl_pri);
+                    pending_changes
+                        .insert(iface_name.to_string(), ctrl_pri + 1);
+                } else if ctrl_iface.base_iface().is_up_priority_valid() {
+                    pending_changes.insert(
+                        iface_name.to_string(),
+                        ctrl_iface.base_iface().up_priority + 1,
+                    );
                 } else {
-                    // Interface has no controller defined in desire
-                    continue;
+                    // Its controller does not have valid up priority yet.
+                    log::debug!(
+                        "Controller {ctrl_name} of {iface_name} has no up \
+                         priority"
+                    );
+                    ret = false;
+                }
+            } else if ctrl_iface.current.is_some() {
+                // Controller interface already exists in current state but not
+                // mentioned in desired, just activate with top priority.
+                if iface.parent().is_none() {
+                    pending_changes.insert(iface_name.to_string(), 1);
                 }
             } else {
-                continue;
+                log::error!(
+                    "BUG: Controller interface {} does not have current and \
+                     for_apply which should never happens: {self:?}",
+                    ctrl_iface.merged.name()
+                );
             }
         }
 

--- a/rust/src/lib/unit_tests/ifaces_ctrller.rs
+++ b/rust/src/lib/unit_tests/ifaces_ctrller.rs
@@ -1066,3 +1066,194 @@ fn test_gen_topoligies_ovs_bridge() {
         ]
     );
 }
+
+#[test]
+fn test_attach_bond_to_exist_bridge() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: bond0
+          type: bond
+          state: up
+          controller: br0
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - eth2
+            - eth1",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+        - name: eth2
+          type: ethernet
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port: []",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let bond_iface = merged_ifaces
+        .kernel_ifaces
+        .get("bond0")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+    let eth1_iface = merged_ifaces
+        .kernel_ifaces
+        .get("eth1")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+    let eth2_iface = merged_ifaces
+        .kernel_ifaces
+        .get("eth2")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+
+    assert!(bond_iface.base_iface().is_up_priority_valid());
+    assert!(eth1_iface.base_iface().is_up_priority_valid());
+    assert!(eth2_iface.base_iface().is_up_priority_valid());
+    assert!(
+        eth1_iface.base_iface().up_priority
+            > bond_iface.base_iface().up_priority
+    );
+    assert!(
+        eth2_iface.base_iface().up_priority
+            > bond_iface.base_iface().up_priority
+    );
+}
+
+#[test]
+fn test_attach_ethernet_to_exist_bridge() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          controller: br0",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+        - name: eth2
+          type: ethernet
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port: []",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let eth1_iface = merged_ifaces
+        .kernel_ifaces
+        .get("eth1")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+
+    assert!(eth1_iface.base_iface().is_up_priority_valid());
+}
+
+#[test]
+fn test_attach_new_vlan_of_new_bond_to_exist_bridge() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: bond0.100
+          type: vlan
+          state: up
+          controller: br0
+          vlan:
+            base-iface: bond0
+            id: 100
+        - name: bond0
+          type: bond
+          state: up
+          link-aggregation:
+            mode: balance-rr
+            port:
+            - eth2
+            - eth1",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+        - name: eth2
+          type: ethernet
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port: []",
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let vlan_iface = merged_ifaces
+        .kernel_ifaces
+        .get("bond0.100")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+    let bond_iface = merged_ifaces
+        .kernel_ifaces
+        .get("bond0")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+    let eth1_iface = merged_ifaces
+        .kernel_ifaces
+        .get("eth1")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+    let eth2_iface = merged_ifaces
+        .kernel_ifaces
+        .get("eth2")
+        .and_then(|i| i.for_apply.as_ref())
+        .unwrap();
+
+    assert!(bond_iface.base_iface().is_up_priority_valid());
+    assert!(eth1_iface.base_iface().is_up_priority_valid());
+    assert!(eth2_iface.base_iface().is_up_priority_valid());
+    assert!(vlan_iface.base_iface().is_up_priority_valid());
+    // VLAN should activate after bond
+    assert!(
+        vlan_iface.base_iface().up_priority
+            > bond_iface.base_iface().up_priority
+    );
+    // bond port should activate after bond
+    assert!(
+        eth1_iface.base_iface().up_priority
+            > bond_iface.base_iface().up_priority
+    );
+    assert!(
+        eth2_iface.base_iface().up_priority
+            > bond_iface.base_iface().up_priority
+    );
+}

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1708,3 +1708,70 @@ def test_delete_bond_with_mac_restriction(bond99_with_mac_restriction):
     libnmstate.apply(state)
 
     assertlib.assert_absent(BOND99)
+
+
+@pytest.fixture
+def empty_br0():
+    with linux_bridge("br0", {}):
+        yield
+
+
+def test_attach_new_bond_to_existing_bridge(empty_br0):
+    with bond_interface(
+        name=BOND99,
+        port=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+            },
+        },
+        create=False,
+    ) as state:
+        state[Interface.KEY][0][Interface.CONTROLLER] = "br0"
+        libnmstate.apply(state)
+        assertlib.assert_state_match(state)
+
+
+@pytest.fixture
+def cleanup_vlan():
+    yield
+    libnmstate.apply(
+        yaml.load(
+            """---
+            interfaces:
+              - name: bond99.101
+                type: vlan
+                state: absent
+                """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+
+
+def test_attach_new_vlan_of_new_bond_to_exist_bridge(empty_br0, cleanup_vlan):
+    with bond_interface(
+        name=BOND99,
+        port=[ETH1, ETH2],
+        extra_iface_state={
+            Bond.CONFIG_SUBTREE: {
+                Bond.MODE: BondMode.ACTIVE_BACKUP,
+            },
+        },
+        create=False,
+    ) as state:
+        state[Interface.KEY].append(
+            yaml.load(
+                """
+                name: bond99.101
+                type: vlan
+                state: up
+                controller: br0
+                vlan:
+                  base-iface: eth1
+                  id: 101
+                """,
+                Loader=yaml.SafeLoader,
+            )
+        )
+        libnmstate.apply(state)
+        assertlib.assert_state_match(state)


### PR DESCRIPTION
When a new bond is creating with controller pointing to existing
interface(e.g. bridge), we will get error:

```
Failed to set up priority
```

Root cause:
 * Current interface does not have `up_priority`.
 * If a bond is referring current interface as controller, it will not
   able to set its `up_priority`.
 * The port of bond still waits bond to hold `up_priority`, hence fail
   the action after max iteration.

Root cause why it does not fails when ethernet interface referring
existing interface as controller:
 * The `set_ifaces_up_priority()` does nothing.
 * Since no other interface depend on this ethernet, no failure.

To fix the issue, this patch set `up_priority` to 1 if its controller
already exists in current and holds no parent.

Unit test and integration test case included.

Resolves: https://issues.redhat.com/browse/RHEL-31981