### PR TITLE
ifaces: stop silently dropping invalid desired state input

### DIFF
--- a/rust/src/lib/iface.rs
+++ b/rust/src/lib/iface.rs
@@ -301,26 +301,34 @@ impl<'de> Deserialize<'de> for Interface {
                 .map_err(serde::de::Error::custom)?,
             Some(InterfaceState::Absent)
         ) {
-            let mut new_value = serde_json::map::Map::new();
-            if let Some(n) = v.get("name") {
-                new_value.insert("name".to_string(), n.clone());
+            const ABSENT_KEPT_PROPS: &[&str] = &[
+                "name",
+                "type",
+                "state",
+                "identifier",
+                "mac-address",
+                "pci-address",
+            ];
+            if let Some(obj) = v.as_object_mut() {
+                let mut discarded: Vec<String> = Vec::new();
+                obj.retain(|k, _| {
+                    let keep = ABSENT_KEPT_PROPS.contains(&k.as_str());
+                    if !keep {
+                        discarded.push(k.clone());
+                    }
+                    keep
+                });
+                if !discarded.is_empty() {
+                    let iface_name = obj
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("unknown");
+                    log::warn!(
+                        "Ignoring properties {discarded:?} of absent \
+                         interface {iface_name:?}"
+                    );
+                }
             }
-            if let Some(t) = v.get("type") {
-                new_value.insert("type".to_string(), t.clone());
-            }
-            if let Some(s) = v.get("state") {
-                new_value.insert("state".to_string(), s.clone());
-            }
-            if let Some(s) = v.get("identifier") {
-                new_value.insert("identifier".to_string(), s.clone());
-            }
-            if let Some(s) = v.get("mac-address") {
-                new_value.insert("mac-address".to_string(), s.clone());
-            }
-            if let Some(s) = v.get("pci-address") {
-                new_value.insert("pci-address".to_string(), s.clone());
-            }
-            v = serde_json::value::Value::Object(new_value);
         }
 
         match Option::deserialize(&v["type"])

--- a/rust/src/lib/ifaces/base.rs
+++ b/rust/src/lib/ifaces/base.rs
@@ -319,6 +319,22 @@ impl MergedInterface {
     }
 
     fn validate_mtu(&self) -> Result<(), NmstateError> {
+        // NM and the kernel store MTU as u32
+        if let Some(desired) = self.desired.as_ref().map(|i| i.base_iface())
+            && let Some(desire_mtu) = desired.mtu
+            && desire_mtu > u32::MAX as u64
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Desired MTU {} for interface {} is bigger than maximum \
+                     supported MTU {}",
+                    desire_mtu,
+                    desired.name,
+                    u32::MAX
+                ),
+            ));
+        }
         if let (Some(desired), Some(current)) = (
             self.desired.as_ref().map(|i| i.base_iface()),
             self.current.as_ref().map(|i| i.base_iface()),

--- a/rust/src/lib/ifaces/hsr.rs
+++ b/rust/src/lib/ifaces/hsr.rs
@@ -272,7 +272,7 @@ impl MergedInterface {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 #[derive(Default)]
 pub struct HsrConfig {

--- a/rust/src/lib/ifaces/inter_ifaces.rs
+++ b/rust/src/lib/ifaces/inter_ifaces.rs
@@ -48,6 +48,12 @@ impl<'de> Deserialize<'de> for Interfaces {
         let mut ret = Self::new();
         for iface in <Vec<Interface> as Deserialize>::deserialize(deserializer)?
         {
+            if ret.is_push_key_taken(&iface) {
+                log::warn!(
+                    "Duplicate interface entry {:?}: last entry wins",
+                    iface.name()
+                );
+            }
             ret.push(iface);
         }
         Ok(ret)
@@ -140,6 +146,16 @@ impl Interfaces {
                 .remove(&(iface_name.to_string(), iface_type))
         } else {
             self.kernel_ifaces.remove(iface_name)
+        }
+    }
+
+    /// Must mirror the keying of [Interfaces::push].
+    pub(crate) fn is_push_key_taken(&self, iface: &Interface) -> bool {
+        if iface.is_userspace() {
+            self.user_ifaces
+                .contains_key(&(iface.name().to_string(), iface.iface_type()))
+        } else {
+            self.kernel_ifaces.contains_key(iface.name())
         }
     }
 

--- a/rust/src/lib/ifaces/ip_tunnel.rs
+++ b/rust/src/lib/ifaces/ip_tunnel.rs
@@ -100,7 +100,7 @@ pub enum Ip6TunnelFlag {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 #[derive(Default)]
 pub struct IpTunnelConfig {

--- a/rust/src/lib/ifaces/macsec.rs
+++ b/rust/src/lib/ifaces/macsec.rs
@@ -105,7 +105,7 @@ impl MacSecInterface {
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 #[derive(Default)]
 pub struct MacSecConfig {

--- a/rust/src/lib/unit_tests/base.rs
+++ b/rust/src/lib/unit_tests/base.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::BaseInterface;
+use crate::{
+    BaseInterface, ErrorKind, InterfaceType, Interfaces, MergedInterfaces,
+};
 
 #[test]
 fn test_base_iface_stringlized_attributes() {
@@ -46,4 +48,50 @@ fn test_base_iface_serialize_copy_mac_from() {
             .unwrap();
 
     assert_eq!(desired, new);
+}
+
+#[test]
+fn test_reject_mtu_exceeding_u32_max() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          type: dummy
+          state: up
+          mtu: 4294967296
+        ",
+    )
+    .unwrap();
+
+    let err = MergedInterfaces::new(
+        desired,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    )
+    .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    assert!(err.msg().contains("maximum supported MTU"));
+}
+
+#[test]
+fn test_accept_mtu_of_u32_max() {
+    let desired = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: dummy1
+          type: dummy
+          state: up
+          mtu: 4294967295
+        ",
+    )
+    .unwrap();
+
+    let merged = MergedInterfaces::new(
+        desired,
+        Interfaces::new(),
+        Default::default(),
+        false,
+    )
+    .unwrap();
+    let iface = merged.get_iface("dummy1", InterfaceType::Dummy).unwrap();
+    assert_eq!(iface.merged.base_iface().mtu, Some(u32::MAX as u64));
 }

--- a/rust/src/lib/unit_tests/hsr.rs
+++ b/rust/src/lib/unit_tests/hsr.rs
@@ -163,3 +163,21 @@ fn test_prp_interlink_is_forbidden() {
     assert_eq!(err.kind(), ErrorKind::InvalidArgument);
     assert!(err.msg().contains("interlink property is not supported"));
 }
+
+#[test]
+fn test_hsr_deny_unknown_config_field() {
+    let result = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: hsr0
+          type: hsr
+          state: up
+          hsr:
+            port1: eth1
+            port2: eth2
+            multicast-specc: 40
+        ",
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("unknown field"));
+    assert!(err.contains("multicast-specc"));
+}

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -158,6 +158,27 @@ fn test_ifaces_deny_unknonw_attribute() {
 }
 
 #[test]
+fn test_macsec_deny_unknown_config_field() {
+    let result = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: macsec0
+  type: macsec
+  state: up
+  macsec:
+    encrypt: true
+    base-iface: eth1
+    mka-cakk: '50b71a8ef0bd5751ea76de6d6c98c03a'
+    port: 0
+    validation: strict
+    send-sci: true
+",
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("unknown field"));
+    assert!(err.contains("mka-cakk"));
+}
+
+#[test]
 fn test_duplicate_iface_entry_last_wins() {
     log_capture::start();
     let ifaces = serde_yaml::from_str::<Interfaces>(

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -226,6 +226,36 @@ fn test_untyped_iface_of_userspace_name_is_not_duplicate() {
 }
 
 #[test]
+fn test_absent_iface_warns_on_ignored_props() {
+    log_capture::start();
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: eth1
+  type: ethernet
+  state: absent
+  mtu: 1500
+",
+    )
+    .unwrap();
+
+    let iface = ifaces.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+    assert_eq!(iface.base_iface().mtu, None);
+    assert_eq!(log_capture::warn_count(), 1);
+
+    log_capture::start();
+    serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: eth1
+  type: ethernet
+  state: absent
+",
+    )
+    .unwrap();
+
+    assert_eq!(log_capture::warn_count(), 0);
+}
+
+#[test]
 fn test_ifaces_resolve_unknown_bond_iface() {
     let current = serde_yaml::from_str::<Interfaces>(
         r"---

--- a/rust/src/lib/unit_tests/ifaces.rs
+++ b/rust/src/lib/unit_tests/ifaces.rs
@@ -4,7 +4,7 @@ use crate::{
     BondMode, ErrorKind, HsrProtocol, Interface, InterfaceState, InterfaceType,
     Interfaces, MergedInterface, MergedInterfaces,
     unit_tests::testlib::{
-        get_mac, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
+        get_mac, log_capture, new_eth_iface, new_ovs_br_iface, new_ovs_iface,
         new_unknown_iface, new_vlan_iface,
     },
 };
@@ -155,6 +155,53 @@ fn test_ifaces_deny_unknonw_attribute() {
         assert!(e.to_string().contains("unknown field"));
         assert!(e.to_string().contains("foo"));
     }
+}
+
+#[test]
+fn test_duplicate_iface_entry_last_wins() {
+    log_capture::start();
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: eth1
+  type: ethernet
+  state: up
+  mtu: 1400
+- name: eth1
+  type: ethernet
+  state: up
+  mtu: 1500
+- name: br0
+  type: ovs-bridge
+  state: up
+- name: br0
+  type: ovs-bridge
+  state: up
+",
+    )
+    .unwrap();
+
+    assert_eq!(ifaces.to_vec().len(), 2);
+    let iface = ifaces.get_iface("eth1", InterfaceType::Ethernet).unwrap();
+    assert_eq!(iface.base_iface().mtu, Some(1500));
+    assert_eq!(log_capture::warn_count(), 2);
+}
+
+#[test]
+fn test_untyped_iface_of_userspace_name_is_not_duplicate() {
+    log_capture::start();
+    let ifaces = serde_yaml::from_str::<Interfaces>(
+        r"---
+- name: br0
+  type: ovs-bridge
+  state: up
+- name: br0
+  state: up
+",
+    )
+    .unwrap();
+
+    assert_eq!(ifaces.to_vec().len(), 2);
+    assert_eq!(log_capture::warn_count(), 0);
 }
 
 #[test]

--- a/rust/src/lib/unit_tests/ip_tunnel.rs
+++ b/rust/src/lib/unit_tests/ip_tunnel.rs
@@ -130,3 +130,21 @@ fn test_reject_invalid_flow_label() {
     assert_eq!(err.kind(), ErrorKind::InvalidArgument);
     assert!(err.msg().contains("Flow label"));
 }
+
+#[test]
+fn test_ip_tunnel_deny_unknown_config_field() {
+    let result = serde_yaml::from_str::<Interfaces>(
+        r"---
+        - name: ipip0
+          type: ip-tunnel
+          state: up
+          ip-tunnel:
+            mode: ipip
+            local: 192.0.2.1
+            remotee: 192.0.2.2
+        ",
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("unknown field"));
+    assert!(err.contains("remotee"));
+}

--- a/rust/src/lib/unit_tests/testlib.rs
+++ b/rust/src/lib/unit_tests/testlib.rs
@@ -304,3 +304,41 @@ pub(crate) fn gen_merged_ifaces_for_route_test()
 
     (merged, current)
 }
+
+/// Exposes no message text: log wording is not a tested interface.
+pub(crate) mod log_capture {
+    use std::{cell::Cell, sync::Once};
+
+    static INIT: Once = Once::new();
+    // The log crate permits one global logger shared by every test, so the
+    // count has to be per thread.
+    thread_local! {
+        static COUNT: Cell<usize> = const { Cell::new(0) };
+    }
+
+    struct CaptureLogger;
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, _record: &log::Record) {
+            COUNT.set(COUNT.get() + 1);
+        }
+
+        fn flush(&self) {}
+    }
+
+    pub(crate) fn start() {
+        INIT.call_once(|| {
+            log::set_logger(&CaptureLogger).unwrap();
+            log::set_max_level(log::LevelFilter::Warn);
+        });
+        COUNT.set(0);
+    }
+
+    pub(crate) fn warn_count() -> usize {
+        COUNT.get()
+    }
+}


### PR DESCRIPTION
Several places in desired-state deserialization silently accepted input that had no effect