### PR TITLE
ci: accept nmstatectl fmt output

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+---
+extends: default
+rules:
+  document-start: disable
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
+  line-length: disable
+  empty-lines:
+    max-end: 1


### PR DESCRIPTION
Add a .yamllint relaxing rules that tripped up on nmstatectl fmt output.

Closes: https://github.com/nmstate/nmstate/issues/2685