### PR TITLE
test: fix IPsec xfrm interface timing flake

### DIFF
--- a/tests/integration/ipsec_test.py
+++ b/tests/integration/ipsec_test.py
@@ -14,7 +14,10 @@ from .testlib import cmdlib
 from .testlib.env import is_el10
 from .testlib.env import nm_libreswan_version_int
 from .testlib.env import version_str_to_int
+from .testlib.ipsec import IPSEC_IFACE_TIMEOUT_SECS
 from .testlib.ipsec import IpsecTestEnv
+from .testlib.ipsec import ipsec_numbered_iface_exists
+from .testlib.ipsec import wait_for_ipsec_numbered_ifaces_gone
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import show_only
 
@@ -96,6 +99,8 @@ def _check_ipsec_policy(left, right):
 
 
 def _check_ipsec_ip(ip_net_prefix, nic):
+    if not ipsec_numbered_iface_exists(nic):
+        return False
     try:
         iface_state = show_only([nic])[Interface.KEY][0]
         for ip in iface_state.get(Interface.IPV4, {}).get(
@@ -104,9 +109,9 @@ def _check_ipsec_ip(ip_net_prefix, nic):
             if ip.get(InterfaceIPv4.ADDRESS_IP, "").startswith(ip_net_prefix):
                 return True
         for ip in iface_state.get(Interface.IPV6, {}).get(
-            InterfaceIPv4.ADDRESS, []
+            InterfaceIPv6.ADDRESS, []
         ):
-            if ip.get(InterfaceIPv4.ADDRESS_IP, "").startswith(ip_net_prefix):
+            if ip.get(InterfaceIPv6.ADDRESS_IP, "").startswith(ip_net_prefix):
                 return True
     except Exception:
         pass
@@ -125,6 +130,7 @@ def ipsec_cli_cleanup():
         Loader=yaml.SafeLoader,
     )
     libnmstate.apply(desired_state)
+    wait_for_ipsec_numbered_ifaces_gone()
 
 
 def test_ipsec_ipv4_libreswan_cert_auth_add_and_remove(ipsec_srv_cert_gw):
@@ -898,7 +904,7 @@ def test_ipsec_dhcpv4_off_and_empty_ip_addr(
     # The libreswan might take time to create xfrm interface after
     # xfrm policy been created.
     assert retry_till_true_or_timeout(
-        RETRY_COUNT, _is_ipsec_nic_ipv4_disabled, "ipsec97"
+        IPSEC_IFACE_TIMEOUT_SECS, _is_ipsec_nic_ipv4_disabled, "ipsec97"
     )
 
 
@@ -928,7 +934,7 @@ def test_ipsec_ipv6_host_to_site_with_dhcpv6_off(ipsec_srv_host_to_site):
             right: {IpsecTestEnv.SRV_ADDR_V6}
             rightid: '%fromcert'
             rightsubnet: {IpsecTestEnv.SRV_SUBNET_V6}
-            ipsec-interface: 97
+            ipsec-interface: 98
             ikev2: insist""",
         Loader=yaml.SafeLoader,
     )
@@ -943,7 +949,7 @@ def test_ipsec_ipv6_host_to_site_with_dhcpv6_off(ipsec_srv_host_to_site):
     # The libreswan might take time to create xfrm interface after
     # xfrm policy been created.
     assert retry_till_true_or_timeout(
-        RETRY_COUNT, _is_ipsec_nic_ipv6_no_auto, "ipsec97"
+        IPSEC_IFACE_TIMEOUT_SECS, _is_ipsec_nic_ipv6_no_auto, "ipsec98"
     )
 
 
@@ -1011,21 +1017,31 @@ def test_ipsec_require_id_on_certificate(ipsec_srv_cert_gw, load_both_keys):
 
 
 def _is_ipsec_nic_ipv4_disabled(nic_name):
+    if not ipsec_numbered_iface_exists(nic_name):
+        return False
     try:
         iface_state = show_only((nic_name,))[Interface.KEY][0]
     except IndexError:
         return False
-    return not iface_state[Interface.IPV4][InterfaceIPv4.ENABLED]
+    ipv4 = iface_state.get(Interface.IPV4)
+    if not ipv4:
+        return False
+    return not ipv4.get(InterfaceIPv4.ENABLED, True)
 
 
 def _is_ipsec_nic_ipv6_no_auto(nic_name):
+    if not ipsec_numbered_iface_exists(nic_name):
+        return False
     try:
         iface_state = show_only((nic_name,))[Interface.KEY][0]
     except IndexError:
         return False
+    ipv6 = iface_state.get(Interface.IPV6)
+    if not ipv6:
+        return False
     return not (
-        iface_state[Interface.IPV6].get(InterfaceIPv6.DHCP)
-        or iface_state[Interface.IPV6].get(InterfaceIPv6.AUTOCONF)
+        ipv6.get(InterfaceIPv6.DHCP, True)
+        or ipv6.get(InterfaceIPv6.AUTOCONF, True)
     )
 
 

--- a/tests/integration/testlib/ipsec.py
+++ b/tests/integration/testlib/ipsec.py
@@ -2,6 +2,7 @@
 
 import glob
 import os
+import re
 import time
 from subprocess import SubprocessError
 
@@ -14,8 +15,41 @@ from libnmstate.schema import InterfaceType
 from libnmstate.schema import Route
 
 from .cmdlib import exec_cmd
+from .retry import retry_till_false_or_timeout
 from .veth import create_veth_pair
 from .veth import remove_veth_pair
+
+# Libreswan may create the xfrm netdev well after xfrm policy/state appear.
+IPSEC_IFACE_TIMEOUT_SECS = 30
+
+
+def ipsec_numbered_iface_exists(nic_name):
+    return os.path.exists(f"/sys/class/net/{nic_name}")
+
+
+def list_ipsec_numbered_ifaces():
+    return sorted(
+        name
+        for name in os.listdir("/sys/class/net")
+        if re.fullmatch(r"ipsec\d+", name)
+    )
+
+
+def _ipsec_numbered_ifaces_exist():
+    return bool(list_ipsec_numbered_ifaces())
+
+
+def wait_for_ipsec_numbered_ifaces_gone(timeout=IPSEC_IFACE_TIMEOUT_SECS):
+    still_exist = retry_till_false_or_timeout(
+        timeout, _ipsec_numbered_ifaces_exist
+    )
+    if still_exist:
+        ifaces = list_ipsec_numbered_ifaces()
+        raise RuntimeError(
+            f"ipsec interfaces {ifaces} still exist after waiting "
+            f"{timeout} seconds"
+        )
+
 
 SRV_CONTAINER_IMG = "quay.io/nmstate/test-env:libreswan-srv-c9s"
 SRV_CONTAINER_NAME = "nmstate-ipsec-srv"


### PR DESCRIPTION
Fixes a flaky integration failure in `test_ipsec_dhcpv4_off_and_empty_ip_addr` caused by a race between xfrm state/policy and the numbered `ipsecN` netdev.

Libreswan can report xfrm state before the kernel creates `ipsec97`, and NetworkManager may not immediately reflect the expected IPv4-disabled state. The test only retried for 10 seconds and could fail while the interface was still coming up or being torn down.