### PR TITLE
poc: OVS bridge support in kernel-only (-k) mode

### DIFF
--- a/rust/src/lib/nispor/apply.rs
+++ b/rust/src/lib/nispor/apply.rs
@@ -41,6 +41,8 @@ pub(crate) async fn nispor_apply(
     let mut np_ifaces: Vec<nispor::IfaceConf> = Vec::new();
     for merged_iface in ifaces.iter().filter(|i| {
         i.merged.iface_type() != InterfaceType::Unknown
+            && i.merged.iface_type() != InterfaceType::OvsBridge
+            && i.merged.iface_type() != InterfaceType::OvsInterface
             && !i.merged.is_absent()
             && i.for_apply.as_ref().is_some()
     }) {

--- a/rust/src/lib/ovsdb/bridge_port.rs
+++ b/rust/src/lib/ovsdb/bridge_port.rs
@@ -1,0 +1,512 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use crate::{
+    Interface, InterfaceState, InterfaceType, MergedNetworkState, NmstateError,
+    OvsBridgeInterface,
+    ovsdb::{
+        OVS_DB_NAME, OvsDbCondition, OvsDbConnection, OvsDbDelete, OvsDbInsert,
+        OvsDbMethodTransact, OvsDbMutate, OvsDbMutation, OvsDbOperation,
+        OvsDbUpdate, build_set_value, named_uuid_ref, uuid_ref,
+    },
+};
+
+const GLOBAL_CONFIG_TABLE: &str = "Open_vSwitch";
+
+pub(crate) async fn ovsdb_apply_bridges(
+    merged_state: &MergedNetworkState,
+) -> Result<(), NmstateError> {
+    for iface in merged_state.interfaces.iter() {
+        let des_iface = if let Some(ref i) = iface.for_apply {
+            i
+        } else if let Some(ref i) = iface.desired {
+            i
+        } else {
+            continue;
+        };
+        if des_iface.base_iface().iface_type != InterfaceType::OvsBridge {
+            continue;
+        }
+        let br_name = &des_iface.base_iface().name;
+
+        if des_iface.base_iface().state == InterfaceState::Absent {
+            if iface.current.is_some() {
+                ovsdb_delete_bridge(br_name).await?;
+            }
+        } else if des_iface.base_iface().state == InterfaceState::Up
+            && let Interface::OvsBridge(br_iface) = des_iface
+        {
+            if let Some(Interface::OvsBridge(cur_br_iface)) =
+                iface.current.as_ref()
+            {
+                ovsdb_update_bridge(br_iface, cur_br_iface).await?;
+            } else {
+                ovsdb_create_bridge(br_iface).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn insert_bridge_options(
+    row: &mut HashMap<String, serde_json::Value>,
+    br_iface: &OvsBridgeInterface,
+) {
+    let options =
+        match br_iface.bridge.as_ref().and_then(|c| c.options.as_ref()) {
+            Some(o) => o,
+            None => return,
+        };
+    if let Some(enabled) = options.stp.as_ref().and_then(|s| s.enabled) {
+        row.insert("stp_enable".to_string(), serde_json::Value::Bool(enabled));
+    }
+    if let Some(rstp) = options.rstp {
+        row.insert("rstp_enable".to_string(), serde_json::Value::Bool(rstp));
+    }
+    if let Some(mcast) = options.mcast_snooping_enable {
+        row.insert(
+            "mcast_snooping_enable".to_string(),
+            serde_json::Value::Bool(mcast),
+        );
+    }
+    if let Some(ref fail_mode) =
+        options.fail_mode.as_ref().filter(|m| !m.is_empty())
+    {
+        row.insert(
+            "fail_mode".to_string(),
+            serde_json::Value::String(fail_mode.to_string()),
+        );
+    }
+}
+
+async fn ovsdb_create_bridge(
+    br_iface: &OvsBridgeInterface,
+) -> Result<(), NmstateError> {
+    let mut cli = OvsDbConnection::new().await?;
+    let mut ops = Vec::new();
+    let br_name = &br_iface.base.name;
+
+    let mut port_uuid_refs = Vec::new();
+
+    if let Some(port_confs) =
+        br_iface.bridge.as_ref().and_then(|c| c.ports.as_ref())
+    {
+        for port_conf in port_confs {
+            let port_uuid_name =
+                format!("port_{}", port_conf.name.replace('-', "_"));
+
+            if let Some(bond_conf) = &port_conf.bond {
+                let mut iface_uuid_refs = Vec::new();
+                if let Some(bond_ports) = &bond_conf.ports {
+                    for bond_port in bond_ports {
+                        let iface_uuid_name = format!(
+                            "iface_{}",
+                            bond_port.name.replace('-', "_")
+                        );
+                        let mut iface_row = HashMap::new();
+                        iface_row.insert(
+                            "name".to_string(),
+                            serde_json::Value::String(bond_port.name.clone()),
+                        );
+                        ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                            table: "Interface".to_string(),
+                            row: iface_row,
+                            uuid_name: Some(iface_uuid_name.clone()),
+                        }));
+                        iface_uuid_refs.push(named_uuid_ref(&iface_uuid_name));
+                    }
+                }
+
+                let mut port_row = HashMap::new();
+                port_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                port_row.insert(
+                    "interfaces".to_string(),
+                    build_set_value(&iface_uuid_refs),
+                );
+                if let Some(ref mode) = bond_conf.mode {
+                    port_row.insert(
+                        "bond_mode".to_string(),
+                        serde_json::Value::String(mode.to_string()),
+                    );
+                }
+                if let Some(updelay) = bond_conf.bond_updelay {
+                    port_row.insert(
+                        "bond_updelay".to_string(),
+                        serde_json::Value::Number(updelay.into()),
+                    );
+                }
+                if let Some(downdelay) = bond_conf.bond_downdelay {
+                    port_row.insert(
+                        "bond_downdelay".to_string(),
+                        serde_json::Value::Number(downdelay.into()),
+                    );
+                }
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Port".to_string(),
+                    row: port_row,
+                    uuid_name: Some(port_uuid_name.clone()),
+                }));
+            } else {
+                // Non-bond port: single interface with same name
+                let iface_uuid_name =
+                    format!("iface_{}", port_conf.name.replace('-', "_"));
+                let mut iface_row = HashMap::new();
+                iface_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                iface_row.insert(
+                    "type".to_string(),
+                    serde_json::Value::String("internal".to_string()),
+                );
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Interface".to_string(),
+                    row: iface_row,
+                    uuid_name: Some(iface_uuid_name.clone()),
+                }));
+
+                let mut port_row = HashMap::new();
+                port_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                port_row.insert(
+                    "interfaces".to_string(),
+                    named_uuid_ref(&iface_uuid_name),
+                );
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Port".to_string(),
+                    row: port_row,
+                    uuid_name: Some(port_uuid_name.clone()),
+                }));
+            }
+            port_uuid_refs.push(named_uuid_ref(&port_uuid_name));
+        }
+    }
+
+    // Build Bridge row
+    let bridge_uuid_name = format!("bridge_{}", br_name.replace('-', "_"));
+    let mut bridge_row = HashMap::new();
+    bridge_row.insert(
+        "name".to_string(),
+        serde_json::Value::String(br_name.clone()),
+    );
+    if !port_uuid_refs.is_empty() {
+        bridge_row
+            .insert("ports".to_string(), build_set_value(&port_uuid_refs));
+    }
+
+    insert_bridge_options(&mut bridge_row, br_iface);
+
+    ops.push(OvsDbOperation::Insert(OvsDbInsert {
+        table: "Bridge".to_string(),
+        row: bridge_row,
+        uuid_name: Some(bridge_uuid_name.clone()),
+    }));
+
+    // MUTATE Open_vSwitch to add bridge
+    ops.push(OvsDbOperation::Mutate(OvsDbMutate {
+        table: GLOBAL_CONFIG_TABLE.to_string(),
+        conditions: vec![],
+        mutations: vec![OvsDbMutation {
+            column: "bridges".to_string(),
+            mutator: "insert".to_string(),
+            value: named_uuid_ref(&bridge_uuid_name),
+        }],
+    }));
+
+    cli.transact(&OvsDbMethodTransact {
+        db_name: OVS_DB_NAME.to_string(),
+        operations: ops,
+    })
+    .await?;
+    log::info!("Created OVS bridge {br_name} via OVSDB");
+    Ok(())
+}
+
+async fn ovsdb_delete_bridge(br_name: &str) -> Result<(), NmstateError> {
+    let mut cli = OvsDbConnection::new().await?;
+
+    // Get the bridge UUID and its port UUIDs
+    let bridges = cli.get_ovs_bridges().await?;
+    let (bridge_uuid, bridge_entry) =
+        match bridges.iter().find(|(_, e)| e.name == br_name) {
+            Some((uuid, entry)) => (uuid.clone(), entry),
+            None => {
+                log::warn!(
+                    "OVS bridge {br_name} not found in OVSDB, skipping delete"
+                );
+                return Ok(());
+            }
+        };
+
+    let port_uuids = bridge_entry.ports.clone();
+
+    // Get interface UUIDs from ports
+    let all_ports = cli.get_ovs_ports().await?;
+    let mut iface_uuids = Vec::new();
+    for port_uuid in &port_uuids {
+        if let Some(port_entry) = all_ports.get(port_uuid) {
+            iface_uuids.extend(port_entry.ports.clone());
+        }
+    }
+
+    let mut ops = Vec::new();
+
+    // DELETE interfaces
+    for iface_uuid in &iface_uuids {
+        ops.push(OvsDbOperation::Delete(OvsDbDelete {
+            table: "Interface".to_string(),
+            conditions: vec![OvsDbCondition {
+                column: "_uuid".to_string(),
+                function: "==".to_string(),
+                value: uuid_ref(iface_uuid),
+            }],
+        }));
+    }
+
+    // DELETE ports
+    for port_uuid in &port_uuids {
+        ops.push(OvsDbOperation::Delete(OvsDbDelete {
+            table: "Port".to_string(),
+            conditions: vec![OvsDbCondition {
+                column: "_uuid".to_string(),
+                function: "==".to_string(),
+                value: uuid_ref(port_uuid),
+            }],
+        }));
+    }
+
+    // DELETE bridge
+    ops.push(OvsDbOperation::Delete(OvsDbDelete {
+        table: "Bridge".to_string(),
+        conditions: vec![OvsDbCondition {
+            column: "_uuid".to_string(),
+            function: "==".to_string(),
+            value: uuid_ref(&bridge_uuid),
+        }],
+    }));
+
+    // MUTATE Open_vSwitch to remove bridge
+    ops.push(OvsDbOperation::Mutate(OvsDbMutate {
+        table: GLOBAL_CONFIG_TABLE.to_string(),
+        conditions: vec![],
+        mutations: vec![OvsDbMutation {
+            column: "bridges".to_string(),
+            mutator: "delete".to_string(),
+            value: uuid_ref(&bridge_uuid),
+        }],
+    }));
+
+    cli.transact(&OvsDbMethodTransact {
+        db_name: OVS_DB_NAME.to_string(),
+        operations: ops,
+    })
+    .await?;
+    log::info!("Deleted OVS bridge {br_name} via OVSDB");
+    Ok(())
+}
+
+async fn ovsdb_update_bridge(
+    desired_br: &OvsBridgeInterface,
+    current_br: &OvsBridgeInterface,
+) -> Result<(), NmstateError> {
+    let mut cli = OvsDbConnection::new().await?;
+    let br_name = &desired_br.base.name;
+    let mut ops = Vec::new();
+
+    let name_condition = OvsDbCondition {
+        column: "name".to_string(),
+        function: "==".to_string(),
+        value: serde_json::Value::String(br_name.clone()),
+    };
+
+    let mut bridge_row_updates: HashMap<String, serde_json::Value> =
+        HashMap::new();
+
+    if let Some(ref desired_conf) = desired_br.bridge {
+        insert_bridge_options(&mut bridge_row_updates, desired_br);
+
+        // Handle port changes
+        let desired_ports = desired_conf.ports.as_deref().unwrap_or(&[]);
+        let current_ports = current_br
+            .bridge
+            .as_ref()
+            .and_then(|c| c.ports.as_deref())
+            .unwrap_or(&[]);
+
+        let desired_port_names: Vec<&str> =
+            desired_ports.iter().map(|p| p.name.as_str()).collect();
+        let current_port_names: Vec<&str> =
+            current_ports.iter().map(|p| p.name.as_str()).collect();
+
+        // Ports to add
+        let ports_to_add: Vec<_> = desired_ports
+            .iter()
+            .filter(|p| !current_port_names.contains(&p.name.as_str()))
+            .collect();
+
+        // Ports to remove
+        let ports_to_remove: Vec<_> = current_ports
+            .iter()
+            .filter(|p| !desired_port_names.contains(&p.name.as_str()))
+            .collect();
+
+        if !ports_to_remove.is_empty() {
+            let all_ports = cli.get_ovs_ports().await?;
+            for port_conf in &ports_to_remove {
+                if let Some((port_uuid, port_entry)) =
+                    all_ports.iter().find(|(_, e)| e.name == port_conf.name)
+                {
+                    // Delete interfaces of this port
+                    for iface_uuid in &port_entry.ports {
+                        ops.push(OvsDbOperation::Delete(OvsDbDelete {
+                            table: "Interface".to_string(),
+                            conditions: vec![OvsDbCondition {
+                                column: "_uuid".to_string(),
+                                function: "==".to_string(),
+                                value: uuid_ref(iface_uuid),
+                            }],
+                        }));
+                    }
+
+                    // MUTATE bridge to remove port
+                    ops.push(OvsDbOperation::Mutate(OvsDbMutate {
+                        table: "Bridge".to_string(),
+                        conditions: vec![name_condition.clone()],
+                        mutations: vec![OvsDbMutation {
+                            column: "ports".to_string(),
+                            mutator: "delete".to_string(),
+                            value: uuid_ref(port_uuid),
+                        }],
+                    }));
+
+                    // Delete port row
+                    ops.push(OvsDbOperation::Delete(OvsDbDelete {
+                        table: "Port".to_string(),
+                        conditions: vec![OvsDbCondition {
+                            column: "_uuid".to_string(),
+                            function: "==".to_string(),
+                            value: uuid_ref(port_uuid),
+                        }],
+                    }));
+                }
+            }
+        }
+
+        // Add ports
+        for port_conf in &ports_to_add {
+            let port_uuid_name =
+                format!("port_{}", port_conf.name.replace('-', "_"));
+
+            if let Some(bond_conf) = &port_conf.bond {
+                let mut iface_uuid_refs = Vec::new();
+                if let Some(bond_ports) = &bond_conf.ports {
+                    for bond_port in bond_ports {
+                        let iface_uuid_name = format!(
+                            "iface_{}",
+                            bond_port.name.replace('-', "_")
+                        );
+                        let mut iface_row = HashMap::new();
+                        iface_row.insert(
+                            "name".to_string(),
+                            serde_json::Value::String(bond_port.name.clone()),
+                        );
+                        ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                            table: "Interface".to_string(),
+                            row: iface_row,
+                            uuid_name: Some(iface_uuid_name.clone()),
+                        }));
+                        iface_uuid_refs.push(named_uuid_ref(&iface_uuid_name));
+                    }
+                }
+
+                let mut port_row = HashMap::new();
+                port_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                port_row.insert(
+                    "interfaces".to_string(),
+                    build_set_value(&iface_uuid_refs),
+                );
+                if let Some(ref mode) = bond_conf.mode {
+                    port_row.insert(
+                        "bond_mode".to_string(),
+                        serde_json::Value::String(mode.to_string()),
+                    );
+                }
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Port".to_string(),
+                    row: port_row,
+                    uuid_name: Some(port_uuid_name.clone()),
+                }));
+            } else {
+                let iface_uuid_name =
+                    format!("iface_{}", port_conf.name.replace('-', "_"));
+                let mut iface_row = HashMap::new();
+                iface_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                iface_row.insert(
+                    "type".to_string(),
+                    serde_json::Value::String("internal".to_string()),
+                );
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Interface".to_string(),
+                    row: iface_row,
+                    uuid_name: Some(iface_uuid_name.clone()),
+                }));
+
+                let mut port_row = HashMap::new();
+                port_row.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(port_conf.name.clone()),
+                );
+                port_row.insert(
+                    "interfaces".to_string(),
+                    named_uuid_ref(&iface_uuid_name),
+                );
+                ops.push(OvsDbOperation::Insert(OvsDbInsert {
+                    table: "Port".to_string(),
+                    row: port_row,
+                    uuid_name: Some(port_uuid_name.clone()),
+                }));
+            }
+
+            // MUTATE bridge to add port
+            ops.push(OvsDbOperation::Mutate(OvsDbMutate {
+                table: "Bridge".to_string(),
+                conditions: vec![name_condition.clone()],
+                mutations: vec![OvsDbMutation {
+                    column: "ports".to_string(),
+                    mutator: "insert".to_string(),
+                    value: named_uuid_ref(&port_uuid_name),
+                }],
+            }));
+        }
+    }
+
+    if !bridge_row_updates.is_empty() {
+        ops.push(OvsDbOperation::Update(OvsDbUpdate {
+            table: "Bridge".to_string(),
+            conditions: vec![name_condition],
+            row: bridge_row_updates,
+        }));
+    }
+
+    if !ops.is_empty() {
+        cli.transact(&OvsDbMethodTransact {
+            db_name: OVS_DB_NAME.to_string(),
+            operations: ops,
+        })
+        .await?;
+        log::info!("Updated OVS bridge {br_name} via OVSDB");
+    }
+    Ok(())
+}

