### PR TITLE
nm: fallback to MAC-based lookup in get_prefered_saved()

### DIFF
--- a/rust/src/lib/nm/conn_matcher.rs
+++ b/rust/src/lib/nm/conn_matcher.rs
@@ -240,11 +240,7 @@ impl NmConnectionMatcher {
             }
         }
 
-        let mut nm_conns: Vec<&NmConnection> =
-            nm_conns.iter().map(|n| n.as_ref()).collect();
-        nm_conns.sort_unstable_by_key(|c| nm_conn_activation_sort_keys(c));
-
-        nm_conns.pop()
+        best_saved_conn(nm_conns)
     }
 
     /// Find the best saved NmConnection in the order of:
@@ -277,40 +273,19 @@ impl NmConnectionMatcher {
                     &nm_iface_type,
                 ),
             Some(InterfaceIdentifier::MacAddress) => {
-                if let Some(mac) = base_iface.mac_address.as_deref() {
-                    let mut nm_conns: Vec<&NmConnection> = self
-                        .saved_by_mac
-                        .get(&(mac.to_string(), nm_iface_type))
-                        .map(|nm_conns| {
-                            nm_conns.iter().map(Rc::as_ref).collect()
-                        })
-                        .unwrap_or_default();
-                    nm_conns.sort_unstable_by(|a, b| {
-                        nm_conn_activation_sort_keys(a)
-                            .cmp(&nm_conn_activation_sort_keys(b))
-                    });
-                    nm_conns.pop()
-                } else {
-                    None
-                }
+                base_iface.mac_address.as_deref().and_then(|mac| {
+                    best_saved_conn(
+                        self.saved_by_mac
+                            .get(&(mac.to_string(), nm_iface_type))?,
+                    )
+                })
             }
             Some(InterfaceIdentifier::PciAddress) => {
-                if let Some(pci) = base_iface.pci_address {
-                    let mut nm_conns: Vec<&NmConnection> = self
-                        .saved_by_pci
-                        .get(&(pci, nm_iface_type))
-                        .map(|nm_conns| {
-                            nm_conns.iter().map(Rc::as_ref).collect()
-                        })
-                        .unwrap_or_default();
-                    nm_conns.sort_unstable_by(|a, b| {
-                        nm_conn_activation_sort_keys(a)
-                            .cmp(&nm_conn_activation_sort_keys(b))
-                    });
-                    nm_conns.pop()
-                } else {
-                    None
-                }
+                base_iface.pci_address.and_then(|pci| {
+                    best_saved_conn(
+                        self.saved_by_pci.get(&(pci, nm_iface_type))?,
+                    )
+                })
             }
         }
     }
@@ -436,6 +411,17 @@ impl NmConnectionMatcher {
     ) -> Option<&NmActiveConnection> {
         self.acs_by_uuid.get(uuid).map(Rc::as_ref)
     }
+}
+
+/// Pick the best saved NmConnection from a list by activation sort keys:
+///  (connection.autoconnect-priority, connection.timestamp, connection.uuid)
+fn best_saved_conn(
+    nm_conns: &[Rc<NmConnection>],
+) -> Option<&NmConnection> {
+    let mut nm_conns: Vec<&NmConnection> =
+        nm_conns.iter().map(|n| n.as_ref()).collect();
+    nm_conns.sort_unstable_by_key(|c| nm_conn_activation_sort_keys(c));
+    nm_conns.pop()
 }
 
 const NM_IFACE_TYPES_USE_PARENT_MAC: [NmIfaceType; 3] =

--- a/rust/src/lib/nm/conn_matcher.rs
+++ b/rust/src/lib/nm/conn_matcher.rs
@@ -243,6 +243,17 @@ impl NmConnectionMatcher {
         best_saved_conn(nm_conns)
     }
 
+    fn get_prefered_saved_by_mac<'s>(
+        &'s self,
+        mac: &str,
+        nm_iface_type: &NmIfaceType,
+    ) -> Option<&'s NmConnection> {
+        best_saved_conn(
+            self.saved_by_mac
+                .get(&(mac.to_uppercase(), *nm_iface_type))?,
+        )
+    }
+
     /// Find the best saved NmConnection in the order of:
     /// * Currently activated
     /// * Biggest `connection.autoconnect-priority`
