### PR TITLE
route: resolve sriov VF references in next-hop-interface

### DIFF
--- a/rust/src/lib/ifaces/mod.rs
+++ b/rust/src/lib/ifaces/mod.rs
@@ -71,6 +71,7 @@ pub use ovs::{
     OvsBridgeConfig, OvsBridgeInterface, OvsBridgeOptions, OvsBridgePortConfig,
     OvsBridgeStpOptions, OvsDpdkConfig, OvsInterface, OvsPatchConfig,
 };
+pub(crate) use sriov::parse_sriov_vf_naming;
 pub use sriov::{SrIovConfig, SrIovVfConfig};
 pub use vlan::{
     VlanConfig, VlanInterface, VlanProtocol, VlanQosMapping,

--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -337,7 +337,7 @@ impl Interfaces {
     }
 }
 
-fn parse_sriov_vf_naming(
+pub(crate) fn parse_sriov_vf_naming(
     iface_name: &str,
 ) -> Result<Option<(&str, u32)>, NmstateError> {
     if iface_name.starts_with(SrIovConfig::VF_NAMING_PREFIX) {

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -10,7 +10,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ErrorKind, InterfaceType, MergedInterfaces, NmstateError,
+    ErrorKind, Interface, InterfaceType, MergedInterfaces, NmstateError,
+    ifaces::parse_sriov_vf_naming,
     ip::{is_ipv6_addr, sanitize_ip_network},
 };
 
@@ -123,58 +124,27 @@ impl Routes {
         &mut self,
         merged_ifaces: &MergedInterfaces,
     ) -> Result<(), NmstateError> {
-        let iface_name_search = &merged_ifaces.iface_name_search;
-
         if let Some(config_routes) = self.config.as_mut() {
             for route in config_routes.iter_mut() {
                 let new_iface_name = if let Some(next_hop_iface) =
                     route.next_hop_iface.as_ref()
                 {
-                    let kernel_names = iface_name_search.get(next_hop_iface);
-                    // Prefer kernel name as port name
-                    if kernel_names.contains(&next_hop_iface.as_str()) {
-                        continue;
-                    }
-                    if kernel_names.is_empty() && !route.is_absent() {
-                        if merged_ifaces.ignored_ifaces.iter().any(
-                            |(name, iface_type)| {
-                                name == next_hop_iface
-                                    && !iface_type.is_userspace()
-                            },
-                        ) {
-                            return Err(NmstateError::new(
-                                ErrorKind::InvalidArgument,
-                                format!(
-                                    "Route '{}': next hop interface {} is \
-                                     marked as ignored",
-                                    route,
-                                    next_hop_iface.as_str()
-                                ),
-                            ));
-                        } else {
-                            return Err(NmstateError::new(
-                                ErrorKind::InvalidArgument,
-                                format!(
-                                    "Route '{}': next hop interface {} not \
-                                     found",
-                                    route,
-                                    next_hop_iface.as_str()
-                                ),
-                            ));
-                        }
-                    } else if kernel_names.len() > 1 {
-                        return Err(NmstateError::new(
-                            ErrorKind::InvalidArgument,
-                            format!(
-                                "Route '{}' defined with next hop interface \
-                                 {} but multiple interfaces are sharing this \
-                                 profile name",
-                                route,
-                                next_hop_iface.as_str()
-                            ),
-                        ));
+                    if let Some((pf_name, vf_id)) =
+                        parse_sriov_vf_naming(next_hop_iface)?
+                    {
+                        Some(resolve_sriov_vf_iface_name(
+                            route,
+                            next_hop_iface,
+                            pf_name,
+                            vf_id,
+                            merged_ifaces,
+                        )?)
                     } else {
-                        kernel_names.first().map(|s| s.to_string())
+                        resolve_kernel_iface_name(
+                            route,
+                            next_hop_iface,
+                            merged_ifaces,
+                        )?
                     }
                 } else {
                     None
@@ -186,6 +156,85 @@ impl Routes {
         }
         Ok(())
     }
+}
+
+fn resolve_sriov_vf_iface_name(
+    route: &RouteEntry,
+    next_hop_iface: &str,
+    pf_name: &str,
+    vf_id: u32,
+    merged_ifaces: &MergedInterfaces,
+) -> Result<String, NmstateError> {
+    if let Some(mi) = merged_ifaces.kernel_ifaces.get(pf_name)
+        && let Some(Interface::Ethernet(eth)) = mi.current.as_ref()
+        && let Some(eth_config) = eth.ethernet.as_ref()
+        && let Some(sriov) = eth_config.sr_iov.as_ref()
+        && let Some(vfs) = sriov.vfs.as_ref()
+        && let Some(vf) = vfs.iter().find(|vf| vf.id == vf_id)
+        && !vf.iface_name.is_empty()
+    {
+        log::info!(
+            "SR-IOV VF route next-hop {} resolved to {}",
+            next_hop_iface,
+            vf.iface_name
+        );
+        Ok(vf.iface_name.clone())
+    } else {
+        Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Route '{}': failed to resolve SR-IOV VF interface name for {}",
+                route, next_hop_iface
+            ),
+        ))
+    }
+}
+
+/// Returns `None` when `next_hop_iface` is already a kernel name.
+fn resolve_kernel_iface_name(
+    route: &RouteEntry,
+    next_hop_iface: &str,
+    merged_ifaces: &MergedInterfaces,
+) -> Result<Option<String>, NmstateError> {
+    let kernel_names = merged_ifaces.iface_name_search.get(next_hop_iface);
+    if kernel_names.contains(&next_hop_iface) {
+        return Ok(None);
+    }
+    if kernel_names.is_empty() && !route.is_absent() {
+        if merged_ifaces
+            .ignored_ifaces
+            .iter()
+            .any(|(name, iface_type)| {
+                name == next_hop_iface && !iface_type.is_userspace()
+            })
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Route '{}': next hop interface {} is marked as ignored",
+                    route, next_hop_iface,
+                ),
+            ));
+        } else {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Route '{}': next hop interface {} not found",
+                    route, next_hop_iface,
+                ),
+            ));
+        }
+    } else if kernel_names.len() > 1 {
+        return Err(NmstateError::new(
+            ErrorKind::InvalidArgument,
+            format!(
+                "Route '{}' defined with next hop interface {} but multiple \
+                interfaces are sharing this profile name",
+                route, next_hop_iface,
+            ),
+        ));
+    }
+    Ok(kernel_names.first().map(|s| s.to_string()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ErrorKind, InterfaceType, Interfaces, MergedRoutes, RouteEntry, RouteState,
-    Routes,
+    ErrorKind, InterfaceType, Interfaces, MergedInterfaces, MergedRoutes,
+    RouteEntry, RouteState, Routes,
     query_apply::is_route_delayed_by_nm,
     unit_tests::testlib::{
         TEST_IPV4_ADDR1, TEST_IPV4_NET1, TEST_IPV6_ADDR1, TEST_IPV6_ADDR2,
@@ -936,4 +936,106 @@ fn test_route_lock_mtu_deserialize_from_string() {
     .unwrap();
 
     assert_eq!(route.lock_mtu, Some(true));
+}
+
+fn gen_sriov_merged_ifaces() -> MergedInterfaces {
+    let mut current = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: eth1
+          type: ethernet
+          state: up
+          ethernet:
+            sr-iov:
+              total-vfs: 2
+              vfs:
+              - id: 0
+              - id: 1
+        - name: sriov:eth1:0
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: true
+            address:
+            - ip: 192.0.2.10
+              prefix-length: 24
+        - name: sriov:eth1:1
+          type: ethernet
+          state: up
+          ipv6:
+            enabled: true
+            address:
+            - ip: 2001:db8:1::11
+              prefix-length: 64
+        ",
+    )
+    .unwrap();
+    let Some(crate::Interface::Ethernet(eth)) =
+        current.kernel_ifaces.get_mut("eth1")
+    else {
+        panic!("eth1 not found or not Ethernet");
+    };
+    for vf in eth
+        .ethernet
+        .as_mut()
+        .unwrap()
+        .sr_iov
+        .as_mut()
+        .unwrap()
+        .vfs
+        .as_mut()
+        .unwrap()
+    {
+        vf.iface_name = format!("eth1v{}", vf.id);
+    }
+    MergedInterfaces::new(Interfaces::new(), current, Default::default(), false)
+        .unwrap()
+}
+
+#[test]
+fn test_route_resolve_sriov_next_hop() {
+    let routes = serde_yaml::from_str::<Routes>(
+        r"---
+        config:
+        - destination: 192.0.2.0/24
+          next-hop-address: 192.0.2.1
+          next-hop-interface: sriov:eth1:0
+        - destination: 2001:db8:1::/64
+          next-hop-address: 2001:db8:1::1
+          next-hop-interface: sriov:eth1:1
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = gen_sriov_merged_ifaces();
+    let merged_routes =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap();
+
+    let eth1v0_routes = merged_routes.merged.get("eth1v0").unwrap();
+    assert_eq!(eth1v0_routes.len(), 1);
+    assert_eq!(eth1v0_routes[0].next_hop_iface, Some("eth1v0".to_string()));
+
+    let eth1v1_routes = merged_routes.merged.get("eth1v1").unwrap();
+    assert_eq!(eth1v1_routes.len(), 1);
+    assert_eq!(eth1v1_routes[0].next_hop_iface, Some("eth1v1".to_string()));
+}
+
+#[test]
+fn test_route_resolve_sriov_next_hop_invalid_vf() {
+    let routes = serde_yaml::from_str::<Routes>(
+        r"---
+        config:
+        - destination: 192.0.2.0/24
+          next-hop-address: 192.0.2.1
+          next-hop-interface: sriov:eth1:5
+        ",
+    )
+    .unwrap();
+
+    let merged_ifaces = gen_sriov_merged_ifaces();
+    let result = MergedRoutes::new(routes, Routes::new(), &merged_ifaces);
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    assert!(err.msg().contains("sriov:eth1:5"));
 }


### PR DESCRIPTION
The sriov:PF:VF_ID naming syntax is resolved for interface names in resolve_sriov_reference_iface_name(), but route next-hop-interface fields are not resolved. This causes routes with sriov: references to fail validation with "next hop interface not found" because the interface name search only knows the resolved kernel name.

Resolve sriov VF references in route next-hop-interface the same way as interface names: parse the sriov:PF:VF_ID syntax, look up the PF in the merged interfaces, and find the kernel VF name from the current SR-IOV configuration.