### PR TITLE
ci: bump kubevirtci to k8s-1.35 and fix integ_tier1-k8s

### DIFF
--- a/k8s/kubevirtci.sh
+++ b/k8s/kubevirtci.sh
@@ -1,5 +1,5 @@
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.27'}
-export KUBEVIRTCI_TAG='2310060757-0afa095'
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-'k8s-1.35'}
+export KUBEVIRTCI_TAG='2606030700-d560ba85'
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
 KUBEVIRTCI_PATH="${PWD}/_kubevirtci"

--- a/k8s/up.sh
+++ b/k8s/up.sh
@@ -15,21 +15,53 @@ if [[ "$KUBEVIRT_PROVIDER" =~ ^(okd|ocp)-.*$$ ]]; then \
 fi
 
 for node in $(./k8s/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
+    # Upgrade NetworkManager to the latest available version.
+    # The base node image ships an older NM whose "strictly unmanaged"
+    # enforcement and OVS activation paths differ from the container CI
+    # environment, causing spurious test failures. This aligns the k8s CI
+    # node with the kubernetes-nmstate project's setup.
+    ./k8s/ssh.sh $node -- "sudo dnf upgrade -y NetworkManager --allowerasing"
+    # Remove the dhclient drop-in shipped by newer kubevirtci images.
+    # This keeps the NM internal DHCP client consistent with the container
+    # CI and with kubernetes-nmstate's cluster/up.sh.
+    ./k8s/ssh.sh $node -- "sudo rm -f /etc/NetworkManager/conf.d/002-dhclient.conf"
+    # openvswitch is already installed in the node image, so just enable
+    # the service.
     ./k8s/ssh.sh $node -- \
-        "sudo dnf upgrade -y \
-            openvswitch \
-            NetworkManager \
-            NetworkManager-ovs && \
-        sudo systemctl enable openvswitch && \
+        "sudo systemctl enable openvswitch && \
         sudo sed -i -e 's/^#RateLimitInterval=.*/RateLimitInterval=0/' \
             -e 's/^#RateLimitBurst=.*/RateLimitBurst=0/' \
             /etc/systemd/journald.conf"
     ./k8s/ssh.sh $node  -- "echo "[logging]" | sudo tee /etc/NetworkManager/conf.d/97-trace-logging.conf && \
                             echo "level=TRACE" | sudo tee -a /etc/NetworkManager/conf.d/97-trace-logging.conf && \
                             echo "domain=ALL" | sudo tee -a /etc/NetworkManager/conf.d/97-trace-logging.conf"
+    # The integration tests create veth pairs with arbitrary names
+    # (veth1, veth1peer, 1x_cli, …).  NetworkManager ships a udev rule
+    # (/usr/lib/udev/rules.d/85-nm-unmanaged.rules) that sets
+    # NM_UNMANAGED=1 for every veth whose name does not match eth[0-9]*.
+    # This makes the devices "strictly unmanaged" at the udev level —
+    # neither `nmcli device set … managed yes` nor an NM conf [device]
+    # section can override it.
+    #
+    # Fix: install an override in /etc/udev/rules.d/ (which takes
+    # priority over /usr/lib/) that keeps the VirtualBox / VMWare /
+    # Parallels / USB-gadget rules but drops the blanket veth rule.
+    ./k8s/ssh.sh $node -- 'cat <<'"'"'EOF'"'"' | sudo tee /etc/udev/rules.d/85-nm-unmanaged.rules >/dev/null
+SUBSYSTEM!="net", GOTO="nm_unmanaged_end"
+ACTION!="add|change|move", GOTO="nm_unmanaged_end"
+ENV{INTERFACE}=="vboxnet[0-9]*", ENV{NM_UNMANAGED}="1"
+ATTR{address}=="00:50:56:*", ENV{INTERFACE}=="vmnet[0-9]*", ENV{NM_UNMANAGED}="1"
+ATTR{address}=="00:1c:42:*", ENV{INTERFACE}=="vnic[0-9]*", ENV{NM_UNMANAGED}="1"
+ENV{DEVTYPE}=="gadget", ENV{NM_UNMANAGED}="1"
+LABEL="nm_unmanaged_end"
+EOF'
+    ./k8s/ssh.sh $node -- 'sudo udevadm control --reload-rules && sudo udevadm trigger --subsystem-match=net'
     ./k8s/ssh.sh $node -- sudo systemctl daemon-reload
     ./k8s/ssh.sh $node -- sudo systemctl restart NetworkManager
     ./k8s/ssh.sh $node -- sudo systemctl restart openvswitch
+    # Enable persistent journal so logs survive node reboots
+    ./k8s/ssh.sh $node -- sudo mkdir -p /var/log/journal
+    ./k8s/ssh.sh $node -- sudo systemctl restart systemd-journald
     for nic in $FIRST_SECONDARY_NIC $SECOND_SECONDARY_NIC; do
 	      uuid=$(./k8s/cli.sh ssh $node -- nmcli --fields=device,uuid  c show  |grep $nic|awk '{print $2}')
 	      if [ ! -z "$uuid" ]; then
@@ -38,4 +70,3 @@ for node in $(./k8s/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
 	      fi
     done
 done
-

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -11,11 +11,34 @@ from libnmstate.schema import Veth
 from .cmdlib import exec_cmd
 
 
+def _free_iface_name(nic):
+    """
+    Make the interface name {nic} available for a test veth.
+
+    Some kubevirtci node images (e.g. k8s-1.35, which boots with
+    net.ifnames=0) ship a physical secondary NIC already named eth1/eth2.
+    Such a kernel device cannot be removed with `ip link del`, so it
+    collides with the veth pair the tests want to create. Detach it from
+    NetworkManager and rename it out of the way so the name is free.
+    """
+    rc, _, _ = exec_cmd(f"ip link show {nic}".split())
+    if rc != 0:
+        # No interface with this name exists, nothing to do.
+        return
+    parked = f"{nic}.phys"
+    exec_cmd(f"nmcli device set {nic} managed no".split())
+    exec_cmd(f"ip link set {nic} down".split())
+    # Remove a stale parked link from a previous run, if any.
+    exec_cmd(f"ip link del {parked}".split())
+    exec_cmd(f"ip link set {nic} name {parked}".split(), check=True)
+
+
 def create_veth_pair(nic, nic_peer, peer_ns):
     """
     Create a veth pair and place the {peer} into {peer_ns} namespace.
     The {nic} will be marked as managed by NetworkManager
     """
+    _free_iface_name(nic)
     exec_cmd(
         f"ip link add {nic} type veth peer name {nic_peer}".split(),
         check=True,


### PR DESCRIPTION
## Why

`pull-nmstate-integ_tier1-k8s` has been broken since the kubevirtci `k8s-1.27` provider image was EOL'd — the pinned node image references the retired Kubic cri-o 1.27 dnf mirror, which now returns HTTP 404 during `dnf upgrade` in `k8s/up.sh`. Every CI run dies at cluster provisioning before any test executes.

## What

Bump kubevirtci to tag `2606030700-d560ba85` (`k8s-1.35`) and fix three classes of test failures exposed by the new node image:

### 1. Physical-NIC name collision (`testlib/veth.py`)

The k8s-1.35 node boots with `net.ifnames=0`, so its secondary NIC is named `eth1` — the same name the test fixtures use for veth pairs. A new `_free_iface_name()` helper detects and parks any pre-existing physical NIC out of the way before creating the test veth.

### 2. udev 'strictly unmanaged' veths (`k8s/up.sh`)

NetworkManager ships `/usr/lib/udev/rules.d/85-nm-unmanaged.rules` which sets `NM_UNMANAGED=1` for every veth not matching `eth[0-9]*`. This makes the devices strictly unmanaged at the udev level — neither `nmcli device set managed yes` nor an NM conf `[device]` section can override it. The fix installs an override in `/etc/udev/rules.d/` that keeps the VirtualBox/VMWare/Parallels/gadget rules but drops the blanket veth rule.

### 3. Node environment alignment with kubernetes-nmstate (`k8s/up.sh`)

Follow what `kubernetes-nmstate/cluster/up.sh` does:
- **Upgrade NetworkManager** (`dnf upgrade -y NetworkManager --allowerasing`) — the base node image ships an older NM whose 'strictly unmanaged' enforcement and OVS activation paths differ from the container CI
- **Remove the dhclient drop-in** (`002-dhclient.conf`) — keeps the NM internal DHCP client consistent with the container CI
- **Enable persistent journal** — so test logs survive node reboots

### Removed the broken `dnf upgrade openvswitch NetworkManager NetworkManager-ovs`

The original `k8s/up.sh` tried to upgrade all three packages in a single `dnf upgrade` command. The bare `openvswitch` package name doesn't resolve in the node repos — this command only ever succeeded as a side effect of also upgrading NM. Replaced with the targeted `dnf upgrade -y NetworkManager --allowerasing` that kubernetes-nmstate uses.