### PR TITLE
tests: make test_missing_operation compatible with clap 3 and 4

### DIFF
--- a/tests/integration/nmstatectl_test.py
+++ b/tests/integration/nmstatectl_test.py
@@ -130,7 +130,7 @@ def test_missing_operation():
     rc, out, err = ret
 
     assert rc != cmdlib.RC_SUCCESS, cmdlib.format_exec_cmd_result(ret)
-    assert "unrecognized subcommand 'no-such-oper'" in err
+    assert "no-such-oper" in err
 
 
 def test_show_command_with_json():


### PR DESCRIPTION
The error message format changed between clap 3 and clap 4:
- clap 3: "Found argument 'no-such-oper' which wasn't expected"
- clap 4: "unrecognized subcommand 'no-such-oper'"

Relax the assertion to check for 'no-such-oper' in the error output, which works with both versions.