### PR TITLE
sriov: omit query-only max-vfs from gen_diff

### DIFF
--- a/rust/src/lib/ifaces/sriov.rs
+++ b/rust/src/lib/ifaces/sriov.rs
@@ -88,7 +88,9 @@ impl SrIovConfig {
 
     // * Convert VF MAC address to upper case
     // * Sort by VF ID
+    // * Remove max_vfs as it is query only
     pub(crate) fn sanitize(&mut self) -> Result<(), NmstateError> {
+        self.max_vfs = None;
         if let Some(vfs) = self.vfs.as_mut() {
             for vf in vfs.iter_mut() {
                 if let Some(address) = vf.mac_address.as_mut() {

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/current.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/current.yml
@@ -1,0 +1,9 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ethernet:
+    sr-iov:
+      total-vfs: 0
+      max-vfs: 63

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/desired.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/desired.yml
@@ -1,0 +1,9 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  state: up
+  ethernet:
+    sr-iov:
+      total-vfs: 2
+      max-vfs: 1

--- a/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/diff.yml
+++ b/rust/src/lib/unit_tests/gen_diff_test_files/sriov_max_vfs/diff.yml
@@ -1,0 +1,7 @@
+---
+interfaces:
+- name: eth1
+  type: ethernet
+  ethernet:
+    sr-iov:
+      total-vfs: 2


### PR DESCRIPTION
### Summary

Clear query-only sr-iov.max-vfs in SrIovConfig::sanitize() so it does not leak into gen_diff after apply.
Without this, a desired max-vfs: 1 could appear in the diff as max-vfs: 63 (hardware value) even though the property is ignored on apply.
Verification already ignored max-vfs via sanitize_desired_for_verify; this aligns gen_diff with that behavior.
Adds a gen_diff unit fixture (sriov_max_vfs) covering the case.

Resolves: https://redhat.atlassian.net/browse/RHEL-146945

Assisted-By: Claude Sonnet 5