### PR TITLE
ip: static IP in kernel mode re-ordering

### DIFF
--- a/rust/src/lib/ip.rs
+++ b/rust/src/lib/ip.rs
@@ -470,6 +470,38 @@ impl InterfaceIpv4 {
         }
         Ok(())
     }
+
+    pub fn is_ipv4_primary_first(&self) -> bool {
+        let addrs = self.addresses.as_deref().unwrap_or(&[]);
+        let mut seen_nets: Vec<(Ipv4Addr, u8)> = Vec::new();
+        let mut seen_secondary = false;
+        for addr in addrs {
+            if let IpAddr::V4(ip) = addr.ip {
+                let mask = if addr.prefix_length >= 32 {
+                    u32::MAX
+                } else {
+                    u32::MAX << (32 - addr.prefix_length)
+                };
+
+                let network = Ipv4Addr::from(u32::from(ip) & mask);
+                let is_secondary = seen_nets.iter().any(|(net, plen)| {
+                    *plen == addr.prefix_length && *net == network
+                });
+
+                if is_secondary {
+                    seen_secondary = true;
+                } else {
+                    // primary has been seen after a secondary
+                    if seen_secondary {
+                        return false;
+                    }
+                    seen_nets.push((network, addr.prefix_length));
+                }
+            }
+        }
+
+        true
+    }
 }
 
 impl<'de> Deserialize<'de> for InterfaceIpv4 {

--- a/rust/src/lib/nispor/ip.rs
+++ b/rust/src/lib/nispor/ip.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use crate::{
     InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6, MergedInterface,
-    nispor::mptcp::get_mptcp_flags,
+    ip::is_ipv6_unicast_link_local, nispor::mptcp::get_mptcp_flags,
 };
 
 pub(crate) fn np_ipv4_to_nmstate(
@@ -155,44 +156,78 @@ pub(crate) fn nmstate_ipv4_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
 
-    // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
-        && let (Some(nms_cur_ipv4), Some(nms_des_ipv4)) = (
-            &nms_cur_iface.base_iface().ipv4,
-            &nms_merged_iface.merged.base_iface().ipv4,
-        )
-    {
-        let des_ips: Vec<_> = nms_des_ipv4
-            .addresses
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .collect();
+    let mut to_add = Vec::new();
+    let mut to_remove = Vec::new();
 
-        for nms_addr in nms_cur_ipv4.addresses.as_deref().unwrap_or_default() {
-            if !des_ips.contains(&nms_addr) {
-                np_ip_conf.addresses.push({
-                    let mut ip_conf = nispor::IpAddrConf::default();
-                    ip_conf.address = nms_addr.ip.to_string();
-                    ip_conf.prefix_len = nms_addr.prefix_length;
-                    ip_conf.remove = true;
-                    ip_conf
-                });
-            }
-        }
+    if let Some(ipv4) = nms_merged_iface.merged.base_iface().ipv4.as_ref()
+        && !ipv4.is_ipv4_primary_first()
+    {
+        log::info!(
+            "Kernel will re-order ip addresses due to primary addresses being found after secondary addresses"
+        );
     }
 
-    // Add new ip address entries before deleting
-    if let Some(nms_des_ipv4) = &nms_merged_iface.merged.base_iface().ipv4 {
-        for nms_addr in nms_des_ipv4.addresses.as_deref().unwrap_or_default() {
+    let des_ips = if let Some(ipv4) =
+        nms_merged_iface.merged.base_iface().ipv4.as_ref()
+    {
+        ipv4.addresses.as_deref().unwrap_or(&[])
+    } else {
+        &[]
+    };
+    let cur_ips = if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
+        && let Some(nms_cur_ipv4) = nms_cur_iface.base_iface().ipv4.as_ref()
+    {
+        nms_cur_ipv4.addresses.as_deref().unwrap_or(&[])
+    } else {
+        &[]
+    };
+
+    let des_len = des_ips.len();
+    let cur_len = cur_ips.len();
+
+    if cur_len > des_len {
+        if cur_ips.starts_with(des_ips) {
+            to_remove.extend(cur_ips.iter().skip(des_len));
+        } else {
+            to_remove.extend(cur_ips.iter());
+            to_add.extend(des_ips.iter());
+        }
+    } else if des_ips.starts_with(cur_ips) {
+        to_add.extend(des_ips.iter().skip(cur_len));
+    } else {
+        to_remove.extend(cur_ips.iter());
+        to_add.extend(des_ips.iter());
+    }
+
+    // purge and add
+    to_remove
+        .iter()
+        .filter(|addr| {
+            if let IpAddr::V4(ip) = addr.ip
+                && addr.is_auto()
+            {
+                log::info!("Skipping purge of dynamic IPv4 address: {ip}");
+                return false;
+            }
+            true
+        })
+        .for_each(|addr| {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
-                ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length;
+                ip_conf.address = addr.ip.to_string();
+                ip_conf.prefix_len = addr.prefix_length;
+                ip_conf.remove = true;
                 ip_conf
             });
-        }
-    }
+        });
+    to_add.iter().for_each(|addr| {
+        np_ip_conf.addresses.push({
+            let mut ip_conf = nispor::IpAddrConf::default();
+            ip_conf.address = addr.ip.to_string();
+            ip_conf.prefix_len = addr.prefix_length;
+            ip_conf
+        });
+    });
     np_ip_conf
 }
 
