### PR TITLE
tests: fix test cleanup and route metric collisions

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -191,6 +191,31 @@ port0_up = eth1_up
 port1_up = eth2_up
 
 
+NM_INTERN_CONF = "/var/lib/NetworkManager/NetworkManager-intern.conf"
+
+
+@pytest.fixture(autouse=True)
+def clean_dns():
+    yield
+    libnmstate.apply({DNS.KEY: {DNS.CONFIG: {}}}, verify_change=False)
+    _remove_global_dns()
+
+
+def _remove_global_dns():
+    try:
+        with open(NM_INTERN_CONF) as f:
+            content = f.read()
+        if "[.intern.global-dns" in content:
+            import re
+
+            content = re.sub(r"\[\.intern\.global-dns[^\[]*", "", content)
+            with open(NM_INTERN_CONF, "w") as f:
+                f.write(content)
+            subprocess.run(["nmcli", "general", "reload"], check=False)
+    except FileNotFoundError:
+        pass
+
+
 def pytest_report_header(config):
     nm_ver = _get_package_nvr("NetworkManager")
     try:

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -2068,9 +2068,9 @@ def test_switch_auto_to_static_with_dynamic_ips(dhcpcli_up):
     )
 
     libnmstate.apply(desired_state)
-    assertlib.assert_state(desired_state)
     assert _poll(_has_dhcpv4_addr)
     assert _poll(_has_dhcpv6_addr)
+    assertlib.assert_state(desired_state)
 
     # User might just copy current state and disable DHCP/autoconf
     current_state = statelib.show_only((DHCP_CLI_NIC,))

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -113,8 +113,8 @@ def _check_ipsec_ip(ip_net_prefix, nic):
     return False
 
 
-@pytest.fixture
-def ipsec_cli_cleanup(scope="function", autouse=True):
+@pytest.fixture(scope="function", autouse=True)
+def ipsec_cli_cleanup():
     yield
     desired_state = yaml.load(
         f"""---

--- a/tests/integration/mac_identifer_test.py
+++ b/tests/integration/mac_identifer_test.py
@@ -60,6 +60,16 @@ def clean_up():
           """
         )
     )
+    libnmstate.apply(
+        load_yaml(
+            """---
+            interfaces:
+            - name: mtap0
+              type: mac-vlan
+              state: absent
+          """
+        )
+    )
 
 
 def test_bond_port_ref_by_mac(eth1_up, eth2_up, clean_up):

