### PR TITLE
route: catch metric-less route conflicts in kernel mode

### DIFF
--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -362,7 +362,7 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
         } else {
             continue;
         };
-        let mut hashed_rts: HashMap<(&str, Option<u32>), &RouteEntry> =
+        let mut hashed_rts: HashMap<(&str, u32, u32), &RouteEntry> =
             HashMap::new();
         for rt in iface_routes {
             if rt.weight.is_some() {
@@ -381,9 +381,13 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
                 continue;
             };
 
+            // Key on the metric and table the kernel will actually use, so a
+            // metric-less desired route conflicts with an existing route that
+            // the kernel reports with the coerced default metric (e.g. IPv6
+            // default route metric 1024).
             if hashed_rts
                 .insert(
-                    (dst, rt.metric.and_then(|m| u32::try_from(m).ok())),
+                    (dst, rt.effective_table_id(), rt.effective_metric()),
                     rt,
                 )
                 .is_some()
@@ -392,11 +396,123 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
                     ErrorKind::InvalidArgument,
                     format!(
                         "Multiple routes to {dst} are sharing the same \
-                         metric, please use `state: absent` to remove others."
+                         metric and table, please use `state: absent` to \
+                         remove others."
                     ),
                 ));
             }
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(
+        dst: &str,
+        via: &str,
+        metric: Option<i64>,
+        table: u32,
+    ) -> RouteEntry {
+        RouteEntry {
+            destination: Some(dst.to_string()),
+            next_hop_iface: Some("eth1".to_string()),
+            next_hop_addr: Some(via.to_string()),
+            metric,
+            table_id: Some(table),
+            ..Default::default()
+        }
+    }
+
+    fn merged_for(routes: Vec<RouteEntry>) -> MergedRoutes {
+        let mut merged = HashMap::new();
+        merged.insert("eth1".to_string(), routes);
+        MergedRoutes {
+            merged,
+            route_changed_ifaces: vec!["eth1".to_string()],
+            ..Default::default()
+        }
+    }
+
+    // Kernel reports the existing IPv6 default route with metric 1024 while the
+    // desired route omits the metric. Both must be treated as conflicting.
+    #[test]
+    fn test_metricless_ipv6_conflicts_with_kernel_default() {
+        let merged = merged_for(vec![
+            route("::/0", "2001:db8:1::3", Some(1024), 200),
+            route("::/0", "2001:db8:1::2", None, 200),
+        ]);
+        let err = validate_routes(&merged).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    // IPv4 default metric is 0, so a metric-less route and an explicit metric 0
+    // route to the same destination conflict.
+    #[test]
+    fn test_ipv4_metricless_conflicts_with_metric_zero() {
+        let merged = merged_for(vec![
+            route("0.0.0.0/0", "192.0.2.1", Some(0), 200),
+            route("0.0.0.0/0", "192.0.2.2", None, 200),
+        ]);
+        let err = validate_routes(&merged).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    // An unset table resolves to the main table, so it conflicts with an
+    // explicit table 254.
+    #[test]
+    fn test_default_table_conflicts_with_explicit_main() {
+        let merged = merged_for(vec![
+            route("::/0", "2001:db8:1::3", Some(1024), 0),
+            route("::/0", "2001:db8:1::2", None, 254),
+        ]);
+        let err = validate_routes(&merged).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    // Same destination and (defaulted) metric but different tables must not be
+    // flagged as a conflict.
+    #[test]
+    fn test_same_dst_different_table_no_conflict() {
+        let merged = merged_for(vec![
+            route("::/0", "2001:db8:1::3", None, 200),
+            route("::/0", "2001:db8:1::2", None, 254),
+        ]);
+        validate_routes(&merged).unwrap();
+    }
+
+    // Same destination and table but distinct explicit metrics are valid.
+    #[test]
+    fn test_same_dst_different_metric_no_conflict() {
+        let merged = merged_for(vec![
+            route("::/0", "2001:db8:1::3", Some(100), 200),
+            route("::/0", "2001:db8:1::2", Some(200), 200),
+        ]);
+        validate_routes(&merged).unwrap();
+    }
+
+    // IPv4 unset metric maps to 0, not 1024, so it must not collide with an
+    // explicit metric 1024 route to the same destination.
+    #[test]
+    fn test_ipv4_metricless_differs_from_metric_1024() {
+        let merged = merged_for(vec![
+            route("0.0.0.0/0", "192.0.2.1", Some(1024), 200),
+            route("0.0.0.0/0", "192.0.2.2", None, 200),
+        ]);
+        validate_routes(&merged).unwrap();
+    }
+
+    // The kernel coerces an explicit IPv6 metric 0 to 1024, so it conflicts
+    // with a metric-less route to the same destination.
+    #[test]
+    fn test_ipv6_metric_zero_conflicts_with_metricless() {
+        let merged = merged_for(vec![
+            route("::/0", "2001:db8:1::3", Some(0), 200),
+            route("::/0", "2001:db8:1::2", None, 200),
+        ]);
+        let err = validate_routes(&merged).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
 }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -16,6 +16,9 @@ use crate::{
 
 const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
 const LOOPBACK_IFACE_NAME: &str = "lo";
+// Kernel metric for user/static IPv6 routes with unset/0 metric.
+#[cfg(feature = "query_apply")]
+const IP6_RT_PRIO_USER: u32 = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -558,6 +561,27 @@ impl RouteEntry {
     pub(crate) fn is_ipv6(&self) -> bool {
         self.destination.as_ref().map(|d| is_ipv6_addr(d.as_str()))
             == Some(true)
+    }
+
+    // Metric the kernel will assign, for conflict detection. Unset/0 IPv6
+    // metric is coerced to 1024, IPv4 to 0.
+    #[cfg(feature = "query_apply")]
+    pub(crate) fn effective_metric(&self) -> u32 {
+        match self.metric.and_then(|m| u32::try_from(m).ok()) {
+            Some(m) if m > 0 => m,
+            _ if self.is_ipv6() => IP6_RT_PRIO_USER,
+            _ => 0,
+        }
+    }
+
+    // Table the kernel will assign, for conflict detection. Unset table is
+    // the main table.
+    #[cfg(feature = "query_apply")]
+    pub(crate) fn effective_table_id(&self) -> u32 {
+        match self.table_id {
+            None | Some(Self::USE_DEFAULT_ROUTE_TABLE) => DEFAULT_TABLE_ID,
+            Some(t) => t,
+        }
     }
 
     pub(crate) fn is_unicast(&self) -> bool {

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -2583,12 +2583,24 @@ def test_apply_ignored_routes_to_iface(eth1_static_ip):
               metric: 500
             """
         ),
+        (
+            """
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::2
+              next-hop-interface: veth1
+              metric: 1024
+            - destination: 2001:db8:2::/64
+              next-hop-address: 2001:db8:1::3
+              next-hop-interface: veth1
+            """
+        ),
     ],
     ids=[
         "v4_without_metric",
         "v4_with_metric",
         "v6_without_metric",
         "v6_with_metric",
+        "v6_metricless_vs_kernel_default",
     ],
 )
 def test_kernel_mode_fail_on_same_dst_metric_routes(

--- a/tests/integration/testlib/servicelib.py
+++ b/tests/integration/testlib/servicelib.py
@@ -6,29 +6,32 @@ import time
 from . import cmdlib
 
 
+def _wait_until(cmd, want_success, timeout=5):
+    while timeout > 0:
+        ret, _, _ = cmdlib.exec_cmd(cmd, check=False)
+        if (ret == 0) == want_success:
+            return
+        time.sleep(1)
+        timeout -= 1
+
+
 @contextmanager
 def disable_service(service):
     cmdlib.exec_cmd(("systemctl", "stop", service), check=True)
-    # Wait service actually stopped
-    ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service), check=False)
-    timeout = 5
-    while timeout > 0:
-        if ret != 0:
-            break
-        time.sleep(1)
-        timeout -= 1
-        ret, _, _ = cmdlib.exec_cmd(
-            ("systemctl", "status", service), check=False
-        )
+    _wait_until(("systemctl", "status", service), want_success=False)
     try:
         yield
     finally:
+        # A rapid stop/start cycle trips systemd's start-limit, leaving the
+        # unit unactivatable; reset-failed clears the counter before start.
+        cmdlib.exec_cmd(("systemctl", "reset-failed", service), check=False)
         cmdlib.exec_cmd(("systemctl", "start", service), check=True)
-        ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service))
-        timeout = 5
-        while timeout > 0:
-            if ret == 0:
-                break
-            time.sleep(1)
-            timeout -= 1
-            ret, _, _ = cmdlib.exec_cmd(("systemctl", "status", service))
+        _wait_until(("systemctl", "status", service), want_success=True)
+        # systemd reports NetworkManager active before it claims its D-Bus
+        # name; wait for it to answer so callers do not hit "not activatable".
+        if service == "NetworkManager":
+            _wait_until(
+                ("nmcli", "general", "status"),
+                want_success=True,
+                timeout=10,
+            )


### PR DESCRIPTION
Kernel-mode conflict validation keyed on the raw route metric, so a desired route that omits the metric (None) never collided with an existing route the kernel reports at its coerced default. IPv6 default routes carry metric 1024, so a metric-less IPv6 route bypassed pre-apply validation and failed only at post-apply verification.

Key the conflict map on the metric and table the kernel actually assigns (unspecified/0 IPv6 -> 1024, IPv4 -> 0; unset table -> main).

Resolves: https://redhat.atlassian.net/browse/NMT-2067