### PR TITLE
ci: add + document gitlint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,23 @@ jobs:
         shell: bash
         run: ./automation/run-lint-tests.sh
 
+  commit_lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install gitlint
+        run: pip install gitlint==0.19.1
+      - name: Run gitlint
+        run: >-
+          gitlint --commits
+          ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+
   integ:
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,15 @@
+[general]
+regex-style-search=True
+# Signed-off-by is checked by the DCO job; subject-only commits are fine,
+# and release commit bodies shrink below min length once bullets are ignored
+ignore=body-is-missing,body-min-length
+
+# skip changelog bullets in release commits, URLs, and -by trailers
+[ignore-body-lines]
+regex=(^ - )|(https?://)|(^[A-Za-z]+(-[A-Za-z]+)*-by: )
+
+[title-max-length]
+line-length=50
+
+[body-max-line-length]
+line-length=72

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
         language: system
         files: ^rust/.*\.rs$
         pass_filenames: false
+
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,17 @@ Here are a few rules to keep in mind while writing a commit message
  See also: #456, #789
 
 Do not forget to sign your commit! Use `git commit -s`
+```
 
+Rules 1, 2, 4 and 6 are enforced by
+[gitlint](https://jorisroovers.com/gitlint/) in CI (see `.gitlint`);
+besides a period, gitlint also rejects `!`, `,` and `;` at the end of
+the subject line.
+To check commit messages locally, and to run the Rust lint hooks,
+install the [pre-commit](https://pre-commit.com/) hooks:
+
+```console
+pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
 This is taken from [chris beams git commit](https://chris.beams.io/posts/git-commit/).


### PR DESCRIPTION
CONTRIBUTING.md asks for a 50 character subject, no trailing period and a body wrapped at 72 columns, but nothing checks any of it, so reviewers have to do it by hand. 

Add a gitlint config encoding those rules, a CI job linting the commit range of each pull request, and a commit-msg hook in the existing pre-commit config so contributors catch
violations before pushing. 

Release changelog bullets, URLs and trailers are exempt from the body length limit; the sign-off stays with the DCO check.
