### PR TITLE
ovs: Support internal interfaces in down state

### DIFF
--- a/rust/src/lib/nispor/mod.rs
+++ b/rust/src/lib/nispor/mod.rs
@@ -19,6 +19,7 @@ mod linux_bridge_port_vlan;
 mod mac_vlan;
 mod macsec;
 mod mptcp;
+mod ovs;
 mod route;
 mod route_rule;
 mod show;
@@ -34,3 +35,4 @@ pub(crate) use show::nispor_retrieve;
 pub(crate) use self::alt_name::{
     apply_ifaces_alt_names, persist_alt_name_config,
 };
+pub(crate) use self::ovs::enforce_ovs_internal_link_state;

--- a/rust/src/lib/nispor/ovs.rs
+++ b/rust/src/lib/nispor/ovs.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ErrorKind, InterfaceType, MergedInterfaces, NmstateError};
+
+/// NetworkManager always brings an OVS internal interface link up on
+/// activation and offers no way to keep it administratively down while the
+/// connection stays active (the only "down" it has detaches the port from the
+/// bridge). To support `state: down` on OVS internal interfaces — keeping them
+/// attached to the bridge with the link DOWN, like `ovs-vsctl add-br` — we set
+/// the kernel link state directly via nispor after the NetworkManager apply.
+/// See NMT-2268.
+pub(crate) async fn enforce_ovs_internal_link_state(
+    merged_ifaces: &MergedInterfaces,
+) -> Result<(), NmstateError> {
+    let np_ifaces: Vec<nispor::IfaceConf> = merged_ifaces
+        .kernel_ifaces
+        .values()
+        .filter_map(|i| {
+            let iface = i.for_apply.as_ref()?;
+            if !i.is_desired()
+                || iface.iface_type() != InterfaceType::OvsInterface
+            {
+                return None;
+            }
+            let state = if iface.is_down() {
+                nispor::IfaceState::Down
+            } else if iface.is_up() {
+                nispor::IfaceState::Up
+            } else {
+                return None;
+            };
+            let mut np_iface = nispor::IfaceConf::default();
+            np_iface.name = iface.name().to_string();
+            np_iface.iface_type = Some(nispor::IfaceType::OpenvSwitch);
+            np_iface.state = state;
+            Some(np_iface)
+        })
+        .collect();
+
+    if np_ifaces.is_empty() {
+        return Ok(());
+    }
+
+    let mut net_conf = nispor::NetConf::default();
+    net_conf.ifaces = Some(np_ifaces);
+
+    // The OVS internal kernel link may not be ready immediately after the
+    // NetworkManager activation returns, so retry a few times.
+    let mut last_err = None;
+    for _ in 0..5 {
+        match net_conf.apply_async().await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+        }
+    }
+    if let Some(e) = last_err {
+        return Err(NmstateError::new(
+            ErrorKind::PluginFailure,
+            format!(
+                "Failed to set OVS internal interface link state: {} {}",
+                e.kind, e.msg
+            ),
+        ));
+    }
+    Ok(())
+}

