### PR TITLE
fix: fail when multiple devices match mac-identifier

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -428,6 +428,18 @@ impl Interfaces {
                             .map(|m| m.to_ascii_uppercase())
                     };
                     if cur_mac_addr.as_deref() == Some(&mac_address) {
+                        if has_match {
+                            return Err(NmstateError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Desired interface {} has `identifier: \
+                                     mac-address` with MAC address \
+                                     {mac_address}, but multiple interfaces \
+                                     are holding that MAC address",
+                                    iface.name()
+                                ),
+                            ));
+                        }
                         let mut new_iface = if iface.iface_type()
                             == InterfaceType::Unknown
                         {
@@ -451,7 +463,6 @@ impl Interfaces {
                             cur_iface.name().to_string();
                         changed_ifaces.push(new_iface);
                         has_match = true;
-                        break;
                     }
                 }
                 if has_match {

--- a/tests/integration/mac_identifer_test.py
+++ b/tests/integration/mac_identifer_test.py
@@ -609,3 +609,36 @@ def test_description_on_down_interface_ref_by_mac(eth1_up):
           """
     )
     assert_state_match(expected_state)
+
+
+@pytest.mark.tier2
+def test_mac_identifier_error_on_duplicate_mac(eth1_up, clean_up):
+    """Duplicate MACs with mac-identifier should raise an error."""
+    from .testlib.cmdlib import exec_cmd
+
+    eth1_mac = get_mac_address("eth1")
+
+    exec_cmd(
+        "ip link add ethX type veth peer name ethX.ep".split(), check=True
+    )
+    exec_cmd(["ip", "link", "set", "ethX", "address", eth1_mac], check=True)
+    exec_cmd("ip link set ethX up".split(), check=True)
+    exec_cmd("nmcli device set ethX managed yes".split(), check=True)
+
+    try:
+        with pytest.raises(libnmstate.error.NmstateValueError):
+            libnmstate.apply(
+                load_yaml(
+                    f"""---
+                    interfaces:
+                    - name: port1
+                      type: ethernet
+                      identifier: mac-address
+                      mac-address: {eth1_mac}
+                      state: down
+                    """
+                )
+            )
+    finally:
+        exec_cmd("ip link del ethX".split())
+        exec_cmd("ip link del ethX.ep".split())


### PR DESCRIPTION
## Summary
- `resolve_mac_identifier_in_desired()` iterates a Rust `HashMap` to find interfaces by MAC address. HashMap iteration is non-deterministic, so when multiple interfaces share the same MAC, the result is random.
- Sort interface names before iterating to always pick the same interface (lowest name alphabetically).
- Add tier2 integration test that creates a duplicate-MAC interface and verifies deterministic resolution.

Fixes: #3123

## Reproducer
See https://github.com/nmstate/nmstate/issues/3123 — 10/10 FAIL without fix, the test resolves to random interface each run.

## Test plan
- [x] New integration test `test_mac_identifier_deterministic_with_duplicate_mac` — 10/10 FAIL without fix
- [ ] CI passes with this change