### PR TITLE
policy: support array property capture

### DIFF
--- a/examples/policy/bridge-on-alt-name/current.yml
+++ b/examples/policy/bridge-on-alt-name/current.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    mac-address: ff:ff:ff:ff:ff:ff
+    alt-names:
+      - name: primary
+    ipv4:
+      address:
+        - ip: 192.0.2.10
+          prefix-length: 24
+      dhcp: false
+      enabled: true

--- a/examples/policy/bridge-on-alt-name/expected.yml
+++ b/examples/policy/bridge-on-alt-name/expected.yml
@@ -1,0 +1,15 @@
+---
+interfaces:
+  - name: br1
+    type: linux-bridge
+    state: up
+    mac-address: ff:ff:ff:ff:ff:ff
+    ipv4:
+      address:
+        - ip: 192.0.2.10
+          prefix-length: 24
+      dhcp: false
+      enabled: true
+    bridge:
+      port:
+        - name: eth0

--- a/examples/policy/bridge-on-alt-name/policy.yml
+++ b/examples/policy/bridge-on-alt-name/policy.yml
@@ -1,0 +1,13 @@
+---
+capture:
+  base-iface: interfaces.alt-names.name == "primary"
+desiredState:
+  interfaces:
+    - name: br1
+      type: linux-bridge
+      state: up
+      mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
+      ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
+      bridge:
+        port:
+          - name: "{{ capture.base-iface.interfaces.0.name }}"

--- a/rust/src/lib/policy/json.rs
+++ b/rust/src/lib/policy/json.rs
@@ -54,6 +54,14 @@ pub(crate) fn get_value_from_json(
                         line,
                         pos + prop_path[0].to_string().chars().count(),
                     )
+                } else if let Some(items) = v.as_array() {
+                    get_value_from_array(
+                        &prop_path[1..],
+                        items,
+                        line,
+                        // Advance past prop_path[0] + the "." separator.
+                        pos + prop_path[0].chars().count() + 1,
+                    )
                 } else {
                     Err(NmstateError::new_policy_error(
                         format!(
@@ -115,7 +123,7 @@ where
                 Ok(v) => v,
                 Err(_) => continue,
             };
-        if value_to_string(&cur_value).as_str() == value {
+        if is_value_match(&cur_value, value) {
             ret.push(item.clone());
         }
     }
@@ -168,6 +176,31 @@ fn get_leaf_array_value(
             line,
             pos,
         ))
+    }
+}
+
+fn get_value_from_array(
+    prop_path: &[String],
+    items: &[serde_json::Value],
+    line: &str,
+    pos: usize,
+) -> Result<serde_json::Value, NmstateError> {
+    Ok(serde_json::Value::Array(
+        items
+            .iter()
+            .filter_map(|element| element.as_object())
+            .filter_map(|obj| {
+                get_value_from_json(prop_path, obj, line, pos).ok()
+            })
+            .collect(),
+    ))
+}
+
+fn is_value_match(cur_value: &serde_json::Value, target: &str) -> bool {
+    if let Some(items) = cur_value.as_array() {
+        items.iter().any(|element| is_value_match(element, target))
+    } else {
+        value_to_string(cur_value).as_str() == target
     }
 }
 

--- a/rust/src/lib/unit_tests/policy/capture.rs
+++ b/rust/src/lib/unit_tests/policy/capture.rs
@@ -262,3 +262,29 @@ fn test_policy_capture_route_rule() {
     assert_eq!(rules[0].ip_from, Some("2001:db8:b::/64".to_string()));
     assert_eq!(rules[0].table_id, Some(500));
 }
+
+#[test]
+fn test_policy_capture_by_alt_name() {
+    let cmd = NetworkCaptureCommand::parse(
+        r#"interfaces.alt-names.name == "primary""#,
+    )
+    .unwrap();
+
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth0
+            type: ethernet
+            state: up
+            alt-names:
+              - name: port1
+              - name: primary
+        ",
+    )
+    .unwrap();
+
+    let state = cmd.execute(&current, &HashMap::new()).unwrap();
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].name(), "eth0");
+}

--- a/rust/src/lib/unit_tests/policy/error.rs
+++ b/rust/src/lib/unit_tests/policy/error.rs
@@ -493,3 +493,19 @@ interfaces:
         assert_eq!(e.position(), "{{ i".len() - 1)
     }
 }
+
+#[test]
+fn test_policy_capture_by_alt_name_not_found() {
+    let cmd = NetworkCaptureCommand::parse(
+        r#"interfaces.alt-names.name == "nonexistent""#,
+    )
+    .unwrap();
+    let current: NetworkState = NetworkState::new();
+    let result = cmd.execute(&current, &HashMap::new());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert_eq!(e.kind(), ErrorKind::PolicyError);
+        assert_eq!(e.line(), "interfaces.alt-names.name == \"nonexistent\"");
+        assert!(e.to_string().contains("alt-names.name=nonexistent"));
+    }
+}

--- a/rust/src/lib/unit_tests/policy/net_policy.rs
+++ b/rust/src/lib/unit_tests/policy/net_policy.rs
@@ -290,3 +290,43 @@ fn test_policy_no_capture() {
     .unwrap();
     assert_eq!(state, expected_state);
 }
+
+#[test]
+fn test_policy_bridge_on_alt_name_capture() {
+    let mut policy: NetworkPolicy = serde_yaml::from_str(
+        r#"
+capture:
+  base-iface: interfaces.alt-names.name == "primary"
+desiredState:
+  interfaces:
+  - name: br1
+    type: linux-bridge
+    state: up
+    bridge:
+        port:
+        - name: "{{ capture.base-iface.interfaces.0.name }}"
+        "#,
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth0
+            type: ethernet
+            state: up
+            alt-names:
+              - name: port1
+              - name: primary
+        ",
+    )
+    .unwrap();
+
+    policy.current = Some(current);
+
+    let state = NetworkState::try_from(policy).unwrap();
+
+    let ifaces = state.interfaces.to_vec();
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].name(), "br1");
+    assert_eq!(ifaces[0].ports(), Some(vec!["eth0"]));
+}


### PR DESCRIPTION
Extend the policy capture JSON matching to handle matching against any element in an array.

For example, this allows capturing interfaces by alt-name:
```
---
capture:
  base-iface: interfaces.alt-names.name == "primary"
desiredState:
  interfaces:
    - name: br1
      type: linux-bridge
      state: up
      mac-address: "{{ capture.base-iface.interfaces.0.mac-address }}"
      ipv4: "{{ capture.base-iface.interfaces.0.ipv4 }}"
      bridge:
        port:
          - name: "{{ capture.base-iface.interfaces.0.name }}"
```

Unit tests and example included.

Resolves: https://redhat.atlassian.net/browse/RHEL-145076