--- a/tests/integration/nm/route_test.py
+++ b/tests/integration/nm/route_test.py
@@ -63,7 +63,8 @@ def eth1_with_old_gateway_format():
     )
     exec_cmd(
         f"nmcli c modify eth1 ipv4.gateway {TEST_GATEAY4} "
-        f"ipv6.gateway {TEST_GATEAY6}".split(),
+        f"ipv6.gateway {TEST_GATEAY6} "
+        f"ipv6.route-metric 500".split(),
         check=True,
     )
     exec_cmd("nmcli c up eth1".split(), check=True)

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -426,14 +426,14 @@ def _get_ipv4_test_routes(nic="eth1"):
     return [
         {
             Route.DESTINATION: "198.51.100.0/24",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: "192.0.2.1",
             Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV4_ROUTE_TABLE_ID1,
         },
         {
             Route.DESTINATION: "203.0.113.0/24",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: "192.0.2.1",
             Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV4_ROUTE_TABLE_ID2,
@@ -445,14 +445,14 @@ def _get_ipv4_gateways():
     return [
         {
             Route.DESTINATION: "0.0.0.0/0",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: "192.0.2.1",
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
         },
         {
             Route.DESTINATION: "0.0.0.0/0",
-            Route.METRIC: 101,
+            Route.METRIC: 501,
             Route.NEXT_HOP_ADDRESS: "192.0.2.2",
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
@@ -464,14 +464,14 @@ def _get_ipv6_test_routes(nic="eth1"):
     return [
         {
             Route.DESTINATION: "2001:db8:a::/64",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: "2001:db8:1::a",
             Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV6_ROUTE_TABLE_ID1,
         },
         {
             Route.DESTINATION: "2001:db8:b::/64",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: "2001:db8:1::b",
             Route.NEXT_HOP_INTERFACE: nic,
             Route.TABLE_ID: IPV6_ROUTE_TABLE_ID2,
@@ -483,14 +483,14 @@ def _get_ipv6_gateways():
     return [
         {
             Route.DESTINATION: "::/0",
-            Route.METRIC: 103,
+            Route.METRIC: 503,
             Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY1,
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
         },
         {
             Route.DESTINATION: "::/0",
-            Route.METRIC: 101,
+            Route.METRIC: 501,
             Route.NEXT_HOP_ADDRESS: IPV6_GATEWAY2,
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
@@ -2134,11 +2134,11 @@ def test_kernel_mode_static_route_and_remove(cleanup_veth1_kernel_mode):
            - destination: 0.0.0.0/0
              next-hop-address: 192.0.2.1
              next-hop-interface: veth1
-             metric: 109
+             metric: 502
            - destination: ::/0
              next-hop-address: 2001:db8:1::2
              next-hop-interface: veth1
-             metric: 102
+             metric: 500
         """
     )
     libnmstate.apply(desired_state, kernel_only=True)
@@ -2554,11 +2554,11 @@ def test_apply_ignored_routes_to_iface(eth1_static_ip):
             - destination: 203.0.113.0/24
               next-hop-address: 192.0.2.1
               next-hop-interface: veth1
-              metric: 109
+              metric: 502
             - destination: 203.0.113.0/24
               next-hop-address: 192.0.2.2
               next-hop-interface: veth1
-              metric: 109
+              metric: 502
             """
         ),
         (
@@ -2576,11 +2576,11 @@ def test_apply_ignored_routes_to_iface(eth1_static_ip):
             - destination: 2001:db8:2::/64
               next-hop-address: 2001:db8:1::2
               next-hop-interface: veth1
-              metric: 102
+              metric: 500
             - destination: 2001:db8:2::/64
               next-hop-address: 2001:db8:1::3
               next-hop-interface: veth1
-              metric: 102
+              metric: 500
             """
         ),
     ],

--- a/tests/integration/testlib/cmdlib.py
+++ b/tests/integration/testlib/cmdlib.py
@@ -51,6 +51,8 @@ def command_log_line(args, cwd=None):
 
 
 def format_exec_cmd_result(result):
+    if isinstance(result, tuple):
+        return "rc={}, out={}, err={}".format(*result)
     return "rc={}, out={}, err={}".format(
         result.returncode, result.stdout, result.stderr
     )


### PR DESCRIPTION
  Fix several issues causing test failures in downstream CI environments with veth-based test interfaces on RHEL 10.2 (NM 1.56, kernel 6.12):

  - ipsec_test: ipsec_cli_cleanup fixture had autouse=True as a function parameter instead of @pytest.fixture decorator argument, so it never ran automatically — leaving stale ipsec-cli-conn
   profiles after tests.

  - mac_identifer_test: split mtap0 cleanup into two libnmstate.apply calls because nmstate rejects deleting an interface with mismatched type (desired mac-vlan vs current mac-vtap). Without
   this, mtap0 stays on eth1 and blocks all subsequent macvlan/macvtap passthru and macsec tests.

  - conftest: add autouse clean_dns fixture that removes DNS config and NM global-dns from NetworkManager-intern.conf after every test. Tests that set global-dns with unreachable servers
  (e.g. Google DNS from an isolated lab network) break external connectivity for all subsequent test files.

  - route_test, nm/route_test: bump route metrics from 101–109 to 501-509. NM assigns RA default route metrics in the 100–102 range on the management interface. When test routes share a
  metric, the kernel merges them into a multipath route that nmstate verification does not recognize.

  - dynamic_ip_test: move assert_state after _poll calls so mptcp section is present when verification runs.

  - cmdlib: handle tuple return from exec_cmd in format_exec_cmd_result.
