### PR TITLE
dns: auto-activate down ifaces for IPv6 link-local DNS and route-rule iif

### DIFF
--- a/rust/src/lib/dns.rs
+++ b/rust/src/lib/dns.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::HashSet,
     net::{Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
@@ -294,22 +295,40 @@ impl MergedDnsState {
         self.servers.is_empty()
             && (!self.searches.is_empty() || !self.options.is_empty())
     }
+
+    /// Servers explicitly set in desired `dns-resolver.config.server`.
+    ///
+    /// Returns `None` when desired DNS omits `server` (including when DNS is
+    /// omitted entirely). Inherited current servers are not included.
+    pub(crate) fn desired_servers(&self) -> Option<&[String]> {
+        self.desired
+            .as_ref()
+            .and_then(|d| d.config.as_ref())
+            .and_then(|c| c.server.as_deref())
+    }
 }
 
 impl MergedNetworkState {
     // * Specified interface is valid for hold IPv6 DNS config.
     // * Cannot have more than one IPv6 link-local DNS interface.
+    // * Disconnected/down interfaces referenced by *desired* link-local DNS are
+    //   auto-activated so validation and apply can succeed without an explicit
+    //   `interfaces: [{name, state: up}]` entry.
+    // * Inherited current link-local DNS must not trigger auto-activation.
     pub(crate) fn validate_ipv6_link_local_address_dns_srv(
-        &self,
+        &mut self,
     ) -> Result<(), NmstateError> {
-        let mut iface_names = Vec::new();
-        for srv in self.dns.servers.as_slice() {
+        let Some(desired_servers) = self.dns.desired_servers() else {
+            return Ok(());
+        };
+
+        // Immutable checks while borrowing desired DNS; collect link-local
+        // targets so we can mutably update interfaces afterwards.
+        let mut pending = Vec::new();
+        for srv in desired_servers {
             if let Some((_, iface_name)) = parse_dns_ipv6_link_local_srv(srv)? {
-                let iface = if let Some(iface) =
-                    self.interfaces.kernel_ifaces.get(iface_name)
-                {
-                    iface
-                } else {
+                let Some(iface) = self.interfaces.kernel_ifaces.get(iface_name)
+                else {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
@@ -319,18 +338,50 @@ impl MergedNetworkState {
                         ),
                     ));
                 };
-                if iface.is_iface_valid_for_dns(true) {
-                    iface_names.push(iface.merged.name());
-                } else {
+                if iface.merged.is_ignore() {
                     return Err(NmstateError::new(
                         ErrorKind::InvalidArgument,
                         format!(
-                            "Interface {iface_name} has IPv6 disabled, hence \
-                             cannot hold desired IPv6 link local DNS server \
-                             {srv}"
+                            "Desired IPv6 link local DNS server {srv} is \
+                             pointing to ignored interface {iface_name}. \
+                             Please include it in desired interfaces with \
+                             state:up."
                         ),
                     ));
                 }
+                pending.push((srv.clone(), iface_name.to_string()));
+            }
+        }
+
+        let mut iface_names = HashSet::new();
+        for (srv, iface_name) in pending {
+            let Some(iface) =
+                self.interfaces.kernel_ifaces.get_mut(iface_name.as_str())
+            else {
+                return Err(NmstateError::new(
+                    ErrorKind::Bug,
+                    format!(
+                        "BUG: Interface {iface_name} for IPv6 link local DNS \
+                         server {srv} was lost after existence check"
+                    ),
+                ));
+            };
+            // Referring by desired link-local DNS auto-activates a
+            // disconnected interface, matching historical nmstate
+            // behavior.
+            if !iface.merged.is_up() {
+                iface.mark_as_up_for_apply();
+            }
+            if iface.is_iface_valid_for_dns(true) {
+                iface_names.insert(iface.merged.name().to_string());
+            } else {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Interface {iface_name} has IPv6 disabled, hence \
+                         cannot hold desired IPv6 link local DNS server {srv}"
+                    ),
+                ));
             }
         }
         if iface_names.len() >= 2 {
@@ -338,8 +389,7 @@ impl MergedNetworkState {
                 ErrorKind::NotImplementedError,
                 format!(
                     "Only support IPv6 link local DNS name server(s) pointing \
-                     to a single interface, but got '{}'",
-                    iface_names.join(" ")
+                     to a single interface, but got {iface_names:?}"
                 ),
             ));
         }

--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -1110,6 +1110,30 @@ impl MergedInterface {
         }
     }
 
