### PR TITLE
test: regenerate eth1-3 in every test that needs them

### DIFF
--- a/tests/integration/bond_test.py
+++ b/tests/integration/bond_test.py
@@ -815,7 +815,7 @@ def test_create_bond_with_both_miimon_and_arp_internal():
 
 
 @pytest.mark.tier1
-def test_change_2_port_bond_mode_from_1_to_5():
+def test_change_2_port_bond_mode_from_1_to_5(eth1_up, eth2_up):
     with bond_interface(
         name=BOND99,
         port=[ETH1, ETH2],
@@ -841,12 +841,6 @@ def test_set_miimon_100_on_existing_bond(bond99_with_2_port):
     assertlib.assert_state_match(state)
 
 
-@pytest.fixture
-def eth1_eth2_with_no_profile():
-    yield
-    ifaces_init(ETH1, ETH2)
-
-
 def _nmcli_simulate_boot(ifname):
     """
     Use nmcli to reactivate the profile to simulate the server reboot.
@@ -859,11 +853,12 @@ def _nmcli_simulate_boot(ifname):
     time.sleep(1)
 
 
+# This test require eth1 and eth2 to have no stored profile
 # TODO: This test case has random failure in Github CI and NMCI environment,
 #       considering this is a ovirt use case which holds low priority,
 #       we remove it from tier1 temporary till issue been resolved.
 # @pytest.mark.tier1
-def test_new_bond_uses_mac_of_first_port_by_name(eth1_eth2_with_no_profile):
+def test_new_bond_uses_mac_of_first_port_by_name(eth1_env, eth2_env):
     """
     On system boot, NetworkManager will by default activate port in the
     order of their name. Nmstate should provide the consistent MAC address for
@@ -1584,7 +1579,7 @@ def test_bond_opt_lacp_active(lacp_bond99_with_2_ports):
 
 
 @pytest.fixture
-def bond99_with_ns_ip6_target(setup_remove_bond99):
+def bond99_with_ns_ip6_target(eth1_up, eth2_up, setup_remove_bond99):
     state = yaml.load(
         """---
         interfaces:
@@ -1717,7 +1712,7 @@ def empty_br0():
         yield
 
 
-def test_attach_new_bond_to_existing_bridge(empty_br0):
+def test_attach_new_bond_to_existing_bridge(eth1_up, eth2_up, empty_br0):
     with bond_interface(
         name=BOND99,
         port=[ETH1, ETH2],
@@ -1749,7 +1744,9 @@ def cleanup_vlan():
     )
 
 
-def test_attach_new_vlan_of_new_bond_to_exist_bridge(empty_br0, cleanup_vlan):
+def test_attach_new_vlan_of_new_bond_to_exist_bridge(
+    eth1_up, eth2_up, empty_br0, cleanup_vlan
+):
     with bond_interface(
         name=BOND99,
         port=[ETH1, ETH2],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,8 +16,7 @@ from libnmstate.schema import Route
 from libnmstate.schema import RouteRule
 
 from .testlib import ifacelib
-from .testlib.veth import create_veth_pair
-from .testlib.veth import remove_veth_pair
+from .testlib.veth import veth_pair_env
 from .testlib.ipsec import IpsecTestEnv
 
 REPORT_HEADER = """RPMs: {rpms}
@@ -99,26 +98,8 @@ def test_env_setup():
     old_state = libnmstate.show()
     old_state = _remove_interfaces_from_env(old_state)
     _remove_dns_route_route_rule()
-    for nic_name in ["eth1", "eth2"]:
-        remove_veth_pair(nic_name, ISOLATE_NAMESPACE)
-    for nic_name in ["eth1", "eth2"]:
-        create_veth_pair(nic_name, f"{nic_name}.ep", ISOLATE_NAMESPACE)
-    _ethx_init()
     yield
-    for nic_name in ["eth1", "eth2"]:
-        remove_veth_pair(nic_name, ISOLATE_NAMESPACE)
     restore_old_state(old_state)
-
-
-# eth3 is only needed for some specific tests (HSR).
-# If it's not necessary, do not set it up to save time.
-@pytest.fixture(scope="session")
-def test_env_setup_eth3(test_env_setup):
-    remove_veth_pair("eth3", ISOLATE_NAMESPACE_ETH3)
-    create_veth_pair("eth3", "eth3.ep", ISOLATE_NAMESPACE_ETH3)
-    ifacelib.ifaces_init("eth3")
-    yield
-    remove_veth_pair("eth3", ISOLATE_NAMESPACE_ETH3)
 
 
 def _remove_dns_route_route_rule():
@@ -144,11 +125,6 @@ def _logging_setup():
     )
 
 
-def _ethx_init():
-    """Remove any existing definitions on the ethX interfaces."""
-    ifacelib.ifaces_init("eth1", "eth2")
-
-
 def _remove_interfaces_from_env(state):
     """
     Remove references from interfaces passed to environment variable
@@ -170,19 +146,37 @@ def _remove_interfaces_from_env(state):
 
 
 @pytest.fixture(scope="function")
-def eth1_up(test_env_setup):
+def eth1_env(test_env_setup):
+    with veth_pair_env("eth1", "eth1.ep", ISOLATE_NAMESPACE) as ifstate:
+        yield ifstate
+
+
+@pytest.fixture(scope="function")
+def eth1_up(eth1_env):
     with ifacelib.iface_up("eth1") as ifstate:
         yield ifstate
 
 
 @pytest.fixture(scope="function")
-def eth2_up(test_env_setup):
+def eth2_env(test_env_setup):
+    with veth_pair_env("eth2", "eth2.ep", ISOLATE_NAMESPACE) as ifstate:
+        yield ifstate
+
+
+@pytest.fixture(scope="function")
+def eth2_up(eth2_env):
     with ifacelib.iface_up("eth2") as ifstate:
         yield ifstate
 
 
 @pytest.fixture(scope="function")
-def eth3_up(test_env_setup_eth3):
+def eth3_env(test_env_setup):
+    with veth_pair_env("eth3", "eth3.ep", ISOLATE_NAMESPACE_ETH3) as ifstate:
+        yield ifstate
+
+
+@pytest.fixture(scope="function")
+def eth3_up(eth3_env):
     with ifacelib.iface_up("eth3") as ifstate:
         yield ifstate
 

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -1389,7 +1389,7 @@ def test_static_ip_with_routes_switch_back_to_dynamic(
 
 
 @pytest.fixture(scope="function")
-def eth1_with_dhcp6_no_dhcp_server():
+def eth1_with_dhcp6_no_dhcp_server(eth1_env):
     # Cannot depend on eth1_up fixture as the reproducer requires the
     # veth profile been created with DHCPv6 enabled.
     iface_state = {

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -28,8 +28,8 @@ def eth1_with_ipv6(eth1_up):
 
 
 @pytest.mark.tier1
-def test_increase_iface_mtu():
-    desired_state = statelib.show_only(("eth1",))
+def test_increase_iface_mtu(eth1_up):
+    desired_state = eth1_up
     eth1_desired_state = desired_state[Interface.KEY][0]
     eth1_desired_state[Interface.MTU] = 1900
 
@@ -39,8 +39,8 @@ def test_increase_iface_mtu():
 
 
 @pytest.mark.tier1
-def test_decrease_iface_mtu():
-    desired_state = statelib.show_only(("eth1",))
+def test_decrease_iface_mtu(eth1_up):
+    desired_state = eth1_up
     eth1_desired_state = desired_state[Interface.KEY][0]
     eth1_desired_state[Interface.MTU] = 1400
 
@@ -50,8 +50,8 @@ def test_decrease_iface_mtu():
 
 
 @pytest.mark.tier1
-def test_upper_limit_jambo_iface_mtu():
-    desired_state = statelib.show_only(("eth1",))
+def test_upper_limit_jambo_iface_mtu(eth1_up):
+    desired_state = eth1_up
     eth1_desired_state = desired_state[Interface.KEY][0]
     eth1_desired_state[Interface.MTU] = 9000
 
@@ -60,8 +60,8 @@ def test_upper_limit_jambo_iface_mtu():
     assertlib.assert_state(desired_state)
 
 
-def test_increase_more_than_jambo_iface_mtu():
-    desired_state = statelib.show_only(("eth1",))
+def test_increase_more_than_jambo_iface_mtu(eth1_up):
+    desired_state = eth1_up
     eth1_desired_state = desired_state[Interface.KEY][0]
     eth1_desired_state[Interface.MTU] = 10000
 

--- a/tests/integration/ethernet_mtu_test.py
+++ b/tests/integration/ethernet_mtu_test.py
@@ -7,6 +7,8 @@ import pytest
 import libnmstate
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv6
+from libnmstate.schema import InterfaceState
+from libnmstate.schema import InterfaceType
 from libnmstate.error import NmstateValueError
 
 from .testlib.apply import apply_with_description
@@ -95,11 +97,23 @@ def test_decrease_to_lower_than_min_ipv6_iface_mtu(eth1_with_ipv6):
 
 
 def test_mtu_without_ipv6(eth1_up):
-    eth1_up[Interface.KEY][0][Interface.MTU] = 576
+    desired_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.MTU: 576,
+                Interface.IPV6: {
+                    InterfaceIPv6.ENABLED: False,
+                },
+            }
+        ]
+    }
     apply_with_description(
-        "Setting MTU of eth1 to 576 with IPv6 disabled", eth1_up
+        "Setting MTU of eth1 to 576 with IPv6 disabled", desired_state
     )
-    assertlib.assert_state(eth1_up)
+    assertlib.assert_state(desired_state)
 
 
 @pytest.mark.tier1

--- a/tests/integration/examples_test.py
+++ b/tests/integration/examples_test.py
@@ -209,7 +209,7 @@ def test_add_ib_pkey_nic_and_remove():
     assertlib.assert_absent(f"{test_nic}.80ff")
 
 
-def test_add_mac_vlan_and_remove():
+def test_add_mac_vlan_and_remove(eth1_up):
     with example_state(
         "mac_vlan_create.yml", cleanup="mac_vlan_absent.yml"
     ) as desired_state:
@@ -218,7 +218,7 @@ def test_add_mac_vlan_and_remove():
     assertlib.assert_absent("macvlan0")
 
 
-def test_add_mac_vtap_and_remove():
+def test_add_mac_vtap_and_remove(eth1_up):
     with example_state(
         "mac_vtap_create.yml", cleanup="mac_vtap_absent.yml"
     ) as desired_state:
@@ -263,7 +263,7 @@ def test_add_macsec_and_remove_example(eth1_up):
 
 
 @pytest.mark.tier1
-def test_add_hsr_and_remove_example(eth1_up):
+def test_add_hsr_and_remove_example(eth1_up, eth2_up):
     with example_state(
         "hsr0_up.yml", cleanup="hsr0_absent.yml"
     ) as desired_state:

--- a/tests/integration/mem_leak_test.py
+++ b/tests/integration/mem_leak_test.py
@@ -35,7 +35,7 @@ def test_libnmstate_show_fd_leak(disable_logging):
 
 
 @pytest.mark.tier1
-def test_libnmstate_apply_fd_leak(disable_logging):
+def test_libnmstate_apply_fd_leak(eth1_env, disable_logging):
     original_fd = get_current_open_fd()
     for x in range(0, 10):
         with ifacelib.iface_up("eth1"):

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -26,7 +26,7 @@ RETRY_TIMEOUT = 10
 
 
 @pytest.fixture
-def unmanaged_eth1_with_static_gw():
+def unmanaged_eth1_with_static_gw(eth1_env):
     try:
         cmdlib.exec_cmd(f"nmcli connection delete {ETH1}".split(), check=False)
         cmdlib.exec_cmd(f"nmcli dev set {ETH1} managed no".split(), check=True)

--- a/tests/integration/nm/dns_test.py
+++ b/tests/integration/nm/dns_test.py
@@ -157,6 +157,40 @@ def auto_eth1(eth1_up):
             Interface.KEY: [
                 {
                     Interface.NAME: "eth1",
+                    Interface.PROFILE_NAME: "eth1",
+                    Interface.TYPE: InterfaceType.ETHERNET,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: True,
+                        InterfaceIPv4.DHCP: True,
+                        InterfaceIPv4.AUTO_DNS: True,
+                        InterfaceIPv4.AUTO_ROUTES: True,
+                        InterfaceIPv4.AUTO_GATEWAY: True,
+                    },
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: True,
+                        InterfaceIPv6.DHCP: True,
+                        InterfaceIPv6.AUTO_DNS: True,
+                        InterfaceIPv6.AUTO_ROUTES: True,
+                        InterfaceIPv6.AUTO_GATEWAY: True,
+                    },
+                }
+            ],
+        }
+    )
+    yield
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {}}})
+
+
+@pytest.fixture
+def auto_eth2(eth2_up):
+    libnmstate.apply(
+        {
+            DNS.KEY: {DNS.CONFIG: {DNS.SERVER: [], DNS.SEARCH: []}},
+            Interface.KEY: [
+                {
+                    Interface.NAME: "eth2",
+                    Interface.PROFILE_NAME: "eth2",
                     Interface.TYPE: InterfaceType.ETHERNET,
                     Interface.STATE: InterfaceState.UP,
                     Interface.IPV4: {
@@ -285,6 +319,7 @@ def test_reselect_iface_dns_if_desired(eth1_up):
             server: {}
         interfaces:
         - name: eth1
+          profile-name: eth1
           type: ethernet
           state: up
           ipv4:
@@ -313,6 +348,7 @@ def test_write_both_global_dns_and_iface_dns(eth1_up):
         """---
         interfaces:
         - name: eth1
+          profile-name: eth1
           type: ethernet
           state: up
           ipv4:
@@ -331,10 +367,9 @@ def test_write_both_global_dns_and_iface_dns(eth1_up):
 
 
 # https://issues.redhat.com/browse/RHEL-102333
-def test_set_dns_search_only_in_down_iface(auto_eth1, eth2_up):
+def test_set_dns_search_only_in_down_iface(auto_eth1, auto_eth2):
     # Add a DNS search domain to a down interface
     cmdlib.exec_cmd("nmcli device down eth2".split(), check=True)
-    cmdlib.exec_cmd("nmcli c modify eth2 ipv4.method auto".split(), check=True)
     cmdlib.exec_cmd(
         "nmcli c modify eth2 ipv4.dns-search 'example.com'".split(),
         check=True,

--- a/tests/integration/nm/gen_conf_test.py
+++ b/tests/integration/nm/gen_conf_test.py
@@ -129,7 +129,7 @@ interfaces:
 
 
 @pytest.mark.tier1
-def test_gen_conf_routes_rules():
+def test_gen_conf_routes_rules(eth1_up):
     desired_state = load_yaml(
         """---
         routes:
@@ -213,7 +213,7 @@ def verify_ovs_ports(bridge_name, port_names):
     assert cur_ports == port_names
 
 
-def test_gen_conf_ecmp_routes():
+def test_gen_conf_ecmp_routes(eth1_up):
     desired_state = load_yaml(
         """---
         interfaces:
@@ -249,7 +249,7 @@ def test_gen_conf_ecmp_routes():
         assert_routes(desired_routes, cur_state)
 
 
-def test_gen_conf_lldp():
+def test_gen_conf_lldp(eth1_up):
     desired_state = load_yaml(
         """---
         interfaces:
@@ -479,7 +479,7 @@ def test_gen_conf_route_next_hop_iface_ref_by_mac(eth1_eth2_up_with_no_config):
         assert_routes(expected_routes, cur_state)
 
 
-def test_gen_conf_route_initcwnd_mtu_quickack_advmss_lock_mtu():
+def test_gen_conf_route_initcwnd_mtu_quickack_advmss_lock_mtu(eth1_up):
     desired_state = load_yaml(
         """---
         routes:

--- a/tests/integration/nm/ip_test.py
+++ b/tests/integration/nm/ip_test.py
@@ -71,7 +71,7 @@ def test_get_applied_config_for_dhcp_state_with_dhcp_disabled_on_disk(
 
 
 @pytest.fixture
-def eth1_up_with_static_ip_and_route_by_iproute():
+def eth1_up_with_static_ip_and_route_by_iproute(eth1_env):
     cmdlib.exec_cmd("ip link set eth1 up".split(), check=True)
     cmdlib.exec_cmd(
         f"ip addr add {IPV4_ADDRESS1}/24 dev eth1 ".split(), check=True

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -34,7 +34,7 @@ DUMMY1 = "dummy1"
 
 
 @pytest.fixture
-def eth1_with_old_gateway_format():
+def eth1_with_old_gateway_format(eth1_up):
     libnmstate.apply(
         yaml.load(
             """---

--- a/tests/integration/nmstate_service_test.py
+++ b/tests/integration/nmstate_service_test.py
@@ -221,7 +221,7 @@ def conf_override():
 
 
 @pytest.fixture
-def empty_eth1_yaml_conf():
+def empty_eth1_yaml_conf(eth1_env):
     file_path = f"{CONFIG_DIR}/eth1.yml"
     with open(file_path, "w") as fd:
         fd.write(

--- a/tests/integration/nmstatectl_edit_test.py
+++ b/tests/integration/nmstatectl_edit_test.py
@@ -21,7 +21,7 @@ def test_edit_cancel(eth1_up):
     assert_rc(rc, os.EX_DATAERR, ret)
 
 
-def test_edit_no_change_eth1():
+def test_edit_no_change_eth1(eth1_env):
     runenv = dict(os.environ)
     env = {"EDITOR": "touch"}
 

--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -213,14 +213,14 @@ def test_show_command_with_short_show_secrets():
     state_match(LOOPBACK_CONFIG, current_state)
 
 
-def test_apply_command_with_yaml_format():
+def test_apply_command_with_yaml_format(eth1_up):
     ret = cmdlib.exec_cmd(APPLY_CMD, stdin=ETH1_YAML_CONFIG)
     rc, out, err = ret
 
     assert rc == cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
 
 
-def test_set_command_with_yaml_deprecated():
+def test_set_command_with_yaml_deprecated(eth1_up):
     ret = cmdlib.exec_cmd(SET_CMD, stdin=ETH1_YAML_CONFIG)
     rc, out, err = ret
 
@@ -228,7 +228,7 @@ def test_set_command_with_yaml_deprecated():
     assert SET_WARNING in err.rstrip()
 
 
-def test_apply_command_with_two_states():
+def test_apply_command_with_two_states(eth1_up):
     examples = find_examples_dir()
     cmd = APPLY_CMD + [
         os.path.join(examples, "linuxbrige_eth1_up.yml"),

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -756,7 +756,7 @@ def _get_routes_from_iproute(family, table):
     return out
 
 
-def test_remove_default_ipv6_gateway_and_revert():
+def test_remove_default_ipv6_gateway_and_revert(eth1_up):
     gateway1 = {
         Route.DESTINATION: "::/0",
         Route.METRIC: -1,

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -678,6 +678,7 @@ def test_static_route_with_empty_ip(eth1_up):
     }
     eth1_state[Interface.IPV6] = {
         InterfaceIPv6.DHCP: False,
+        InterfaceIPv6.AUTOCONF: False,
         InterfaceIPv6.ENABLED: True,
         InterfaceIPv4.ADDRESS: [],
     }

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -9,6 +9,16 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Veth
 
 from .cmdlib import exec_cmd
+from . import statelib
+
+
+@contextmanager
+def veth_pair_env(nic, nic_peer, peer_ns):
+    try:
+        create_veth_pair(nic, nic_peer, peer_ns)
+        yield statelib.show_only((nic,))
+    finally:
+        remove_veth_pair(nic, peer_ns)
 
 
 def create_veth_pair(nic, nic_peer, peer_ns):

--- a/tests/integration/vrf_test.py
+++ b/tests/integration/vrf_test.py
@@ -33,7 +33,7 @@ TEST_BOND0_VLAN = "test-bond0.100"
 
 
 @pytest.fixture
-def vrf0_with_port0(port1_up):
+def vrf0_with_port0(port0_up):
     vrf_iface_info = {
         Interface.NAME: TEST_VRF0,
         Interface.TYPE: InterfaceType.VRF,


### PR DESCRIPTION
Tests should be independent, so better to avoid possible leftovers from
previously ran tests. I.e. we have seen some tests leaving eth1 and eth2
with identical MAC, making next tests that match by MAC to fail.

With this change, eth1, eth2 and eth3 need to be pulled via fixture
explicitly for every test that needs them.

This intends to be a solution for https://redhat.atlassian.net/browse/RHEL-157317 that is not only a workaround, but an improvement to the current testing implementation (replacing @vbenes PR https://github.com/nmstate/nmstate/pull/3121 which I consider a workaround).