### PR TITLE
(DO NOT MERGE, pending nispor changes) route: support IPv6 ECMP routes

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ serde_yaml = "0.9"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0.75", default-features = false }
 nmstate = { path = "src/lib", version = "2.2", default-features = false }
-nispor = "2.0.3"
+nispor = { git = "https://github.com/nispor/nispor", rev = "003b90c8f9e63028ebc9c2fdff3ed3bd08792bb0" }
 uuid = { version = "1.1 ", default-features = false, features = ["v4"] }
 nix = { version = "0.31", default-features = false, features = ["feature", "hostname"] }
 zbus = { version = "5.1.0", default-features = false, features = ["tokio"] }

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -287,9 +287,7 @@ fn flat_multipath_route(
             new_np_route.oif = Some(mp_route.iface.to_string());
             let mut route =
                 np_route_to_nmstate(&new_np_route, table_id_to_vrf_names);
-            if np_route.address_family == nispor::AddressFamily::Ipv4 {
-                route.weight = Some(mp_route.weight);
-            }
+            route.weight = Some(mp_route.weight);
             ret.push(route);
         }
     }

--- a/rust/src/lib/nispor/route.rs
+++ b/rust/src/lib/nispor/route.rs
@@ -319,12 +319,6 @@ fn nmstate_to_nispor_route_conf(
             ret.table = Some(table_id as u8);
         }
     }