@@ -201,43 +236,78 @@ pub(crate) fn nmstate_ipv6_to_np(
 ) -> nispor::IpConf {
     let mut np_ip_conf = nispor::IpConf::default();
 
-    // delete ip addresses not in desired state
-    if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
-        && let (Some(nms_cur_ipv6), Some(nms_des_ipv6)) = (
-            &nms_cur_iface.base_iface().ipv6,
-            &nms_merged_iface.merged.base_iface().ipv6,
-        )
-    {
-        let des_ips: Vec<_> = nms_des_ipv6
-            .addresses
-            .as_deref()
-            .unwrap_or_default()
-            .iter()
-            .collect();
+    let mut to_add = Vec::new();
+    let mut to_remove = Vec::new();
 
-        for nms_addr in nms_cur_ipv6.addresses.as_deref().unwrap_or_default() {
-            if !des_ips.contains(&nms_addr) {
-                np_ip_conf.addresses.push({
-                    let mut ip_conf = nispor::IpAddrConf::default();
-                    ip_conf.address = nms_addr.ip.to_string();
-                    ip_conf.prefix_len = nms_addr.prefix_length;
-                    ip_conf.remove = true;
-                    ip_conf
-                });
-            }
+    let des_ips = if let Some(ipv6) =
+        nms_merged_iface.merged.base_iface().ipv6.as_ref()
+    {
+        ipv6.addresses.as_deref().unwrap_or(&[])
+    } else {
+        &[]
+    };
+    let cur_ips = if let Some(nms_cur_iface) = nms_merged_iface.current.as_ref()
+        && let Some(nms_cur_ipv6) = nms_cur_iface.base_iface().ipv6.as_ref()
+    {
+        nms_cur_ipv6.addresses.as_deref().unwrap_or(&[])
+    } else {
+        &[]
+    };
+
+    let des_len = des_ips.len();
+    let cur_len = cur_ips.len();
+
+    if cur_len > des_len {
+        if cur_ips.starts_with(des_ips) {
+            to_remove.extend(cur_ips.iter().skip(des_len));
+        } else {
+            to_remove.extend(cur_ips.iter());
+            to_add.extend(des_ips.iter());
         }
+    } else if des_ips.starts_with(cur_ips) {
+        to_add.extend(des_ips.iter().skip(cur_len));
+    } else {
+        to_remove.extend(cur_ips.iter());
+        to_add.extend(des_ips.iter());
     }
 
-    // Add new ip address entries after deleting
-    if let Some(nms_des_ipv6) = &nms_merged_iface.merged.base_iface().ipv6 {
-        for nms_addr in nms_des_ipv6.addresses.as_deref().unwrap_or_default() {
+    // purge and add
+    to_remove
+        .iter()
+        .filter(|addr| {
+            if let IpAddr::V6(ip) = addr.ip
+            {
+                if addr.is_auto() {
+                        log::info!(
+                            "Skipping purge of dynamic IPv6 address: {ip}"
+                        );
+                        return false;
+                }
+                if is_ipv6_unicast_link_local(&ip) {
+                    log::info!(
+                        "Skipping purge of unicast link local IPv6 address: {ip}"
+                    );
+                    return false;
+                }
+            };
+            true
+        })
+        .for_each(|addr| {
             np_ip_conf.addresses.push({
                 let mut ip_conf = nispor::IpAddrConf::default();
-                ip_conf.address = nms_addr.ip.to_string();
-                ip_conf.prefix_len = nms_addr.prefix_length;
+                ip_conf.address = addr.ip.to_string();
+                ip_conf.prefix_len = addr.prefix_length;
+                ip_conf.remove = true;
                 ip_conf
             });
-        }
-    }
+        });
+    to_add.iter().for_each(|addr| {
+        np_ip_conf.addresses.push({
+            let mut ip_conf = nispor::IpAddrConf::default();
+            ip_conf.address = addr.ip.to_string();
+            ip_conf.prefix_len = addr.prefix_length;
+            ip_conf
+        });
+    });
     np_ip_conf
 }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -727,3 +727,116 @@ fn test_error_on_route_metric_out_of_range() {
         }
     }
 }
