### PR TITLE
test: Fix `test_attach_new_vlan_of_new_bond_to_exist_bridge`

### DIFF
--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -127,7 +127,7 @@ impl MergedInterfaces {
     }
 
     pub(crate) fn validate_hsr_mac(&self) -> Result<(), NmstateError> {
-        for hsr_iface in self.kernel_ifaces.iter().filter_map(|(_, iface)| {
+        for hsr_iface in self.kernel_ifaces.values().filter_map(|iface| {
             if let Interface::Hsr(hsr_iface) = iface.desired.as_ref()? {
                 let hsr_conf = hsr_iface.hsr.as_ref()?;
 
@@ -187,7 +187,7 @@ impl MergedInterfaces {
         let mut pending_changes = Vec::new();
 
         for (hsr_iface, hsr_conf, mac) in
-            self.kernel_ifaces.iter().filter_map(|(_, iface)| {
+            self.kernel_ifaces.values().filter_map(|iface| {
                 if !iface.is_desired() || !iface.merged.is_up() {
                     return None;
                 }

--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -1768,7 +1768,7 @@ def test_attach_new_vlan_of_new_bond_to_exist_bridge(empty_br0, cleanup_vlan):
                 state: up
                 controller: br0
                 vlan:
-                  base-iface: eth1
+                  base-iface: bond99
                   id: 101
                 """,
                 Loader=yaml.SafeLoader,


### PR DESCRIPTION
The `test_attach_new_vlan_of_new_bond_to_exist_bridge` incorrectly
set the VLAN to `eth1` as parent which is not the purpose of testing,
it should be use newly created bond99 as parent.