-    if nmstate_rt.weight.is_some() {
-        return Err(NmstateError::new(
-            ErrorKind::NotImplementedError,
-            "nispor apply does not support route weight yet".into(),
-        ));
-    }
 
     if nmstate_rt.route_type.is_some() {
         return Err(NmstateError::new(
@@ -342,14 +336,65 @@ fn nmstate_to_nispor_route_conf(
     Ok(ret)
 }
 
+fn nmstate_rt_to_nispor_multipath(
+    rt: &RouteEntry,
+) -> nispor::RouteMultipathConf {
+    let mut mp = nispor::RouteMultipathConf::default();
+    mp.via = rt.next_hop_addr.clone();
+    mp.weight = rt.weight;
+    mp.iface = rt.next_hop_iface.clone();
+    mp
+}
+
 pub(crate) fn gen_nispor_route_confs(
     merged_routes: &MergedRoutes,
 ) -> Result<Vec<nispor::RouteConf>, NmstateError> {
     validate_routes(merged_routes)?;
-    let mut ret = Vec::new();
-    for nmstate_rt in merged_routes.changed_routes.as_slice() {
-        ret.push(nmstate_to_nispor_route_conf(nmstate_rt)?)
+
+    // Group changed routes by (dst, table_id, metric) so that ECMP routes
+    // (same destination, multiple weighted nexthops) are applied as a single
+    // multipath RouteConf rather than as separate single-nexthop entries.
+    type EcmpKey = (String, Option<u32>, Option<i64>);
+    let mut ecmp_groups: HashMap<EcmpKey, Vec<&RouteEntry>> = HashMap::new();
+    let mut plain_routes: Vec<&RouteEntry> = Vec::new();
+
+    for rt in merged_routes.changed_routes.as_slice() {
+        if rt.weight.is_some() {
+            let key = (
+                rt.destination.clone().unwrap_or_default(),
+                rt.table_id,
+                rt.metric,
+            );
+            ecmp_groups.entry(key).or_default().push(rt);
+        } else {
+            plain_routes.push(rt);
+        }
     }
+
+    let mut ret = Vec::new();
+
+    for rt in plain_routes {
+        ret.push(nmstate_to_nispor_route_conf(rt)?);
+    }
+
+    for (_, group) in ecmp_groups {
+        // All routes in the group share the same dst/table/metric; use the
+        // first entry to set those fields and build the multipath nexthop list.
+        let first = group[0];
+        let mut conf = nmstate_to_nispor_route_conf(first)?;
+        // Clear the flat single-nexthop fields — they're expressed via
+        // multipath.
+        conf.oif = None;
+        conf.via = None;
+        conf.multipath = Some(
+            group
+                .iter()
+                .map(|rt| nmstate_rt_to_nispor_multipath(rt))
+                .collect(),
+        );
+        ret.push(conf);
+    }
+
     Ok(ret)
 }
 
@@ -360,16 +405,12 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
         } else {
             continue;
         };
-        let mut hashed_rts: HashMap<(&str, u32, u32), &RouteEntry> =
+        // Group routes by (dst, effective_table, effective_metric).
+        // A group with > 1 entry is only valid when every entry carries a
+        // weight (ECMP).  Without weight it is an unresolvable conflict.
+        let mut groups: HashMap<(&str, u32, u32), Vec<&RouteEntry>> =
             HashMap::new();
         for rt in iface_routes {
-            if rt.weight.is_some() {
-                return Err(NmstateError::new(
-                    ErrorKind::NotSupportedError,
-                    "Kernel mode does not support ECMP routes".to_string(),
-                ));
-            }
-
             // The `Routes::validate()` already confirmed non-absent routes
             // always has destination.
             // The `merged_routes.merged` does not have absent route.
@@ -383,13 +424,13 @@ fn validate_routes(merged_routes: &MergedRoutes) -> Result<(), NmstateError> {
             // metric-less desired route conflicts with an existing route that
             // the kernel reports with the coerced default metric (e.g. IPv6
             // default route metric 1024).
-            if hashed_rts
-                .insert(
-                    (dst, rt.effective_table_id(), rt.effective_metric()),
-                    rt,
-                )
-                .is_some()
-            {
+            groups
+                .entry((dst, rt.effective_table_id(), rt.effective_metric()))
+                .or_default()
+                .push(rt);
+        }
+        for ((dst, _, _), group) in &groups {
+            if group.len() > 1 && group.iter().any(|rt| rt.weight.is_none()) {
                 return Err(NmstateError::new(
                     ErrorKind::InvalidArgument,
                     format!(
@@ -509,6 +550,43 @@ mod tests {
         let merged = merged_for(vec![
             route("::/0", "2001:db8:1::3", Some(0), 200),
             route("::/0", "2001:db8:1::2", None, 200),
+        ]);
+        let err = validate_routes(&merged).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidArgument);
+    }
+
+    fn ecmp_route(
+        dst: &str,
+        via: &str,
+        metric: Option<i64>,
+        table: u32,
+        weight: u16,
+    ) -> RouteEntry {
+        RouteEntry {
+            destination: Some(dst.to_string()),
+            next_hop_iface: Some("eth1".to_string()),
+            next_hop_addr: Some(via.to_string()),
+            metric,
+            table_id: Some(table),
+            weight: Some(weight),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_ipv6_ecmp_routes_valid_in_kernel_mode() {
+        let merged = merged_for(vec![
+            ecmp_route("::/0", "2001:db8:1::2", Some(1024), 254, 1),
+            ecmp_route("::/0", "2001:db8:1::3", Some(1024), 254, 256),
+        ]);
+        validate_routes(&merged).unwrap();
+    }
+
+    #[test]
+    fn test_ecmp_mixed_weight_conflicts() {
+        let merged = merged_for(vec![
+            ecmp_route("::/0", "2001:db8:1::2", Some(1024), 254, 1),
+            route("::/0", "2001:db8:1::3", Some(1024), 254),
         ]);
         let err = validate_routes(&merged).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidArgument);

--- a/rust/src/lib/route.rs
+++ b/rust/src/lib/route.rs
@@ -514,25 +514,16 @@ impl RouteEntry {
                 self.source = Some(new_src);
             }
         }
-        if let Some(weight) = self.weight {
-            if !(1..=256).contains(&weight) {
-                return Err(NmstateError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Invalid ECMP route weight {weight}, should be in the \
-                         range of 1 to 256"
-                    ),
-                ));
-            }
-            if let Some(dst) = self.destination.as_deref()
-                && is_ipv6_addr(dst)
-            {
-                return Err(NmstateError::new(
-                    ErrorKind::NotSupportedError,
-                    "IPv6 ECMP route with weight is not supported yet"
-                        .to_string(),
-                ));
-            }
+        if let Some(weight) = self.weight
+            && !(1..=256).contains(&weight)
+        {
+            return Err(NmstateError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Invalid ECMP route weight {weight}, should be in the \
+                     range of 1 to 256"
+                ),
+            ));
         }
         if let Some(cwnd) = self.cwnd
             && cwnd == 0

--- a/rust/src/lib/unit_tests/route.rs
+++ b/rust/src/lib/unit_tests/route.rs
@@ -304,9 +304,35 @@ fn test_route_sanitize_ipv6_ecmp() {
         ",
     )
     .unwrap();
-    let result = route.sanitize();
-    assert!(result.is_err());
-    assert_eq!(result.err().unwrap().kind(), ErrorKind::NotSupportedError);
+    route.sanitize().unwrap();
+}
+
+#[test]
+fn test_route_ipv6_ecmp_is_match() {
+    let absent_route: RouteEntry = serde_yaml::from_str(
+        r"
+        destination: 2001:db8::/32
+        metric: 150
+        next-hop-address: 2001:db8::2
+        next-hop-interface: eth1
+        weight: 2
+        table-id: 254
+        state: absent
+        ",
+    )
+    .unwrap();
+    let route: RouteEntry = serde_yaml::from_str(
+        r"
+        destination: 2001:db8::/32
+        metric: 150
+        next-hop-address: 2001:db8::2
+        next-hop-interface: eth1
+        weight: 2
+        table-id: 254
+        ",
+    )
+    .unwrap();
+    assert!(absent_route.is_match(&route));
 }
 
 #[test]

--- a/tests/integration/alt_name_test.py
+++ b/tests/integration/alt_name_test.py
@@ -8,6 +8,7 @@ import pytest
 import libnmstate
 
 from libnmstate.error import NmstateValueError
+from libnmstate.iplib import is_ipv6_address
 from libnmstate.schema import Bond
 from libnmstate.schema import Interface
 from libnmstate.schema import InterfaceAltName
@@ -355,6 +356,8 @@ class TestAltNames:
 
         for route in expected_routes:
             route[Route.NEXT_HOP_INTERFACE] = "eth1"
+            if is_ipv6_address(route[Route.DESTINATION]):
+                route[Route.WEIGHT] = 1
 
         cur_state = libnmstate.show()
         assert_routes(expected_routes, cur_state)

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1476,6 +1476,7 @@ def test_support_query_multipath_route(eth1_with_multipath_route):
             Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
+            Route.WEIGHT: 1,
         },
         {
             Route.DESTINATION: IPV6_TEST_NET1,
@@ -1483,6 +1484,7 @@ def test_support_query_multipath_route(eth1_with_multipath_route):
             Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
             Route.NEXT_HOP_INTERFACE: "eth1",
             Route.TABLE_ID: 254,
+            Route.WEIGHT: 1,
         },
     ]
     cur_state = libnmstate.show()
@@ -1973,6 +1975,43 @@ def test_add_and_remove_ecmp_route(eth1_static_ip):
             Route.KEY: {Route.CONFIG: routes},
         }
     )
+
+
+# https://redhat.atlassian.net/browse/RHEL-113392
+@pytest.mark.tier1
+def test_add_and_remove_ipv6_ecmp_route(eth1_static_ip):
+    routes = [
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
+            Route.WEIGHT: 1,
+        },
+        {
+            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
+            Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
+            Route.WEIGHT: 256,
+        },
+    ]
+    libnmstate.apply(
+        {
+            Route.KEY: {Route.CONFIG: routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes(routes, cur_state)
+
+    absent_routes = [
+        dict(r, **{Route.STATE: Route.STATE_ABSENT}) for r in routes
+    ]
+    libnmstate.apply(
+        {
+            Route.KEY: {Route.CONFIG: absent_routes},
+        }
+    )
+    cur_state = libnmstate.show()
+    assert_routes_missing(routes, cur_state)
 
 
 @pytest.fixture

--- a/tests/integration/route_test.py
+++ b/tests/integration/route_test.py
@@ -1977,41 +1977,84 @@ def test_add_and_remove_ecmp_route(eth1_static_ip):
     )
 
 
+@pytest.fixture
+def ipv6_ecmp_iface(request, kernel_only):
+    if not kernel_only:
+        request.getfixturevalue("eth1_static_ip")
+        return "eth1"
+
+    request.getfixturevalue("cleanup_veth1_kernel_mode")
+    desired_state = load_yaml(
+        """---
+        interfaces:
+        - name: veth1
+          type: veth
+          state: up
+          veth:
+            peer: veth1_peer
+          ipv6:
+            enabled: true
+            autoconf: false
+            dhcp: false
+            address:
+            - ip: 2001:db8:1::1
+              prefix-length: 64
+        """
+    )
+    libnmstate.apply(desired_state, kernel_only=True)
+    return "veth1"
+
+
 # https://redhat.atlassian.net/browse/RHEL-113392
-@pytest.mark.tier1
-def test_add_and_remove_ipv6_ecmp_route(eth1_static_ip):
+@pytest.mark.parametrize(
+    "kernel_only",
+    [
+        pytest.param(False, id="nm", marks=pytest.mark.tier1),
+        pytest.param(True, id="kernel", marks=pytest.mark.kernel),
+    ],
+)
+def test_add_and_remove_ipv6_ecmp_route(ipv6_ecmp_iface, kernel_only):
     routes = [
         {
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: ipv6_ecmp_iface,
             Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
             Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS2,
             Route.WEIGHT: 1,
         },
         {
-            Route.NEXT_HOP_INTERFACE: "eth1",
+            Route.NEXT_HOP_INTERFACE: ipv6_ecmp_iface,
             Route.DESTINATION: IPV6_DEFAULT_GATEWAY,
             Route.NEXT_HOP_ADDRESS: IPV6_ADDRESS3,
             Route.WEIGHT: 256,
         },
     ]
     libnmstate.apply(
-        {
-            Route.KEY: {Route.CONFIG: routes},
-        }
+        {Route.KEY: {Route.CONFIG: routes}}, kernel_only=kernel_only
     )
-    cur_state = libnmstate.show()
-    assert_routes(routes, cur_state)
+    cur_state = libnmstate.show(kernel_only=kernel_only)
+    assert_routes(routes, cur_state, nic=ipv6_ecmp_iface)
+
+    shown_routes = [
+        route
+        for route in cur_state[Route.KEY][Route.CONFIG]
+        if route.get(Route.NEXT_HOP_INTERFACE) == ipv6_ecmp_iface
+        and route.get(Route.DESTINATION) == IPV6_DEFAULT_GATEWAY
+    ]
+    assert len(shown_routes) == 2
+    libnmstate.apply(
+        {Route.KEY: {Route.CONFIG: shown_routes}}, kernel_only=kernel_only
+    )
+    cur_state = libnmstate.show(kernel_only=kernel_only)
+    assert_routes(routes, cur_state, nic=ipv6_ecmp_iface)
 
     absent_routes = [
         dict(r, **{Route.STATE: Route.STATE_ABSENT}) for r in routes
     ]
     libnmstate.apply(
-        {
-            Route.KEY: {Route.CONFIG: absent_routes},
-        }
+        {Route.KEY: {Route.CONFIG: absent_routes}}, kernel_only=kernel_only
     )
-    cur_state = libnmstate.show()
-    assert_routes_missing(routes, cur_state)
+    cur_state = libnmstate.show(kernel_only=kernel_only)
+    assert_routes_missing(routes, cur_state, nic=ipv6_ecmp_iface)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allow IPv6 multipath routes to round-trip through show/apply by reporting weight for IPv6 multipath entries and removing the NotSupportedError that blocked applying them.

Resolves: https://redhat.atlassian.net/browse/RHEL-113392