### PR TITLE
tests: remove unnecessary eth1_up fixture from mac identifier test

### DIFF
--- a/tests/integration/mac_identifer_test.py
+++ b/tests/integration/mac_identifer_test.py
@@ -578,7 +578,7 @@ def test_macsec_parent_ref_by_mac(eth1_up, clean_up):
 
 # https://issues.redhat.com/browse/RHEL-86240
 @pytest.mark.tier1
-def test_description_on_down_interface_ref_by_mac(eth1_up):
+def test_description_on_down_interface_ref_by_mac(test_env_setup):
     port1_mac = get_mac_address("eth1")
 
     state = load_yaml(


### PR DESCRIPTION
The `eth1_up` fixture creates a name-based `eth1` connection that competes with the test's MAC-based `port1` connection during verify, causing ~30% failure rate in CI.

The test only needs the kernel interface for its MAC address, not an NM-managed connection.

See analysis: https://github.com/nmstate/nmstate/pull/3111#issuecomment-4236905670