### PR TITLE
Revert "ci: pin crun path to /usr/local/bin"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,14 +152,6 @@ jobs:
       - name: Enable openvswitch kernel module
         run: sudo modprobe openvswitch
 
-      - name: Configure podman to use newer crun
-        run: |
-          # Workaround for ubuntu-24.04 runner image crun version mismatch
-          # See: https://github.com/actions/runner-images/issues/14473
-          sudo mkdir -p /etc/containers
-          ( echo '[engine.runtimes]';
-            echo 'crun = [ "/usr/local/bin/crun" ]' ) | sudo tee /etc/containers/containers.conf
-
       - name: Download compiled EL9 rpm
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
This reverts commit 6249dc90fd3c9ae1fac9d8608d22361358fe2a9d.

The underlying problem should now be resolved, so this workaround is no longer needed.