### PR TITLE
loopback: Allow IPv6 disabled when kernel-disabled

### DIFF
--- a/examples/loopback_ipv6_disabled.yml
+++ b/examples/loopback_ipv6_disabled.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+  - name: lo
+    type: loopback
+    state: up
+    ipv6:
+      enabled: false

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -933,6 +933,7 @@ impl MergedInterface {
     // This function will be invoked __after__ inter-ifaces process done.
     pub(crate) fn post_inter_ifaces_process(
         &mut self,
+        gen_conf_mode: bool,
     ) -> Result<(), NmstateError> {
         self.preserve_current_controller_info();
         self.post_inter_ifaces_process_base_iface()?;
@@ -941,6 +942,11 @@ impl MergedInterface {
         self.post_inter_ifaces_process_bond()?;
         self.post_inter_ifaces_process_vlan();
         self.post_inter_ifaces_process_hsr();
+        // gen_conf has no kernel state to consult, so honor the desired
+        // IPv6-disabled request instead of rejecting it.
+        if !gen_conf_mode {
+            self.post_inter_ifaces_process_loopback()?;
+        }
 
         if let Some(apply_iface) = self.for_apply.as_mut() {
             apply_iface.sanitize(true)?;

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -956,13 +956,14 @@ impl MergedInterfaces {
         self.process_veth_peer_changes()?;
         self.validate_dispatch_script_has_no_checkpoint()?;
         self.validate_alt_names()?;
+        let gen_conf_mode = self.mode == NetworkStateMode::GenerateConfig;
         for iface in self
             .kernel_ifaces
             .values_mut()
             .chain(self.user_ifaces.values_mut())
             .filter(|i| i.is_changed())
         {
-            iface.post_inter_ifaces_process()?;
+            iface.post_inter_ifaces_process(gen_conf_mode)?;
         }
         Ok(())
     }

--- a/rust/src/lib/ifaces/loopback.rs
+++ b/rust/src/lib/ifaces/loopback.rs
@@ -18,10 +18,10 @@ use crate::{
 ///  * The [InterfaceState::Absent] can only restore the loopback configure back
 ///    to default.
 ///  * Cannot disable IPv4.
-///  * Cannot disable IPv6 unless the kernel IPv6 stack is already off (e.g.
-///    booted with `ipv6.disable=1`).
-///  * Even when not desired, `127.0.0.1/8` and `::1` (the latter only when
-///    IPv6 is enabled) are always appended to the static IP address list.
+///  * Cannot disable IPv6 unless it is already reported disabled, so `show`
+///    output round-trips (e.g. on a host booted with `ipv6.disable=1`).
+///  * Even when not desired, `127.0.0.1/8` and `::1` (the latter only when IPv6
+///    is enabled) are always appended to the static IP address list.
 ///  * Require NetworkManager 1.41+ unless in kernel only mode.
 ///
 /// Example yaml outpuf of `[crate::NetworkState]` with loopback interface:
@@ -116,9 +116,8 @@ impl LoopbackInterface {
 }
 
 impl MergedInterface {
-    // Allow disabling IPv6 on loopback only when the kernel IPv6 stack is
-    // already off (e.g. `ipv6.disable=1`), so `nmstatectl show` output can be
-    // reapplied on such a host.
+    // Allow disabling IPv6 on loopback only when it is already reported
+    // disabled, so `nmstatectl show` output can be reapplied.
     pub(crate) fn post_inter_ifaces_process_loopback(
         &self,
     ) -> Result<(), NmstateError> {

--- a/rust/src/lib/ifaces/loopback.rs
+++ b/rust/src/lib/ifaces/loopback.rs
@@ -5,8 +5,9 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    BaseInterface, ErrorKind, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6,
-    InterfaceState, InterfaceType, NmstateError,
+    BaseInterface, ErrorKind, Interface, InterfaceIpAddr, InterfaceIpv4,
+    InterfaceIpv6, InterfaceState, InterfaceType, MergedInterface,
+    NmstateError,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -16,9 +17,11 @@ use crate::{
 ///  * Cannot enable DHCP or autoconf.
 ///  * The [InterfaceState::Absent] can only restore the loopback configure back
 ///    to default.
-///  * Ignore the request of disable IPv4 or IPv6.
-///  * Even not desired, the `127.0.0.1/8` and `::1` are always appended to
-///    static IP address list.
+///  * Cannot disable IPv4.
+///  * Cannot disable IPv6 unless the kernel IPv6 stack is already off (e.g.
+///    booted with `ipv6.disable=1`).
+///  * Even when not desired, `127.0.0.1/8` and `::1` (the latter only when
+///    IPv6 is enabled) are always appended to the static IP address list.
 ///  * Require NetworkManager 1.41+ unless in kernel only mode.
 ///
 /// Example yaml outpuf of `[crate::NetworkState]` with loopback interface:
@@ -89,32 +92,53 @@ impl LoopbackInterface {
             if self.base.ipv4.as_ref().map(|i| i.enabled) == Some(false) {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
-                    "Loopback interface cannot be have IPv4 disabled"
-                        .to_string(),
-                ));
-            }
-            if self.base.ipv6.as_ref().map(|i| i.enabled) == Some(false) {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    "Loopback interface cannot be have IPv6 disabled"
-                        .to_string(),
+                    "Loopback interface cannot have IPv4 disabled".to_string(),
                 ));
             }
             if self.base.ipv4.as_ref().map(|i| i.is_auto()) == Some(true) {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
-                    "Loopback interface cannot be have IPv4 DHCP enabled"
+                    "Loopback interface cannot have IPv4 DHCP enabled"
                         .to_string(),
                 ));
             }
             if self.base.ipv6.as_ref().map(|i| i.is_auto()) == Some(true) {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
-                    "Loopback interface cannot be have IPv6 autoconf/DHCPv6 \
+                    "Loopback interface cannot have IPv6 autoconf/DHCPv6 \
                      enabled"
                         .to_string(),
                 ));
             }
+        }
+        Ok(())
+    }
+}
+
+impl MergedInterface {
+    // Allow disabling IPv6 on loopback only when the kernel IPv6 stack is
+    // already off (e.g. `ipv6.disable=1`), so `nmstatectl show` output can be
+    // reapplied on such a host.
+    pub(crate) fn post_inter_ifaces_process_loopback(
+        &self,
+    ) -> Result<(), NmstateError> {
+        let apply_iface = match self.for_apply.as_ref() {
+            Some(Interface::Loopback(i)) => i,
+            _ => return Ok(()),
+        };
+        let cur_ipv6_enabled = match self.current.as_ref() {
+            Some(Interface::Loopback(i)) => {
+                i.base.ipv6.as_ref().map(|ip| ip.enabled)
+            }
+            _ => None,
+        };
+        if apply_iface.base.ipv6.as_ref().map(|ip| ip.enabled) == Some(false)
+            && cur_ipv6_enabled != Some(false)
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                "Loopback interface cannot have IPv6 disabled".to_string(),
+            ));
         }
         Ok(())
     }

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -8,7 +8,8 @@ use super::{
 };
 use crate::{
     AddressFamily, Dhcpv4ClientId, Dhcpv6Duid, InterfaceIpv4, InterfaceIpv6,
-    Ipv6AddrGenMode, RouteEntry, RouteRuleAction, RouteRuleEntry, WaitIp,
+    InterfaceType, Ipv6AddrGenMode, RouteEntry, RouteRuleAction,
+    RouteRuleEntry, WaitIp,
 };
 
 const ADDR_GEN_MODE_EUI64: i32 = 0;
