### PR TITLE
Fix ovs iface missing setting

### DIFF
--- a/rust/src/lib/nm/settings/connection.rs
+++ b/rust/src/lib/nm/settings/connection.rs
@@ -250,7 +250,9 @@ pub(crate) fn iface_to_nm_connections(
         nm_conn.bridge_port = None;
     }
 
-    if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort) {
+    if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort)
+        && nm_conn.iface_type() != Some(&NmIfaceType::OvsIface)
+    {
         nm_conn.ovs_iface = None;
     }
 

--- a/tests/integration/nm/ovs_test.py
+++ b/tests/integration/nm/ovs_test.py
@@ -572,6 +572,29 @@ def test_gc_on_ovs_dpdk():
     assert "devargs=0000:af:00.1" in ovs_iface_conf
 
 
+def test_gc_ovs_iface_always_includes_ovs_interface_setting():
+    """
+    Regression test for nm/settings/connection.rs: the guard that clears
+    nm_conn.ovs_iface must not fire for connections whose own iface_type is
+    ovs-interface, even when controller_type is absent (e.g. stale OVSDB
+    state where the parent port was already removed). Without the fix, the
+    generated NM connection lacks the required [ovs-interface] setting and
+    NM >= 1.54 rejects it with Connection(MissingSetting).
+    """
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: br-ex
+          type: ovs-interface
+          state: up
+        """
+    )
+    confs = libnmstate.generate_configurations(desired_state)["NetworkManager"]
+    ovs_iface_conns = [c for c in confs if c[0].startswith("br-ex-if")]
+    assert ovs_iface_conns, "No ovs-interface connection generated for br-ex"
+    assert "[ovs-interface]" in ovs_iface_conns[0][1]
+
+
 @pytest.fixture
 def unmaaged_dummy1():
     with nm_unmanaged_dummy(DUMMY1):


### PR DESCRIPTION
  ## Problem

  When an `ovs-interface` exists in OVSDB but its NM connection was
  removed (e.g. stale OVSDB state during async cleanup after
  `nmcli connection del`), nmstate generates a new NM connection to
  sync state. A guard in `nm/settings/connection.rs` is supposed to
  clear `nm_conn.ovs_iface` for non-OVS-port connections, but it also
  fires for `ovs-interface` connections where `controller_type` is
  absent:

      // Before fix — fires for ovs-interface with no controller_type:
      if nm_conn.controller_type() != Some(&NmIfaceType::OvsPort) {
          nm_conn.ovs_iface = None;
      }

  This strips the `[ovs-interface]` NM setting which NM requires for
  all connections of type `ovs-interface`. NM >= 1.54 (RHEL 9+) rejects
  such a connection with:

      NmstateValueError: Connection(MissingSetting): ovs-interface:
        setting required for connection of type 'ovs-interface'

  Older NM accepted the incomplete connection silently, so the bug only
  reproduces on RHEL 9 and later.

  The immediate trigger was the `clean_dns` autouse fixture running
  immediately after `nmcli connection del` in OVS test teardown, before
  OVSDB cleanup completed. That race was eliminated separately by
  replacing `nmcli connection del` with `libnmstate.apply(absent)` in
  the fixture teardown. This patch is a defensive fix that prevents the
  same crash in any future scenario where `controller_type` is absent
  for an `ovs-interface` connection.

  ## Fix

  Add `&& nm_conn.iface_type() != Some(&NmIfaceType::OvsIface)` to the
  guard. Connections whose own type is `ovs-interface` always require
  the `[ovs-interface]` setting regardless of their controller context.

  ## Test

  `test_gc_ovs_iface_has_ovs_interface_section` uses
  `generate_configurations` with a standalone `ovs-interface` (no
  bridge context). This produces a new NM connection with
  `controller_type = None` and `iface_type = Some(OvsIface)` — the
  exact path the guard incorrectly cleared. Without the fix, the
  generated config lacks `[ovs-interface]`. The test does not interact
  with NM directly and requires no version gating.
