### PR TITLE
ipv6: report disabled when kernel has no IPv6 stack

### DIFF
--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -186,11 +186,20 @@ impl Interfaces {
     // Reset every present IPv6 section to a disabled state on interfaces where
     // `is_disabled` returns true.
     #[cfg(feature = "query_apply")]
-    pub(crate) fn disable_ipv6_where(&mut self, is_disabled: fn(&str) -> bool) {
+    pub(crate) fn disable_ipv6_where(
+        &mut self,
+        is_disabled: impl Fn(&str) -> bool,
+    ) {
         for iface in self.iter_mut() {
             let base = iface.base_iface_mut();
-            if is_disabled(base.name.as_str()) {
-                reset_disabled_ipv6(base);
+            if is_disabled(base.name.as_str())
+                && let Some(ipv6_conf) = base.ipv6.as_mut()
+            {
+                *ipv6_conf = crate::InterfaceIpv6 {
+                    enabled: false,
+                    enabled_defined: true,
+                    ..Default::default()
+                };
             }
         }
     }
@@ -727,17 +736,6 @@ impl Interfaces {
                     Some(iface.name().to_string());
             }
         }
-    }
-}
-
-#[cfg(feature = "query_apply")]
-fn reset_disabled_ipv6(base: &mut crate::BaseInterface) {
-    if let Some(ipv6_conf) = base.ipv6.as_mut() {
-        *ipv6_conf = crate::InterfaceIpv6 {
-            enabled: false,
-            enabled_defined: true,
-            ..Default::default()
-        };
     }
 }
 

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -183,6 +183,18 @@ impl Interfaces {
             .chain(self.kernel_ifaces.values_mut())
     }
 
+    // Reset every present IPv6 section to a disabled state on interfaces where
+    // `is_disabled` returns true.
+    #[cfg(feature = "query_apply")]
+    pub(crate) fn disable_ipv6_where(&mut self, is_disabled: fn(&str) -> bool) {
+        for iface in self.iter_mut() {
+            let base = iface.base_iface_mut();
+            if is_disabled(base.name.as_str()) {
+                reset_disabled_ipv6(base);
+            }
+        }
+    }
+
     // Not allowing changing veth peer away from ignored peer unless previous
     // peer changed from ignore to managed
     // Not allowing creating veth without peer config
@@ -715,6 +727,17 @@ impl Interfaces {
                     Some(iface.name().to_string());
             }
         }
+    }
+}
+
+#[cfg(feature = "query_apply")]
+fn reset_disabled_ipv6(base: &mut crate::BaseInterface) {
+    if let Some(ipv6_conf) = base.ipv6.as_mut() {
+        *ipv6_conf = crate::InterfaceIpv6 {
+            enabled: false,
+            enabled_defined: true,
+            ..Default::default()
+        };
     }
 }
 

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -138,6 +138,13 @@ impl NetworkState {
         // Mark routes next hop to ignored interface as ignored
         self.routes.apply_ignored_ifaces(&self.interfaces);
 
+        // A kernel booted with `ipv6.disable=1` has no IPv6 stack, but NM
+        // profiles using `method=auto` would still report `ipv6.enabled: true`.
+        // Force IPv6 off everywhere in that case.
+        if ipv6_disabled_in_kernel() {
+            self.interfaces.disable_ipv6_where(|_| true);
+        }
+
         Ok(self)
     }
 
@@ -459,6 +466,17 @@ impl NetworkState {
         }
         Ok(ret)
     }
+}
+
+// `/proc/sys/net/ipv6` is absent only when the kernel has no IPv6 stack at all.
+// The runtime `disable_ipv6` sysctl keeps the directory present and is
+// overridable per interface, so it is deliberately not forced off here.
+// Only a confirmed absence counts; a probe error must not wipe IPv6 state.
+fn ipv6_disabled_in_kernel() -> bool {
+    matches!(
+        std::path::Path::new("/proc/sys/net/ipv6").try_exists(),
+        Ok(false)
+    )
 }
 
 async fn with_nm_checkpoint<T, Fut>(

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -140,10 +140,12 @@ impl NetworkState {
 
         // A kernel booted with `ipv6.disable=1` has no IPv6 stack, but NM
         // profiles using `method=auto` would still report `ipv6.enabled: true`.
-        // Force IPv6 off everywhere in that case.
-        if ipv6_disabled_in_kernel() {
-            self.interfaces.disable_ipv6_where(|_| true);
-        }
+        // Force IPv6 off everywhere in that case. IPv6 can also be disabled per
+        // interface while the stack is present; handle those individually.
+        let kernel_disabled = ipv6_disabled_in_kernel();
+        self.interfaces.disable_ipv6_where(|name| {
+            kernel_disabled || ipv6_disabled_in_kernel_for_iface(name)
+        });
 
         Ok(self)
     }
@@ -477,6 +479,15 @@ fn ipv6_disabled_in_kernel() -> bool {
         std::path::Path::new("/proc/sys/net/ipv6").try_exists(),
         Ok(false)
     )
+}
+
+// Unlike `conf/all/disable_ipv6`, the per-interface value is a reliable signal.
+// A missing file (stack absent or interface gone) means not disabled.
+fn ipv6_disabled_in_kernel_for_iface(iface_name: &str) -> bool {
+    std::fs::read_to_string(format!(
+        "/proc/sys/net/ipv6/conf/{iface_name}/disable_ipv6"
+    ))
+    .is_ok_and(|v| v.trim() == "1")
 }
 
 async fn with_nm_checkpoint<T, Fut>(

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    BaseInterface, ErrorKind, Interface, InterfaceState, Interfaces,
-    MergedInterfaces, RouteEntry, ip::sanitize_ip_network,
+    BaseInterface, ErrorKind, Interface, InterfaceIpv6, InterfaceState,
+    Interfaces, MergedInterfaces, RouteEntry, ip::sanitize_ip_network,
     unit_tests::testlib::new_eth_iface,
 };
 
