### PR TITLE
cli/apply: log warning message when timeout is ignored

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -46,7 +46,15 @@ where
     let timeout = if matches.try_contains_id("TIMEOUT").unwrap_or_default() {
         match matches.try_get_one::<String>("TIMEOUT") {
             Ok(Some(t)) => match u32::from_str(t) {
-                Ok(i) => i,
+                Ok(i) => {
+                    if !no_commit {
+                        log::warn!(
+                            "--timeout is only effective when used with \
+                             --no-commit. The timeout value will be ignored."
+                        );
+                    }
+                    i
+                }
                 Err(e) => {
                     return Err(CliError {
                         code: crate::error::EX_DATAERR,


### PR DESCRIPTION
Demo:
```
$ nmstatectl apply --timeout 1
[2026-03-12T09:59:21Z INFO  nmstatectl] Nmstate version: 2.2.60
[2026-03-12T09:59:21Z WARN  nmstatectl::apply] --timeout is only effective when used with --no-commit. The timeout value will be ignored.
^C

$ nmstatectl apply --timeout 1 --no-commit
[2026-03-12T09:59:35Z INFO  nmstatectl] Nmstate version: 2.2.60
^C
```

Resolves: https://issues.redhat.com/browse/RHEL-88994
Signed-off-by: Jan Vaclav <jvaclav@redhat.com>