--- a/rust/src/lib/ovsdb/db.rs
+++ b/rust/src/lib/ovsdb/db.rs
@@ -17,9 +17,9 @@ pub(crate) const DEFAULT_OVS_DB_SOCKET_PATH: &str = "/run/openvswitch/db.sock";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct OvsDbCondition {
-    column: String,
-    function: String,
-    value: Value,
+    pub(crate) column: String,
+    pub(crate) function: String,
+    pub(crate) value: Value,
 }
 
 impl OvsDbCondition {

--- a/rust/src/lib/ovsdb/mod.rs
+++ b/rust/src/lib/ovsdb/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod bridge_port;
 mod db;
 mod global_conf;
 mod json_rpc;
@@ -7,6 +8,7 @@ mod method;
 mod operation;
 mod show;
 
+pub(crate) use bridge_port::ovsdb_apply_bridges;
 pub(crate) use show::{ovsdb_is_running, ovsdb_retrieve};
 
 pub(crate) use self::{
@@ -17,6 +19,7 @@ pub(crate) use self::{
     global_conf::ovsdb_apply_global_conf,
     method::{OvsDbMethodEcho, OvsDbMethodTransact},
     operation::{
-        OvsDbMutate, OvsDbMutation, OvsDbOperation, OvsDbSelect, OvsDbUpdate,
+        OvsDbDelete, OvsDbInsert, OvsDbMutate, OvsDbMutation, OvsDbOperation,
+        OvsDbSelect, OvsDbUpdate, build_set_value, named_uuid_ref, uuid_ref,
     },
 };

--- a/rust/src/lib/ovsdb/operation.rs
+++ b/rust/src/lib/ovsdb/operation.rs
@@ -13,6 +13,8 @@ pub(crate) enum OvsDbOperation {
     Select(OvsDbSelect),
     Update(OvsDbUpdate),
     Mutate(OvsDbMutate),
+    Insert(OvsDbInsert),
+    Delete(OvsDbDelete),
 }
 
 impl OvsDbOperation {
@@ -21,6 +23,8 @@ impl OvsDbOperation {
             Self::Select(s) => s.to_value(),
             Self::Update(s) => s.to_value(),
             Self::Mutate(s) => s.to_value(),
+            Self::Insert(s) => s.to_value(),
+            Self::Delete(s) => s.to_value(),
         }
     }
 }
@@ -121,4 +125,70 @@ impl OvsDbMutate {
         ret.insert("mutations".to_string(), Value::Array(mutations));
         Value::Object(ret)
     }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct OvsDbInsert {
+    pub(crate) table: String,
+    pub(crate) row: HashMap<String, Value>,
+    pub(crate) uuid_name: Option<String>,
+}
+
+impl OvsDbInsert {
+    pub(crate) fn to_value(&self) -> Value {
+        let mut ret = Map::new();
+        ret.insert("op".to_string(), Value::String("insert".to_string()));
+        ret.insert("table".to_string(), Value::String(self.table.clone()));
+        let mut row_map = Map::new();
+        for (k, v) in self.row.iter() {
+            row_map.insert(k.to_string(), v.clone());
+        }
+        ret.insert("row".to_string(), Value::Object(row_map));
+        if let Some(ref uuid_name) = self.uuid_name {
+            ret.insert(
+                "uuid-name".to_string(),
+                Value::String(uuid_name.clone()),
+            );
+        }
+        Value::Object(ret)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct OvsDbDelete {
+    pub(crate) table: String,
+    pub(crate) conditions: Vec<OvsDbCondition>,
+}
+
+impl OvsDbDelete {
+    pub(crate) fn to_value(&self) -> Value {
+        let mut ret = Map::new();
+        ret.insert("op".to_string(), Value::String("delete".to_string()));
+        ret.insert("table".to_string(), Value::String(self.table.clone()));
+        let condition_values: Vec<Value> =
+            self.conditions.iter().map(|c| c.to_value()).collect();
+        ret.insert("where".to_string(), Value::Array(condition_values));
+        Value::Object(ret)
+    }
+}
+
+pub(crate) fn build_set_value(items: &[Value]) -> Value {
+    Value::Array(vec![
+        Value::String("set".to_string()),
+        Value::Array(items.to_vec()),
+    ])
+}
+
+pub(crate) fn named_uuid_ref(name: &str) -> Value {
+    Value::Array(vec![
+        Value::String("named-uuid".to_string()),
+        Value::String(name.to_string()),
+    ])
+}
+
+pub(crate) fn uuid_ref(uuid: &str) -> Value {
+    Value::Array(vec![
+        Value::String("uuid".to_string()),
+        Value::String(uuid.to_string()),
+    ])
 }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -14,8 +14,8 @@ use crate::{
         nm_checkpoint_rollback, nm_checkpoint_timeout_extend, nm_retrieve,
     },
     ovsdb::{
-        DEFAULT_OVS_DB_SOCKET_PATH, ovsdb_apply_global_conf, ovsdb_is_running,
-        ovsdb_retrieve,
+        DEFAULT_OVS_DB_SOCKET_PATH, ovsdb_apply_bridges,
+        ovsdb_apply_global_conf, ovsdb_is_running, ovsdb_retrieve,
     },
 };
 
@@ -384,6 +384,10 @@ impl NetworkState {
         )?;
 
         nispor_apply(&merged_state).await?;
+        if ovsdb_is_running().await {
+            ovsdb_apply_bridges(&merged_state).await?;
+            ovsdb_apply_global_conf(&merged_state).await?;
+        }
         if let Some(running_hostname) =
             self.hostname.as_ref().and_then(|c| c.running.as_ref())
         {

--- a/tests/integration/ovs_kernel_test.py
+++ b/tests/integration/ovs_kernel_test.py
@@ -1,0 +1,372 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+
+import pytest
+import yaml
+
+from .testlib import cmdlib
+
+APPLY_CMD = ["nmstatectl", "apply", "-k", "--no-verify"]
+SHOW_CMD = ["nmstatectl", "show", "-k", "--json"]
+
+BRIDGE0 = "br-test0"
+PORT0 = "ovs-port0"
+PORT1 = "ovs-port1"
+
+
+def apply_kernel(state_dict):
+    """Apply state via nmstatectl -k using a temp YAML file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as f:
+        yaml.dump(state_dict, f)
+        f.flush()
+        rc, out, err = cmdlib.exec_cmd(APPLY_CMD + [f.name])
+    assert rc == 0, f"nmstatectl apply -k failed: {err}"
+
+
+def show_kernel():
+    """Show state via nmstatectl -k --json."""
+    rc, out, err = cmdlib.exec_cmd(SHOW_CMD)
+    assert rc == 0, f"nmstatectl show -k failed: {err}"
+    return json.loads(out)
+
+
+def cleanup_bridge(br_name):
+    """Delete an OVS bridge via ovs-vsctl."""
+    cmdlib.exec_cmd(["ovs-vsctl", "--if-exists", "del-br", br_name])
+
+
+def _bridge_exists(br_name):
+    rc, _, _ = cmdlib.exec_cmd(["ovs-vsctl", "br-exists", br_name])
+    return rc == 0
+
+
+def _find_iface(state, name):
+    for iface in state.get("interfaces", []):
+        if iface["name"] == name:
+            return iface
+    return None
+
+
+@pytest.fixture
+def bridge_cleanup():
+    """Fixture that ensures cleanup of test bridge after test."""
+    yield
+    if _bridge_exists(BRIDGE0):
+        cleanup_bridge(BRIDGE0)
+
+
+class TestOvsKernelBridge:
+    """OVS bridge CRUD via kernel-only (-k) mode."""
+
+    def test_create_ovs_bridge_with_internal_port(self, bridge_cleanup):
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                        "options": {"stp": False},
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                    "ipv4": {"enabled": False},
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        # Verify with ovs-vsctl
+        assert _bridge_exists(BRIDGE0)
+
+        # Verify with nmstatectl show -k
+        current = show_kernel()
+        br_iface = _find_iface(current, BRIDGE0)
+        assert br_iface is not None
+        assert br_iface["type"] == "ovs-bridge"
+
+    def test_delete_ovs_bridge(self, bridge_cleanup):
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+        assert _bridge_exists(BRIDGE0)
+
+        cleanup_bridge(BRIDGE0)
+        assert not _bridge_exists(BRIDGE0)
+
+    def test_ovs_bridge_with_stp(self, bridge_cleanup):
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                        "options": {"stp": True, "fail-mode": "secure"},
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        assert br["bridge"]["options"]["stp"]["enabled"] is True
+        assert br["bridge"]["options"]["fail-mode"] == "secure"
+
+    def test_ovs_bridge_mcast_snooping(self, bridge_cleanup):
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                        "options": {"mcast-snooping-enable": True},
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        assert br["bridge"]["options"]["mcast-snooping-enable"] is True
+
+    def test_show_kernel_returns_ovs_topology(self, bridge_cleanup):
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [
+                            {"name": PORT0},
+                            {"name": PORT1},
+                        ],
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+                {
+                    "name": PORT1,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        port_names = [p["name"] for p in br["bridge"]["port"]]
+        assert PORT0 in port_names
+        assert PORT1 in port_names
+
+    def test_update_bridge_options(self, bridge_cleanup):
+        # Create bridge with STP disabled
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                        "options": {"stp": False},
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        # Update to enable STP
+        update_state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                        "options": {"stp": True},
+                    },
+                },
+            ]
+        }
+        apply_kernel(update_state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        assert br["bridge"]["options"]["stp"]["enabled"] is True
+
+    def test_add_port_to_existing_bridge(self, bridge_cleanup):
+        # Create bridge with one port
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [{"name": PORT0}],
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        # Add a second port
+        update_state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [
+                            {"name": PORT0},
+                            {"name": PORT1},
+                        ],
+                    },
+                },
+                {
+                    "name": PORT1,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(update_state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        port_names = [p["name"] for p in br["bridge"]["port"]]
+        assert PORT0 in port_names
+        assert PORT1 in port_names
+
+
+class TestOvsKernelBond:
+    """OVS bond via kernel-only (-k) mode."""
+
+    @pytest.fixture
+    def two_eth_ports(self):
+        """
+        Fixture that provides two ethernet port names for bonding.
+        Override in CI with actual available interfaces.
+        """
+        rc, out, _ = cmdlib.exec_cmd(["nmstatectl", "show", "-k", "--json"])
+        if rc != 0:
+            pytest.skip("nmstatectl show -k failed")
+        state = json.loads(out)
+        eth_ifaces = [
+            i["name"]
+            for i in state.get("interfaces", [])
+            if i.get("type") == "ethernet"
+            and i["name"] not in ("lo",)
+            and i.get("state") == "up"
+        ]
+        if len(eth_ifaces) < 2:
+            pytest.skip("Need at least 2 ethernet interfaces for bond test")
+        return eth_ifaces[0], eth_ifaces[1]
+
+    def test_create_ovs_bridge_with_bond(self, bridge_cleanup, two_eth_ports):
+        port0, port1 = two_eth_ports
+        state = {
+            "interfaces": [
+                {
+                    "name": BRIDGE0,
+                    "type": "ovs-bridge",
+                    "state": "up",
+                    "bridge": {
+                        "port": [
+                            {
+                                "name": "bond0",
+                                "link-aggregation": {
+                                    "mode": "balance-slb",
+                                    "port": [
+                                        {"name": port0},
+                                        {"name": port1},
+                                    ],
+                                },
+                            },
+                            {"name": PORT0},
+                        ],
+                    },
+                },
+                {
+                    "name": PORT0,
+                    "type": "ovs-interface",
+                    "state": "up",
+                },
+            ]
+        }
+        apply_kernel(state)
+
+        current = show_kernel()
+        br = _find_iface(current, BRIDGE0)
+        assert br is not None
+        bond_port = None
+        for p in br["bridge"]["port"]:
+            if p["name"] == "bond0":
+                bond_port = p
+                break
+        assert bond_port is not None
+        assert bond_port["link-aggregation"]["mode"] == "balance-slb"
+
+        # Cleanup
+        cleanup_bridge(BRIDGE0)


### PR DESCRIPTION
Add OVSDB-based OVS bridge CRUD operations for kernel-only mode, bypassing NetworkManager entirely and talking directly to OVSDB via the existing JSON-RPC client.

New OVSDB operations (operation.rs):
- OvsDbInsert, OvsDbDelete structs for RFC-7047 insert/delete ops
- Helper functions: build_set_value, named_uuid_ref, uuid_ref

OVS bridge CRUD (bridge_port.rs - new file):
- ovsdb_create_bridge: atomic INSERT with named-uuid cross-refs (Interface + Port + Bridge + MUTATE Open_vSwitch)
- ovsdb_delete_bridge: cascading DELETE of ifaces/ports/bridge
- ovsdb_update_bridge: UPDATE options, diff ports (add/remove)

Wiring (net_state.rs):
- Apply: call ovsdb_apply_bridges() + ovsdb_apply_global_conf() after nispor_apply() in apply_without_nm_backend()

Also makes OvsDbCondition fields pub(crate) for use in bridge_port.

Integration tests (ovs_kernel_test.py):
- 7 tests for bridge create/delete/update/show/STP/mcast/ports
- 1 bond test (requires 2 eth interfaces)
- All 7 bridge tests pass in container with OVS