### PR TITLE
test: Retry flaky libreswan Copr pretest

### DIFF
--- a/.github/workflows/run_test.sh
+++ b/.github/workflows/run_test.sh
@@ -43,9 +43,10 @@ fi
 
 if [ $NM_TYPE == "nm_min" ];then
     TEST_ARG="$TEST_ARG --copr nmstate/nm-rhel9"
-    PRETEST_EXEC='dnf copr enable -y nmstate/nm-libreswan-rhel9; \
-        dnf remove -y NetworkManager-libreswan; \
-        dnf install -y NetworkManager-libreswan \
+    # distro-sync to the Copr NEVRA without removing first. A Copr metadata
+    # timeout used to leave the system with no NetworkManager-libreswan.
+    PRETEST_EXEC='dnf copr enable -y nmstate/nm-libreswan-rhel9 && \
+        dnf distro-sync -y --refresh NetworkManager-libreswan \
             --disablerepo="*" \
             --enablerepo="copr:copr.fedorainfracloud.org:nmstate:nm-libreswan-rhel9"'
 fi

--- a/automation/run-tests.sh
+++ b/automation/run-tests.sh
@@ -85,7 +85,18 @@ function exec_cmd {
 # Some command like DNF might fail in container, hence we retry on failure
 function exec_cmd_with_retry {
     if [ ! -z ${RUN_BAREMETAL} ];then
-        bash -c "$1"
+        local retries=5
+        local i
+        for i in $(seq 1 $retries); do
+            if bash -c "$1"; then
+                return 0
+            fi
+            if [ "$i" -lt "$retries" ]; then
+                echo "Command failed, retrying ($i/$retries) after 10s..."
+                sleep 10
+            fi
+        done
+        return 1
     else
         container_exec_with_retry "$1"
     fi
@@ -405,7 +416,7 @@ fi
 install_nmstate
 
 if [[ -v PRETEST_EXEC ]];then
-    exec_cmd "$PRETEST_EXEC"
+    exec_cmd_with_retry "$PRETEST_EXEC"
 fi
 
 run_tests

--- a/automation/tests-container-utils.sh
+++ b/automation/tests-container-utils.sh
@@ -13,10 +13,20 @@ function container_exec {
 }
 
 function container_exec_with_retry {
-    time ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
-        /bin/bash -c "cd $CONTAINER_WORKSPACE && $1" ||
-    time ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
-        /bin/bash -c "cd $CONTAINER_WORKSPACE && $1"
+    local retries=5
+    local i
+    for ((i=1; i<=retries; i++)); do
+        if time ${CONTAINER_CMD} exec $USE_TTY -i $CONTAINER_ID \
+            /bin/bash -c "cd $CONTAINER_WORKSPACE && $1"
+        then
+            return 0
+        fi
+        if [ "$i" -lt "$retries" ]; then
+            echo "Command failed, retrying ($i/$retries) after 10s..."
+            sleep 10
+        fi
+    done
+    return 1
 }
 
 function open_shell {


### PR DESCRIPTION
- `nm_min` CI failed before pytest when Copr metadata for `NetworkManager-libreswan` timed out (HTTP 504) after the package had already been removed.
- Sync the Copr build with `dnf distro-sync --refresh` instead of remove-then-install, so a download flake leaves the installed package in place.
- Retry pretest and other DNF commands up to five times with a 10s delay.