### PR TITLE
automation: add --nmstate-copr and --nmstate-rpm-dir to run-tests-in-nmci.sh

### DIFF
--- a/automation/run-tests-in-nmci.sh
+++ b/automation/run-tests-in-nmci.sh
@@ -5,7 +5,7 @@ PROJECT_DIR="$(dirname $EXEC_DIR)"
 TEST_CMD="${EXEC_DIR}/run-tests.sh"
 
 options=$(getopt --options "" \
-    --long "copr:,rpm-dir:,help,debug-shell,el8,el9,el10,fed,rawhide" \
+    --long "copr:,rpm-dir:,compiled-rpms-dir:,nmstate-copr:,help,debug-shell,el8,el9,el10,fed,rawhide" \
     -- "${@}")
 eval set -- "$options"
 while true; do
@@ -30,14 +30,23 @@ while true; do
         ;;
     --rpm-dir)
         shift
-        NM_RPM_DIR="$1"
+        COMPILED_RPMS_DIR="$1"
+        ;;
+    --compiled-rpms-dir)
+        shift
+        COMPILED_RPMS_DIR="$1"
+        ;;
+    --nmstate-copr)
+        shift
+        NMSTATE_COPR="$1"
         ;;
     --debug-shell)
         debug_exit_shell="1"
         ;;
     --help)
         set +x
-        echo -n "$0 [--copr=...] [--rpm-dir=...] [--debug-shell] "
+        echo -n "$0 [--copr=...] [--compiled-rpms-dir=...] [--nmstate-copr=...] "
+        echo -n "[--debug-shell] "
         echo -n "[--el8] [--el9] [--el10] [--fed] [--rawhide]"
         echo
         exit
@@ -50,33 +59,43 @@ while true; do
     shift
 done
 
-echo $NM_COPR
-echo $NM_RPM_DIR
+echo "NM_COPR: ${NM_COPR:-}"
+echo "NMSTATE_COPR: ${NMSTATE_COPR:-}"
+echo "COMPILED_RPMS_DIR: ${COMPILED_RPMS_DIR:-}"
 
-ARGS="--test-type integ_tier1 --nolog"
+ARGS=("--test-type" "integ_tier1" "--nolog")
 if [[ -v NM_COPR ]];then
-    ARGS="$ARGS --copr $NM_COPR"
+    ARGS+=("--copr" "$NM_COPR")
 fi
 
-if [[ -v NM_RPM_DIR ]];then
-    ARGS="$ARGS --nm-rpm-dir $NM_RPM_DIR"
+if [[ -v COMPILED_RPMS_DIR ]];then
+    ARGS+=("--compiled-rpms-dir" "$COMPILED_RPMS_DIR")
+fi
+
+if [[ -v NMSTATE_COPR ]];then
+    ARGS+=("--use-installed-nmstate")
+    COPR_CMD="dnf5 install --assumeyes 'dnf5-command(copr)' 2>/dev/null"
+    COPR_CMD+=" || dnf install --assumeyes 'dnf-command(copr)' &&"
+    COPR_CMD+=" dnf copr enable --assumeyes \"$NMSTATE_COPR\""
+    COPR_CMD+=" && dnf install --assumeyes nmstate"
+    ARGS+=("--customize" "$COPR_CMD")
 fi
 
 if [[ -v debug_exit_shell ]];then
-    ARGS="$ARGS --debug-shell"
+    ARGS+=("--debug-shell")
 fi
 
 if [[ -v use_el8 ]];then
-    ARGS="$ARGS --el8"
+    ARGS+=("--el8")
 elif [[ -v use_el10 ]];then
-    ARGS="$ARGS --el10"
+    ARGS+=("--el10")
 elif [[ -v use_fed ]];then
-    ARGS="$ARGS --fed"
+    ARGS+=("--fed")
 elif [[ -v use_rawhide ]];then
-    ARGS="$ARGS --rawhide"
+    ARGS+=("--rawhide")
 else
-    ARGS="$ARGS --el9"
+    ARGS+=("--el9")
 fi
 
 cd $PROJECT_DIR
-env CONTAINER_CMD="podman" CI="true" $TEST_CMD $ARGS
+env CONTAINER_CMD="podman" CI="true" "$TEST_CMD" "${ARGS[@]}"


### PR DESCRIPTION
## Summary

Add options to `run-tests-in-nmci.sh` to install nmstate from a Copr repository or a local RPM directory instead of building from source.

- `--nmstate-copr <owner/project>` — enables the Copr repo in the container and installs nmstate from it, skipping the source build via `--use-installed-nmstate`
- `--nmstate-rpm-dir <path>` — passes through to `--compiled-rpms-dir` in `run-tests.sh` to install pre-built nmstate RPMs

This is useful for CI systems (like NMCI) that want to test a specific nmstate build without the overhead of compiling from source.

## Example usage

```bash
# Test with nmstate from nmstate-git copr
./automation/run-tests-in-nmci.sh --el10 --nmstate-copr nmstate/nmstate-git

# Test with pre-built nmstate RPMs
./automation/run-tests-in-nmci.sh --el10 --nmstate-rpm-dir /path/to/rpms/
```