### PR TITLE
nm: Fix error when modify port list of down interface

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use super::{
     NmConnectionMatcher,
     device::create_index_for_nm_devs,
@@ -16,6 +18,7 @@ pub(crate) struct PreparedNmConnections {
     pub(crate) to_store: Vec<NmConnection>,
     pub(crate) to_activate: Vec<NmConnection>,
     pub(crate) to_deactivate: Vec<NmDevice>,
+    pub(crate) to_delete: Vec<String>,
 }
 
 pub(crate) fn prepare_nm_conns(
@@ -137,11 +140,24 @@ pub(crate) fn prepare_nm_conns(
 
     fix_ip_dhcp_timeout(&mut nm_conns_to_update);
 
-    Ok(PreparedNmConnections {
+    let mut ret = PreparedNmConnections {
         to_store: nm_conns_to_update,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_devs_to_deactivate,
-    })
+        to_delete: Vec::new(),
+    };
+
+    // When port list is desired on controller interface, we need to update
+    // saved NmConnection to prevent undesired port attached by
+    // `auto-connect-ports: true`. Hence we use this Vec to track
+    // port list desired ifaces.
+    detach_saved_nm_conn_from_controller(
+        &mut ret,
+        &merged_state.interfaces,
+        conn_matcher,
+    );
+
+    Ok(ret)
 }
 
 // When a new virtual interface is desired, if its controller is also newly
@@ -211,4 +227,148 @@ fn can_skip_activation(
         }
     }
     false
+}
+
+// If a controller has port list desired, detach saved inactive NmConnection
+// from this controller
+fn detach_saved_nm_conn_from_controller(
+    prepared_conns: &mut PreparedNmConnections,
+    merged_ifaces: &MergedInterfaces,
+    conn_matcher: &NmConnectionMatcher,
+) {
+    // Only need to check inactive NmConnection because active NmConnection
+    // is already processed by `MergedInterfaces::handle_changed_ports()`.
+    let saved_inactive_port_nm_conn: Vec<&NmConnection> = conn_matcher
+        .saved_iter()
+        .filter(|nm_conn| {
+            if let Some(uuid) = nm_conn.uuid() {
+                !conn_matcher.is_uuid_activated(uuid)
+                    && !is_prepared_to_store(prepared_conns, uuid)
+                    && nm_conn.controller().is_some()
+            } else {
+                false
+            }
+        })
+        .collect();
+
+    if saved_inactive_port_nm_conn.is_empty() {
+        return;
+    }
+
+    let mut changed_ctrl_names: HashSet<(&str, NmIfaceType)> = HashSet::new();
+    let mut changed_ctrl_uuids: HashSet<(&str, NmIfaceType)> = HashSet::new();
+
+    for merged_iface in merged_ifaces.iter().filter(|merged_iface| {
+        is_ctrl_iface_desired_port_changes(merged_iface)
+            && merged_iface.for_apply.as_ref().map(|i| i.is_up()) == Some(true)
+    }) {
+        let ctrl_iface_name = merged_iface.merged.name();
+        let ctrl_iface_type = &merged_iface.merged.base_iface().iface_type;
+        let ctrl_nm_iface_type = NmIfaceType::from(ctrl_iface_type);
+        if let Some(ctrl_nm_conn) = prepared_conns
+            .to_activate
+            .as_slice()
+            .iter()
+            .find(|nm_conn| {
+                nm_conn.iface_name() == Some(ctrl_iface_name)
+                    && nm_conn.iface_type() == Some(&ctrl_nm_iface_type)
+            })
+            && let Some(uuid) = ctrl_nm_conn.uuid()
+        {
+            changed_ctrl_names.insert((ctrl_iface_name, ctrl_nm_iface_type));
+            changed_ctrl_uuids.insert((uuid, ctrl_nm_iface_type));
+        }
+    }
+
+    let mut orphan_ovs_port_uuids: HashSet<&str> = HashSet::new();
+    let mut orphan_ovs_port_names: HashSet<&str> = HashSet::new();
+
+    for nm_conn in saved_inactive_port_nm_conn.as_slice() {
+        if let Some(ctrl_name) = nm_conn.controller()
+            && let Some(nm_ctrl_type) = nm_conn.controller_type()
+            && ((is_uuid(ctrl_name)
+                && changed_ctrl_uuids.contains(&(ctrl_name, *nm_ctrl_type)))
+                || changed_ctrl_names.contains(&(ctrl_name, *nm_ctrl_type)))
+        {
+            if nm_conn.iface_type() == Some(&NmIfaceType::OvsPort) {
+                if let Some(uuid) = nm_conn.uuid() {
+                    log::debug!("Deleting orphan OVS port {uuid}");
+                    log::info!(
+                        "Deleting connection {uuid}: {}/ovs-port",
+                        nm_conn.iface_name().unwrap_or_default(),
+                    );
+                    prepared_conns.to_delete.push(uuid.to_string());
+                    orphan_ovs_port_uuids.insert(uuid);
+                    if let Some(ovs_port_iface_name) = nm_conn.iface_name() {
+                        orphan_ovs_port_names.insert(ovs_port_iface_name);
+                    }
+                }
+            } else {
+                let mut changed_nm_conn = (*nm_conn).clone();
+                if let Some(nm_conn_set) = changed_nm_conn.connection.as_mut() {
+                    log::debug!(
+                        "Detaching inactive controller port {}: {}/{}",
+                        nm_conn.uuid().unwrap_or_default(),
+                        nm_conn.iface_name().unwrap_or_default(),
+                        nm_conn.iface_type().unwrap_or(&NmIfaceType::Unknown)
+                    );
+                    nm_conn_set.controller = None;
+                    nm_conn_set.controller_type = None;
+                    changed_nm_conn.bond_port = None;
+                    changed_nm_conn.bridge_port = None;
+                    prepared_conns.to_store.push(changed_nm_conn);
+                }
+            }
+        }
+    }
+
+    // Detach OVS system and internal interface which refer to orphan OVS ports
+    for nm_conn in saved_inactive_port_nm_conn {
+        if nm_conn.controller_type() == Some(&NmIfaceType::OvsPort)
+            && let Some(ctrl_name) = nm_conn.controller()
+            && (is_uuid(ctrl_name)
+                && orphan_ovs_port_uuids.contains(&ctrl_name)
+                || orphan_ovs_port_names.contains(&ctrl_name))
+        {
+            // OVS internal interface cannot live without its parent
+            if nm_conn.iface_type() == Some(&NmIfaceType::OvsIface) {
+                if let Some(uuid) = nm_conn.uuid() {
+                    prepared_conns.to_delete.push(uuid.to_string());
+                }
+            } else {
+                let mut changed_nm_conn = nm_conn.clone();
+                if let Some(nm_conn_set) = changed_nm_conn.connection.as_mut() {
+                    log::debug!(
+                        "Detaching inactive OVS interface {}: {}/{}",
+                        nm_conn.uuid().unwrap_or_default(),
+                        nm_conn.iface_name().unwrap_or_default(),
+                        nm_conn.iface_type().unwrap_or(&NmIfaceType::Unknown)
+                    );
+                    nm_conn_set.controller = None;
+                    nm_conn_set.controller_type = None;
+                    changed_nm_conn.ovs_iface = None;
+                    prepared_conns.to_store.push(changed_nm_conn);
+                }
+            }
+        }
+    }
+}
+
+fn is_prepared_to_store(
+    prepared_conns: &PreparedNmConnections,
+    uuid: &str,
+) -> bool {
+    prepared_conns
+        .to_store
+        .as_slice()
+        .iter()
+        .any(|nm_conn| nm_conn.uuid() == Some(uuid))
+}
+
+fn is_ctrl_iface_desired_port_changes(merged_iface: &MergedInterface) -> bool {
+    merged_iface.for_apply.as_ref().map(|i| i.ports().is_some()) == Some(true)
+}
+
+pub(crate) fn is_uuid(value: &str) -> bool {
+    uuid::Uuid::parse_str(value).is_ok()
 }

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -4,18 +4,18 @@ use std::collections::HashSet;
 
 use super::super::{
     NmConnectionMatcher,
-    connection::{PreparedNmConnections, prepare_nm_conns},
+    connection::{PreparedNmConnections, is_uuid, prepare_nm_conns},
     device::create_index_for_nm_devs,
     error::nm_error_to_nmstate,
     nm_dbus::{NmApi, NmConnection, NmIfaceType, NmVersion, NmVersionInfo},
     query_apply::{
-        activate_nm_connections, connection::is_uuid,
-        deactivate_nm_connections, deactivate_nm_devices,
-        delete_exist_connections, delete_orphan_ovs_ports,
-        dispatch::apply_dispatch_script, dns::store_dns_config, is_hsr_changed,
-        is_ip_tunnel_changed, is_ipvlan_changed, is_mptcp_flags_changed,
-        is_route_removed, is_veth_peer_changed, is_vlan_changed,
-        is_vrf_table_id_changed, is_vxlan_changed, save_nm_connections,
+        activate_nm_connections, deactivate_nm_connections,
+        deactivate_nm_devices, delete_exist_connections,
+        delete_orphan_ovs_ports, dispatch::apply_dispatch_script,
+        dns::store_dns_config, is_hsr_changed, is_ip_tunnel_changed,
+        is_ipvlan_changed, is_mptcp_flags_changed, is_route_removed,
+        is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
+        is_vxlan_changed, save_nm_connections,
     },
     route::store_route_config,
     route_rule::store_route_rule_config,
@@ -106,6 +106,7 @@ pub(crate) async fn nm_apply(
         to_store: nm_conns_to_store,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_devs_to_deactivate,
+        to_delete: nm_conns_to_delete,
     } = prepare_nm_conns(
         &merged_state,
         &conn_matcher,
@@ -114,6 +115,13 @@ pub(crate) async fn nm_apply(
         is_retry,
         ipv4_forward_support,
     )?;
+
+    for uuid in &nm_conns_to_delete {
+        nm_api
+            .connection_delete(uuid)
+            .await
+            .map_err(nm_error_to_nmstate)?;
+    }
 
     let nm_conns_to_deactivate_first = gen_nm_conn_need_to_deactivate_first(
         &merged_state.interfaces,

--- a/rust/src/lib/nm/query_apply/connection.rs
+++ b/rust/src/lib/nm/query_apply/connection.rs
@@ -312,7 +312,3 @@ async fn reapply_or_activate(
 
     Ok(())
 }
-
-pub(crate) fn is_uuid(value: &str) -> bool {
-    uuid::Uuid::parse_str(value).is_ok()
-}

--- a/rust/src/lib/nm/query_apply/ovs.rs
+++ b/rust/src/lib/nm/query_apply/ovs.rs
@@ -5,10 +5,11 @@ use std::collections::HashSet;
 use super::{
     super::{
         NmConnectionMatcher,
+        connection::is_uuid,
         nm_dbus::{NmApi, NmConnection, NmIfaceType},
         show::fill_iface_by_nm_conn_data,
     },
-    connection::{delete_connections, is_uuid},
+    connection::delete_connections,
 };
 use crate::{
     InterfaceType, MergedInterface, MergedInterfaces, NetworkState,

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -29,6 +29,7 @@ from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import add_port_to_bridge
 from .testlib.bridgelib import create_bridge_subtree_state
 from .testlib.bridgelib import linux_bridge
+from .testlib.dummy import dummy_interface
 from .testlib.env import is_k8s
 from .testlib.ifacelib import get_mac_address
 from .testlib.ifacelib import ifaces_init
@@ -1775,3 +1776,49 @@ def test_attach_new_vlan_of_new_bond_to_exist_bridge(empty_br0, cleanup_vlan):
         )
         libnmstate.apply(state)
         assertlib.assert_state_match(state)
+
+
+@pytest.fixture
+def bond99_down_with_2_ports_in_config(bond99_with_2_port):
+    libnmstate.apply(
+        yaml.load(
+            """
+            interfaces:
+              - name: bond99
+                type: bond
+                state: down
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+    yield
+
+
+@pytest.fixture
+def dummy1_up():
+    with dummy_interface("dummy1"):
+        yield
+
+
+def test_changed_port_list_of_down_bond(
+    bond99_down_with_2_ports_in_config, dummy1_up
+):
+    libnmstate.apply(
+        yaml.load(
+            """
+            interfaces:
+            - name: bond99
+              type: bond
+              state: up
+              link-aggregation:
+                mode: balance-rr
+                port:
+                  - dummy1
+            """,
+            Loader=yaml.SafeLoader,
+        )
+    )
+
+    bond_iface = statelib.show_only(("bond99",))[Interface.KEY][0]
+
+    assert bond_iface[Bond.CONFIG_SUBTREE][Bond.PORT] == ["dummy1"]

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -32,13 +32,13 @@ from .testlib.bridgelib import generate_vlan_id_config
 from .testlib.bridgelib import generate_vlan_id_range_config
 from .testlib.bridgelib import linux_bridge
 from .testlib.cmdlib import exec_cmd
+from .testlib.dummy import dummy_interface
 from .testlib.ifacelib import get_mac_address
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import show_only
 from .testlib.vlan import vlan_interface
 from .testlib.yaml import load_yaml
-
 
 TEST_BRIDGE0 = "linux-br0"
 TEST_TAP0 = "test-tap0"
@@ -1163,8 +1163,7 @@ def eth1_eth2_up_with_description(eth1_up, eth2_up):
 def test_policy_create_bridge_by_description_of_port(
     eth1_eth2_up_with_description,
 ):
-    policy = load_yaml(
-        """---
+    policy = load_yaml("""---
         capture:
           primary-nic: interfaces.description == "primary"
           secondary-nic: interfaces.description == "secondary"
@@ -1184,8 +1183,7 @@ def test_policy_create_bridge_by_description_of_port(
                 port:
                   - name: "{{ capture.primary-nic.interfaces.0.name }}"
                   - name: "{{ capture.secondary-nic.interfaces.0.name }}"
-        """
-    )
+        """)
     eth2_mac = get_mac_address("eth2")
     cur_state = libnmstate.show()
     desired_state = libnmstate.gen_net_state_from_policy(policy, cur_state)
@@ -1210,14 +1208,12 @@ def test_policy_create_bridge_by_description_of_port(
     finally:
         apply_with_description(
             "Delete bridge linux-br0",
-            load_yaml(
-                """---
+            load_yaml("""---
                 interfaces:
                 - name: linux-br0
                   type: linux-bridge
                   state: absent
-                """
-            ),
+                """),
             verify_change=False,
         )
 
@@ -1382,3 +1378,39 @@ def test_change_mtu_with_stable_link_up(bridge0_with_port0):
     )
 
     assertlib.assert_state(desired_state)
+
+
+@pytest.fixture
+def down_bridge0(bridge0_with_port0):
+    libnmstate.apply(load_yaml(f"""---
+        interfaces:
+        - name: {TEST_BRIDGE0}
+          type: linux-bridge
+          state: down"""))
+    yield
+
+
+@pytest.fixture
+def dummy1_up():
+    with dummy_interface("dummy1"):
+        yield
+
+
+def test_changed_port_list_of_down_linux_bridge(down_bridge0, dummy1_up):
+    libnmstate.apply(load_yaml(f"""---
+      interfaces:
+        - name: {TEST_BRIDGE0}
+          type: linux-bridge
+          state: up
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: dummy1"""))
+
+    current_state = show_only([TEST_BRIDGE0])
+    br_iface = current_state[Interface.KEY][0]
+    br_ports = br_iface[LinuxBridge.CONFIG_SUBTREE][LinuxBridge.PORT_SUBTREE]
+    assert len(br_ports) == 1
+    assert br_ports[0][LinuxBridge.Port.NAME] == "dummy1"

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -1163,7 +1163,8 @@ def eth1_eth2_up_with_description(eth1_up, eth2_up):
 def test_policy_create_bridge_by_description_of_port(
     eth1_eth2_up_with_description,
 ):
-    policy = load_yaml("""---
+    policy = load_yaml(
+        """---
         capture:
           primary-nic: interfaces.description == "primary"
           secondary-nic: interfaces.description == "secondary"
@@ -1183,7 +1184,8 @@ def test_policy_create_bridge_by_description_of_port(
                 port:
                   - name: "{{ capture.primary-nic.interfaces.0.name }}"
                   - name: "{{ capture.secondary-nic.interfaces.0.name }}"
-        """)
+        """
+    )
     eth2_mac = get_mac_address("eth2")
     cur_state = libnmstate.show()
     desired_state = libnmstate.gen_net_state_from_policy(policy, cur_state)
@@ -1208,12 +1210,14 @@ def test_policy_create_bridge_by_description_of_port(
     finally:
         apply_with_description(
             "Delete bridge linux-br0",
-            load_yaml("""---
+            load_yaml(
+                """---
                 interfaces:
                 - name: linux-br0
                   type: linux-bridge
                   state: absent
-                """),
+                """
+            ),
             verify_change=False,
         )
 
@@ -1382,11 +1386,15 @@ def test_change_mtu_with_stable_link_up(bridge0_with_port0):
 
 @pytest.fixture
 def down_bridge0(bridge0_with_port0):
-    libnmstate.apply(load_yaml(f"""---
+    libnmstate.apply(
+        load_yaml(
+            f"""---
         interfaces:
         - name: {TEST_BRIDGE0}
           type: linux-bridge
-          state: down"""))
+          state: down"""
+        )
+    )
     yield
 
 
@@ -1397,7 +1405,9 @@ def dummy1_up():
 
 
 def test_changed_port_list_of_down_linux_bridge(down_bridge0, dummy1_up):
-    libnmstate.apply(load_yaml(f"""---
+    libnmstate.apply(
+        load_yaml(
+            f"""---
       interfaces:
         - name: {TEST_BRIDGE0}
           type: linux-bridge
@@ -1407,7 +1417,9 @@ def test_changed_port_list_of_down_linux_bridge(down_bridge0, dummy1_up):
               stp:
                 enabled: false
             port:
-              - name: dummy1"""))
+              - name: dummy1"""
+        )
+    )
 
     current_state = show_only([TEST_BRIDGE0])
     br_iface = current_state[Interface.KEY][0]

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -525,7 +525,8 @@ def test_do_not_touch_ovs_port_when_not_desired_internal_iface(
 
 
 def test_gc_on_ovs_dpdk():
-    desired_state = load_yaml("""---
+    desired_state = load_yaml(
+        """---
         interfaces:
         - name: ovs0
           type: ovs-interface
@@ -544,7 +545,8 @@ def test_gc_on_ovs_dpdk():
               datapath: "netdev"
             port:
             - name: ovs0
-        """)
+        """
+    )
     confs = libnmstate.generate_configurations(desired_state)["NetworkManager"]
     ovs_iface_conf = [conf for conf in confs if conf[0].startswith("ovs0-if")][
         0
@@ -636,7 +638,9 @@ def test_ovs_port_has_autoconnect_ports(eth1_up):
 
 @pytest.fixture
 def down_br0(eth1_up):
-    libnmstate.apply(load_yaml("""---
+    libnmstate.apply(
+        load_yaml(
+            """---
         interfaces:
         - name: ovs0
           type: ovs-interface
@@ -647,10 +651,14 @@ def down_br0(eth1_up):
             port:
             - name: ovs0
             - name: eth1
-        """))
+        """
+        )
+    )
     # Due to NM bug https://issues.redhat.com/browse/RHEL-149781 ,
     # we have to explicitly mark OVS ports down also
-    libnmstate.apply(load_yaml("""---
+    libnmstate.apply(
+        load_yaml(
+            """---
         interfaces:
         - name: br0
           type: ovs-bridge
@@ -660,19 +668,27 @@ def down_br0(eth1_up):
           state: down
         - name: eth1
           type: ethernet
-          state: down"""))
+          state: down"""
+        )
+    )
     yield
-    libnmstate.apply(load_yaml("""---
+    libnmstate.apply(
+        load_yaml(
+            """---
         interfaces:
         - name: br0
           type: ovs-bridge
-          state: absent"""))
+          state: absent"""
+        )
+    )
 
 
 def test_changed_port_list_of_down_ovs_bridge_delete_orphans(
     down_br0, eth2_up
 ):
-    libnmstate.apply(load_yaml("""---
+    libnmstate.apply(
+        load_yaml(
+            """---
       interfaces:
         - name: br0
           type: ovs-bridge
@@ -682,7 +698,9 @@ def test_changed_port_list_of_down_ovs_bridge_delete_orphans(
               stp:
                 enabled: false
             port:
-              - name: eth2"""))
+              - name: eth2"""
+        )
+    )
 
     cur_nm_conns = cmdlib.exec_cmd("nmcli c show".split())[1]
     # NM ovs-port and ovs-iface connection for ovs0 should be deleted

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -19,7 +19,6 @@ from ..testlib.retry import retry_till_true_or_timeout
 from ..testlib.dummy import nm_unmanaged_dummy
 from ..testlib.yaml import load_yaml
 
-
 BRIDGE0 = "brtest0"
 BRIDGE1 = "brtest1"
 IFACE0 = "ovstest0"
@@ -526,8 +525,7 @@ def test_do_not_touch_ovs_port_when_not_desired_internal_iface(
 
 
 def test_gc_on_ovs_dpdk():
-    desired_state = load_yaml(
-        """---
+    desired_state = load_yaml("""---
         interfaces:
         - name: ovs0
           type: ovs-interface
@@ -546,8 +544,7 @@ def test_gc_on_ovs_dpdk():
               datapath: "netdev"
             port:
             - name: ovs0
-        """
-    )
+        """)
     confs = libnmstate.generate_configurations(desired_state)["NetworkManager"]
     ovs_iface_conf = [conf for conf in confs if conf[0].startswith("ovs0-if")][
         0
@@ -635,3 +632,66 @@ def test_ovs_port_has_autoconnect_ports(eth1_up):
                 """,
             )
         )
+
+
+@pytest.fixture
+def down_br0(eth1_up):
+    libnmstate.apply(load_yaml("""---
+        interfaces:
+        - name: ovs0
+          type: ovs-interface
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: ovs0
+            - name: eth1
+        """))
+    # Due to NM bug https://issues.redhat.com/browse/RHEL-149781 ,
+    # we have to explicitly mark OVS ports down also
+    libnmstate.apply(load_yaml("""---
+        interfaces:
+        - name: br0
+          type: ovs-bridge
+          state: down
+        - name: ovs0
+          type: ovs-interface
+          state: down
+        - name: eth1
+          type: ethernet
+          state: down"""))
+    yield
+    libnmstate.apply(load_yaml("""---
+        interfaces:
+        - name: br0
+          type: ovs-bridge
+          state: absent"""))
+
+
+def test_changed_port_list_of_down_ovs_bridge_delete_orphans(
+    down_br0, eth2_up
+):
+    libnmstate.apply(load_yaml("""---
+      interfaces:
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: eth2"""))
+
+    cur_nm_conns = cmdlib.exec_cmd("nmcli c show".split())[1]
+    # NM ovs-port and ovs-iface connection for ovs0 should be deleted
+    assert "ovs0" not in cur_nm_conns
+
+    # OVS system interface should be detached.
+    assert (
+        cmdlib.exec_cmd(
+            "nmcli -g connection.controller conn show eth1".split()
+        )[1].strip()
+        == ""
+    )

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -31,6 +31,7 @@ from .testlib import iprule
 from .testlib import statelib
 from .testlib.bondlib import bond_interface
 from .testlib.bridgelib import linux_bridge
+from .testlib.dummy import dummy_interface
 from .testlib.env import is_k8s
 from .testlib.genconf import gen_conf_apply
 from .testlib.iproutelib import ip_monitor_assert_stable_link_up
@@ -41,7 +42,6 @@ from .testlib.servicelib import disable_service
 from .testlib.statelib import state_match
 from .testlib.vlan import vlan_interface
 from .testlib.yaml import load_yaml
-
 
 BOND1 = "bond1"
 BRIDGE0 = "br0"
@@ -1801,9 +1801,7 @@ def test_crate_ovs_bond(cleanup_ovs_bridge, eth1_up, eth2_up, bond_mode):
                 port:
                 - name: eth1
                 - name: eth2
-            """.format(
-            bond_mode=bond_mode
-        ),
+            """.format(bond_mode=bond_mode),
         Loader=yaml.SafeLoader,
     )
     libnmstate.apply(desired_state)
@@ -2335,13 +2333,11 @@ def cleanup_20480_test_bridge():
     yield
     desired_state = {Interface.KEY: []}
     for i in range(0, 15):
-        iface_state = load_yaml(
-            f"""
+        iface_state = load_yaml(f"""
             name: br{i}
             type: ovs-bridge
             state: absent
-            """
-        )
+            """)
         desired_state[Interface.KEY].append(iface_state)
     libnmstate.apply(desired_state)
 
@@ -2354,8 +2350,7 @@ def cleanup_20480_test_bridge():
 def test_ovs_20480_json_string_length(cleanup_20480_test_bridge):
     desired_state = {Interface.KEY: []}
     for i in range(0, 15):
-        iface_state = load_yaml(
-            f"""
+        iface_state = load_yaml(f"""
             name: br{i}
             type: ovs-bridge
             state: up
@@ -2365,11 +2360,54 @@ def test_ovs_20480_json_string_length(cleanup_20480_test_bridge):
             ovs-db:
               external_ids:
                 key0: value0
-            """
-        )
+            """)
         for j in range(0, 255):
             iface_state[OvsDB.OVS_DB_SUBTREE][OvsDB.EXTERNAL_IDS][
                 f"key{j}"
             ] = f"longlonglonglonglonglonglonglonglonglong{j}"
         desired_state[Interface.KEY].append(iface_state)
     libnmstate.apply(desired_state)
+
+
+@pytest.fixture
+def down_bridge1(bridge_with_ports):
+    # Due to NM bug https://issues.redhat.com/browse/RHEL-149781 ,
+    # we have to explicitly mark OVS ports down also
+    libnmstate.apply(load_yaml(f"""---
+        interfaces:
+        - name: {BRIDGE1}
+          type: ovs-bridge
+          state: down
+        - name: {PORT1}
+          type: ovs-interface
+          state: down
+        - name: eth1
+          type: ethernet
+          state: down"""))
+    yield
+
+
+@pytest.fixture
+def dummy1_up():
+    with dummy_interface("dummy1"):
+        yield
+
+
+def test_changed_port_list_of_down_ovs_bridge(down_bridge1, dummy1_up):
+    libnmstate.apply(load_yaml(f"""---
+      interfaces:
+        - name: {BRIDGE1}
+          type: ovs-bridge
+          state: up
+          bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+              - name: dummy1"""))
+
+    cur_state = statelib.show_only((BRIDGE1,))
+    br_iface = cur_state[Interface.KEY][0]
+    br_ports = br_iface[OVSBridge.CONFIG_SUBTREE][OVSBridge.PORT_SUBTREE]
+    assert len(br_ports) == 1
+    assert br_ports[0][LinuxBridge.Port.NAME] == "dummy1"

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -1801,7 +1801,9 @@ def test_crate_ovs_bond(cleanup_ovs_bridge, eth1_up, eth2_up, bond_mode):
                 port:
                 - name: eth1
                 - name: eth2
-            """.format(bond_mode=bond_mode),
+            """.format(
+            bond_mode=bond_mode
+        ),
         Loader=yaml.SafeLoader,
     )
     libnmstate.apply(desired_state)
@@ -2333,11 +2335,13 @@ def cleanup_20480_test_bridge():
     yield
     desired_state = {Interface.KEY: []}
     for i in range(0, 15):
-        iface_state = load_yaml(f"""
+        iface_state = load_yaml(
+            f"""
             name: br{i}
             type: ovs-bridge
             state: absent
-            """)
+            """
+        )
         desired_state[Interface.KEY].append(iface_state)
     libnmstate.apply(desired_state)
 
@@ -2350,7 +2354,8 @@ def cleanup_20480_test_bridge():
 def test_ovs_20480_json_string_length(cleanup_20480_test_bridge):
     desired_state = {Interface.KEY: []}
     for i in range(0, 15):
-        iface_state = load_yaml(f"""
+        iface_state = load_yaml(
+            f"""
             name: br{i}
             type: ovs-bridge
             state: up
@@ -2360,7 +2365,8 @@ def test_ovs_20480_json_string_length(cleanup_20480_test_bridge):
             ovs-db:
               external_ids:
                 key0: value0
-            """)
+            """
+        )
         for j in range(0, 255):
             iface_state[OvsDB.OVS_DB_SUBTREE][OvsDB.EXTERNAL_IDS][
                 f"key{j}"
@@ -2373,7 +2379,9 @@ def test_ovs_20480_json_string_length(cleanup_20480_test_bridge):
 def down_bridge1(bridge_with_ports):
     # Due to NM bug https://issues.redhat.com/browse/RHEL-149781 ,
     # we have to explicitly mark OVS ports down also
-    libnmstate.apply(load_yaml(f"""---
+    libnmstate.apply(
+        load_yaml(
+            f"""---
         interfaces:
         - name: {BRIDGE1}
           type: ovs-bridge
@@ -2383,7 +2391,9 @@ def down_bridge1(bridge_with_ports):
           state: down
         - name: eth1
           type: ethernet
-          state: down"""))
+          state: down"""
+        )
+    )
     yield
 
 
@@ -2394,7 +2404,9 @@ def dummy1_up():
 
 
 def test_changed_port_list_of_down_ovs_bridge(down_bridge1, dummy1_up):
-    libnmstate.apply(load_yaml(f"""---
+    libnmstate.apply(
+        load_yaml(
+            f"""---
       interfaces:
         - name: {BRIDGE1}
           type: ovs-bridge
@@ -2404,7 +2416,9 @@ def test_changed_port_list_of_down_ovs_bridge(down_bridge1, dummy1_up):
               stp:
                 enabled: false
             port:
-              - name: dummy1"""))
+              - name: dummy1"""
+        )
+    )
 
     cur_state = statelib.show_only((BRIDGE1,))
     br_iface = cur_state[Interface.KEY][0]


### PR DESCRIPTION
When modifying port list of the controller interface in `state: down`,
nmstate forgot to detach saved inactive NM connection from this
controller causing verification error on port list.

To fix the issue, this patch introduced
`detach_saved_nm_conn_from_controller()` to detach saved inactive NM
connection from controller interface which has port list desired.
For OVS bridge, will delete orphan OVS port and internal interface.

Another approach to fix this issue is update query support in NM for
showing `state:down` virtual interfaces from saved NmConnection, then
existing code is enough to handle changed ports. This patch does not
take that approach because:

```
Much bigger code changes are required to query `state: down` virtual
interface from saved NmConnection which does not exist before.
Currently, nmstate does not show `state:down` virtual interface, if we
are showing them, we need to make sure all properties are actuate which
is overkill for this corner case.
```

Integration test cases included for bond, ovs bridge and linux bridge.

Resolves: https://issues.redhat.com/browse/RHEL-52334