### PR TITLE
route: Reject conflicting special routes

### DIFF
--- a/rust/src/lib/revert/route.rs
+++ b/rust/src/lib/revert/route.rs
@@ -19,15 +19,15 @@ impl MergedRoutes {
             }
         }
 
-        // Add back the deleted routes
-        if let Some(config_rts) = self.desired.config.as_ref() {
-            for config_rt in config_rts.iter().filter(|r| r.is_absent()) {
-                for cur_rt in current_rts
-                    .iter()
-                    .filter(|cur_rt| config_rt.is_match(cur_rt))
-                {
-                    let rt = cur_rt.clone();
-                    revert_rts.push(rt);
+        // Add back routes removed during merge (explicit absent entries and
+        // inferred special-route replacements tracked in changed_routes).
+        for removed_rt in self.changed_routes.iter().filter(|r| r.is_absent()) {
+            for cur_rt in current_rts {
+                let mut matcher = removed_rt.clone();
+                matcher.state = None;
+                if matcher.is_match(cur_rt) {
+                    revert_rts.push(cur_rt.clone());
+                    break;
                 }
             }
         }

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -930,7 +930,7 @@ fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
                         ));
                     }
                 };
-                if prefix >= 8 && route.is_unicast() {
+                if prefix >= 8 && route.is_unicast() && !route.is_absent() {
                     let e = NmstateError::new(
                         ErrorKind::InvalidArgument,
                         "0.0.0.0/8 and its subnet cannot be used as the route \
@@ -941,7 +941,7 @@ fn validate_route_dst(route: &RouteEntry) -> Result<(), NmstateError> {
                     log::error!("{e}");
                     return Err(e);
                 }
-            } else if route.is_unicast() {
+            } else if route.is_unicast() && !route.is_absent() {
                 let e = NmstateError::new(
                     ErrorKind::InvalidArgument,
                     "0.0.0.0/8 and its subnet cannot be used as the route \

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -17,7 +17,6 @@ use crate::{
 const DEFAULT_TABLE_ID: u32 = 254; // main route table ID
 const LOOPBACK_IFACE_NAME: &str = "lo";
 // Kernel metric for user/static IPv6 routes with unset/0 metric.
-#[cfg(feature = "query_apply")]
 const IP6_RT_PRIO_USER: u32 = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -565,7 +564,6 @@ impl RouteEntry {
 
     // Metric the kernel will assign, for conflict detection. Unset/0 IPv6
     // metric is coerced to 1024, IPv4 to 0.
-    #[cfg(feature = "query_apply")]
     pub(crate) fn effective_metric(&self) -> u32 {
         match self.metric.and_then(|m| u32::try_from(m).ok()) {
             Some(m) if m > 0 => m,
@@ -576,7 +574,6 @@ impl RouteEntry {
 
     // Table the kernel will assign, for conflict detection. Unset table is
     // the main table.
-    #[cfg(feature = "query_apply")]
     pub(crate) fn effective_table_id(&self) -> u32 {
         match self.table_id {
             None | Some(Self::USE_DEFAULT_ROUTE_TABLE) => DEFAULT_TABLE_ID,
@@ -587,6 +584,18 @@ impl RouteEntry {
     pub(crate) fn is_unicast(&self) -> bool {
         self.route_type.is_none()
             || u8::from(self.route_type.unwrap()) == RTN_UNICAST
+    }
+
+    // True when both are non-unicast routes to the same destination, table,
+    // and metric. Netlink rejects a second route for the same triple on
+    // normal `ip route add` (IPv4/IPv6 fib); different metrics may coexist.
+    pub(crate) fn is_special_route_conflict_with(&self, other: &Self) -> bool {
+        !self.is_unicast()
+            && !other.is_unicast()
+            && self.destination.is_some()
+            && self.destination == other.destination
+            && self.effective_table_id() == other.effective_table_id()
+            && self.effective_metric() == other.effective_metric()
     }
 }
 
@@ -643,6 +652,9 @@ impl std::fmt::Display for RouteEntry {
         }
         if let Some(v) = self.table_id.as_ref() {
             props.push(format!("table-id: {v}"));
+        }
+        if let Some(v) = self.route_type.as_ref() {
+            props.push(format!("route-type: {v}"));
         }
         if let Some(v) = self.weight {
             props.push(format!("weight: {v}"));
@@ -711,6 +723,10 @@ impl MergedRoutes {
                 desired_routes.push(rt);
             }
         }
+        // After VRF resolution and destination sanitization so the key matches
+        // the destination/table/metric the kernel will use.
+        #[cfg(feature = "query_apply")]
+        validate_special_route_conflicts(desired_routes.as_slice())?;
 
         let mut changed_ifaces: HashSet<&str> = HashSet::new();
         let mut changed_routes: HashSet<RouteEntry> = HashSet::new();
@@ -799,6 +815,17 @@ impl MergedRoutes {
 
         let mut merged_routes: Vec<RouteEntry> = Vec::new();
 
+        // Desired special route with a different type for the same
+        // destination/table/metric replaces the current one (IPv4 has no oif;
+        // IPv6 keeps the kernel oif, so this must run in both branches below).
+        let is_replaced_special = |rt: &RouteEntry| {
+            desired_routes.as_slice().iter().any(|des_rt| {
+                !des_rt.is_absent()
+                    && des_rt.is_special_route_conflict_with(rt)
+                    && des_rt.route_type != rt.route_type
+            })
+        };
+
         if let Some(cur_rts) = current.config.as_ref() {
             for rt in cur_rts {
                 if let Some(via) = rt.next_hop_iface.as_ref() {
@@ -817,10 +844,29 @@ impl MergedRoutes {
                             .iter()
                             .filter(|r| r.is_absent())
                             .any(|absent_rt| absent_rt.is_match(rt))
+                        || is_replaced_special(rt)
                     {
                         let mut new_rt = rt.clone();
                         new_rt.state = Some(RouteState::Absent);
                         changed_routes.insert(new_rt);
+                    } else {
+                        merged_routes.push(rt.clone());
+                    }
+                } else if rt.route_type.is_some() {
+                    // Special routes with no next-hop interface. Drop them when
+                    // desired marks them absent or replaces the route-type for
+                    // the same destination, table, and metric.
+                    if desired_routes
+                        .as_slice()
+                        .iter()
+                        .filter(|r| r.is_absent())
+                        .any(|absent_rt| absent_rt.is_match(rt))
+                        || is_replaced_special(rt)
+                    {
+                        let mut new_rt = rt.clone();
+                        new_rt.state = Some(RouteState::Absent);
+                        changed_routes.insert(new_rt);
+                        changed_ifaces.insert(LOOPBACK_IFACE_NAME);
                     } else {
                         merged_routes.push(rt.clone());
                     }
@@ -905,6 +951,57 @@ impl MergedRoutes {
     pub(crate) fn is_changed(&self) -> bool {
         !self.route_changed_ifaces.is_empty()
     }
+}
+
+// Netlink rejects a second route when destination, table, and metric match on
+// normal `ip route add` (IPv4/IPv6 fib). Different metrics may coexist. IPv4
+// can store both special types via append; IPv6 replace keeps only the new
+// route because duplicate-nexthop comparison ignores route type. Callers must
+// pass routes after VRF resolution and destination sanitization so keys match
+// what the backend uses.
+#[cfg(feature = "query_apply")]
+fn validate_special_route_conflicts(
+    routes: &[RouteEntry],
+) -> Result<(), NmstateError> {
+    let mut special_routes: HashMap<(&str, u32, u32), &RouteEntry> =
+        HashMap::new();
+    for route in routes
+        .iter()
+        .filter(|rt| !rt.is_absent() && !rt.is_unicast())
+    {
+        let dst = if let Some(dst) = route.destination.as_deref() {
+            dst
+        } else {
+            continue;
+        };
+        let table = route.effective_table_id();
+        let metric = route.effective_metric();
+        if let Some(existing) = special_routes.get(&(dst, table, metric)) {
+            if existing.route_type != route.route_type {
+                return Err(NmstateError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Multiple special routes to {dst} in table {table} \
+                         with metric {metric} are not allowed, found '{}' and \
+                         '{}'. Netlink can only hold one of blackhole, \
+                         unreachable, or prohibit for the same destination, \
+                         table, and metric.",
+                        existing
+                            .route_type
+                            .map(|t| t.to_string())
+                            .unwrap_or_default(),
+                        route
+                            .route_type
+                            .map(|t| t.to_string())
+                            .unwrap_or_default(),
+                    ),
+                ));
+            }
+        } else {
+            special_routes.insert((dst, table, metric), route);
+        }
+    }
+    Ok(())
 }
 
 // Validating if the route destination network is valid,

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -937,3 +937,20 @@ fn test_route_lock_mtu_deserialize_from_string() {
 
     assert_eq!(route.lock_mtu, Some(true));
 }
+
+#[test]
+fn test_allow_absent_zero_network_without_route_type() {
+    // Absent entries are wildcards; 0.0.0.0/8 must be removable without
+    // setting route-type (which would otherwise look like a unicast route).
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          state: absent
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    routes.validate().unwrap();
+}

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -954,3 +954,352 @@ fn test_allow_absent_zero_network_without_route_type() {
 
     routes.validate().unwrap();
 }
+
+#[test]
+fn test_reject_conflicting_special_routes_same_table() {
+    // Same destination, table, and metric with different special types is
+    // rejected by the kernel (RTNETLINK File exists).
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        - destination: 0.0.0.0/8
+          route-type: prohibit
+          metric: 200
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let err =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    assert!(err.msg().contains("0.0.0.0/8"));
+    assert!(err.msg().contains("99"));
+    assert!(err.msg().contains("200"));
+}
+
+#[test]
+fn test_allow_special_routes_same_table_different_metrics() {
+    // Distinct metrics make distinct fib entries; both types may coexist.
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        - destination: 0.0.0.0/8
+          route-type: prohibit
+          metric: 300
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let merged =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap();
+    assert_eq!(merged.changed_routes.len(), 2);
+}
+
+#[test]
+fn test_allow_special_routes_different_tables() {
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          table-id: 99
+        - destination: 0.0.0.0/8
+          route-type: prohibit
+          table-id: 100
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let merged =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap();
+    assert_eq!(merged.changed_routes.len(), 2);
+}
+
+#[test]
+fn test_reject_equivalent_special_route_destinations() {
+    // 192.0.2.1/24 sanitizes to 192.0.2.0/24, so these collide.
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 192.0.2.1/24
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        - destination: 192.0.2.0/24
+          route-type: prohibit
+          metric: 200
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let err =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    assert!(err.msg().contains("192.0.2.0/24"));
+}
+
+#[test]
+fn test_allow_special_routes_in_different_vrfs() {
+    use crate::{Interfaces, MergedInterfaces};
+
+    let cur_ifaces: Interfaces = serde_yaml::from_str(
+        r"---
+        - name: vrf0
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 100
+        - name: vrf1
+          type: vrf
+          state: up
+          vrf:
+            route-table-id: 101
+        ",
+    )
+    .unwrap();
+
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          vrf-name: vrf0
+        - destination: 0.0.0.0/8
+          route-type: prohibit
+          vrf-name: vrf1
+        "#,
+    )
+    .unwrap();
+
+    let merged_ifaces = MergedInterfaces::new(
+        Interfaces::default(),
+        cur_ifaces,
+        Default::default(),
+        false,
+    )
+    .unwrap();
+
+    let merged =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap();
+    assert_eq!(merged.changed_routes.len(), 2);
+}
+
+#[test]
+fn test_gen_diff_reports_special_route_type_change() {
+    use crate::NetworkState;
+
+    let current: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 0.0.0.0/8
+            route-type: blackhole
+            metric: 200
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 0.0.0.0/8
+            route-type: prohibit
+            metric: 200
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let diff = desired.gen_diff(&current).unwrap();
+    let diff_routes = diff.routes.config.as_ref().unwrap();
+    assert!(
+        diff_routes.iter().any(|rt| {
+            rt.route_type == Some(crate::RouteType::Prohibit) && !rt.is_absent()
+        }),
+        "gen_diff should report the new prohibit route: {diff_routes:?}"
+    );
+    assert!(
+        diff_routes.iter().any(|rt| {
+            rt.is_absent() && rt.route_type == Some(crate::RouteType::Blackhole)
+        }),
+        "gen_diff should mark the old blackhole route absent: {diff_routes:?}"
+    );
+}
+
+#[test]
+fn test_gen_diff_keeps_special_route_when_type_change_uses_different_metric() {
+    // Distinct metrics are separate fib entries; changing route-type alone
+    // must not remove the existing special route.
+    use crate::NetworkState;
+
+    let current: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 0.0.0.0/8
+            route-type: blackhole
+            metric: 200
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 0.0.0.0/8
+            route-type: prohibit
+            metric: 300
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let diff = desired.gen_diff(&current).unwrap();
+    let diff_routes = diff.routes.config.as_ref().unwrap();
+    assert!(
+        diff_routes.iter().any(|rt| {
+            rt.route_type == Some(crate::RouteType::Prohibit)
+                && rt.metric == Some(300)
+                && !rt.is_absent()
+        }),
+        "gen_diff should add the new prohibit route: {diff_routes:?}"
+    );
+    assert!(
+        !diff_routes.iter().any(|rt| {
+            rt.is_absent() && rt.route_type == Some(crate::RouteType::Blackhole)
+        }),
+        "gen_diff must not mark the blackhole absent when metrics differ: \
+         {diff_routes:?}"
+    );
+}
+
+#[test]
+fn test_gen_diff_reports_ipv6_special_route_type_change_with_oif() {
+    // IPv6 special routes retain next-hop-interface from the kernel oif.
+    use crate::NetworkState;
+
+    let current: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 2001:db8:1::/64
+            route-type: blackhole
+            next-hop-interface: lo
+            metric: 200
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+    let desired: NetworkState = serde_yaml::from_str(
+        r#"
+        routes:
+          config:
+          - destination: 2001:db8:1::/64
+            route-type: unreachable
+            metric: 200
+            table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let diff = desired.gen_diff(&current).unwrap();
+    let diff_routes = diff.routes.config.as_ref().unwrap();
+    assert!(
+        diff_routes.iter().any(|rt| {
+            rt.route_type == Some(crate::RouteType::Unreachable)
+                && !rt.is_absent()
+        }),
+        "gen_diff should report the new unreachable route: {diff_routes:?}"
+    );
+    assert!(
+        diff_routes.iter().any(|rt| {
+            rt.is_absent()
+                && rt.route_type == Some(crate::RouteType::Blackhole)
+                && rt.next_hop_iface.as_deref() == Some("lo")
+        }),
+        "gen_diff should mark the old blackhole route absent and keep oif lo: \
+         {diff_routes:?}"
+    );
+}
+
+#[test]
+fn test_allow_duplicate_identical_special_routes() {
+    let routes: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let merged =
+        MergedRoutes::new(routes, Routes::new(), &merged_ifaces).unwrap();
+    assert_eq!(merged.changed_routes.len(), 1);
+}
+
+#[test]
+fn test_revert_restores_replaced_special_route() {
+    let current: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: blackhole
+          metric: 200
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+    let desired: Routes = serde_yaml::from_str(
+        r#"
+        config:
+        - destination: 0.0.0.0/8
+          route-type: prohibit
+          metric: 200
+          table-id: 99
+        "#,
+    )
+    .unwrap();
+
+    let (merged_ifaces, _) = gen_merged_ifaces_for_route_test();
+    let merged = MergedRoutes::new(desired, current, &merged_ifaces).unwrap();
+    let revert = merged.generate_revert();
+    let revert_routes = revert.config.as_ref().unwrap();
+    assert!(
+        revert_routes.iter().any(|rt| {
+            rt.route_type == Some(crate::RouteType::Blackhole)
+                && !rt.is_absent()
+        }),
+        "revert should restore the replaced blackhole route: {revert_routes:?}"
+    );
+    assert!(
+        revert_routes.iter().any(|rt| {
+            rt.is_absent() && rt.route_type == Some(crate::RouteType::Prohibit)
+        }),
+        "revert should remove the added prohibit route: {revert_routes:?}"
+    );
+}

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -301,6 +301,68 @@ def test_apply_route_with_route_type_multiple_times(eth1_up):
     assert routes_out_v6.count("unreachable") == 1
 
 
+# https://redhat.atlassian.net/browse/RHEL-82785
+@pytest.mark.tier1
+def test_reject_conflicting_special_routes_same_table():
+    routes = [
+        {
+            Route.DESTINATION: "0.0.0.0/8",
+            Route.ROUTETYPE: Route.ROUTETYPE_BLACKHOLE,
+            Route.METRIC: 200,
+            Route.TABLE_ID: 99,
+        },
+        {
+            Route.DESTINATION: "0.0.0.0/8",
+            Route.ROUTETYPE: Route.ROUTETYPE_PROHIBIT,
+            Route.METRIC: 200,
+            Route.TABLE_ID: 99,
+        },
+    ]
+    with pytest.raises(NmstateValueError):
+        libnmstate.apply({Route.KEY: {Route.CONFIG: routes}})
+
+
+# https://redhat.atlassian.net/browse/RHEL-82785
+@pytest.mark.tier1
+def test_change_special_route_type_is_reported():
+    blackhole = [
+        {
+            Route.DESTINATION: "0.0.0.0/8",
+            Route.ROUTETYPE: Route.ROUTETYPE_BLACKHOLE,
+            Route.METRIC: 200,
+            Route.TABLE_ID: 99,
+        }
+    ]
+    prohibit = [
+        {
+            Route.DESTINATION: "0.0.0.0/8",
+            Route.ROUTETYPE: Route.ROUTETYPE_PROHIBIT,
+            Route.METRIC: 200,
+            Route.TABLE_ID: 99,
+        }
+    ]
+    libnmstate.apply({Route.KEY: {Route.CONFIG: blackhole}})
+    current = libnmstate.show_running_config()
+    diff = libnmstate.generate_differences(
+        {Route.KEY: {Route.CONFIG: prohibit}}, current
+    )
+    changed = diff.get(Route.KEY, {}).get(Route.CONFIG, [])
+    assert any(
+        rt.get(Route.ROUTETYPE) == Route.ROUTETYPE_PROHIBIT
+        and rt.get(Route.STATE) != Route.STATE_ABSENT
+        for rt in changed
+    ), f"expected prohibit route in gen_diff, got {changed}"
+    assert any(
+        rt.get(Route.ROUTETYPE) == Route.ROUTETYPE_BLACKHOLE
+        and rt.get(Route.STATE) == Route.STATE_ABSENT
+        for rt in changed
+    ), f"expected absent blackhole route in gen_diff, got {changed}"
+    libnmstate.apply({Route.KEY: {Route.CONFIG: prohibit}})
+    routes_out = _get_routes_from_iproute(4, 99)
+    assert Route.ROUTETYPE_PROHIBIT in routes_out
+    assert Route.ROUTETYPE_BLACKHOLE not in routes_out
+
+
 @pytest.mark.tier1
 def test_add_gateway(eth1_up):
     routes = [_get_ipv4_gateways()[0], _get_ipv6_test_routes()[0]]


### PR DESCRIPTION
Reject desired states that put more than one special route (blackhole / unreachable / prohibit) on the same destination and table. The kernel only keeps one and nmstate used to apply silently with no error.
Handle no-next-hop special routes in MergedRoutes so a route-type change marks the old route absent and shows up in gen_diff.
Unit and integration coverage for the collision error and for reporting a type change.

Resolves: https://redhat.atlassian.net/browse/RHEL-82785