### PR TITLE
ci: add pre-commit config for rust lint checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,25 +32,11 @@ jobs:
 
     - name: Check fmt
       if: matrix.rust_version == 'stable'
-      run: cd rust && cargo fmt -- --check
+      run: make fmt_check
 
     - name: Check clippy
       if: matrix.rust_version == 'nightly'
-      run: cd rust && cargo clippy -- -D warnings
-
-    - name: Check clippy gen_conf
-      if: matrix.rust_version == 'nightly'
-      run: |
-        cd rust && cargo clippy \
-          --no-default-features --features gen_conf \
-          -- -D warnings
-
-    - name: Check clippy query_apply
-      if: matrix.rust_version == 'nightly'
-      run: |
-        cd rust && cargo clippy \
-          --no-default-features --features query_apply \
-          -- -D warnings
+      run: make clippy_check
 
   rust_unit:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,30 +12,21 @@ on:
 
 jobs:
   rust_lint:
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - rust_version: "stable"
-          - rust_version: "nightly"
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6
 
-    - name: Install Rust ${{ matrix.rust_version }}
+    - name: Install Rust nightly
       run: |
-        rustup override set ${{ matrix.rust_version }}
-        rustup update ${{ matrix.rust_version }}
+        rustup override set nightly
+        rustup update nightly
         rustup component add rustfmt clippy
 
     - name: Check fmt
-      if: matrix.rust_version == 'stable'
       run: make fmt_check
 
     - name: Check clippy
-      if: matrix.rust_version == 'nightly'
       run: make clippy_check
 
   rust_unit:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: make fmt_check
+        language: system
+        files: ^rust/.*\.rs$
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: make clippy_check
+        language: system
+        files: ^rust/.*\.rs$
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,23 @@ go_check: $(CLIB_SO_DEV_DEBUG) $(CLIB_HEADER)
 		go test $(WHAT)
 	rm -rf $(TMPDIR)
 
+.PHONY: fmt_check
+fmt_check:
+	cd rust && \
+	if cargo +nightly fmt --version >/dev/null 2>&1; then \
+		cargo +nightly fmt -- --check; \
+	else \
+		cargo fmt -- --check; \
+	fi
+
+.PHONY: clippy_check
+clippy_check:
+	cd rust && cargo clippy -- -D warnings
+	cd rust && cargo clippy --no-default-features --features gen_conf \
+		-- -D warnings
+	cd rust && cargo clippy --no-default-features --features query_apply \
+		-- -D warnings
+
 rust_check:
 	cd rust; cargo test -- --test-threads=1 --show-output;
 	if [ "CHK$(CI)" != "CHKtrue" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -242,19 +242,14 @@ go_check: $(CLIB_SO_DEV_DEBUG) $(CLIB_HEADER)
 
 .PHONY: fmt_check
 fmt_check:
-	cd rust && \
-	if cargo +nightly fmt --version >/dev/null 2>&1; then \
-		cargo +nightly fmt -- --check; \
-	else \
-		cargo fmt -- --check; \
-	fi
+	cd rust && cargo +nightly fmt -- --check
 
 .PHONY: clippy_check
 clippy_check:
-	cd rust && cargo clippy -- -D warnings
-	cd rust && cargo clippy --no-default-features --features gen_conf \
+	cd rust && cargo +nightly clippy -- -D warnings
+	cd rust && cargo +nightly clippy --no-default-features --features gen_conf \
 		-- -D warnings
-	cd rust && cargo clippy --no-default-features --features query_apply \
+	cd rust && cargo +nightly clippy --no-default-features --features query_apply \
 		-- -D warnings
 
 rust_check:

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -395,9 +395,9 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
                     format!(
-                        "Multiple routes to {dst} are sharing the same \
-                         metric and table, please use `state: absent` to \
-                         remove others."
+                        "Multiple routes to {dst} are sharing the same metric \
+                         and table, please use `state: absent` to remove \
+                         others."
                     ),
                 ));
             }


### PR DESCRIPTION
These local hooks mirror the rust_lint job (fmt plus clippy on default/gen_conf/query_apply) so issues are caught before push.