### PR TITLE
github: change dependabot to run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
   - package-ecosystem: cargo
     directory: "/rust"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Updating dependency too frequent will cause Fedora dependent crate not
been shipped yet. For example dependabot update the `toml` dependency to
1.0.3 while it is not yet released to Fedora yet
https://src.fedoraproject.org/rpms/rust-toml

This cause nmstate not able to build in Fedora.

Instead of updating dependency weekly, change to monthly check.

Also removed python pip dependency check because we don't have version
requirement on PyYAML, no need to check.