### PR TITLE
bridge: allow extra ports in verification stage

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -710,6 +710,54 @@ impl Interface {
         }
     }
 
+    pub fn allow_extra_ports(&self) -> Option<bool> {
+        match self {
+            Self::LinuxBridge(iface) => {
+                iface.bridge.as_ref().and_then(|b| b.allow_extra_ports)
+            }
+            Self::OvsBridge(iface) => {
+                iface.bridge.as_ref().and_then(|b| b.allow_extra_ports)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn set_allow_extra_ports(&mut self, value: Option<bool>) {
+        match self {
+            Self::LinuxBridge(iface) => {
+                if let Some(b) = iface.bridge.as_mut() {
+                    b.allow_extra_ports = value;
+                }
+            }
+            Self::OvsBridge(iface) => {
+                if let Some(b) = iface.bridge.as_mut() {
+                    b.allow_extra_ports = value;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(crate) fn remove_extra_ports(&self, current: &mut Self) {
+        let (Some(des_ports), Some(cur_ports)) =
+            (self.ports(), current.ports())
+        else {
+            return;
+        };
+
+        let to_delete: Vec<String> = cur_ports
+            .iter()
+            .filter(|p| !des_ports.contains(p))
+            .map(|p| p.to_string())
+            .collect();
+        if to_delete.is_empty() {
+            return;
+        }
+        for port in to_delete {
+            current.remove_port(&port);
+        }
+    }
+
     // This function is for pre-edit clean up and check on current, `for_apply`,
     // `for_verify` states.
     //
@@ -941,6 +989,21 @@ impl MergedInterface {
         {
             verify_iface.copy_mac_from = None;
             verify_iface.mac_address = Some(mac);
+        }
+    }
+
+    pub(crate) fn process_allow_extra_bridge_ports(&mut self) {
+        let (Some(des_iface), Some(for_verify)) =
+            (self.desired.as_mut(), self.for_verify.as_mut())
+        else {
+            return;
+        };
+        if des_iface.allow_extra_ports() != Some(true) {
+            return;
+        }
+        for_verify.set_allow_extra_ports(None);
+        if let Some(cur_iface) = self.current.as_mut() {
+            des_iface.remove_extra_ports(cur_iface);
         }
     }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -903,6 +903,7 @@ impl MergedInterfaces {
     // Contains all the smart modifications, validations among interfaces
     fn process(&mut self) -> Result<(), NmstateError> {
         self.process_allow_extra_ovs_patch_ports_for_apply();
+        self.process_allow_extra_bridge_ports_for_apply();
         self.apply_copy_mac_from()?;
         self.validate_hsr_mac()?;
         self.copy_hsr_mac()?;
@@ -946,6 +947,15 @@ impl MergedInterfaces {
              interfaces in desire state to place controller before its ports"
                 .to_string(),
         ))
+    }
+
+    fn process_allow_extra_bridge_ports_for_apply(&mut self) {
+        for merged_iface in self
+            .iter_mut()
+            .filter(|mi| mi.desired.as_ref().map(|i| i.is_up()) == Some(true))
+        {
+            merged_iface.process_allow_extra_bridge_ports();
+        }
     }
 
     fn apply_copy_mac_from(&mut self) -> Result<(), NmstateError> {

--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -345,6 +345,12 @@ impl LinuxBridgeInterface {
 /// Linux bridge specific configuration.
 pub struct LinuxBridgeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Only validate for applying, when set to `true`, Ignore extra ports
+    /// attached to bridge. Default is false. This property will not be
+    /// persisted, every time you modify ports of specified bridge, you
+    /// need to explicitly define this property if not using default value.
+    pub allow_extra_ports: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Linux bridge options. When applying, existing options will merged into
     /// desired.
     pub options: Option<LinuxBridgeOptions>,

--- a/rust/src/lib/ifaces/ovs.rs
+++ b/rust/src/lib/ifaces/ovs.rs
@@ -266,6 +266,12 @@ pub struct OvsBridgeConfig {
     /// Deserialize from `allow-extra-patch-ports`.
     pub allow_extra_patch_ports: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Only validate for applying, when set to `true`, Ignore extra ports
+    /// attached to bridge. Default is false. This property will not be
+    /// persisted, every time you modify ports of specified bridge, you
+    /// need to explicitly define this property if not using default value.
+    pub allow_extra_ports: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<OvsBridgeOptions>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -196,6 +196,7 @@ impl MergedInterfaces {
         current.remove_ignored_ifaces(self.ignored_ifaces.as_slice());
         current.remove_unknown_type_port();
         merged.process_allow_extra_ovs_patch_ports_for_verify(&mut current);
+        merged.process_allow_extra_bridge_ports_for_verify(&mut current);
 
         for iface in current
             .kernel_ifaces
@@ -254,5 +255,25 @@ impl MergedInterfaces {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn process_allow_extra_bridge_ports_for_verify(
+        &mut self,
+        post_apply_current: &mut Interfaces,
+    ) {
+        for merged_iface in self.iter().filter(|merged_iface| {
+            if let Some(i) = merged_iface.desired.as_ref() {
+                i.allow_extra_ports() == Some(true) && i.is_up()
+            } else {
+                false
+            }
+        }) {
+            if let Some(des_iface) = merged_iface.desired.as_ref()
+                && let Some(cur_iface) = post_apply_current
+                    .get_iface_mut(des_iface.name(), des_iface.iface_type())
+            {
+                des_iface.remove_extra_ports(cur_iface);
+            }
+        }
     }
 }

--- a/rust/src/lib/unit_tests/bridge.rs
+++ b/rust/src/lib/unit_tests/bridge.rs
@@ -769,3 +769,146 @@ fn test_linux_bridge_is_default_pvid_changed() {
 
     assert!(!merged_iface.is_default_pvid_changed())
 }
+
+#[test]
+fn test_linux_bridge_ignore_extra_ports_for_verify() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            allow-extra-ports: true
+            port:
+            - name: eth1
+            - name: eth2
+        ",
+    )
+    .unwrap();
+    let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    merged_ifaces.verify(&cur_ifaces).unwrap();
+}
+
+#[test]
+fn test_linux_bridge_ignore_extra_ports_for_apply() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            allow-extra-ports: true
+            port:
+            - name: eth1
+            - name: eth2
+        ",
+    )
+    .unwrap();
+    let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: linux-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let for_apply_bridge = merged_ifaces
+        .get_iface("br0", InterfaceType::LinuxBridge)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+    let for_apply_eth3 = merged_ifaces
+        .get_iface("eth3", InterfaceType::Ethernet)
+        .unwrap()
+        .for_apply
+        .as_ref();
+
+    assert_eq!(for_apply_bridge.ports(), Some(vec!["eth1", "eth2"]));
+    assert_eq!(for_apply_eth3, None);
+}

--- a/rust/src/lib/unit_tests/ovs.rs
+++ b/rust/src/lib/unit_tests/ovs.rs
@@ -1022,3 +1022,146 @@ bridge:
 
     assert_eq!(bond_conf.mode, Some(OvsBridgeBondMode::BalanceSlb));
 }
+
+#[test]
+fn test_ovs_bridge_ignore_extra_ports_for_verify() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            allow-extra-ports: true
+            port:
+            - name: eth1
+            - name: eth2
+        ",
+    )
+    .unwrap();
+    let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    merged_ifaces.verify(&cur_ifaces).unwrap();
+}
+
+#[test]
+fn test_ovs_bridge_ignore_extra_ports_for_apply() {
+    let des_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            allow-extra-ports: true
+            port:
+            - name: eth1
+            - name: eth2
+        ",
+    )
+    .unwrap();
+    let pre_apply_cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+        - name: eth2
+          type: ethernet
+          state: up
+        - name: eth3
+          type: ethernet
+          state: up
+        - name: br0
+          type: ovs-bridge
+          state: up
+          bridge:
+            port:
+            - name: eth1
+            - name: eth2
+            - name: eth3
+        ",
+    )
+    .unwrap();
+    let merged_ifaces = MergedInterfaces::new(
+        des_ifaces,
+        pre_apply_cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let for_apply_bridge = merged_ifaces
+        .get_iface("br0", InterfaceType::OvsBridge)
+        .unwrap()
+        .for_apply
+        .as_ref()
+        .unwrap();
+    let for_apply_eth3 = merged_ifaces
+        .get_iface("eth3", InterfaceType::Ethernet)
+        .unwrap()
+        .for_apply
+        .as_ref();
+
+    assert_eq!(for_apply_bridge.ports(), Some(vec!["eth1", "eth2"]));
+    assert_eq!(for_apply_eth3, None);
+}

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -255,6 +255,7 @@ class Bridge:
 class LinuxBridge(Bridge):
     TYPE = "linux-bridge"
     MULTICAST_SUBTREE = "multicast"
+    ALLOW_EXTRA_PORTS = "allow-extra-ports"
 
     class Options:
         GROUP_FORWARD_MASK = "group-forward-mask"
@@ -402,6 +403,7 @@ class OVSInterface(OvsDB):
 class OVSBridge(Bridge, OvsDB):
     TYPE = "ovs-bridge"
     ALLOW_EXTRA_PATCH_PORTS = "allow-extra-patch-ports"
+    ALLOW_EXTRA_PORTS = "allow-extra-ports"
 
     class Options:
         FAIL_MODE = "fail-mode"

--- a/tests/integration/linux_bridge_test.py
+++ b/tests/integration/linux_bridge_test.py
@@ -44,6 +44,7 @@ TEST_BRIDGE0 = "linux-br0"
 TEST_TAP0 = "test-tap0"
 TEST_BOND0 = "test-bond0"
 ETH1 = "eth1"
+ETH2 = "eth2"
 # RFC 7042 reserved EUI-48 MAC range for document
 TEST_MAC_ADDRESS = "00:00:5E:00:53:01"
 VERIFY_RETRY_TMO = 5
@@ -253,6 +254,52 @@ def test_add_port_to_existing_bridge(bridge0_with_port0, port1_up):
     )
 
     assertlib.assert_state(desired_state)
+
+
+@pytest.mark.tier1
+def test_allow_extra_linux_bridge_ports(eth1_up, eth2_up):
+    bridge_state = _create_bridge_subtree_config((ETH1, ETH2))
+    with (
+        dummy_interface("dummy1"),
+        linux_bridge(TEST_BRIDGE0, bridge_state) as desired_state,
+    ):
+        desired_state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+            LinuxBridge.ALLOW_EXTRA_PORTS
+        ] = True
+        exec_cmd(
+            ("ip", "link", "set", "dummy1", "master", TEST_BRIDGE0),
+            check=True,
+        )
+        libnmstate.apply(desired_state)
+
+        dummy1_state = show_only(("dummy1",))
+        assert (
+            dummy1_state[Interface.KEY][0][Interface.CONTROLLER]
+            == TEST_BRIDGE0
+        )
+
+
+@pytest.mark.tier1
+def test_create_linux_bridge_with_allow_extra_ports(eth1_up, eth2_up):
+    bridge_state = _create_bridge_subtree_config((ETH1, ETH2))
+
+    # create the bridge with ALLOW_EXTRA_PORTS enabled
+    # which should not affect regular bridge creation
+    bridge_state[LinuxBridge.ALLOW_EXTRA_PORTS] = True
+    with (linux_bridge(TEST_BRIDGE0, bridge_state),):
+        state = show_only((TEST_BRIDGE0,))
+        assert (
+            state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+                LinuxBridge.PORT_SUBTREE
+            ][0][LinuxBridge.Port.NAME]
+            == ETH1
+        )
+        assert (
+            state[Interface.KEY][0][LinuxBridge.CONFIG_SUBTREE][
+                LinuxBridge.PORT_SUBTREE
+            ][1][LinuxBridge.Port.NAME]
+            == ETH2
+        )
 
 
 @pytest.mark.tier1

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2144,6 +2144,74 @@ def test_allow_extra_ovs_patch_ports(ovs_bridge_with_patch_ports):
 
 
 @pytest.fixture
