### PR TITLE
iface: Raise error when trying to merge ifaces with different type

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -1167,6 +1167,20 @@ fn merge_desire_with_current(
     desired: &Interface,
     current: &Interface,
 ) -> Result<Interface, NmstateError> {
+    // No need to handle InterfaceType::Unknown, `resolve_unknown_ifaces()`
+    // already checked.
+    if desired.iface_type() != current.iface_type() {
+        return Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Desired interface {} holds different interface type than \
+                 current: desired {} vs current {}",
+                desired.name(),
+                desired.iface_type(),
+                current.iface_type()
+            ),
+        ));
+    }
     let mut desired_value = serde_json::to_value(desired)?;
     let current_value = serde_json::to_value(current)?;
     merge_json_value(&mut desired_value, &current_value);

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     BondMode, ErrorKind, HsrProtocol, Interface, InterfaceState, InterfaceType,
-    Interfaces, MergedInterfaces,
+    Interfaces, MergedInterface, MergedInterfaces,
     unit_tests::testlib::{
         get_mac, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
         new_unknown_iface, new_vlan_iface,
@@ -945,4 +945,31 @@ fn test_sort_ovs_bridge_with_same_name() {
     assert_eq!(sorted_ifaces_1[0].iface_type(), InterfaceType::OvsBridge);
     assert_eq!(sorted_ifaces_1[1].name(), "br-ex");
     assert_eq!(sorted_ifaces_1[1].iface_type(), InterfaceType::OvsInterface);
+}
+
+#[test]
+fn test_error_when_merge_two_different_type_ifaces() {
+    let desired = serde_yaml::from_str::<Interface>(
+        r"---
+        name: gretap0
+        type: ethernet
+        state: up
+        ethernet: {}
+        ",
+    )
+    .unwrap();
+    let current = serde_yaml::from_str::<Interface>(
+        r"---
+        name: gretap0
+        type: ip-tunnel
+        state: up
+        ip-tunnel: {}
+        ",
+    )
+    .unwrap();
+
+    let error = MergedInterface::new(Some(desired), Some(current)).unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::InvalidArgument);
+    assert!(error.msg().contains("different interface type"));
 }

--- a/tests/integration/mac_identifer_test.py
+++ b/tests/integration/mac_identifer_test.py
@@ -52,7 +52,7 @@ def clean_up():
               type: mac-vlan
               state: absent
             - name: mtap0
-              type: mac-vlan
+              type: mac-vtap
               state: absent
             - name: macsec0
               type: macsec


### PR DESCRIPTION
For `gretap` interface, nispor 2.0.0 is incorrectly treating it as
`InterfaceType::Ethernet` while NetworkManager is treating it as
`InterfaceType::IpTunnel`, when nmstate merging these two interfaces, we
got wired error:

    Invalid YAML string: interfaces: unknown field `ethernet`

This is caused by `merge_desire_with_current()` copy `ethernet` section
to a `ip-tunnel` interface.

This patch changed `merge_desire_with_current()` to raise error instead
of blindly merging two interface literally.

Unit test case included.