### PR TITLE
test: fix race in IPv6 link-local detection

### DIFF
--- a/tests/integration/nm/iproute_config_test.py
+++ b/tests/integration/nm/iproute_config_test.py
@@ -19,6 +19,7 @@ from ..testlib import cmdlib
 from ..testlib.assertlib import assert_absent
 from ..testlib.assertlib import assert_state_match
 from ..testlib.dummy import nm_unmanaged_dummy
+from ..testlib.retry import retry_till_true_or_timeout
 from ..testlib.iproutelib import iproute_get_ip_addrs_with_order
 from ..testlib.statelib import show_only
 
@@ -176,11 +177,11 @@ def external_managed_veth1_with_static_ip():
     )
     cmdlib.exec_cmd("ip link set veth1-ep up".split(), check=True)
     cmdlib.exec_cmd("ip link set veth1 up".split(), check=True)
-    cmdlib.exec_cmd("nmcli d set veth1 managed true".split(), check=True)
     cmdlib.exec_cmd("ip addr add 192.0.2.2/24 dev veth1".split(), check=True)
     cmdlib.exec_cmd(
         "ip addr add 2001:db8:f::1/64 dev veth1".split(), check=True
     )
+    cmdlib.exec_cmd("nmcli d set veth1 managed true".split(), check=True)
     yield
     cmdlib.exec_cmd("ip link del veth1".split())
     libnmstate.apply(
@@ -210,10 +211,19 @@ def test_external_managed_veth_with_static_ip(
         }
     ]
     assert ipv6_info[InterfaceIPv6.ENABLED]
-    assert {
-        InterfaceIPv6.ADDRESS_IP: "2001:db8:f::1",
-        InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
-    } in ipv6_info[InterfaceIPv6.ADDRESS]
+
+    # Retry to handle kernels that are slow to complete DAD for the static
+    # IPv6 address after it is assigned with ip-addr(8).
+    def _has_static_ipv6():
+        cur_ipv6 = show_only(("veth1",))[Interface.KEY][0].get(
+            Interface.IPV6, {}
+        )
+        return {
+            InterfaceIPv6.ADDRESS_IP: "2001:db8:f::1",
+            InterfaceIPv6.ADDRESS_PREFIX_LENGTH: 64,
+        } in cur_ipv6.get(InterfaceIPv6.ADDRESS, [])
+
+    assert retry_till_true_or_timeout(10, _has_static_ipv6)
 
 
 def test_bring_unmanaged_iface_down(unmanged_dummy1_with_static_ip):

--- a/tests/integration/static_ip_address_test.py
+++ b/tests/integration/static_ip_address_test.py
@@ -15,6 +15,7 @@ from .testlib import assertlib
 from .testlib import cmdlib
 from .testlib import statelib
 from .testlib.apply import apply_with_description
+from .testlib.retry import retry_till_true_or_timeout
 from .testlib.dummy import nm_unmanaged_dummy
 from .testlib.env import nm_minor_version
 from .testlib.ifacelib import get_mac_address
@@ -456,10 +457,20 @@ def test_add_static_ipv6_with_no_address(eth1_up):
         desired_state,
     )
 
-    cur_state = statelib.show_only(("eth1",))
-    eth1_cur_state = cur_state[Interface.KEY][0]
-    # Should have at least 1 link-local address.
-    assert len(eth1_cur_state[Interface.IPV6][InterfaceIPv6.ADDRESS]) >= 1
+    def _has_link_local():
+        cur = statelib.show_only(("eth1",))
+        ipv6 = cur[Interface.KEY][0].get(Interface.IPV6, {})
+        return any(
+            is_ipv6_link_local_addr(
+                addr[InterfaceIPv6.ADDRESS_IP],
+                addr[InterfaceIPv6.ADDRESS_PREFIX_LENGTH],
+            )
+            for addr in ipv6.get(InterfaceIPv6.ADDRESS, [])
+        )
+
+    # Should have at least 1 link-local address. Retry to handle kernels
+    # that are slow to assign the link-local address after IPv6 is enabled.
+    assert retry_till_true_or_timeout(10, _has_link_local)
 
 
 def test_add_static_ipv6_with_min_state(eth2_up):

--- a/tests/integration/testlib/veth.py
+++ b/tests/integration/testlib/veth.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
 from contextlib import contextmanager
 
 import libnmstate
@@ -9,6 +11,7 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Veth
 
 from .cmdlib import exec_cmd
+from .retry import retry_till_false_or_timeout
 
 
 def create_veth_pair(nic, nic_peer, peer_ns):
@@ -74,3 +77,10 @@ def veth_interface(ifname, peer, kernel_mode=False):
             }
         )
         libnmstate.apply(d_state, kernel_only=kernel_mode)
+        if retry_till_false_or_timeout(
+            5, os.path.exists, f"/sys/class/net/{ifname}"
+        ):
+            msg = f"{ifname} still in /sys/class/net after absent apply"
+            if sys.exc_info()[1] is None:
+                raise RuntimeError(msg)
+            print(f"WARNING: {msg}")


### PR DESCRIPTION
Some kernels/NM versions are slow to assign the link-local address after IPv6 is enabled, causing a race condition where the address key is missing in the returned state. Use retry_till_true_or_timeout to wait up to 10 seconds for the link-local address to appear.