### PR TITLE
ipsec: support `leftsubnets` and `rightsubnets` options.

### DIFF
--- a/rust/src/lib/ifaces/ipsec.rs
+++ b/rust/src/lib/ifaces/ipsec.rs
@@ -143,7 +143,11 @@ pub struct LibreswanConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rightsubnet: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub rightsubnets: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub leftsubnet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub leftsubnets: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub leftmodecfgclient: Option<bool>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
@@ -204,7 +208,9 @@ impl std::fmt::Debug for LibreswanConfig {
             .field("ipsec_interface", &self.ipsec_interface)
             .field("authby", &self.authby)
             .field("rightsubnet", &self.rightsubnet)
+            .field("rightsubnets", &self.rightsubnets)
             .field("leftsubnet", &self.leftsubnet)
+            .field("leftsubnets", &self.leftsubnets)
             .field("leftmodecfgclient", &self.leftmodecfgclient)
             .field("kind", &self.kind)
             .field("hostaddrfamily", &self.hostaddrfamily)

--- a/rust/src/lib/nm/query_apply/vpn.rs
+++ b/rust/src/lib/nm/query_apply/vpn.rs
@@ -92,7 +92,9 @@ fn get_libreswan_conf(nm_set_vpn: &NmSettingVpn) -> LibreswanConfig {
         ret.leftmodecfgclient =
             data.get("leftmodecfgclient").map(|s| s == "yes");
         ret.rightsubnet = data.get("rightsubnet").cloned();
+        ret.rightsubnets = data.get("rightsubnets").cloned();
         ret.leftsubnet = data.get("leftsubnet").cloned();
+        ret.leftsubnets = data.get("leftsubnets").cloned();
         ret.kind = data.get("type").and_then(|s| match s.as_str() {
             "tunnel" => Some(LibreswanConnectionType::Tunnel),
             "transport" => Some(LibreswanConnectionType::Transport),

--- a/rust/src/lib/nm/settings/vpn.rs
+++ b/rust/src/lib/nm/settings/vpn.rs
@@ -82,8 +82,14 @@ pub(crate) fn gen_nm_ipsec_vpn_setting(
         if let Some(v) = conf.rightsubnet.as_deref() {
             vpn_data.insert("rightsubnet".into(), v.to_string());
         }
+        if let Some(v) = conf.rightsubnets.as_deref() {
+            vpn_data.insert("rightsubnets".into(), v.to_string());
+        }
         if let Some(v) = conf.leftsubnet.as_deref() {
             vpn_data.insert("leftsubnet".into(), v.to_string());
+        }
+        if let Some(v) = conf.leftsubnets.as_deref() {
+            vpn_data.insert("leftsubnets".into(), v.to_string());
         }
         if let Some(v) = conf.kind {
             vpn_data.insert("type".into(), v.to_string());

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 import libnmstate
+from libnmstate.error import NmstateVerificationError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -1176,3 +1177,105 @@ def test_ipsec_leftprotoport_rightprotoport(ipsec_srv_cert_gw_icmp):
         IpsecTestEnv.SRV_POOL_PREFIX_V4,
         IpsecTestEnv.CLI_NIC,
     )
+
+
+# https://issues.redhat.com/browse/RHEL-32947
+@pytest.mark.tier1
+@pytest.mark.xfail(
+    raises=NmstateVerificationError,
+    reason="leftsubnets need patched NetworkManager-libreswan",
+)
+@pytest.mark.skipif(is_k8s(), reason="K8S CI does not support IPSec yet")
+def test_ipsec_ipv4_libreswan_leftsubnets(ipsec_srv_site_to_site):
+    leftsubnets = (
+        f"{IpsecTestEnv.CLI_SUBNET_V4},{IpsecTestEnv.CLI_SUBNET_V4_2}"
+    )
+    rightsubnets = (
+        f"{IpsecTestEnv.SRV_SUBNET_V4},{IpsecTestEnv.SRV_SUBNET_V4_2}"
+    )
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: {IPSEC_CONN_NAME}
+          type: ipsec
+          ipv4:
+            enabled: true
+            dhcp: true
+          libreswan:
+            nm-auto-defaults: false
+            left: {IpsecTestEnv.CLI_ADDR_V4}
+            leftid: '@{IpsecTestEnv.CLI_KEY_ID}'
+            leftcert: {IpsecTestEnv.CLI_KEY_ID}
+            leftsubnets: "{leftsubnets}"
+            right: {IpsecTestEnv.SRV_ADDR_V4}
+            rightid: '@{IpsecTestEnv.SRV_KEY_ID}'
+            rightsubnets: "{rightsubnets}"
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec,
+        IpsecTestEnv.CLI_ADDR_V4,
+        IpsecTestEnv.SRV_ADDR_V4,
+    )
+    cli_subnets = [IpsecTestEnv.CLI_SUBNET_V4, IpsecTestEnv.CLI_SUBNET_V4_2]
+    srv_subnets = [IpsecTestEnv.SRV_SUBNET_V4, IpsecTestEnv.SRV_SUBNET_V4_2]
+    for cli_subnet, srv_subnet in zip(cli_subnets, srv_subnets):
+        assert retry_till_true_or_timeout(
+            RETRY_COUNT,
+            _check_ipsec_policy,
+            cli_subnet,
+            srv_subnet,
+        )
+
+
+@pytest.mark.xfail(
+    raises=NmstateVerificationError,
+    reason="leftsubnets need patched NetworkManager-libreswan",
+)
+@pytest.mark.skipif(is_k8s(), reason="K8S CI does not support IPSec yet")
+def test_ipsec_ipv6_libreswan_leftsubnets(ipsec_srv_site_to_site):
+    leftsubnets = (
+        f"{IpsecTestEnv.CLI_SUBNET_V6},{IpsecTestEnv.CLI_SUBNET_V6_2}"
+    )
+    rightsubnets = (
+        f"{IpsecTestEnv.SRV_SUBNET_V6},{IpsecTestEnv.SRV_SUBNET_V6_2}"
+    )
+    desired_state = yaml.load(
+        f"""---
+        interfaces:
+        - name: {IPSEC_CONN_NAME}
+          type: ipsec
+          ipv6:
+            enabled: true
+            dhcp: true
+          libreswan:
+            nm-auto-defaults: false
+            left: {IpsecTestEnv.CLI_ADDR_V6}
+            leftid: '%fromcert'
+            leftcert: {IpsecTestEnv.CLI_KEY_ID}
+            leftsubnets: "{leftsubnets}"
+            right: {IpsecTestEnv.SRV_ADDR_V6}
+            rightid: '%fromcert'
+            rightsubnets: "{rightsubnets}"
+            ikev2: insist""",
+        Loader=yaml.SafeLoader,
+    )
+    libnmstate.apply(desired_state)
+    assert retry_till_true_or_timeout(
+        RETRY_COUNT,
+        _check_ipsec,
+        IpsecTestEnv.CLI_ADDR_V6,
+        IpsecTestEnv.SRV_ADDR_V6,
+    )
+    cli_subnets = [IpsecTestEnv.CLI_SUBNET_V6, IpsecTestEnv.CLI_SUBNET_V6_2]
+    srv_subnets = [IpsecTestEnv.SRV_SUBNET_V6, IpsecTestEnv.SRV_SUBNET_V6_2]
+    for cli_subnet, srv_subnet in zip(cli_subnets, srv_subnets):
+        assert retry_till_true_or_timeout(
+            RETRY_COUNT,
+            _check_ipsec_policy,
+            cli_subnet,
+            srv_subnet,
+        )

--- a/tests/integration/test_ipsec_files/site_to_site.conf
+++ b/tests/integration/test_ipsec_files/site_to_site.conf
@@ -4,7 +4,7 @@ conn site_to_site_ipv4
     left=192.0.2.1
     leftid=%fromcert
     leftcert=ipsec-srv.example.org
-    leftsubnet=10.0.0.0/24
+    leftsubnets=10.0.0.0/24,10.1.0.0/24
     leftsendcert=always
     leftmodecfgserver=no
     rightmodecfgclient=no
@@ -12,7 +12,7 @@ conn site_to_site_ipv4
     rightid=@cli-a.example.org
     rightca=%same
     rightrsasigkey=%cert
-    rightsubnet=10.0.9.0/24
+    rightsubnets=10.0.9.0/24,10.0.10.0/24
     ikev2=insist
 
 conn site_to_site_ipv6
@@ -21,7 +21,7 @@ conn site_to_site_ipv6
     left=2001:db8:a::1
     leftid=%fromcert
     leftcert=ipsec-srv.example.org
-    leftsubnet=fd00:a::/64
+    leftsubnets=fd00:a::/64,fd00:b::/64
     leftsendcert=always
     leftmodecfgserver=no
     rightmodecfgclient=no
@@ -29,5 +29,5 @@ conn site_to_site_ipv6
     rightid=@cli-a.example.org
     rightca=%same
     rightrsasigkey=%cert
-    rightsubnet=fd00:9::/64
+    rightsubnets=fd00:9::/64,fd00:10::/64
     ikev2=insist

--- a/tests/integration/testlib/ipsec.py
+++ b/tests/integration/testlib/ipsec.py
@@ -56,12 +56,18 @@ class IpsecTestEnv:
     SRV_POOL_PREFIX_V4 = "10.0.1"
     SRV_POOL_PREFIX_V6 = "2001:db8:c::"
     SRV_SUBNET_V4 = "10.0.0.0/24"
+    SRV_SUBNET_V4_2 = "10.1.0.0/24"
     SRV_SUBNET_V6 = "fd00:a::/64"
+    SRV_SUBNET_V6_2 = "fd00:b::/64"
     CLI_SUBNET_V4 = "10.0.9.0/24"
+    CLI_SUBNET_V4_2 = "10.0.10.0/24"
     CLI_SUBNET_V6 = "fd00:9::/64"
+    CLI_SUBNET_V6_2 = "fd00:10::/64"
     CLI_SUBNET_NIC_NAME = "cli-sub0"
     CLI_SUBADDR_V4 = "10.0.9.2"
+    CLI_SUBADDR_V4_2 = "10.0.10.2"
     CLI_SUBADDR_V6 = "fd00:9::2"
+    CLI_SUBADDR_V6_2 = "fd00:10::2"
     CLI_KEY_ID = "cli-a.example.org"
     SRV_KEY_ID = "ipsec-srv.example.org"
     CLI_NIC = "ipsec_cli0"
@@ -243,7 +249,11 @@ def setup_cli_ip():
                         {
                             IPv4.ADDRESS_IP: IpsecTestEnv.CLI_SUBADDR_V4,
                             IPv4.ADDRESS_PREFIX_LENGTH: 24,
-                        }
+                        },
+                        {
+                            IPv4.ADDRESS_IP: IpsecTestEnv.CLI_SUBADDR_V4_2,
+                            IPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        },
                     ],
                 },
                 Interface.IPV6: {
@@ -254,7 +264,11 @@ def setup_cli_ip():
                         {
                             IPv6.ADDRESS_IP: IpsecTestEnv.CLI_SUBADDR_V6,
                             IPv6.ADDRESS_PREFIX_LENGTH: 64,
-                        }
+                        },
+                        {
+                            IPv6.ADDRESS_IP: IpsecTestEnv.CLI_SUBADDR_V6_2,
+                            IPv6.ADDRESS_PREFIX_LENGTH: 64,
+                        },
                     ],
                 },
             },


### PR DESCRIPTION
Instead of using `Vec<String>` for these two options, we use String in order to align with what `ipsec.conf` manpage describes without any parsing/modification.

Waiting NetworkManager support via https://issues.redhat.com/browse/RHEL-155372

Integration test case included and marked as xfail instead of skipif because NM-libreswan will not tag new release for this fix, we cannot tell whether this feature is supported or not by checking rpm version.

Resolves: https://issues.redhat.com/browse/RHEL-32947