### PR TITLE
alt-name: use OriginalName match rule for non-ethernet interfaces

### DIFF
--- a/rust/src/lib/nispor/alt_name.rs
+++ b/rust/src/lib/nispor/alt_name.rs
@@ -282,7 +282,11 @@ async fn save_systemd_network_link_file(
     }
     let iface_name = des_base_iface.name.as_str();
 
-    let match_rules = match des_base_iface.identifier.as_ref() {
+    let identifier = &des_base_iface
+        .identifier
+        .or_else(|| cur_base_iface.and_then(|i| i.identifier));
+
+    let match_rules = match identifier {
         Some(InterfaceIdentifier::MacAddress) => {
             let mut match_rules = if let Some(mac) =
                 des_base_iface.permanent_mac_address.as_ref()

--- a/rust/src/lib/nispor/alt_name.rs
+++ b/rust/src/lib/nispor/alt_name.rs
@@ -217,6 +217,10 @@ fn gen_systemd_network_link_match_rules(
     des_iface: &BaseInterface,
     cur_iface: Option<&BaseInterface>,
 ) -> String {
+    if des_iface.iface_type != InterfaceType::Ethernet {
+        return format!("OriginalName={}", des_iface.name);
+    }
+
     if let Some(cur_iface) = cur_iface {
         match (
             cur_iface.permanent_mac_address.as_ref(),
@@ -244,21 +248,16 @@ fn gen_systemd_network_link_match_rules(
             }
         }
     } else {
-        // User is creating software interface or gen_conf mode
-        if des_iface.iface_type == InterfaceType::Ethernet {
-            match (des_iface.mac_address.as_ref(), des_iface.driver.as_ref()) {
-                (Some(mac), Some(driver)) => {
-                    format!("MACAddress={mac}\nDriver={driver}")
-                }
-                (Some(mac), None) => {
-                    format!("MACAddress={mac}")
-                }
-                (None, _) => {
-                    format!("OriginalName={}", des_iface.name)
-                }
+        match (des_iface.mac_address.as_ref(), des_iface.driver.as_ref()) {
+            (Some(mac), Some(driver)) => {
+                format!("MACAddress={mac}\nDriver={driver}")
             }
-        } else {
-            format!("OriginalName={}", des_iface.name)
+            (Some(mac), None) => {
+                format!("MACAddress={mac}")
+            }
+            (None, _) => {
+                format!("OriginalName={}", des_iface.name)
+            }
         }
     }
 }

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -434,6 +434,71 @@ class TestAltNames:
             [],
         )
 
+    # https://redhat.atlassian.net/browse/RHEL-167955
+    @pytest.mark.tier1
+    def test_vlan_alt_name_uses_original_name_on_reapply(self, eth1_up):
+        link_file = "/etc/systemd/network/98-nmstate-{}.link".format(
+            TEST_VLAN_NIC
+        )
+        vlan_with_alt_name = load_yaml(
+            """---
+            interfaces:
+            - name: {}
+              type: vlan
+              state: up
+              vlan:
+                base-iface: eth1
+                id: 101
+              alt-names:
+              - name: my-vlan
+            """.format(
+                TEST_VLAN_NIC
+            )
+        )
+        try:
+            libnmstate.apply(vlan_with_alt_name)
+            with open(link_file) as f:
+                content = f.read()
+            assert "OriginalName={}".format(TEST_VLAN_NIC) in content
+            assert "MACAddress" not in content
+
+            libnmstate.apply(vlan_with_alt_name)
+            with open(link_file) as f:
+                content = f.read()
+            assert "OriginalName={}".format(TEST_VLAN_NIC) in content
+            assert "MACAddress" not in content
+        finally:
+            libnmstate.apply(
+                load_yaml(
+                    """---
+                    interfaces:
+                    - name: {}
+                      type: vlan
+                      state: up
+                      vlan:
+                        base-iface: eth1
+                        id: 101
+                      alt-names:
+                      - name: my-vlan
+                        state: absent
+                    """.format(
+                        TEST_VLAN_NIC
+                    )
+                )
+            )
+            libnmstate.apply(
+                load_yaml(
+                    """---
+                    interfaces:
+                    - name: {}
+                      type: vlan
+                      state: absent
+                    """.format(
+                        TEST_VLAN_NIC
+                    )
+                )
+            )
+
     # https://issues.redhat.com/browse/NMT-2202
     @pytest.mark.tier1
     def test_policy_capture_by_alt_name(self, eth1_with_alt_names):


### PR DESCRIPTION
When a non-ethernet interface with alt-names already exists in the kernel at apply time, the .link file [Match] section was generated using MACAddress instead of OriginalName. This happened because the interface type check was only applied when current state was absent (first apply), but not when current state was present.

For a VLAN on top of a bond, the MAC is inherited from the bond's active port and can change on failover. Using MACAddress for the match rule is both unreliable and can match the wrong interface since the bond and all its VLANs share the same MAC.

Hoist the non-ethernet type check to the top of
gen_systemd_network_link_match_rules() so that OriginalName is always used for non-ethernet interfaces (as implied by the original comment) regardless of whether current state exists.

Resolves: https://redhat.atlassian.net/browse/RHEL-167955

Assisted-by: Claude Opus 4.6