### PR TITLE
nispor: adapt ip6tnl flow-label to nispor 2.0.3

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "2.0.2"
+nispor = "2.0.3"
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.31", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }

--- a/rust/src/lib/nispor/ip_tunnel.rs
+++ b/rust/src/lib/nispor/ip_tunnel.rs
@@ -37,9 +37,9 @@ pub(crate) fn np_ip_tunnel_to_nmstate(
                 remote: np_ip_tunnel_info.remote,
                 ttl: np_ip_tunnel_info.ttl,
                 tos: np_ip_tunnel_info.tos,
-                flow_label: np_ip_tunnel_info.flow_info.map(|flow_info| {
-                    u32::from_be(flow_info) & IPV6_FLOWLABEL_MASK
-                }),
+                flow_label: np_ip_tunnel_info
+                    .flow_info
+                    .map(|flow_info| flow_info & IPV6_FLOWLABEL_MASK),
                 ip6tun_flags: np_ip_tunnel_info
                     .ip6tun_flags
                     .as_deref()


### PR DESCRIPTION
netlink-packet-route 0.33 (via nispor 2.0.3) now decodes IFLA_IPTUN_FLOWINFO into host byte order, so the u32::from_be() compensation double-swaps and every ip6tnl flow-label reads as 0, failing verification. Drop the swap and require nispor >= 2.0.3.