### PR TITLE
iface: support matching against alt-name in copy-mac-from

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -970,8 +970,22 @@ impl MergedInterfaces {
             if let Some(src_iface_name) =
                 &merged_iface.merged.base_iface().copy_mac_from
             {
-                if let Some(src_iface) =
-                    self.kernel_ifaces.get(src_iface_name).map(|i| &i.merged)
+                let kernel_names = self.iface_name_search.get(src_iface_name);
+                if kernel_names.len() > 1 {
+                    let e = NmstateError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "copy-mac-from {src_iface_name} of iface \
+                             {iface_name} matches multiple interfaces"
+                        ),
+                    );
+                    log::error!("{e}");
+                    return Err(e);
+                }
+                if let Some(src_iface) = kernel_names
+                    .first()
+                    .and_then(|n| self.kernel_ifaces.get(*n))
+                    .map(|i| &i.merged)
                 {
                     if !is_opt_str_empty(
                         &src_iface.base_iface().permanent_mac_address,

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -434,6 +434,21 @@ class TestAltNames:
             [],
         )
 
+    # https://redhat.atlassian.net/browse/RHEL-145074
+    @pytest.mark.tier1
+    def test_copy_mac_from_alt_name(self, eth1_with_alt_names):
+        eth1_state = show_only(("eth1",))[Interface.KEY][0]
+        eth1_mac = eth1_state[Interface.MAC]
+
+        with linux_bridge(
+            TEST_BRIDGE_NIC,
+            {},
+            ports=[TEST_ALT_NAMES[0]],
+            extra_iface_state={Interface.COPY_MAC_FROM: TEST_ALT_NAMES[0]},
+        ):
+            br_state = show_only((TEST_BRIDGE_NIC,))[Interface.KEY][0]
+            assert br_state[Interface.MAC] == eth1_mac
+
     # https://issues.redhat.com/browse/NMT-2202
     @pytest.mark.tier1
     def test_policy_capture_by_alt_name(self, eth1_with_alt_names):


### PR DESCRIPTION
Resolve the copy-mac-from interface reference through iface_name_search which already maps alt-names and profile names to kernel names.

Integration test included.

Resolves: https://redhat.atlassian.net/browse/RHEL-145074