### PR TITLE
test: Disable dnf-makecache.timer in container images

### DIFF
--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -41,6 +41,7 @@ RUN echo net.ipv6.conf.all.disable_ipv6=0 > \
     echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > \
     /etc/sysctl.d/01-export-kernel-cores.conf
 
-RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec
+RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec && \
+    systemctl disable dnf-makecache.timer
 
 CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.c8s-nmstate-dev
+++ b/packaging/Dockerfile.c8s-nmstate-dev
@@ -53,6 +53,7 @@ COPY network_manager_enable_trace.conf \
 COPY network_manager_keyfile.conf \
      /etc/NetworkManager/conf.d/96-keyfile.conf
 
-RUN systemctl enable dbus systemd-udevd NetworkManager ipsec openvswitch
+RUN systemctl enable dbus systemd-udevd NetworkManager ipsec openvswitch && \
+    systemctl disable dnf-makecache.timer
 
 CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.c9s-nmstate-dev
+++ b/packaging/Dockerfile.c9s-nmstate-dev
@@ -40,6 +40,7 @@ RUN echo net.ipv6.conf.all.disable_ipv6=0 > \
     echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > \
     /etc/sysctl.d/01-export-kernel-cores.conf
 
-RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec
+RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec && \
+    systemctl disable dnf-makecache.timer
 
 CMD ["/usr/sbin/init"]

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -26,7 +26,8 @@ RUN echo net.ipv6.conf.all.disable_ipv6=0 > \
     echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > \
     /etc/sysctl.d/01-export-kernel-cores.conf
 
-RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec
+RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec && \
+    systemctl disable dnf-makecache.timer
 
 # Fedora has `tsflags=nodocs` which will not install document files in a rpm,
 # this will causing rust rpm build failure.

--- a/packaging/Dockerfile.fed-nmstate-dev:rawhide
+++ b/packaging/Dockerfile.fed-nmstate-dev:rawhide
@@ -25,7 +25,8 @@ RUN echo net.ipv6.conf.all.disable_ipv6=0 > \
     echo kernel.core_pattern=/exported-artifacts/core.%h.%e.%t > \
     /etc/sysctl.d/01-export-kernel-cores.conf
 
-RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec
+RUN systemctl enable systemd-udevd NetworkManager openvswitch ipsec && \
+    systemctl disable dnf-makecache.timer
 
 RUN sed -i -e '/nodocs/d' /etc/dnf/dnf.conf
 


### PR DESCRIPTION
The dnf-makecache.timer runs automatically after systemd starts in test containers. When it races with foreground dnf operations (e.g. during NM upgrade), it causes "[Errno 2] No such file or directory: '/var/lib/dnf/rpmdb_lock.pid'" errors.

Disable the timer in all dev container images since metadata cache is built on-demand by dnf anyway.