@@ -271,14 +282,21 @@ impl NmConnectionMatcher {
                 .get_prefered_saved_by_name_type(
                     base_iface.name.as_str(),
                     &nm_iface_type,
-                ),
-            Some(InterfaceIdentifier::MacAddress) => {
-                base_iface.mac_address.as_deref().and_then(|mac| {
-                    best_saved_conn(
-                        self.saved_by_mac
-                            .get(&(mac.to_string(), nm_iface_type))?,
+                )
+                .or_else(|| {
+                    // Fallback: for disconnected interfaces, the saved
+                    // connection might use MAC identifier without
+                    // connection.interface-name set. Try MAC-based lookup.
+                    self.get_prefered_saved_by_mac(
+                        base_iface.mac_address.as_deref()?,
+                        &nm_iface_type,
                     )
-                })
+                }),
+            Some(InterfaceIdentifier::MacAddress) => {
+                self.get_prefered_saved_by_mac(
+                    base_iface.mac_address.as_deref()?,
+                    &nm_iface_type,
+                )
             }
             Some(InterfaceIdentifier::PciAddress) => {
                 base_iface.pci_address.and_then(|pci| {
@@ -418,10 +436,10 @@ impl NmConnectionMatcher {
 fn best_saved_conn(
     nm_conns: &[Rc<NmConnection>],
 ) -> Option<&NmConnection> {
-    let mut nm_conns: Vec<&NmConnection> =
-        nm_conns.iter().map(|n| n.as_ref()).collect();
-    nm_conns.sort_unstable_by_key(|c| nm_conn_activation_sort_keys(c));
-    nm_conns.pop()
+    nm_conns
+        .iter()
+        .map(Rc::as_ref)
+        .max_by_key(|c| nm_conn_activation_sort_keys(c))
 }
 
 const NM_IFACE_TYPES_USE_PARENT_MAC: [NmIfaceType; 3] =


### PR DESCRIPTION
## Summary
- When querying a disconnected interface with a MAC-identifier connection (no `connection.interface-name` set), `get_prefered_saved()` fails to find the saved connection because only name+type lookup is used.
- Added MAC-based fallback in the `identifier = None/Name` branch: when name+type search returns `None` and the interface has a MAC address, try the `saved_by_mac` index.
- Fixes `test_description_on_down_interface_ref_by_mac` which applies `state: down` with `identifier: mac-address` and then queries the disconnected device.

## Race condition analysis

The failure is intermittent — a race condition between nmstate's query and NM's internal state transitions.

### Flow during `apply(state: down, identifier: mac-address)`:
1. nmstate creates/updates an NM connection profile with `802-3-ethernet.mac-address` set but **no** `connection.interface-name`
2. nmstate tells NM to deactivate the interface
3. `apply()` returns

### Flow during the subsequent `show()` (query):
1. Nispor gathers kernel interface state (eth1 is always there, even when DOWN, with its MAC)
2. `nm_retrieve()` queries NM for connections, active connections, and devices
3. `NmConnectionMatcher` is created — connections get indexed:
   - `add_nm_saved_conn()` calls `get_nm_connection_iface_name()`
   - No `connection.interface-name` is set, so it tries to resolve the MAC — searches `merged_ifaces` for an interface with that MAC
   - This should always succeed (eth1 is in the kernel), but NM can be in a transitional state
4. For each NM device, `get_prefered_saved()` is called to find the matching saved connection

### Where the race happens:
The race is between steps 2 and 3 — NM can be in a transitional state where:
- **Test passes (without fix):** The active connection still exists (NM hasn't finished deactivating) — UUID-based lookup from active connection succeeds
- **Test fails (without fix):** The active connection is already gone, AND MAC resolution during indexing failed (NM returned the connection before it finished processing the device state) — name+type lookup fails — connection not found

### Why MAC fallback is the right fix:
- The `saved_by_mac` index is populated independently of MAC-to-name resolution during `add_nm_saved_conn()` and always works
- The fallback adds zero performance overhead in the normal case (only triggers when name+type lookup returns None)
- Alternative approaches (retry loops, waiting for NM to settle) would add latency to every `nmstatectl show` call even when no race occurs

## Test plan
- [x] `test_description_on_down_interface_ref_by_mac` passes with this fix (verified on CentOS Stream 9 with NM 1.54.3 and RHEL 10.2 with NM 1.57.3)

Fix: https://redhat.atlassian.net/browse/RHEL-157317