### PR TITLE
Drop the need of `once_cell` crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,6 @@ nix = { version = "0.31", default-features = false, features = ["feature", "host
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }
 zvariant = {version = "5.1.0", default-features = false}
 libc = "0.2.74"
-once_cell = "1.12.0"
 env_logger = "0.11.6"
 clap = { version = "3.1", features = ["cargo"] }
 time = { version = "0.3", default-features = false, features = ["std", "formatting", "parsing"] }

--- a/rust/src/clib/Cargo.toml
+++ b/rust/src/clib/Cargo.toml
@@ -21,7 +21,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
-once_cell = { workspace = true }
 
 [features]
 default = ["query_apply", "gen_conf"]

--- a/rust/src/clib/lib.rs
+++ b/rust/src/clib/lib.rs
@@ -18,11 +18,10 @@ mod state;
 #[cfg(feature = "query_apply")]
 mod validate;
 
-use std::ffi::CString;
+use std::{ffi::CString, sync::OnceLock};
 
 use libc::{c_char, c_int};
 use nmstate::NmstateError;
-use once_cell::sync::OnceCell;
 
 #[cfg(feature = "query_apply")]
 pub use crate::apply::nmstate_net_state_apply;
@@ -45,7 +44,7 @@ pub(crate) const NMSTATE_FAIL: c_int = 1;
 
 pub use crate::format::nmstate_net_state_format;
 
-static INSTANCE: OnceCell<MemoryLogger> = OnceCell::new();
+static INSTANCE: OnceLock<MemoryLogger> = OnceLock::new();
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[unsafe(no_mangle)]
@@ -64,28 +63,16 @@ pub(crate) fn init_logger() -> Result<&'static MemoryLogger, NmstateError> {
             Ok(l)
         }
         None => {
-            if INSTANCE.set(MemoryLogger::new()).is_err() {
-                return Err(NmstateError::new(
-                    nmstate::ErrorKind::Bug,
-                    "Failed to set once_sync for logger".to_string(),
-                ));
-            }
-            if let Some(l) = INSTANCE.get() {
-                if let Err(e) = log::set_logger(l) {
-                    Err(NmstateError::new(
-                        nmstate::ErrorKind::Bug,
-                        format!("Failed to log::set_logger: {e}"),
-                    ))
-                } else {
-                    l.add_consumer();
-                    log::set_max_level(log::LevelFilter::Debug);
-                    Ok(l)
-                }
-            } else {
+            let l = INSTANCE.get_or_init(MemoryLogger::new);
+            if let Err(e) = log::set_logger(l) {
                 Err(NmstateError::new(
                     nmstate::ErrorKind::Bug,
-                    "Failed to get logger from once_sync".to_string(),
+                    format!("Failed to log::set_logger: {e}"),
                 ))
+            } else {
+                l.add_consumer();
+                log::set_max_level(log::LevelFilter::Debug);
+                Ok(l)
             }
         }
     }

--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -27,9 +27,6 @@ mod ovs;
 mod sriov;
 mod vlan;
 
-#[cfg(test)]
-// The pub(crate) re-export is only for unit tests (see unit_tests/ethtool.rs).
-pub(crate) use self::ethtool::ETHTOOL_FEATURE_CLI_ALIAS;
 pub use base::*;
 pub use bond::{
     BondAdSelect, BondAllPortsActive, BondArpAllTargets, BondArpValidate,
@@ -82,6 +79,10 @@ pub use vlan::{
 pub use vrf::{VrfConfig, VrfInterface};
 pub use vxlan::{VxlanConfig, VxlanInterface};
 
+#[cfg(test)]
+// The pub(crate) re-export is only for unit tests (see
+// unit_tests/ethtool.rs).
+pub(crate) use self::ethtool::ETHTOOL_FEATURE_CLI_ALIAS;
 pub(crate) use self::inter_ifaces::MergedInterfaces;
 pub use self::{
     alt_name::{AltNameEntry, AltNameState},

--- a/rust/src/lib/unit_tests/debug_trait.rs
+++ b/rust/src/lib/unit_tests/debug_trait.rs
@@ -26,8 +26,8 @@ fn test_debug_trait() {
     let mut net_state = NetworkState::new();
     net_state.interfaces.push(ethernet.clone());
 
-    let debug_tr_eth = format!("{:?}", &des_eth);
-    let debug_tr_net_state = format!("{:?}", &net_state);
+    let debug_tr_eth = format!("{:?}", des_eth);
+    let debug_tr_net_state = format!("{:?}", net_state);
 
     let password_hid_by_nmstate = "private_key_password: \
                                    Some(\"<_password_hid_by_nmstate>\")"

--- a/rust/src/lib/unit_tests/ethtool.rs
+++ b/rust/src/lib/unit_tests/ethtool.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ifaces::ETHTOOL_FEATURE_CLI_ALIAS;
 use crate::{
     EthernetInterface, EthtoolConfig, EthtoolFeatureConfig, EthtoolFecConfig,
+    ifaces::ETHTOOL_FEATURE_CLI_ALIAS,
 };
 
 #[test]


### PR DESCRIPTION
The rust 1.70+ already ships `std::sync::OnceLock` which could be replace
our use of external crate `once_cell`.

All integration test code is based on C binding which is sufficient to test
this change.