### PR TITLE
doc: document time units for Linux bridge timing options

### DIFF
--- a/rust/src/lib/ifaces/linux_bridge.rs
+++ b/rust/src/lib/ifaces/linux_bridge.rs
@@ -460,6 +460,7 @@ pub struct LinuxBridgeOptions {
         default,
         deserialize_with = "crate::deserializer::option_u32_or_string"
     )]
+    /// MAC address ageing time is in seconds.
     pub mac_ageing_time: Option<u32>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -472,12 +473,14 @@ pub struct LinuxBridgeOptions {
         default,
         deserialize_with = "crate::deserializer::option_u64_or_string"
     )]
+    /// Multicast last member interval is in centiseconds (1/100s).
     pub multicast_last_member_interval: Option<u64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
         deserialize_with = "crate::deserializer::option_u64_or_string"
     )]
+    /// Multicast membership interval is in centiseconds (1/100s).
     pub multicast_membership_interval: Option<u64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -490,6 +493,7 @@ pub struct LinuxBridgeOptions {
         default,
         deserialize_with = "crate::deserializer::option_u64_or_string"
     )]
+    /// Multicast querier interval is in centiseconds (1/100s).
     pub multicast_querier_interval: Option<u64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -502,6 +506,7 @@ pub struct LinuxBridgeOptions {
         default,
         deserialize_with = "crate::deserializer::option_u64_or_string"
     )]
+    /// Multicast query response interval is in centiseconds (1/100s).
     pub multicast_query_response_interval: Option<u64>,
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -532,6 +537,7 @@ pub struct LinuxBridgeOptions {
         default,
         deserialize_with = "crate::deserializer::option_u64_or_string"
     )]
+    /// Multicast startup query interval is in centiseconds (1/100s).
     pub multicast_startup_query_interval: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stp: Option<LinuxBridgeStpOptions>,
@@ -619,18 +625,21 @@ pub struct LinuxBridgeStpOptions {
         default,
         deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
+    /// Spanning tree forward delay is in seconds. Valid range: 2-30.
     pub forward_delay: Option<u8>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
         deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
+    /// Spanning tree hello time is in seconds. Valid range: 1-10.
     pub hello_time: Option<u8>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
         deserialize_with = "crate::deserializer::option_u8_or_string"
     )]
+    /// Spanning tree max age is in seconds. Valid range: 6-40.
     pub max_age: Option<u8>,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/rust/src/python/libnmstate/schema.py
+++ b/rust/src/python/libnmstate/schema.py
@@ -225,9 +225,9 @@ class Bridge:
 
     class STP:
         ENABLED = "enabled"
-        FORWARD_DELAY = "forward-delay"
-        HELLO_TIME = "hello-time"
-        MAX_AGE = "max-age"
+        FORWARD_DELAY = "forward-delay"  # seconds (valid range: 2-30)
+        HELLO_TIME = "hello-time"  # seconds (valid range: 1-10)
+        MAX_AGE = "max-age"  # seconds (valid range: 6-40)
         PRIORITY = "priority"
 
     class Port:
@@ -259,7 +259,7 @@ class LinuxBridge(Bridge):
 
     class Options:
         GROUP_FORWARD_MASK = "group-forward-mask"
-        MAC_AGEING_TIME = "mac-ageing-time"
+        MAC_AGEING_TIME = "mac-ageing-time"  # seconds
         MULTICAST_SNOOPING = "multicast-snooping"
         GROUP_ADDR = "group-addr"
         GROUP_FWD_MASK = "group-fwd-mask"
@@ -267,15 +267,25 @@ class LinuxBridge(Bridge):
         HASH_MAX = "hash-max"
         MULTICAST_ROUTER = "multicast-router"
         MULTICAST_LAST_MEMBER_COUNT = "multicast-last-member-count"
-        MULTICAST_LAST_MEMBER_INTERVAL = "multicast-last-member-interval"
-        MULTICAST_MEMBERSHIP_INTERVAL = "multicast-membership-interval"
+        MULTICAST_LAST_MEMBER_INTERVAL = (
+            "multicast-last-member-interval"  # centiseconds (1/100s)
+        )
+        MULTICAST_MEMBERSHIP_INTERVAL = (
+            "multicast-membership-interval"  # centiseconds (1/100s)
+        )
         MULTICAST_QUERIER = "multicast-querier"
-        MULTICAST_QUERIER_INTERVAL = "multicast-querier-interval"
+        MULTICAST_QUERIER_INTERVAL = (
+            "multicast-querier-interval"  # centiseconds (1/100s)
+        )
         MULTICAST_QUERY_USE_IFADDR = "multicast-query-use-ifaddr"
         MULTICAST_QUERY_INTERVAL = "multicast-query-interval"
-        MULTICAST_QUERY_RESPONSE_INTERVAL = "multicast-query-response-interval"
+        MULTICAST_QUERY_RESPONSE_INTERVAL = (
+            "multicast-query-response-interval"  # centiseconds (1/100s)
+        )
         MULTICAST_STARTUP_QUERY_COUNT = "multicast-startup-query-count"
-        MULTICAST_STARTUP_QUERY_INTERVAL = "multicast-startup-query-interval"
+        MULTICAST_STARTUP_QUERY_INTERVAL = (
+            "multicast-startup-query-interval"  # centiseconds (1/100s)
+        )
         VLAN_PROTOCOL = "vlan-protocol"
         VLAN_DEFAULT_PVID = "vlan-default-pvid"
 


### PR DESCRIPTION
  Specifying that forward_delay, hello_time, max_age and mac_ageing_time
  are in seconds, and multicast timing intervals are in centiseconds
  (1/100 of a second).

  Resolving: https://github.com/nmstate/nmstate/issues/1216