### PR TITLE
fix: extend checkpoint timeout for SR-IOV operations

### DIFF
--- a/rust/src/lib/query_apply/ethernet.rs
+++ b/rust/src/lib/query_apply/ethernet.rs
@@ -191,6 +191,26 @@ impl NetworkState {
     }
 }
 
+async fn query_sriov_vf_count(iface_name: &str) -> u32 {
+    let mut iface_filter = nispor::NetStateIfaceFilter::minimum();
+    iface_filter.iface_name = Some(iface_name.to_string());
+    iface_filter.include_sriov_vf_info = true;
+    let mut filter = nispor::NetStateFilter::minimum();
+    filter.iface = Some(iface_filter);
+    if let Ok(np_state) =
+        nispor::NetState::retrieve_with_filter_async(&filter).await
+    {
+        np_state
+            .ifaces
+            .get(iface_name)
+            .and_then(|i| i.sriov.as_ref())
+            .map(|s| s.vfs.len() as u32)
+            .unwrap_or(0)
+    } else {
+        0
+    }
+}
+
 impl MergedInterfaces {
     pub(crate) fn get_sriov_vf_count(&self) -> u32 {
         let mut ret = 0u32;
@@ -208,5 +228,40 @@ impl MergedInterfaces {
             }
         }
         ret
+    }
+
+    pub(crate) async fn verify_sriov_vf_count(
+        &self,
+    ) -> Result<(), NmstateError> {
+        for iface in self.kernel_ifaces.values().filter(|i| {
+            (i.is_desired() || i.is_changed())
+                && i.merged.iface_type() == InterfaceType::Ethernet
+        }) {
+            if let Interface::Ethernet(eth_iface) = &iface.merged {
+                if let Some(desired_vfs) = eth_iface
+                    .ethernet
+                    .as_ref()
+                    .and_then(|e| e.sr_iov.as_ref())
+                    .and_then(|s| s.total_vfs)
+                {
+                    let current =
+                        query_sriov_vf_count(iface.merged.name()).await;
+                    if current != desired_vfs {
+                        return Err(NmstateError::new(
+                            ErrorKind::VerificationError,
+                            format!(
+                                "Verification failure: {}.interface.\
+                                 ethernet.sr-iov.total-vfs \
+                                 desire '{}', current '{}'",
+                                iface.merged.name(),
+                                desired_vfs,
+                                current,
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -235,9 +235,13 @@ impl NetworkState {
             )?);
         }
 
+        let has_sriov = merged_state
+            .as_ref()
+            .map(|s| s.interfaces.get_sriov_vf_count() > 0)
+            .unwrap_or(false);
         let timeout = if let Some(t) = self.timeout {
             t
-        } else if pf_state.is_some() {
+        } else if pf_state.is_some() || has_sriov {
             VERIFY_RETRY_COUNT_SRIOV_MAX as u32
         } else {
             DEFAULT_ROLLBACK_TIMEOUT
@@ -353,6 +357,10 @@ impl NetworkState {
                         retry_count,
                         |_| async {
                             nm_checkpoint_timeout_extend(checkpoint, timeout)
+                                .await?;
+                            merged_state
+                                .interfaces
+                                .verify_sriov_vf_count()
                                 .await?;
                             let mut new_cur_net_state = cur_net_state.clone();
                             new_cur_net_state.set_include_secrets(true);


### PR DESCRIPTION
When SR-IOV VFs are being created or modified, the NM activation can take longer than the default 60s checkpoint timeout, causing the checkpoint to expire and NM to auto-rollback.

Use VERIFY_RETRY_COUNT_SRIOV_MAX (300s) as checkpoint timeout when SR-IOV VFs are detected in the desired state, not only for the special PF state case.