### PR TITLE
nm: suppress multiconnect autoconnect on state absent

### DIFF
--- a/rust/src/lib/nm/connection.rs
+++ b/rust/src/lib/nm/connection.rs
@@ -18,6 +18,7 @@ pub(crate) struct PreparedNmConnections {
     pub(crate) to_store: Vec<NmConnection>,
     pub(crate) to_activate: Vec<NmConnection>,
     pub(crate) to_deactivate: Vec<NmDevice>,
+    pub(crate) suppress_autoconnect_dev_names: HashSet<String>,
     pub(crate) to_delete: Vec<String>,
 }
 
@@ -50,18 +51,28 @@ pub(crate) fn prepare_nm_conns(
     });
 
     let nm_devs_indexed = create_index_for_nm_devs(nm_devs);
-    let mut nm_devs_to_deactivate: Vec<NmDevice> = ifaces
-        .iter()
-        .filter(|iface| {
-            iface.for_apply.as_ref().map(|i| i.is_down()) == Some(true)
-        })
-        .filter_map(|iface| {
-            nm_devs_indexed
-                .get(&(iface.merged.name(), iface.merged.iface_type()))
-                .copied()
-        })
-        .cloned()
-        .collect();
+    let mut nm_devs_to_deactivate: Vec<NmDevice> = Vec::new();
+    let mut suppress_autoconnect_dev_names: HashSet<String> = HashSet::new();
+    for iface in ifaces.iter() {
+        let should_deactivate = iface
+            .for_apply
+            .as_ref()
+            .map(|i| i.is_down() || i.is_absent())
+            == Some(true);
+        if !should_deactivate {
+            continue;
+        }
+        if let Some(nm_dev) = nm_devs_indexed
+            .get(&(iface.merged.name(), iface.merged.iface_type()))
+            .copied()
+        {
+            nm_devs_to_deactivate.push(nm_dev.clone());
+            if iface.merged.is_absent() {
+                suppress_autoconnect_dev_names
+                    .insert(iface.merged.name().to_string());
+            }
+        }
+    }
 
     for merged_iface in ifaces.iter().filter(|i| {
         i.merged.iface_type() != InterfaceType::Unknown && !i.merged.is_absent()
@@ -144,6 +155,7 @@ pub(crate) fn prepare_nm_conns(
         to_store: nm_conns_to_update,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_devs_to_deactivate,
+        suppress_autoconnect_dev_names,
         to_delete: Vec::new(),
     };
 

--- a/rust/src/lib/nm/query_apply/apply.rs
+++ b/rust/src/lib/nm/query_apply/apply.rs
@@ -106,6 +106,7 @@ pub(crate) async fn nm_apply(
         to_store: nm_conns_to_store,
         to_activate: nm_conns_to_activate,
         to_deactivate: nm_devs_to_deactivate,
+        suppress_autoconnect_dev_names,
         to_delete: nm_conns_to_delete,
     } = prepare_nm_conns(
         &merged_state,
@@ -170,7 +171,12 @@ pub(crate) async fn nm_apply(
     // We have deleted most of the other matching connections, but we cannot
     // delete some connections with "multiconnect". This would lead to unwanted
     // connection activations if we use deactivate_nm_connections.
-    deactivate_nm_devices(&mut nm_api, &nm_devs_to_deactivate).await?;
+    deactivate_nm_devices(
+        &mut nm_api,
+        &nm_devs_to_deactivate,
+        &suppress_autoconnect_dev_names,
+    )
+    .await?;
 
     Ok(())
 }

--- a/rust/src/lib/nm/query_apply/device.rs
+++ b/rust/src/lib/nm/query_apply/device.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use crate::{
     InterfaceType, NmstateError,
     nm::{
@@ -46,6 +48,7 @@ pub(crate) fn nm_dev_iface_type_to_nmstate(nm_dev: &NmDevice) -> InterfaceType {
 pub(crate) async fn deactivate_nm_devices(
     nm_api: &mut NmApi<'_>,
     nm_devs: &[NmDevice],
+    suppress_autoconnect_dev_names: &HashSet<String>,
 ) -> Result<(), NmstateError> {
     for nm_dev in nm_devs {
         log::info!("Deactivating device {}", nm_dev.name);
@@ -53,6 +56,9 @@ pub(crate) async fn deactivate_nm_devices(
             && e.kind != ErrorKind::Device(NmDeviceError::NotActive)
         {
             return Err(nm_error_to_nmstate(e));
+        }
+        if suppress_autoconnect_dev_names.contains(&nm_dev.name) {
+            log::warn!("autoconnect has been suppressed for {}", nm_dev.name);
         }
     }
     Ok(())

--- a/tests/integration/nm/profile_test.py
+++ b/tests/integration/nm/profile_test.py
@@ -3,6 +3,8 @@
 from contextlib import contextmanager
 from subprocess import SubprocessError
 
+import logging
+
 import pytest
 
 import time
@@ -822,4 +824,83 @@ def test_down_iface_with_multiconnect_profile(
             "nmcli -g GENERAL.CONNECTION d show eth1".split(), check=True
         )[1]
         == "\n"
+    )
+
+
+def _connection_active_on_iface(iface_name):
+    _, out, _ = cmdlib.exec_cmd(
+        "nmcli -f NAME,DEVICE connection show".split(), check=True
+    )
+    for line in out.strip().splitlines():
+        parts = [part.strip() for part in line.split(":")]
+        if len(parts) == 2 and parts[1] == iface_name:
+            return True
+    return False
+
+
+def _assert_iface_absent_from_multiconnect(iface_name):
+    time.sleep(1)  # Give some time to NetworkManager to auto-activate profiles
+    assert (
+        cmdlib.exec_cmd(
+            f"nmcli -g GENERAL.CONNECTION device show {iface_name}".split(),
+            check=True,
+        )[1].strip()
+        == ""
+    )
+    assert not _connection_active_on_iface(iface_name)
+    _, out, _ = cmdlib.exec_cmd(
+        f"ip link show {iface_name}".split(), check=True
+    )
+    assert "state DOWN" in out
+    assert (
+        cmdlib.exec_cmd(
+            f"nmcli -g IP4.ADDRESS device show {iface_name}".split(),
+            check=True,
+        )[1].strip()
+        == ""
+    )
+
+
+def test_state_absent_suppresses_multiconnect_dhcp(
+    multiconnect_profile_with_ip_enabled,
+    caplog,
+):
+    static_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.UP,
+                Interface.IPV4: {
+                    InterfaceIPv4.ENABLED: True,
+                    InterfaceIPv4.DHCP: False,
+                    InterfaceIPv4.ADDRESS: [
+                        {
+                            InterfaceIPv4.ADDRESS_IP: IPV4_ADDRESS1,
+                            InterfaceIPv4.ADDRESS_PREFIX_LENGTH: 24,
+                        }
+                    ],
+                },
+            }
+        ]
+    }
+    absent_state = {
+        Interface.KEY: [
+            {
+                Interface.NAME: "eth1",
+                Interface.TYPE: InterfaceType.ETHERNET,
+                Interface.STATE: InterfaceState.ABSENT,
+            }
+        ]
+    }
+
+    libnmstate.apply(static_state)
+    with caplog.at_level(logging.WARNING, logger="libnmstate"):
+        libnmstate.apply(absent_state)
+        libnmstate.apply(absent_state)
+
+    _assert_iface_absent_from_multiconnect("eth1")
+    assert any(
+        "autoconnect has been suppressed for eth1" in record.message
+        for record in caplog.records
     )


### PR DESCRIPTION
Summary:
Fix state: absent leaving DHCP active when a multi-connect default NM profile exists (OCP NNCP scenario).
When an interface is marked absent, nmstate now disconnects the device via Device.Disconnect (same approach as state: down) so multi-connect profiles cannot auto-attach after the per-interface profile is deleted.
Emit a warning log (autoconnect has been suppressed for <iface>) when suppressing autoconnect for absent interfaces.
Add integration test `test_state_absent_suppresses_multiconnect_dhcp` covering static IP → absent → reapply with a multi-connect DHCP default profile.
Problem
With NetworkManager-config-server and a multi-connect default connection (connection.multi-connect multiple, ipv4.method auto), applying state: absent on eth1 deletes the dedicated profile but NM can still auto-attach the default profile and start DHCP.