### PR TITLE
ip: ipv4.forwarding deserialize from string also

### DIFF
--- a/rust/src/lib/deserializer.rs
+++ b/rust/src/lib/deserializer.rs
@@ -15,7 +15,7 @@ where
         if let Some(i) = i {
             Ok(i)
         } else {
-            Err(de::Error::custom("Required filed undefined"))
+            Err(de::Error::custom("Required field undefined"))
         }
     })
 }
@@ -28,7 +28,7 @@ where
         if let Some(i) = i {
             Ok(i)
         } else {
-            Err(de::Error::custom("Required filed undefined"))
+            Err(de::Error::custom("Required field undefined"))
         }
     })
 }
@@ -41,7 +41,7 @@ where
         if let Some(i) = i {
             Ok(i)
         } else {
-            Err(de::Error::custom("Required filed undefined"))
+            Err(de::Error::custom("Required field undefined"))
         }
     })
 }
@@ -54,7 +54,7 @@ where
         if let Some(i) = i {
             Ok(i)
         } else {
-            Err(de::Error::custom("Required filed undefined"))
+            Err(de::Error::custom("Required field undefined"))
         }
     })
 }

--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -105,7 +105,11 @@ struct InterfaceIp {
         rename = "dhcp-custom-hostname"
     )]
     pub dhcp_custom_hostname: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "crate::deserializer::option_bool_or_string"
+    )]
     pub forwarding: Option<bool>,
 }
 

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -22,6 +22,7 @@ state: up
 ipv4:
   enabled: "true"
   dhcp: "false"
+  forwarding: "true"
   address:
   - ip: "192.168.1.1"
     prefix-length: "24"
@@ -39,6 +40,7 @@ ipv6:
 
     assert!(ipv4_conf.enabled);
     assert_eq!(ipv4_conf.dhcp, Some(false));
+    assert_eq!(ipv4_conf.forwarding, Some(true));
     assert_eq!(
         ipv4_conf.addresses.as_deref().unwrap()[0].ip.to_string(),
         "192.168.1.1"


### PR DESCRIPTION
Be able to use "true" in place of true in ipv4.forwarding:
```
    interfaces:
      - name: eth1
        type: ethernet
        state: up
        ipv4:
          address:
          - ip: 192.0.2.1
            prefix-length: 24
          dhcp: false
          enabled: true
          forwarding: "true"
```

Resolves: https://issues.redhat.com/browse/RHEL-153618