### PR TITLE
nm: deactivate when auto-route-table-id changes

### DIFF
--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -14,8 +14,8 @@ use super::super::{
         delete_orphan_ovs_ports, dispatch::apply_dispatch_script,
         dns::store_dns_config, is_hsr_changed, is_ip_tunnel_changed,
         is_ipvlan_changed, is_mptcp_flags_changed, is_route_removed,
-        is_veth_peer_changed, is_vlan_changed, is_vrf_table_id_changed,
-        is_vxlan_changed, save_nm_connections,
+        is_route_table_changed, is_veth_peer_changed, is_vlan_changed,
+        is_vrf_table_id_changed, is_vxlan_changed, save_nm_connections,
     },
     route::store_route_config,
     route_rule::store_route_rule_config,
@@ -343,6 +343,8 @@ async fn delete_orphan_ports(
 //  https://bugzilla.redhat.com/1837254
 //  https://issues.redhat.com/browse/RHEL-66262
 //  https://issues.redhat.com/browse/RHEL-67324
+// * Changing ipv4/ipv6.route-table (auto-route-table-id) leaves IPv6 proto
+//   kernel routes in the old table on reapply, so deactivate first.
 // * NM cannot change VRF table ID, so we deactivate first
 // * VLAN config changed.
 // * IP tunnel config changed.
@@ -377,6 +379,7 @@ fn gen_nm_conn_need_to_deactivate_first(
                 conn_matcher.get_applied_by_uuid(uuid)
                 && ((remove_routes_need_deactivate
                     && is_route_removed(nm_conn, nm_applied_conn))
+                    || is_route_table_changed(nm_conn, nm_applied_conn)
                     || is_vrf_table_id_changed(nm_conn, nm_applied_conn)
                     || is_vlan_changed(nm_conn, nm_applied_conn)
                     || is_hsr_changed(nm_conn, nm_applied_conn)

--- a/rust/src/lib/nm/query_apply/mod.rs
+++ b/rust/src/lib/nm/query_apply/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use self::{
     lldp::{get_lldp, is_lldp_enabled},
     mptcp::is_mptcp_flags_changed,
     ovs::delete_orphan_ovs_ports,
-    route::is_route_removed,
+    route::{is_route_removed, is_route_table_changed},
     user::get_description,
     veth::is_veth_peer_changed,
     vlan::is_vlan_changed,

--- a/rust/src/lib/nm/query_apply/route.rs
+++ b/rust/src/lib/nm/query_apply/route.rs
@@ -21,6 +21,42 @@ pub(crate) fn is_route_removed(
     )
 }
 
+/// Return true when ipv4/ipv6.route-table differs between connections.
+///
+/// Missing route-table and route-table=0 are treated as equal defaults so
+/// representation-only differences do not force a deactivate/reactivate.
+/// parse_dhcp_opts() also maps a missing value to 0.
+pub(crate) fn is_route_table_changed(
+    new_nm_conn: &NmConnection,
+    cur_nm_conn: &NmConnection,
+) -> bool {
+    is_nm_ip_route_table_changed(
+        new_nm_conn.ipv4.as_ref(),
+        cur_nm_conn.ipv4.as_ref(),
+    ) || is_nm_ip_route_table_changed(
+        new_nm_conn.ipv6.as_ref(),
+        cur_nm_conn.ipv6.as_ref(),
+    )
+}
+
+/// Compare one address-family route-table after normalizing NM defaults.
+fn is_nm_ip_route_table_changed(
+    new_nm_sett: Option<&NmSettingIp>,
+    cur_nm_sett: Option<&NmSettingIp>,
+) -> bool {
+    if let (Some(new_nm_sett), Some(cur_nm_sett)) = (new_nm_sett, cur_nm_sett) {
+        normalize_nm_route_table(new_nm_sett.route_table)
+            != normalize_nm_route_table(cur_nm_sett.route_table)
+    } else {
+        false
+    }
+}
+
+/// Map NM route-table values so unset and 0 both mean the default table.
+fn normalize_nm_route_table(route_table: Option<u32>) -> u32 {
+    route_table.unwrap_or(NM_IP_SETTING_ROUTE_TABLE_DEFAULT)
+}
+
 fn nm_setting_is_route_removed(
     new_nm_sett: Option<&NmSettingIp>,
     cur_nm_sett: Option<&NmSettingIp>,
@@ -66,4 +102,68 @@ fn clone_normalized_routes(
             new_rt
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        NmConnection, NmSettingIp, is_route_table_changed,
+        normalize_nm_route_table,
+    };
+
+    /// Missing and explicit 0 both normalize to the default table.
+    #[test]
+    fn test_normalize_nm_route_table_treats_missing_as_default() {
+        assert_eq!(normalize_nm_route_table(None), 0);
+        assert_eq!(normalize_nm_route_table(Some(0)), 0);
+        assert_eq!(normalize_nm_route_table(Some(1000)), 1000);
+    }
+
+    /// None vs Some(0) must not be treated as a route-table change.
+    #[test]
+    fn test_is_route_table_changed_ignores_default_representation() {
+        let mut new_nm_sett = NmSettingIp::default();
+        new_nm_sett.route_table = None;
+        let mut cur_nm_sett = NmSettingIp::default();
+        cur_nm_sett.route_table = Some(0);
+
+        let mut new_nm_conn = NmConnection::default();
+        new_nm_conn.ipv6 = Some(new_nm_sett);
+        let mut cur_nm_conn = NmConnection::default();
+        cur_nm_conn.ipv6 = Some(cur_nm_sett);
+
+        assert!(!is_route_table_changed(&new_nm_conn, &cur_nm_conn));
+    }
+
+    /// Changing auto-route-table-id from 1000 to 2000 is a real change.
+    #[test]
+    fn test_is_route_table_changed_detects_table_id_change() {
+        let mut new_nm_sett = NmSettingIp::default();
+        new_nm_sett.route_table = Some(2000);
+        let mut cur_nm_sett = NmSettingIp::default();
+        cur_nm_sett.route_table = Some(1000);
+
+        let mut new_nm_conn = NmConnection::default();
+        new_nm_conn.ipv6 = Some(new_nm_sett);
+        let mut cur_nm_conn = NmConnection::default();
+        cur_nm_conn.ipv6 = Some(cur_nm_sett);
+
+        assert!(is_route_table_changed(&new_nm_conn, &cur_nm_conn));
+    }
+
+    /// IPv4-only auto-route-table-id 1000 to 2000 is also a real change.
+    #[test]
+    fn test_is_route_table_changed_detects_ipv4_table_id_change() {
+        let mut new_nm_sett = NmSettingIp::default();
+        new_nm_sett.route_table = Some(2000);
+        let mut cur_nm_sett = NmSettingIp::default();
+        cur_nm_sett.route_table = Some(1000);
+
+        let mut new_nm_conn = NmConnection::default();
+        new_nm_conn.ipv4 = Some(new_nm_sett);
+        let mut cur_nm_conn = NmConnection::default();
+        cur_nm_conn.ipv4 = Some(cur_nm_sett);
+
+        assert!(is_route_table_changed(&new_nm_conn, &cur_nm_conn));
+    }
 }

--- a/tests/integration/dynamic_ip_test.py
+++ b/tests/integration/dynamic_ip_test.py
@@ -450,6 +450,76 @@ def test_ipv6_dhcp_set_table_id_with_autoconf(dhcpcli_up):
     assertlib.assert_state(desired_state)
 
 
+@pytest.mark.tier1
+def test_change_auto_route_table_id_clears_old_kernel_routes(dhcpcli_up):
+    """
+    Changing auto-route-table-id must migrate IPv4/IPv6 routes, including
+    IPv6 proto kernel prefix routes, out of the old table. A single-family
+    change must clear only that family's previous table.
+    """
+    desired_state = dhcpcli_up
+    dhcp_cli_desired_state = desired_state[Interface.KEY][0]
+    dhcp_cli_desired_state[Interface.STATE] = InterfaceState.UP
+    dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
+        enabled=True, dhcp=True, table_id=1000
+    )
+    dhcp_cli_desired_state[Interface.IPV6] = _create_ipv6_state(
+        enabled=True, dhcp=True, autoconf=True, table_id=1000
+    )
+
+    apply_with_description(
+        "Configure the ethernet device dhcpcli with DHCPv4, IPv4 auto dns, "
+        "IPv4 auto gateway, IPv4 auto routes, IPv4 auto route table ID 1000, "
+        "DHCPv6, autoconf, IPv6 auto dns, IPv6 auto gateway, IPv6 auto "
+        "routes, IPv6 auto route table ID 1000",
+        desired_state,
+    )
+    assert _poll(_has_dhcpv4_addr)
+    assert _poll(_has_dhcpv6_addr)
+    assert _poll(_has_iface_route_in_table, 4, 1000)
+    assert _poll(_has_kernel_route_in_table, 6, 1000)
+
+    # Change only IPv6 table ID; keep IPv4 on table 1000.
+    dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
+        enabled=True, dhcp=True, table_id=1000
+    )
+    dhcp_cli_desired_state[Interface.IPV6] = _create_ipv6_state(
+        enabled=True, dhcp=True, autoconf=True, table_id=2000
+    )
+    apply_with_description(
+        "Configure the ethernet device dhcpcli with IPv4 auto route table "
+        "ID 1000 and IPv6 auto route table ID 2000",
+        desired_state,
+    )
+
+    assert _poll(_has_dhcpv4_addr)
+    assert _poll(_has_dhcpv6_addr)
+    assert _poll(_has_iface_route_in_table, 4, 1000)
+    assert _poll(_has_kernel_route_in_table, 6, 2000)
+    assert _poll(_has_no_kernel_route_in_table, 6, 1000)
+    assert _poll(_has_no_iface_route_in_table, 6, 1000)
+
+    dhcp_cli_desired_state[Interface.IPV4] = _create_ipv4_state(
+        enabled=True, dhcp=True, table_id=2000
+    )
+    dhcp_cli_desired_state[Interface.IPV6] = _create_ipv6_state(
+        enabled=True, dhcp=True, autoconf=True, table_id=2000
+    )
+    apply_with_description(
+        "Configure the ethernet device dhcpcli with IPv4 auto route table "
+        "ID 2000 and IPv6 auto route table ID 2000",
+        desired_state,
+    )
+
+    assert _poll(_has_dhcpv4_addr)
+    assert _poll(_has_dhcpv6_addr)
+    assert _poll(_has_iface_route_in_table, 4, 2000)
+    assert _poll(_has_kernel_route_in_table, 6, 2000)
+    assert _poll(_has_no_iface_route_in_table, 4, 1000)
+    assert _poll(_has_no_kernel_route_in_table, 6, 1000)
+    assert _poll(_has_no_iface_route_in_table, 6, 1000)
+
+
 def test_ipv6_dhcp_and_autoconf_ignore_gateway(dhcpcli_up):
     desired_state = dhcpcli_up
     dhcp_cli_desired_state = desired_state[Interface.KEY][0]
@@ -865,6 +935,37 @@ def _get_running_routes():
     )
     logging.debug("Current running routes: {}".format(running_routes))
     return running_routes