--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -54,6 +54,12 @@ pub(crate) fn prepare_nm_conns(
         .iter()
         .filter(|iface| {
             iface.for_apply.as_ref().map(|i| i.is_down()) == Some(true)
+                // Deactivating an OVS internal interface detaches it from the
+                // bridge, destroying the local port. For state:down we keep it
+                // attached with the link administratively down, matching the
+                // behaviour of `ovs-vsctl add-br` (local port DOWN, no kernel
+                // traffic). See NMT-2268.
+                && iface.merged.iface_type() != InterfaceType::OvsInterface
         })
         .filter_map(|iface| {
             nm_devs_indexed

--- a/rust/src/lib/query_apply/inter_ifaces.rs
+++ b/rust/src/lib/query_apply/inter_ifaces.rs
@@ -223,7 +223,16 @@ impl MergedInterfaces {
             } else {
                 continue;
             };
-            if iface.is_absent() || (iface.is_virtual() && iface.is_down()) {
+            // OVS internal interface with state:down stays attached to its
+            // bridge with the link administratively down (like `ovs-vsctl
+            // add-br`), so it is expected to still be present rather than
+            // deleted. Do not treat it as absent. See NMT-2268.
+            let down_ovs_internal = iface.is_virtual()
+                && iface.is_down()
+                && iface.iface_type() == InterfaceType::OvsInterface;
+            if (iface.is_absent() || (iface.is_virtual() && iface.is_down()))
+                && !down_ovs_internal
+            {
                 if let Some(cur_iface) =
                     current.get_iface(iface.name(), iface.iface_type())
                 {

--- a/rust/src/lib/query_apply/net_state.rs
+++ b/rust/src/lib/query_apply/net_state.rs
@@ -6,8 +6,8 @@ use crate::{
     ErrorKind, MergedInterfaces, MergedNetworkState, NetworkState,
     NetworkStateMode, NmstateError,
     nispor::{
-        apply_ifaces_alt_names, nispor_apply, nispor_retrieve,
-        persist_alt_name_config, set_running_hostname,
+        apply_ifaces_alt_names, enforce_ovs_internal_link_state, nispor_apply,
+        nispor_retrieve, persist_alt_name_config, set_running_hostname,
     },
     nm::{
         nm_apply, nm_checkpoint_create, nm_checkpoint_destroy,
@@ -346,6 +346,13 @@ impl NetworkState {
 
                 apply_ifaces_alt_names(&merged_state.interfaces).await?;
                 persist_alt_name_config(&merged_state.interfaces).await?;
+
+                // NetworkManager always activates OVS internal interfaces with
+                // the link up. Enforce the desired link state (down/up) via
+                // nispor so state:down internal ports stay attached to the
+                // bridge with the link DOWN, like `ovs-vsctl add-br`. NMT-2268.
+                enforce_ovs_internal_link_state(&merged_state.interfaces)
+                    .await?;
 
                 if !self.no_verify {
                     with_retry(

--- a/tests/integration/ovs_test.py
+++ b/tests/integration/ovs_test.py
@@ -2276,6 +2276,64 @@ def test_ovs_internal_iface_link_stable(
     libnmstate.apply(desired_state)
 
 
+def _ovs_bridge_with_internal_port(port_state):
+    return {
+        Interface.KEY: [
+            {
+                Interface.NAME: PORT1,
+                Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                Interface.STATE: port_state,
+            },
+            {
+                Interface.NAME: BRIDGE1,
+                Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                Interface.STATE: InterfaceState.UP,
+                OVSBridge.CONFIG_SUBTREE: {
+                    OVSBridge.PORT_SUBTREE: [
+                        {OVSBridge.Port.NAME: PORT1},
+                    ]
+                },
+            },
+        ]
+    }
+
+
+# https://issues.redhat.com/browse/NMT-2268
+@pytest.mark.tier1
+def test_create_ovs_bridge_with_internal_port_down():
+    libnmstate.apply(_ovs_bridge_with_internal_port(InterfaceState.DOWN))
+    try:
+        # Internal port stays attached to the bridge like `ovs-vsctl add-br`
+        rc, out, _ = cmdlib.exec_cmd(f"ovs-vsctl list-ports {BRIDGE1}".split())
+        assert PORT1 in out
+        # but its kernel link is administratively DOWN (no kernel traffic)
+        rc, out, _ = cmdlib.exec_cmd(f"ip -o link show {PORT1}".split())
+        assert "state DOWN" in out
+        assert "UP" not in out.split(f"{PORT1}:")[1].split("<")[1].split(">")[0]
+
+        # toggling back to up brings the link up
+        libnmstate.apply(_ovs_bridge_with_internal_port(InterfaceState.UP))
+        rc, out, _ = cmdlib.exec_cmd(f"ip -o link show {PORT1}".split())
+        assert "state DOWN" not in out
+    finally:
+        libnmstate.apply(
+            {
+                Interface.KEY: [
+                    {
+                        Interface.NAME: BRIDGE1,
+                        Interface.TYPE: InterfaceType.OVS_BRIDGE,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    },
+                    {
+                        Interface.NAME: PORT1,
+                        Interface.TYPE: InterfaceType.OVS_INTERFACE,
+                        Interface.STATE: InterfaceState.ABSENT,
+                    },
+                ]
+            }
+        )
+
+
 @pytest.fixture
 def ovs_bridge1_with_bond_as_system_iface(eth1_up, eth2_up):
     with bond_interface(BOND1, ["eth1"]):


### PR DESCRIPTION
## What

Support OVS internal interfaces in `state: down`, behaving like `ovs-vsctl add-br`: the internal/local port stays **attached** to the bridge but its kernel link is administratively **DOWN** (no kernel-datapath traffic). Needed for OVS-DPDK.

Jira: NMT-2268

## Before

A down OVS internal interface was treated as absent → NM deactivated it → detached from bridge → `VerificationError` ("still found" / bridge port `null`).

```yaml
interfaces:
- name: br0
  type: ovs-interface
  state: down
- name: br0
  type: ovs-bridge
  state: up
  bridge:
    port: [{name: br0}]
```

## Why nispor (NetworkManager limitation)

Verified in NM source: NM has **no** way to keep a connection active while the link is admin-down.
- Activation always brings the link up — `nm-device.c:11094` `nm_device_bring_up_full()` → `:16061` `nm_platform_link_change_flags(IFF_UP, TRUE)`; OVS internal adds explicit `nm_device_bring_up()` at `nm-device-ovs-interface.c:198,288,449`.
- No "active + admin-down" connection property exists (`SET_ADMIN_STATE` ties admin-down to **unmanaging** the device, `nm-device.c:15073`).
- NM's only "down" is deactivation, which detaches the OVS port from ovsdb — `nm-device-ovs-port.c:247` → `nm-ovsdb.c:1378`.
- ovsdb membership is driven by attach/detach (activation lifecycle), **not** IFF_UP — so clearing IFF_UP out-of-band leaves the port attached and the connection active.

So we set the kernel link state directly via nispor after the NM apply — the same pattern nmstate already uses for `apply_ifaces_alt_names` and `set_running_hostname` right after `nm_apply` (`query_apply/net_state.rs`).

## Change

- `nm/connection.rs`: do not deactivate a down OVS internal interface (deactivation destroys the local port).
- `query_apply/inter_ifaces.rs`: down OVS internal not treated as absent in verification.
- `nispor/ovs.rs`: new `enforce_ovs_internal_link_state()`, invoked from `query_apply/net_state.rs` next to `apply_ifaces_alt_names` — sets the OVS internal link DOWN when desired, UP otherwise.

## Test

Manual (`nmstatectl`) on a NetworkManager + OVS host: down/up/down cycle, LOCAL port + extra internal port, idempotent, parity with `ovs-vsctl add-br`. Added `test_create_ovs_bridge_with_internal_port_down` (attached + DOWN + up-toggle). fmt + clippy clean.

## Open / RFC

- The kernel admin-down is a 5x retry (OVS link may appear late after NM activation) — could be tightened.
- `nmstatectl show` reports the profile up while the link is down.
- Modelling: `state:down` vs an explicit flag — feedback welcome.
- Proper long-term fix likely needs a NetworkManager RFE (admin-link-down property, or decouple OVS bring-up).