+
+#[test]
+fn test_single_ipv4_primary_first() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          address:
+          - ip: "192.168.122.14"
+            prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let ipv4 = iface.base_iface().ipv4.as_ref().unwrap();
+    assert!(ipv4.is_ipv4_primary_first());
+}
+
+#[test]
+fn test_all_primary_ipv4_primary_first() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+          - ip: "192.168.122.16"
+            prefix-length: 24
+          - ip: "10.0.0.16"
+            prefix-length: 24
+          - ip: "10.1.0.16"
+            prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let ipv4 = iface.base_iface().ipv4.as_ref().unwrap();
+    assert!(ipv4.is_ipv4_primary_first());
+}
+
+#[test]
+fn test_one_network_ipv4_primary_first() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+          - ip: "10.0.0.14"
+            prefix-length: 24
+          - ip: "10.0.0.16"
+            prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let ipv4 = iface.base_iface().ipv4.as_ref().unwrap();
+    assert!(ipv4.is_ipv4_primary_first());
+}
+
+#[test]
+fn test_two_networks_ipv4_primary_first() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+          - ip: "10.0.0.14"
+            prefix-length: 24
+          - ip: "10.1.0.16"
+            prefix-length: 24
+          - ip: "10.0.0.16"
+            prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let ipv4 = iface.base_iface().ipv4.as_ref().unwrap();
+    assert!(ipv4.is_ipv4_primary_first());
+}
+
+#[test]
+fn test_two_networks_ipv4_primary_first_out_of_order() {
+    let iface: Interface = serde_yaml::from_str(
+        r#"---
+        name: eth1
+        type: ethernet
+        state: up
+        ipv4:
+          enabled: true
+          dhcp: false
+          address:
+          - ip: "10.0.0.14"
+            prefix-length: 24
+          - ip: "10.0.0.16"
+            prefix-length: 24
+          - ip: "10.1.0.16"
+            prefix-length: 24"#,
+    )
+    .unwrap();
+
+    let ipv4 = iface.base_iface().ipv4.as_ref().unwrap();
+    assert!(!ipv4.is_ipv4_primary_first());
+}

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -1299,3 +1299,197 @@ def test_kernel_mode_change_static_ip(cleanup_veth1_kernel_mode):
         kernel_only=True,
     )
     assertlib.assert_state_match(new_desired_state, kernel_only=True)
+
+
+# This test our understanding of kernel behaviour, and can let
+# us know if ip address ordering changes in the kernel
+def test_kernel_mode_apply_static_ipv4_out_of_order(cleanup_veth1_kernel_mode):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.251/24, 192.0.2.252/24, and 192.0.1.253/24."
+        "This is done with the expectation that the kernel"
+        "will re-order the addresses",
+        desired_state,
+        kernel_only=True,
+    )
+    actual_addrs = iproute_get_ip_addrs_with_order("veth1", is_ipv6=False)
+    assert actual_addrs == ["192.0.2.251", "192.0.1.253", "192.0.2.252"]
+
+
+# This test our understanding of kernel behaviour, and can let
+# us know if ip address ordering changes in the kernel
+def test_kernel_mode_apply_static_ipv4_in_order(cleanup_veth1_kernel_mode):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.251/24, 192.0.2.252/24, and 192.0.1.253/24."
+        "This is done with the expectation that the kernel"
+        "will not re-order the addresses",
+        desired_state,
+        kernel_only=True,
+    )
+    actual_addrs = iproute_get_ip_addrs_with_order("veth1", is_ipv6=False)
+    assert actual_addrs == ["192.0.2.251", "192.0.1.253", "192.0.2.252"]
+
+
+def test_kernel_mode_apply_static_ipv4_tail_append(cleanup_veth1_kernel_mode):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.251/24, 192.0.2.252/24, and 192.0.1.253/24."
+        "This is done with the expectation that the kernel"
+        "will re-order the addresses",
+        desired_state,
+        kernel_only=True,
+    )
+
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            - ip: 192.0.3.254
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    libnmstate.apply(
+        desired_state,
+        kernel_only=True,
+    )
+
+    actual_addrs = iproute_get_ip_addrs_with_order("veth1", is_ipv6=False)
+    assert actual_addrs == [
+        "192.0.2.251",
+        "192.0.1.253",
+        "192.0.3.254",
+        "192.0.2.252",
+    ]
+
+
+def test_kernel_mode_apply_static_ipv4_tail_remove(cleanup_veth1_kernel_mode):
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            - ip: 192.0.3.254
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    apply_with_description(
+        "Configure the veth device veth1 with the peer veth1_peer and "
+        "address 192.0.2.251/24, 192.0.1.253/24, 192.0.2.252/24, and "
+        "192.0.3.254/24 with the expectation that the kernel"
+        "will re-order the addresses",
+        desired_state,
+        kernel_only=True,
+    )
+
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv4:
+            address:
+            - ip: 192.0.2.251
+              prefix-length: 24
+            - ip: 192.0.1.253
+              prefix-length: 24
+            - ip: 192.0.2.252
+              prefix-length: 24
+            dhcp: false
+            enabled: true
+        """
+    )
+    libnmstate.apply(desired_state, kernel_only=True)
+
+    actual_addrs = iproute_get_ip_addrs_with_order("veth1", is_ipv6=False)
+    assert actual_addrs == ["192.0.2.251", "192.0.1.253", "192.0.2.252"]


### PR DESCRIPTION
- If desired state is append or remove tail, we send simple incremental
  netlink request to kernel. Otherwise, we purge all addresses and set with
  desired order.
- Handle the IPv6 link local address carefully, touching it will cause autoconf
  and DHCPv6 restart their process. So if user never explicitly set link local
  address in desire state, we ignore existing link local address, only purge
  non-link-local address when reset required.