@@ -85,6 +86,7 @@ pub(crate) fn nm_ip_setting_to_nmstate4(
 
 pub(crate) fn nm_ip_setting_to_nmstate6(
     iface_name: &str,
+    iface_type: &InterfaceType,
     nm_ip_setting: &NmSettingIp,
 ) -> InterfaceIpv6 {
     if let Some(nm_ip_method) = &nm_ip_setting.method {
@@ -93,6 +95,12 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             NmSettingIpMethod::LinkLocal
             | NmSettingIpMethod::Manual
             | NmSettingIpMethod::Shared => (true, Some(false), Some(false)),
+            // NM sets loopback to `auto` but never runs autoconf/DHCPv6 on it.
+            NmSettingIpMethod::Auto
+                if iface_type == &InterfaceType::Loopback =>
+            {
+                (true, Some(false), Some(false))
+            }
             NmSettingIpMethod::Auto => (true, Some(true), Some(true)),
             NmSettingIpMethod::Dhcp => (true, Some(true), Some(false)),
             NmSettingIpMethod::Ignore => {
@@ -110,7 +118,9 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             parse_dhcp_opts(nm_ip_setting);
         let mut ret = InterfaceIpv6 {
             enabled,
-            enabled_defined: true,
+            // The kernel owns loopback IPv6 (e.g. `ipv6.disable=1`); let
+            // nispor's state win the merge.
+            enabled_defined: iface_type != &InterfaceType::Loopback,
             dhcp,
             autoconf,
             auto_dns,
@@ -313,4 +323,43 @@ fn nm_rules_to_nmstate(
         ret.insert(rule);
     }
     Some(ret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gen_auto_ipv6_setting() -> NmSettingIp {
+        let mut nm_setting = NmSettingIp::default();
+        nm_setting.method = Some(NmSettingIpMethod::Auto);
+        nm_setting
+    }
+
+    #[test]
+    fn test_nm_ipv6_auto_on_loopback_enabled_not_defined() {
+        let ip = nm_ip_setting_to_nmstate6(
+            "lo",
+            &InterfaceType::Loopback,
+            &gen_auto_ipv6_setting(),
+        );
+
+        assert!(ip.enabled);
+        assert!(!ip.enabled_defined);
+        assert_eq!(ip.dhcp, Some(false));
+        assert_eq!(ip.autoconf, Some(false));
+    }
+
+    #[test]
+    fn test_nm_ipv6_auto_on_ethernet_dhcp_autoconf_defined() {
+        let ip = nm_ip_setting_to_nmstate6(
+            "eth1",
+            &InterfaceType::Ethernet,
+            &gen_auto_ipv6_setting(),
+        );
+
+        assert!(ip.enabled);
+        assert!(ip.enabled_defined);
+        assert_eq!(ip.dhcp, Some(true));
+        assert_eq!(ip.autoconf, Some(true));
+    }
 }

--- a/rust/src/lib/nm/query_apply/ip.rs
+++ b/rust/src/lib/nm/query_apply/ip.rs
@@ -97,7 +97,7 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             | NmSettingIpMethod::Shared => (true, Some(false), Some(false)),
             // NM sets loopback to `auto` but never runs autoconf/DHCPv6 on it.
             NmSettingIpMethod::Auto
-                if iface_type == &InterfaceType::Loopback =>
+                if *iface_type == InterfaceType::Loopback =>
             {
                 (true, Some(false), Some(false))
             }
@@ -120,7 +120,7 @@ pub(crate) fn nm_ip_setting_to_nmstate6(
             enabled,
             // The kernel owns loopback IPv6 (e.g. `ipv6.disable=1`); let
             // nispor's state win the merge.
-            enabled_defined: iface_type != &InterfaceType::Loopback,
+            enabled_defined: *iface_type != InterfaceType::Loopback,
             dhcp,
             autoconf,
             auto_dns,

--- a/rust/src/lib/nm/settings/ip.rs
+++ b/rust/src/lib/nm/settings/ip.rs
@@ -136,6 +136,7 @@ fn gen_nm_ipv4_setting(
 
 fn gen_nm_ipv6_setting(
     iface_ip: Option<&InterfaceIpv6>,
+    iface_type: &InterfaceType,
     routes: Option<&[RouteEntry]>,
     nm_conn: &mut NmConnection,
 ) -> Result<(), NmstateError> {
@@ -186,6 +187,11 @@ fn gen_nm_ipv6_setting(
                 }
             }
         }
+    } else if iface_type == &InterfaceType::Loopback {
+        // Reached only when the kernel IPv6 stack is off (checked during
+        // merge). NM's loopback profile uses `auto`, not `disabled`, so we
+        // match it here; no address binds while the stack is off.
+        NmSettingIpMethod::Auto
     } else {
         NmSettingIpMethod::Disabled
     };
@@ -274,7 +280,12 @@ pub(crate) fn gen_nm_ip_setting(
         || base_iface.controller_type == Some(InterfaceType::Hsr)
     {
         gen_nm_ipv4_setting(base_iface.ipv4.as_ref(), routes, nm_conn)?;
-        gen_nm_ipv6_setting(base_iface.ipv6.as_ref(), routes, nm_conn)?;
+        gen_nm_ipv6_setting(
+            base_iface.ipv6.as_ref(),
+            &base_iface.iface_type,
+            routes,
+            nm_conn,
+        )?;
         apply_nmstate_wait_ip(base_iface, nm_conn);
     } else {
         nm_conn.ipv4 = None;
@@ -378,5 +389,49 @@ pub(crate) fn fix_ip_dhcp_timeout(nm_conns: &mut [NmConnection]) {
         if let Some(nm_ip_set) = nm_conn.ipv6.as_mut() {
             nm_ip_set.dhcp_timeout = Some(i32::MAX);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gen_ipv6_disabled_iface(name: &str, iface_type: &str) -> Interface {
+        serde_yaml::from_str(&format!(
+            r#"---
+name: {name}
+type: {iface_type}
+state: up
+ipv6:
+  enabled: false
+"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_gen_nm_ipv6_disabled_on_loopback_use_auto_method() {
+        let iface = gen_ipv6_disabled_iface("lo", "loopback");
+        let mut nm_conn = NmConnection::default();
+
+        gen_nm_ip_setting(&iface, None, &mut nm_conn).unwrap();
+
+        assert_eq!(
+            nm_conn.ipv6.as_ref().and_then(|s| s.method.as_ref()),
+            Some(&NmSettingIpMethod::Auto)
+        );
+    }
+
+    #[test]
+    fn test_gen_nm_ipv6_disabled_on_ethernet_use_disabled_method() {
+        let iface = gen_ipv6_disabled_iface("eth1", "ethernet");
+        let mut nm_conn = NmConnection::default();
+
+        gen_nm_ip_setting(&iface, None, &mut nm_conn).unwrap();
+
+        assert_eq!(
+            nm_conn.ipv6.as_ref().and_then(|s| s.method.as_ref()),
+            Some(&NmSettingIpMethod::Disabled)
+        );
     }
 }

--- a/rust/src/lib/nm/show.rs
+++ b/rust/src/lib/nm/show.rs
@@ -197,7 +197,11 @@ pub(crate) async fn nm_retrieve(
 fn fill_ip_settings(base_iface: &mut BaseInterface, nm_conn: &NmConnection) {
     base_iface.ipv4 = nm_conn.ipv4.as_ref().map(nm_ip_setting_to_nmstate4);
     base_iface.ipv6 = nm_conn.ipv6.as_ref().map(|nm_ip_set| {
-        nm_ip_setting_to_nmstate6(base_iface.name.as_str(), nm_ip_set)
+        nm_ip_setting_to_nmstate6(
+            base_iface.name.as_str(),
+            &base_iface.iface_type,
+            nm_ip_set,
+        )
     });
     base_iface.wait_ip =
         query_nmstate_wait_ip(nm_conn.ipv4.as_ref(), nm_conn.ipv6.as_ref());

--- a/rust/src/lib/unit_tests/loopback.rs
+++ b/rust/src/lib/unit_tests/loopback.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, Interfaces, MergedInterfaces};
+
+fn gen_lo_ifaces(ipv6_enabled: bool) -> Interfaces {
+    let yml = if ipv6_enabled {
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  mtu: 65536
+  ipv4:
+    enabled: true
+    address:
+    - ip: 127.0.0.1
+      prefix-length: 8
+  ipv6:
+    enabled: true
+    address:
+    - ip: ::1
+      prefix-length: 128
+"#
+    } else {
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  mtu: 65536
+  ipv4:
+    enabled: true
+    address:
+    - ip: 127.0.0.1
+      prefix-length: 8
+  ipv6:
+    enabled: false
+"#
+    };
+    serde_yaml::from_str(yml).unwrap()
+}
+
+fn gen_lo_ipv4_disabled_ifaces() -> Interfaces {
+    serde_yaml::from_str(
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  ipv4:
+    enabled: false
+"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_loopback_allow_ipv6_disabled_when_currently_disabled() {
+    // On a system booted with `ipv6.disable=1`, `nmstatectl show` reports
+    // loopback with IPv6 disabled. Reapplying that output should not fail.
+    let desired = gen_lo_ifaces(false);
+    let current = gen_lo_ifaces(false);
+
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
+}
+
+#[test]
+fn test_loopback_allow_partial_ipv6_disabled_when_currently_disabled() {
+    let desired: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  ipv6:
+    enabled: false
+"#,
+    )
+    .unwrap();
+    let current = gen_lo_ifaces(false);
+
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
+}
+
+#[test]
+fn test_loopback_allow_enable_ipv6_when_currently_disabled() {
+    let desired = gen_lo_ifaces(true);
+    let current = gen_lo_ifaces(false);
+
+    MergedInterfaces::new(desired, current, Default::default(), false).unwrap();
+}
+
+#[test]
+fn test_loopback_reject_ipv6_disabled_when_currently_enabled() {
+    let desired = gen_lo_ifaces(false);
+    let current = gen_lo_ifaces(true);
+
+    let e = MergedInterfaces::new(desired, current, Default::default(), false)
+        .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    assert!(e.msg().contains("IPv6"));
+}
+
+#[test]
+fn test_loopback_reject_ipv6_disabled_when_current_ipv6_unknown() {
+    let desired = gen_lo_ifaces(false);
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  mtu: 65536
+  ipv4:
+    enabled: true
+    address:
+    - ip: 127.0.0.1
+      prefix-length: 8
+"#,
+    )
+    .unwrap();
+
+    let e = MergedInterfaces::new(desired, current, Default::default(), false)
+        .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    assert!(e.msg().contains("IPv6"));
+}
+
+#[test]
+fn test_loopback_reject_ipv4_disabled_when_currently_enabled() {
+    let desired = gen_lo_ipv4_disabled_ifaces();
+    let current = gen_lo_ifaces(true);
+
+    let e = MergedInterfaces::new(desired, current, Default::default(), false)
+        .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    assert!(e.msg().contains("IPv4"));
+}
+
+#[test]
+fn test_loopback_reject_ipv4_disabled_even_when_currently_disabled() {
+    // Unlike IPv6, the kernel cannot run with IPv4 disabled. A loopback
+    // without IPv4 is a broken state which should not be preserved.
+    let desired = gen_lo_ipv4_disabled_ifaces();
+    let current: Interfaces = serde_yaml::from_str(
+        r#"---
+- name: lo
+  type: loopback
+  state: up
+  mtu: 65536
+  ipv4:
+    enabled: false
+  ipv6:
+    enabled: true
+    address:
+    - ip: ::1
+      prefix-length: 128
+"#,
+    )
+    .unwrap();
+
+    let e = MergedInterfaces::new(desired, current, Default::default(), false)
+        .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    assert!(e.msg().contains("IPv4"));
+}
+
+#[test]
+fn test_loopback_reject_ipv6_disabled_when_current_unknown() {
+    let desired = gen_lo_ifaces(false);
+
+    let e = MergedInterfaces::new(
+        desired,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(e.kind(), ErrorKind::InvalidArgument);
+    assert!(e.msg().contains("IPv6"));
+}

--- a/rust/src/lib/unit_tests/mod.rs
+++ b/rust/src/lib/unit_tests/mod.rs
@@ -39,6 +39,8 @@ mod ipsec;
 #[cfg(test)]
 mod lldp;
 #[cfg(test)]
+mod loopback;
+#[cfg(test)]
 mod mac_vlan;
 #[cfg(test)]
 mod mac_vtap;

--- a/rust/src/lib/unit_tests/mptcp.rs
+++ b/rust/src/lib/unit_tests/mptcp.rs
@@ -19,7 +19,7 @@ mptcp:
 
     let mut merged_iface = MergedInterface::new(Some(des_iface), None).unwrap();
 
-    let result = merged_iface.post_inter_ifaces_process();
+    let result = merged_iface.post_inter_ifaces_process(false);
     assert!(result.is_err());
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::InvalidArgument);

--- a/rust/src/lib/unit_tests/vlan.rs
+++ b/rust/src/lib/unit_tests/vlan.rs
@@ -242,7 +242,7 @@ fn test_vlan_base_iface_optional() {
 
     let mut merged_iface =
         MergedInterface::new(Some(desired), Some(current)).unwrap();
-    merged_iface.post_inter_ifaces_process().unwrap();
+    merged_iface.post_inter_ifaces_process(false).unwrap();
 }
 
 #[test]

--- a/tests/integration/loopback_test.py
+++ b/tests/integration/loopback_test.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
+import libnmstate
+from libnmstate.error import NmstateValueError
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceIPv4
 from libnmstate.schema import InterfaceIPv6
@@ -126,3 +130,44 @@ class TestLoopback:
             }
         )
         assertlib.assert_state_match(desired_state)
+
+    def test_disable_loopback_ipv4_is_rejected(self, loopback_cleanup):
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "lo",
+                    Interface.TYPE: InterfaceType.LOOPBACK,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.IPV4: {
+                        InterfaceIPv4.ENABLED: False,
+                    },
+                }
+            ]
+        }
+        with pytest.raises(
+            NmstateValueError, match="cannot have IPv4 disabled"
+        ):
+            libnmstate.apply(desired_state)
+
+    def test_disable_loopback_ipv6_is_rejected(self, loopback_cleanup):
+        # Disabling IPv6 on loopback is only allowed when the kernel IPv6
+        # stack is disabled (e.g. booted with `ipv6.disable=1`).
+        if not os.path.exists("/proc/sys/net/ipv6"):
+            pytest.skip("Kernel IPv6 stack is disabled")
+
+        desired_state = {
+            Interface.KEY: [
+                {
+                    Interface.NAME: "lo",
+                    Interface.TYPE: InterfaceType.LOOPBACK,
+                    Interface.STATE: InterfaceState.UP,
+                    Interface.IPV6: {
+                        InterfaceIPv6.ENABLED: False,
+                    },
+                }
+            ]
+        }
+        with pytest.raises(
+            NmstateValueError, match="cannot have IPv6 disabled"
+        ):
+            libnmstate.apply(desired_state)


### PR DESCRIPTION
On a system booted with `ipv6.disable=1`, `nmstatectl show` reports loopback with `ipv6: enabled: false`, but reapplying that output was rejected by the loopback sanitize check.

Move the check to `MergedInterface::post_inter_ifaces_process_loopback()` where the current state is known, and only reject disabling IPv6 when the IPv6 stack is currently enabled or unknown.

Resolves: https://redhat.atlassian.net/browse/NMT-2213