### PR TITLE
tests: handle RPM tilde pre-release versions in NM version parsing

### DIFF
--- a/tests/integration/testlib/env.py
+++ b/tests/integration/testlib/env.py
@@ -25,7 +25,7 @@ def nm_minor_version():
         "rpm -q NetworkManager --qf %{VERSION}".split(),
         check=True,
     )[1]
-    return int(version_str.split(".")[1])
+    return int(version_str.split("~")[0].split(".")[1])
 
 
 def is_k8s():
@@ -46,7 +46,15 @@ def version_int(major, minor, micro=0):
 
 
 def version_str_to_int(version_str):
-    versions = version_str.split(".")
+    parts = version_str.split("~")
+    versions = parts[0].split(".")
+
+    # if it is a rc version, then use 90 based versioning to ensure
+    # that a release candidate is less than a full release.
+    # Example: "1.58~rc1" would become 1.57.90 but "1.58.0" would stay 1.58.0.
+    if len(parts) == 2:
+        rc_num = int(parts[1].lstrip("rc"))
+        return version_int(int(versions[0]), int(versions[1]) - 1, 89 + rc_num)
     return version_int(int(versions[0]), int(versions[1]), int(versions[2]))
 
 


### PR DESCRIPTION
## Summary
- Fix `nm_minor_version()` and `version_str_to_int()` to handle RPM pre-release version strings containing `~` (e.g. `1.58~rc1`)
- Split on `~` before parsing the numeric version segments to strip suffixes like `~rc1`, `~beta2`, etc.

## Problem
NetworkManager `1.58~rc1` causes 9 test collection errors because `int("58~rc1")` raises `ValueError`.