### PR TITLE
automation: allow base repos when installing NM from COPR

### DIFF
--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -233,7 +233,7 @@ function upgrade_nm_from_copr {
     exec_cmd "systemctl stop NetworkManager"
     exec_cmd "dnf remove --assumeyes --noautoremove NetworkManager"
     exec_cmd_with_retry "dnf install --assumeyes NetworkManager \
-        NetworkManager-ovs --disablerepo '*' --enablerepo '${copr_repo_id}'"
+        NetworkManager-ovs --setopt='${copr_repo_id}.priority=1'"
     exec_cmd_with_retry "dnf install --assumeyes NetworkManager-libreswan"
 }
 


### PR DESCRIPTION

The COPR NM builds now require glib2 >= 2.88.2, which is not available in the COPR itself. Replace --disablerepo/--enablerepo with --setopt priority=1 for the COPR repo, so dnf resolves dependencies from the base distro repos while still preferring COPR for NM packages.