@@ -726,4 +726,45 @@ fn test_error_on_route_metric_out_of_range() {
             assert!(error.msg().contains(&format!("ipv4.{prop_name}")));
         }
     }
+}
+
+#[test]
+fn test_disable_ipv6_where_all() {
+    let mut ifaces = Interfaces::new();
+
+    let mut eth1 = new_eth_iface("eth1");
+    eth1.base_iface_mut().ipv6 = Some(InterfaceIpv6 {
+        enabled: true,
+        enabled_defined: false,
+        dhcp: Some(true),
+        autoconf: Some(true),
+        ..Default::default()
+    });
+    ifaces.push(eth1);
+
+    // no IPv6 section: must stay None, not be synthesised
+    ifaces.push(new_eth_iface("eth2"));
+
+    ifaces.disable_ipv6_where(|_| true);
+
+    let eth1_ipv6 = ifaces
+        .get_iface("eth1", crate::InterfaceType::Ethernet)
+        .unwrap()
+        .base_iface()
+        .ipv6
+        .as_ref()
+        .unwrap();
+    assert!(!eth1_ipv6.enabled);
+    assert!(eth1_ipv6.enabled_defined);
+    assert_eq!(eth1_ipv6.dhcp, None);
+    assert_eq!(eth1_ipv6.autoconf, None);
+
+    assert!(
+        ifaces
+            .get_iface("eth2", crate::InterfaceType::Ethernet)
+            .unwrap()
+            .base_iface()
+            .ipv6
+            .is_none()
+    );
 }

--- a/rust/src/lib/unit_tests/ip.rs
+++ b/rust/src/lib/unit_tests/ip.rs
@@ -768,3 +768,51 @@ fn test_disable_ipv6_where_all() {
             .is_none()
     );
 }
+
+#[test]
+fn test_disable_ipv6_where_selective() {
+    let mut ifaces = Interfaces::new();
+
+    let ipv6_on = || {
+        Some(InterfaceIpv6 {
+            enabled: true,
+            enabled_defined: true,
+            dhcp: Some(true),
+            autoconf: Some(true),
+            ..Default::default()
+        })
+    };
+
+    let mut eth1 = new_eth_iface("eth1");
+    eth1.base_iface_mut().ipv6 = ipv6_on();
+    ifaces.push(eth1);
+
+    let mut eth2 = new_eth_iface("eth2");
+    eth2.base_iface_mut().ipv6 = ipv6_on();
+    ifaces.push(eth2);
+
+    ifaces.disable_ipv6_where(|name| name == "eth1");
+
+    let eth1_ipv6 = ifaces
+        .get_iface("eth1", crate::InterfaceType::Ethernet)
+        .unwrap()
+        .base_iface()
+        .ipv6
+        .as_ref()
+        .unwrap();
+    assert!(!eth1_ipv6.enabled);
+    assert_eq!(eth1_ipv6.dhcp, None);
+    assert_eq!(eth1_ipv6.autoconf, None);
+
+    let eth2_ipv6 = ifaces
+        .get_iface("eth2", crate::InterfaceType::Ethernet)
+        .unwrap()
+        .base_iface()
+        .ipv6
+        .as_ref()
+        .unwrap();
+    assert!(eth2_ipv6.enabled);
+    assert!(eth2_ipv6.enabled_defined);
+    assert_eq!(eth2_ipv6.dhcp, Some(true));
+    assert_eq!(eth2_ipv6.autoconf, Some(true));
+}


### PR DESCRIPTION
On a host booted with `ipv6.disable=1` the kernel has no IPv6 stack, but `show` still reported `ipv6: enabled: true` for interfaces whose NM profile uses `method=auto`: the NM backend wins the merge over nispor, which correctly reports the interface as disabled. That state is unrealizable.

Resolves: https://github.com/nmstate/nmstate/issues/3162