+
+
+def _get_routes_from_iproute(family, table):
+    """Return `ip route` output for the given address family and table."""
+    _, out, _ = cmdlib.exec_cmd(
+        f"ip -{family} route show table {table}".split(), check=True
+    )
+    return out
+
+
+def _has_iface_route_in_table(family, table, nic=DHCP_CLI_NIC):
+    """Return True if the interface appears in the given route table."""
+    return nic in _get_routes_from_iproute(family, table)
+
+
+def _has_no_iface_route_in_table(family, table, nic=DHCP_CLI_NIC):
+    """Return True if the interface has no routes in the given table."""
+    return not _has_iface_route_in_table(family, table, nic)
+
+
+def _has_kernel_route_in_table(family, table, nic=DHCP_CLI_NIC):
+    """Return True if a proto kernel route for the iface is in the table."""
+    for line in _get_routes_from_iproute(family, table).splitlines():
+        if nic in line and "proto kernel" in line:
+            return True
+    return False
+
+
+def _has_no_kernel_route_in_table(family, table, nic=DHCP_CLI_NIC):
+    """Return True if no proto kernel route for the iface is in the table."""
+    return not _has_kernel_route_in_table(family, table, nic)
 
 
 def _poll(func, *args, **kwargs):


### PR DESCRIPTION
## Summary
- Detect changes to NM `ipv4.route-table` / `ipv6.route-table` (`auto-route-table-id`).
- Treat them like other settings that need deactivate/reactivate instead of in-place reapply.
- Fixes leftover IPv6 `proto kernel` routes in the old table after changing `auto-route-table-id` (e.g. 1000 → 2000).

Resolves: https://redhat.atlassian.net/browse/RHEL-178772

Assisted-By: Claude Sonnet 5