+def ovs_bridge_with_extra_ports(eth1_up, eth2_up):
+    bridge = Bridge(BRIDGE1)
+    bridge.add_system_port(ETH1)
+    bridge.add_system_port(ETH2)
+    desired_state = bridge.state
+    desired_state[Interface.KEY].append(
+        {
+            Interface.NAME: "dummy1",
+            Interface.TYPE: InterfaceType.DUMMY,
+            Interface.STATE: InterfaceState.UP,
+        }
+    )
+    libnmstate.apply(desired_state)
+    cmdlib.exec_cmd(
+        f"ovs-vsctl --may-exist add-port {BRIDGE1} dummy1".split(),
+        check=True,
+    )
+    yield
+    cmdlib.exec_cmd(
+        f"ovs-vsctl --if-exists del-port {BRIDGE1} dummy1".split(),
+        check=True,
+    )
+    for iface in desired_state[Interface.KEY]:
+        iface[Interface.STATE] = InterfaceState.ABSENT
+    libnmstate.apply(desired_state)
+    assertlib.assert_absent(BRIDGE1)
+    assertlib.assert_absent("dummy1")
+
+
+@pytest.mark.tier1
+def test_allow_extra_ovs_bridge_ports(ovs_bridge_with_extra_ports):
+    bridge = Bridge(BRIDGE1)
+    bridge.add_system_port(ETH1)
+    bridge.add_system_port(ETH2)
+    bridge.set_allow_extra_ports(True)
+    desired_state = bridge.state
+
+    libnmstate.apply(desired_state)
+
+    br1_state = statelib.show_only((BRIDGE1,))
+    br_ports = br1_state[Interface.KEY][0][OVSBridge.CONFIG_SUBTREE][
+        OVSBridge.PORT_SUBTREE
+    ]
+    assert len(br_ports) == 3
+    assert any(port[OVSBridge.Port.NAME] == "dummy1" for port in br_ports)
+
+
+@pytest.mark.tier1
+def test_create_ovs_bridge_with_allow_extra_ports(eth1_up, eth2_up):
+    bridge = Bridge(BRIDGE1)
+    bridge.add_system_port(ETH1)
+    bridge.add_system_port(ETH2)
+
+    # create the bridge with ALLOW_EXTRA_PORTS enabled,
+    # which should not affect regular bridge creation
+    bridge.set_allow_extra_ports(True)
+
+    with bridge.create():
+        br1_state = statelib.show_only((BRIDGE1,))
+        br_ports = br1_state[Interface.KEY][0][OVSBridge.CONFIG_SUBTREE][
+            OVSBridge.PORT_SUBTREE
+        ]
+        assert len(br_ports) == 2
+        assert any(port[OVSBridge.Port.NAME] == ETH1 for port in br_ports)
+        assert any(port[OVSBridge.Port.NAME] == ETH2 for port in br_ports)
+
+
+@pytest.fixture
 def ovs_bridge_with_geneve(bridge_with_ports):
     cmdlib.exec_cmd(
         "ovs-vsctl add-port br1 gen0 -- set interface gen0 type=geneve "

--- a/tests/integration/testlib/ovslib.py
+++ b/tests/integration/testlib/ovslib.py
@@ -31,6 +31,11 @@ class Bridge:
     def set_ovs_db(self, ovs_db_config):
         self._bridge_iface[OVSBridge.OVS_DB_SUBTREE] = ovs_db_config
 
+    def set_allow_extra_ports(self, allow_extra_ports):
+        self._bridge_iface[OVSBridge.CONFIG_SUBTREE][
+            OVSBridge.ALLOW_EXTRA_PORTS
+        ] = allow_extra_ports
+
     def add_system_port(self, name):
         self._add_port(name)
 


### PR DESCRIPTION
Ignores extra ports found in current state bridge during query_apply verification stage.

This avoids failiure when third party tools configures extra ports in a bridge at the same time as when nmstate is creating it. For example, CNI in OpenStack/OCP may attach extra ports to enable communication between pods/VMs.

Resolves: https://redhat.atlassian.net/browse/RHEL-153297