### PR TITLE
ethtool: alias tso and tcp-segmentation-offload to tx-tcp-segmentation

### DIFF
--- a/rust/src/lib/ifaces/ethtool.rs
+++ b/rust/src/lib/ifaces/ethtool.rs
@@ -12,10 +12,13 @@ use serde::{
 
 use crate::MergedInterface;
 
-const ETHTOOL_FEATURE_CLI_ALIAS: [(&str, &str); 17] = [
+// The pub(crate) is only for unit tests (see unit_tests/ethtool.rs).
+pub(crate) const ETHTOOL_FEATURE_CLI_ALIAS: [(&str, &str); 19] = [
     ("rx", "rx-checksum"),
     ("rx-checksumming", "rx-checksum"),
     ("ufo", "tx-udp-fragmentation"),
+    ("tso", "tx-tcp-segmentation"),
+    ("tcp-segmentation-offload", "tx-tcp-segmentation"),
     ("gso", "tx-generic-segmentation"),
     ("generic-segmentation-offload", "tx-generic-segmentation"),
     ("gro", "rx-gro"),

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -27,6 +27,9 @@ mod ovs;
 mod sriov;
 mod vlan;
 
+#[cfg(test)]
+// The pub(crate) re-export is only for unit tests (see unit_tests/ethtool.rs).
+pub(crate) use self::ethtool::ETHTOOL_FEATURE_CLI_ALIAS;
 pub use base::*;
 pub use bond::{
     BondAdSelect, BondAllPortsActive, BondArpAllTargets, BondArpValidate,

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{EthernetInterface, EthtoolFeatureConfig, EthtoolFecConfig};
+use crate::ifaces::ETHTOOL_FEATURE_CLI_ALIAS;
+use crate::{
+    EthernetInterface, EthtoolConfig, EthtoolFeatureConfig, EthtoolFecConfig,
+};
 
 #[test]
 fn test_ethtool_stringlized_attributes() {
@@ -112,6 +115,23 @@ ethtool:
     assert_eq!(ring.rx_mini_max, Some(205));
     assert_eq!(ring.tx, Some(206));
     assert_eq!(ring.tx_max, Some(207));
+}
+
+#[test]
+fn test_ethtool_apply_feature_alias_normalizes_all_cli_aliases() {
+    for (alias, name) in ETHTOOL_FEATURE_CLI_ALIAS {
+        let mut ec: EthtoolConfig = serde_yaml::from_str(&format!(
+            r"---
+            feature:
+              {alias}: false",
+        ))
+        .unwrap();
+
+        ec.apply_feature_alias();
+        let f = ec.feature.as_ref().unwrap();
+        assert_eq!(f.get(name), Some(&false), "alias {alias} -> {name}");
+        assert_eq!(f.get(alias), None, "alias {alias}");
+    }
 }
 
 #[test]

--- a/tests/integration/ethtool_test.py
+++ b/tests/integration/ethtool_test.py
@@ -121,6 +121,65 @@ def test_ethtool_feature_using_ethtool_cli_alias_rx_checksumming(eth1_up):
     assertlib.assert_state_match({Interface.KEY: [desire_iface_state]})
 
 
+def veth_support_tso():
+    """True if eth1 reports tx-tcp-segmentation in nmstate ethtool query."""
+    try:
+        ifaces = show_only(["eth1"]).get(Interface.KEY) or []
+        if not ifaces:
+            return False
+        features = (
+            ifaces[0]
+            .get(Ethtool.CONFIG_SUBTREE, {})
+            .get(Ethtool.Feature.CONFIG_SUBTREE, {})
+        )
+    except (IndexError, KeyError, TypeError):
+        return False
+    return "tx-tcp-segmentation" in features
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason=("CI does not have ethtool kernel option enabled"),
+)
+@pytest.mark.parametrize(
+    "feature_key",
+    ("tso", "tcp-segmentation-offload", "tx-tcp-segmentation"),
+)
+def test_ethtool_tx_tcp_segmentation_aliases_on_eth1(eth1_up, feature_key):
+    """
+    Apply TSO on eth1 (session veth) using CLI-style aliases and the kernel
+    name, then assert against canonical 'tx-tcp-segmentation' in show/verify.
+    """
+    # Use pytest.skip here, not @pytest.mark.skipif(...):
+    # skipif is evaluated at collection time, before fixtures like
+    # eth1_up create or bring up eth1, so show_only(["eth1"])
+    # would run too early and skip wrongly or
+    # flap depending on session/fixture order.
+    if not veth_support_tso():
+        pytest.skip(
+            "eth1 does not list tx-tcp-segmentation in"
+            " changeable ethtool features"
+        )
+
+    for enabled in (True, False):
+        apply_state = {
+            Interface.NAME: "eth1",
+            Ethtool.CONFIG_SUBTREE: {
+                Ethtool.Feature.CONFIG_SUBTREE: {feature_key: enabled}
+            },
+        }
+        libnmstate.apply({Interface.KEY: [apply_state]})
+        expect_match = {
+            Interface.NAME: "eth1",
+            Ethtool.CONFIG_SUBTREE: {
+                Ethtool.Feature.CONFIG_SUBTREE: {
+                    "tx-tcp-segmentation": enabled
+                }
+            },
+        }
+        assertlib.assert_state_match({Interface.KEY: [expect_match]})
+
+
 def test_ethtool_invalid_feature(eth1_up):
     desire_iface_state = {
         Interface.NAME: "eth1",


### PR DESCRIPTION
YAML using `tso` or the ethtool -k name `tcp-segmentation-offload` now normalizes to the kernel feature name used in query and verify, matching `gro`/`gso` behavior and avoiding false verification failures.