### PR TITLE
test: fix OVS teardown race with OVSDB

### DIFF
--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -286,9 +286,15 @@ def ovs_bridge_first_and_ovs_interface_with_same_name_ipv4():
         VERIFY_RETRY_TMO, _verify_ovs_activated, OVS_DUP_NAME
     )
     yield
-    cmdlib.exec_cmd(
-        "nmcli connection del ovs-port-br-ex br-ex ovs-if-br-ex".split(),
-        check=True,
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: OVS_DUP_NAME,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        },
     )
 
 
@@ -313,9 +319,15 @@ def ovs_interface_first_and_ovs_bridge_with_same_name_ipv4():
         VERIFY_RETRY_TMO, _verify_ovs_activated, OVS_DUP_NAME
     )
     yield
-    cmdlib.exec_cmd(
-        "nmcli connection del ovs-port-br-ex br-ex ovs-if-br-ex".split(),
-        check=True,
+    libnmstate.apply(
+        {
+            Interface.KEY: [
+                {
+                    Interface.NAME: OVS_DUP_NAME,
+                    Interface.STATE: InterfaceState.ABSENT,
+                }
+            ]
+        },
     )
 
 


### PR DESCRIPTION
Using `nmcli connection del` in teardown returns before NetworkManager finishes removing the bridge from OVSDB. When `clean_dns` immediately calls `libnmstate.apply()`, `ovsdb_retrieve()` still sees the stale `br-ex` entry with DNS configured, causing nmstate to attempt creating an invalid ovs-interface NM connection.

Replace the raw nmcli teardown with `libnmstate.apply(absent)` which waits for full state convergence (including OVSDB cleanup) before returning, eliminating the race.

Fixing it in the Rust code directly might be worth it as well, something like:
  ⎿  User rejected update to ../../nmstate/rust/src/lib/nm/settings/connection.rs
      250          nm_conn.bridge_port = None;
      251      }
      252
      253 -    if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort) {                                                                                                                                 
      253 +    // Keep the [ovs-interface] section for ovs-interface connections;                                                                                                                            
      254 +    // NM requires it and will reject the connection without it.                                                                                                                                  
      255 +    if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort)                                                                                                                                   
      256 +        && nm_conn.iface_type() != Some(&NmIfaceType::OvsIface)                                                                                                                                   
      257 +    {                                                                                                                                                                                             
      258          nm_conn.ovs_iface = None;
      259      }
      260
