### PR TITLE
cli: add `enable_time` in nmstatectl edit

### DIFF
--- a/rust/src/cli/apply.rs
+++ b/rust/src/cli/apply.rs
@@ -160,6 +160,7 @@ pub(crate) fn state_edit(
     desire_state.set_memory_only(matches.is_present("MEMORY_ONLY"));
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
+        .enable_time()
         .build()
         .map_err(|e| {
             CliError::from(format!("tokio::runtime::Builder failed with {e}"))

--- a/rust/src/cli/persist_nic.rs
+++ b/rust/src/cli/persist_nic.rs
@@ -148,7 +148,7 @@ fn run_persist_immediately(
             .base_iface()
             .driver
             .as_deref()
-            .and_then(|d| if d.is_empty() { None } else { Some(d) });
+            .filter(|&d| !d.is_empty());
         log::info!(
             "Will persist the interface {iface_name} driver {} with MAC {mac}",
             driver.unwrap_or("unknown")

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -1013,10 +1013,9 @@ impl MergedInterface {
         let desired_iface = self.desired.as_ref()?;
 
         if desired_iface.is_absent() {
-            if let Some(ports) = self.current.as_ref().and_then(|c| c.ports()) {
+            {
+                let ports = self.current.as_ref().and_then(|c| c.ports())?;
                 return Some((Vec::new(), ports));
-            } else {
-                return None;
             }
         }
 
@@ -1026,7 +1025,8 @@ impl MergedInterface {
                 // If current interface is in ignore state, even user did not
                 // defining ports in desire, we should preserving existing port
                 // lists
-                if let Some(cur_iface) = self.current.as_ref() {
+                {
+                    let cur_iface = self.current.as_ref()?;
                     if cur_iface.is_ignore() {
                         cur_iface.ports().map(|ports| {
                             HashSet::<&str>::from_iter(ports.iter().cloned())
@@ -1034,8 +1034,6 @@ impl MergedInterface {
                     } else {
                         return None;
                     }
-                } else {
-                    return None;
                 }
             }
         };


### PR DESCRIPTION
Tokio runtime builder in nmstatectl edit command is missing `.enable_time()`, which causes tokio thread to panic when sleep is called in verification error retry logic.

Fixes #3117