### PR TITLE
ci: upgrade Fedora to F44, fix COPR deps, add c10s jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,9 @@ jobs:
           - job_type: "c9s-nm_min-integ_slow"
           - job_type: "fed-nm_main-integ_tier1"
           - job_type: "c10s-nm_stable-integ_tier1"
+          - job_type: "c10s-nm_stable-integ_tier2"
+          - job_type: "c10s-nm_main-integ_tier1"
+          - job_type: "c10s-nm_main-integ_tier2"
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -38,7 +38,7 @@ else
 fi
 
 if [ $NM_TYPE == "nm_main" ];then
-    TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-main"
+    TEST_ARG="$TEST_ARG --copr networkmanager/NetworkManager-main-debug"
 fi
 
 if [ $NM_TYPE == "nm_min" ];then

--- a/packaging/Dockerfile.c10s-nmstate-dev
+++ b/packaging/Dockerfile.c10s-nmstate-dev
@@ -14,6 +14,7 @@ RUN grep -q "^skip_if_unavailable=" /etc/dnf/dnf.conf && \
 
 RUN dnf update -y && \
     dnf -y install centos-release-nfv-openvswitch && \
+    dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
     dnf -y install --setopt=install_weak_deps=False \
         systemd make go rust-toolset NetworkManager NetworkManager-ovs \
@@ -21,6 +22,10 @@ RUN dnf update -y && \
         git iproute rpm-build python3-pytest wpa_supplicant hostapd libndp \
         python3-pip procps-ng dpdk libreswan NetworkManager-libreswan podman \
         openvswitch3.4 && \
+    dnf clean all
+
+RUN dnf install -y epel-release && \
+    dnf install -y tcpreplay && \
     dnf clean all
 
 RUN go env -w GOSUMDB="sum.golang.org" GOPROXY="https://proxy.golang.org,direct"

--- a/packaging/Dockerfile.fed-nmstate-dev:latest
+++ b/packaging/Dockerfile.fed-nmstate-dev:latest
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora:latest
 
-RUN echo "2025-03-12" > /build_time
+RUN echo "2026-05-25" > /build_time
 
 RUN dnf update -y && \
     dnf -y install --setopt=install_weak_deps=False \

--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -11,6 +11,7 @@ from libnmstate.schema import InterfaceIPv6
 
 
 from .testlib import cmdlib
+from .testlib.env import is_el10
 from .testlib.env import is_k8s
 from .testlib.env import nm_libreswan_version_int
 from .testlib.env import version_str_to_int
@@ -684,6 +685,11 @@ def test_ipsec_ipv6_host_to_subnet(ipsec_srv_host_to_site):
     )
 
 
+# https://redhat.atlassian.net/browse/RHEL-176474
+@pytest.mark.skipif(
+    is_el10(),
+    reason="Waive: currently failing on EL10 due to known bug",
+)
 @pytest.mark.xfail(
     nm_libreswan_version_int() < version_str_to_int("1.2.22"),
     reason="Need NetworkManager-libreswan 1.2.22+ to support IPv6",
@@ -855,6 +861,11 @@ def test_ipsec_ipv4_libreswan_change_ipsec_iface(ipsec_psk_with_ipsec_iface):
 
 
 # DHCPv4 off with empty IP address means IP disabled for IPSec interface
+# https://redhat.atlassian.net/browse/RHEL-176474
+@pytest.mark.skipif(
+    is_el10(),
+    reason="Waive: currently failing on EL10 due to known bug",
+)
 def test_ipsec_dhcpv4_off_and_empty_ip_addr(
     ipsec_srv_rsa_gw,
 ):

--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -9,6 +9,17 @@ def is_fedora():
     return os.path.exists("/etc/fedora-release")
 
 
+def is_el10():
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if line.strip() == 'PLATFORM_ID="platform:el10"':
+                    return True
+    except FileNotFoundError:
+        pass
+    return False
+
+
 def nm_minor_version():
     version_str = exec_cmd(
         "rpm -q NetworkManager --qf %{VERSION}".split(),


### PR DESCRIPTION
  - Upgrade Fedora dev container
  - Add c10s integration test jobs: nm_stable-integ_tier2, nm_main-integ_tier1,
    nm_main-integ_tier2
  - Install the missing dependency tcpreplay from EPEL in c10s
  - Temporary: skip a few IPSec tests that are failing in c10s, likely because a bug in the kernel, NM-libreswan or Libreswan (bug already reported)