+    /// Include this interface for apply with `state: up`.
+    ///
+    /// Used when a disconnected/down interface is referenced by other desired
+    /// config (IPv6 link-local DNS, route-rule `iif`, etc.) and should be
+    /// auto-activated without the user listing it under `interfaces`.
+    ///
+    /// Does nothing when the interface is already desired or already changed
+    /// (for example an orphan VLAN marked absent when its parent bond is
+    /// removed), so those states are not overridden.
+    pub(crate) fn mark_as_up_for_apply(&mut self) {
+        if self.desired.is_some() || self.is_changed() {
+            return;
+        }
+        self.mark_as_changed();
+        self.merged.base_iface_mut().state = InterfaceState::Up;
+        if let Some(apply_iface) = self.for_apply.as_mut() {
+            apply_iface.base_iface_mut().state = InterfaceState::Up;
+        }
+        log::info!(
+            "Include interface {} to edit as other desired config required so",
+            self.merged.name()
+        );
+    }
+
     pub(crate) fn mark_as_absent(&mut self) {
         self.mark_as_changed();
         self.merged.base_iface_mut().state = InterfaceState::Absent;

--- a/rust/src/lib/net_state.rs
+++ b/rust/src/lib/net_state.rs
@@ -385,7 +385,7 @@ impl MergedNetworkState {
             current.ovsdb.unwrap_or_default(),
         )?;
 
-        let ret = Self {
+        let mut ret = Self {
             interfaces,
             routes,
             rules,

--- a/rust/src/lib/nm/dns.rs
+++ b/rust/src/lib/nm/dns.rs
@@ -362,6 +362,15 @@ fn _save_dns_to_iface(
     {
         if !iface.is_changed() {
             iface.mark_as_changed();
+            // `mark_as_changed()` defaults for_apply to Up. Keep the merged
+            // state so inherited current DNS (including scoped link-local) on
+            // a down iface does not activate it. Desired link-local DNS
+            // already set merged to Up in
+            // `validate_ipv6_link_local_address_dns_srv()`.
+            if let Some(apply_iface) = iface.for_apply.as_mut() {
+                apply_iface.base_iface_mut().state =
+                    iface.merged.base_iface().state;
+            }
         }
         if let Some(apply_iface) = iface.for_apply.as_mut() {
             if is_ipv6 {

--- a/rust/src/lib/nm/route_rule.rs
+++ b/rust/src/lib/nm/route_rule.rs
@@ -168,7 +168,12 @@ fn append_route_rule(
     if let Some(iface) =
         merged_state.interfaces.kernel_ifaces.get_mut(&iface_name)
     {
-        if !iface.is_changed() {
+        // Referring by route-rule `iif` auto-activates a disconnected
+        // interface so the rule can be applied without an explicit
+        // `interfaces: [{name, state: up}]` entry.
+        if !iface.merged.is_up() && !iface.merged.is_ignore() {
+            iface.mark_as_up_for_apply();
+        } else if !iface.is_changed() {
             iface.mark_as_changed();
         }
         if let Some(apply_iface) = iface.for_apply.as_mut() {

--- a/rust/src/lib/unit_tests/nm/dns.rs
+++ b/rust/src/lib/unit_tests/nm/dns.rs
@@ -95,6 +95,149 @@ fn test_dns_ipv6_link_local_iface_has_ipv6_disabled() {
 }
 
 #[test]
+fn test_dns_ipv6_link_local_on_disconnected_iface() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        dns-resolver:
+          config:
+            server:
+            - fe80::deef:1%eth1
+        ",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: down
+            ipv6:
+              enabled: true
+              address:
+              - ip: fe80::1
+                prefix-length: 64
+        ",
+    )
+    .unwrap();
+
+    let merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let iface = merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    assert!(iface.merged.is_up());
+    assert!(iface.is_changed());
+    assert!(iface.for_apply.as_ref().unwrap().is_up());
+}
+
+#[test]
+fn test_inherited_link_local_dns_does_not_activate_down_iface() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth2
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+        ",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        dns-resolver:
+          config:
+            server:
+            - fe80::deef:1%eth1
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: down
+            ipv6:
+              enabled: true
+              address:
+              - ip: fe80::1
+                prefix-length: 64
+          - name: eth2
+            type: ethernet
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: true
+        ",
+    )
+    .unwrap();
+
+    let mut merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let eth1 = merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    assert!(eth1.merged.is_down());
+    assert!(!eth1.is_changed());
+
+    store_dns_config_to_iface(&mut merged_state, &[], &[]).unwrap();
+
+    let eth1 = merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    assert!(eth1.merged.is_down());
+    assert!(eth1.for_apply.as_ref().unwrap().is_down());
+}
+
+#[test]
+fn test_mark_as_up_for_apply_skips_orphan_absent_iface() {
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: bond0
+            type: bond
+            state: up
+            link-aggregation:
+              mode: balance-rr
+          - name: bond0.100
+            type: vlan
+            state: up
+            vlan:
+              base-iface: bond0
+              id: 100
+            ipv6:
+              enabled: true
+              address:
+              - ip: fe80::1
+                prefix-length: 64
+        ",
+    )
+    .unwrap();
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: bond0
+            type: bond
+            state: absent
+        ",
+    )
+    .unwrap();
+
+    let mut merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    let vlan = merged_state
+        .interfaces
+        .kernel_ifaces
+        .get_mut("bond0.100")
+        .unwrap();
+    assert!(vlan.merged.is_absent());
+    assert!(vlan.is_changed());
+    assert!(vlan.desired.is_none());
+
+    vlan.mark_as_up_for_apply();
+
+    assert!(vlan.merged.is_absent());
+    assert!(vlan.for_apply.as_ref().unwrap().is_absent());
+}
+
+#[test]
 fn test_two_dns_ipv6_link_local_iface() {
     let desired: NetworkState = serde_yaml::from_str(
         r"---
@@ -134,6 +277,37 @@ fn test_two_dns_ipv6_link_local_iface() {
     if let Err(e) = result {
         assert_eq!(e.kind(), ErrorKind::NotImplementedError);
     }
+}
+
+#[test]
+fn test_two_dns_ipv6_link_local_same_iface() {
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        dns-resolver:
+          config:
+            server:
+            - fe80::deef:1%eth1
+            - fe80::deef:2%eth1
+        ",
+    )
+    .unwrap();
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: up
+            ipv6:
+              enabled: true
+              dhcp: true
+              autoconf: true
+              auto-dns: false
+        ",
+    )
+    .unwrap();
+
+    MergedNetworkState::new(desired, current, Default::default(), false)
+        .unwrap();
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/nm/route_rule.rs
+++ b/rust/src/lib/unit_tests/nm/route_rule.rs
@@ -402,3 +402,51 @@ fn test_route_rule_add_twice() {
 
     assert_eq!(ipv4_rules, expected_rules);
 }
+
+#[test]
+fn test_route_rule_iif_on_disconnected_iface() {
+    let current: NetworkState = serde_yaml::from_str(
+        r"---
+        interfaces:
+          - name: eth1
+            type: ethernet
+            state: down
+            ipv4:
+              enabled: true
+              address:
+              - ip: 192.0.2.251
+                prefix-length: 24
+        ",
+    )
+    .unwrap();
+
+    let desired: NetworkState = serde_yaml::from_str(
+        r"---
+        route-rules:
+          config:
+            - family: ipv4
+              ip-to: 192.0.2.0/24
+              priority: 1000
+              route-table: 50
+              iif: eth1
+        ",
+    )
+    .unwrap();
+
+    let mut merged_state =
+        MergedNetworkState::new(desired, current, Default::default(), false)
+            .unwrap();
+
+    store_route_rule_config(&mut merged_state).unwrap();
+
+    let merged_iface =
+        merged_state.interfaces.kernel_ifaces.get("eth1").unwrap();
+    assert!(merged_iface.merged.is_up());
+    assert!(merged_iface.is_changed());
+
+    let iface = get_iface(&merged_state, "eth1", InterfaceType::Ethernet);
+    let ipv4_rules = get_routing_rules(iface, false);
+    assert_eq!(ipv4_rules.len(), 1);
+    assert_eq!(ipv4_rules[0].iif.as_deref(), Some("eth1"));
+    assert_eq!(ipv4_rules[0].table_id, Some(50));
+}


### PR DESCRIPTION
Restore auto-activation of managed but disconnected interfaces when they are only referenced by IPv6 link-local DNS (fe80::…%iface) or by route-rule iif, so apply no longer requires an explicit interfaces: [{ name, state: up }] entry.

Regression from 282b5b9e (is_iface_valid_for_dns() requiring state: up): link-local DNS validation failed with a misleading “IPv6 disabled” error on down/disconnected ifaces that still had IPv6. Route-rule iif similarly left merged down, so activation/verification could fail.

This change adds MergedInterface::mark_as_up_for_apply() and uses it for those reference paths. Unmanaged/ignored ifaces still need an explicit desired entry; DNS search/options are still not placed on arbitrary down ifaces.

Resolves: https://redhat.atlassian.net/browse/RHEL-113828