### PR TITLE
dep: upgrade nispor to 2.0.2

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "2.0.0"
+nispor = "2.0.2"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.31", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }


### PR DESCRIPTION
nispor changelog since 2.0.0:

Breaking changes
- Renamed Ipv6AddrFlag -> IpAddrFlag, expose flags for v4 addrs. (https://github.com/nispor/nispor/commit/2023fe080191bca2f1df019d8b0d0286563b6810)
- wireguard: Changed endpoint from String to SocketAddr. (https://github.com/nispor/nispor/commit/139a1ada56dc47f2ca58bdbadb3d41b450fb79a8)
- Bump minimum supported rust version to 1.88. (https://github.com/nispor/nispor/commit/72b2375cd8b90f01c83c7b113a2c08af28edecbe)
- Bump to Rust Edition 2024. (https://github.com/nispor/nispor/commit/59504ee4badad7618a764b2177e090110d517cba)

New features
- lib: expose AddressScope enum. (https://github.com/nispor/nispor/commit/3d1829a31c855723552ede891220b2bd370ceba8)
- ip: expose scope of ip addresses. (https://github.com/nispor/nispor/commit/9f20373575a579386924b98ed8ac87c244340220)
- Support convert AddressProtocol to u8. (https://github.com/nispor/nispor/commit/583ef309ef07579e72f6952984da342f3e5a0a17)
- Support IP protocol querying and applying. (https://github.com/nispor/nispor/commit/19132b980c955c2685226054748d84bfeff2ebed)
- Support wireguard query and apply. (https://github.com/nispor/nispor/commit/94c0496d3813bbaefdee19f8bfb8969367e1c794)

Bug fixes
- pci: Use IFLA_PARENT_DEV_NAME for PCI address. (https://github.com/nispor/nispor/commit/fcaa432a310e302c454504b901a3730ef0cfbe05)
- Use rtnetlink 0.21.0. (https://github.com/nispor/nispor/commit/b40df596ca0de350db3ffc9481d5bbb220799a21)
- Prefer LinkInfo::Kind as interface type. (https://github.com/nispor/nispor/commit/5e13d3f267b5424b5cc90bd36a2db567dc03c1c4)
- Export WifiMode. (https://github.com/nispor/nispor/commit/8459d20142769b00b779e7c5f8a164d25d7c6a57)
- wireguard: Include private key but hide from Debug and Serialize. (https://github.com/nispor/nispor/commit/cef4c63008944e94091171d8329e6b4eb023effe)

Most notable is `Prefer LinkInfo::Kind as interface type` which resolves a bug where gretap interfaces have a `ethernet: {}` field due to a type mismatch.

Resolves: https://redhat.atlassian.net/browse/RHEL-170926